### PR TITLE
Montte 2

### DIFF
--- a/montte.pen
+++ b/montte.pen
@@ -41934,8 +41934,8 @@
     {
       "type": "frame",
       "id": "3rWB3",
-      "x": 1663,
-      "y": 2102,
+      "x": 3603,
+      "y": 1854,
       "name": "Modais de Contas Bancárias",
       "fill": "#f8fafc",
       "gap": 100,
@@ -62640,8 +62640,8 @@
     {
       "type": "frame",
       "id": "sWy2Q",
-      "x": 3500,
-      "y": 2100,
+      "x": -68,
+      "y": 1854,
       "name": "Contas Financeiras",
       "fill": "#f1f5f9",
       "gap": 200,


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a full UI/UX design skill suite with a BM25-based search to quickly find guidelines and power new agent features. Also tweaks coordinates for the "Modais de Contas Bancárias" and "Contas Financeiras" frames.

- **New Features**
  - BM25 search over a design guideline corpus for fast retrieval.
  - Extensive design guideline data (components, accessibility, UX heuristics).
  - New agent skills for UI/UX tasks: pattern suggestions, critique, layout and naming guidance.

- **Refactors**
  - Adjusted x/y positions for the two frames to fix alignment.

<sup>Written for commit 0d2a239d958d217e3a7813bd0b3d3b521f84683d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes substantial changes to `montte.pen`, a Penpot design file (v2.8), primarily introducing a new **Transactions List** full-page design (with sidebar navigation, bulk-selection toolbar, and transaction table) while reorganising existing modal designs into dedicated canvas sections and adjusting coordinates for the `Modais de Contas Bancárias` and `Contas Financeiras` frames.

**Key changes:**
- The first top-level frame is replaced from `Modal Novo Lançamento — Avançado` to a full-page `Transactions List` screen (1440×900) complete with a `sidebar` (256px) and a `Main Content` area containing page header, filters, bulk toolbar, and paginated transaction rows.
- The original launch modal is preserved but moved inside a new `Modais de Lançamento` grouping frame.
- A new `Telas Lançamentos` canvas section is added as an exploratory or legacy reference — this section does **not** use the `$--*` design token system and uses `Inter` instead of `Sora`, unlike the rest of the updated design.
- `x`/`y` coordinates for `Modais de Contas Bancárias` and `Contas Financeiras` are adjusted to reposition them on the canvas.

**Issues found:**
- Multiple newly introduced elements use hardcoded hex color values (`#ffffff14`, `#ff9d9d`, `#ffb6b6`, `#dbeafe`, `#1e40af`, and an extensive set of Tailwind slate values in `Telas Lançamentos`) instead of the `$--*` design tokens used everywhere else. This breaks theme consistency and dark-mode compatibility.
- The `Telas Lançamentos` frame mixes `Inter` font usage with the `Sora` standard adopted in the rest of the updated screens; it is unclear whether this frame is intended to remain as a source of truth.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for design iteration, but hardcoded colors and the unresolved status of the `Telas Lançamentos` frame should be addressed before handoff to engineering.
- The core new design (Transactions List page with sidebar) is well-structured and consistently uses design tokens and Sora typography. The score is reduced because several newly added elements bypass the token system with raw hex values, the `Telas Lançamentos` section is inconsistent with the rest of the file in both color and font usage, and the diff size (~76k lines) makes thorough review difficult.
- The `montte.pen` file requires attention around the bulk-action toolbar (lines ~4597–4690), the tag chip elements (lines ~14997–15015), and the entire `Telas Lançamentos` canvas section (lines ~21368 onward).

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| montte.pen | Large Penpot design file (v2.8) with ~76k lines changed: replaces the first top-level frame from a modal to a full Transactions List page, adds new canvas sections, and adjusts coordinates for existing frames. Several newly added frames use hardcoded hex color values instead of the established design token system. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PEN["montte.pen\n(Penpot v2.8)"]

    PEN --> TL["Transactions List\n1440×900 (NEW)"]
    PEN --> ML["Modais de Lançamento\n(NEW wrapper)"]
    PEN --> MCLB["Modais de Contas Bancárias\n(coord adjusted)"]
    PEN --> CF["Contas Financeiras\n(coord adjusted)"]
    PEN --> TELA["Telas Lançamentos\n(NEW — legacy style ⚠️)"]

    TL --> SB["sidebar (256px)\n✅ design tokens + Sora"]
    TL --> MC["Main Content\n✅ design tokens + Sora"]

    SB --> SS["Scope Switcher"]
    SB --> SC["Sidebar Content\n(nav items)"]
    SB --> SF["Sidebar Footer"]

    MC --> PH["Page Header"]
    MC --> FLT["Filters & Search"]
    MC --> BT["Bulk Toolbar ⚠️\nhardcoded #ffffff14\n#ff9d9d / #ffb6b6"]
    MC --> ROWS["Transaction Rows\n(tag chips ⚠️ #dbeafe / #1e40af)"]

    ML --> MNA["Modal Novo Lançamento\n— Avançado (moved)"]

    TELA --> TL2["Tela Lançamentos ⚠️\nInter font\nhardcoded Tailwind hex colors\nno $-- tokens"]

    style BT fill:#fff3cd,stroke:#ffc107
    style TELA fill:#fff3cd,stroke:#ffc107
    style TL2 fill:#fff3cd,stroke:#ffc107
    style ROWS fill:#fff3cd,stroke:#ffc107
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `montte.pen`, line 4597 ([link](https://github.com/f-o-t/montte-nx/blob/0d2a239d958d217e3a7813bd0b3d3b521f84683d/montte.pen#L4597)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Hardcoded hex colors bypass design token system**

   Several newly introduced frames use raw hex color values instead of the established `$--*` design token system used throughout the rest of the file. This means these elements will **not** respond to theme changes (e.g. dark mode) and are inconsistent with the rest of the design.

   Occurrences in this PR:

   - `montte.pen:4597` — `"fill": "#ffffff14"` (bulk action buttons — `bulkCategorize`, `bulkDelete`, `bulkConfirm`) should use a token like `$--background` with opacity, or a dedicated `$--primary-foreground/10` token.
   - `montte.pen:4679` & `4684` — `"fill": "#ff9d9d"` / `"fill": "#ffb6b6"` (delete icon + label in bulk toolbar) should use `$--destructive` / `$--destructive-foreground`.
   - `montte.pen:14997` & `15010` — `"fill": "#dbeafe"` / `"fill": "#1e40af"` (tag chip background and text) should use tokens such as `$--accent` / `$--accent-foreground`.
   - `montte.pen:21374` onwards — The entire **"Telas Lançamentos"** canvas section uses raw Tailwind slate values (`#e2e8f0`, `#f1f5f9`, `#334155`, `#64748b`, `#94a3b8`, `#475569`, `#10b981`, `#ffffff`) with no design token references at all.

   Please replace these with the appropriate `$--` design tokens to keep theming consistent and maintainable.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: montte.pen
   Line: 4597

   Comment:
   **Hardcoded hex colors bypass design token system**

   Several newly introduced frames use raw hex color values instead of the established `$--*` design token system used throughout the rest of the file. This means these elements will **not** respond to theme changes (e.g. dark mode) and are inconsistent with the rest of the design.

   Occurrences in this PR:

   - `montte.pen:4597` — `"fill": "#ffffff14"` (bulk action buttons — `bulkCategorize`, `bulkDelete`, `bulkConfirm`) should use a token like `$--background` with opacity, or a dedicated `$--primary-foreground/10` token.
   - `montte.pen:4679` & `4684` — `"fill": "#ff9d9d"` / `"fill": "#ffb6b6"` (delete icon + label in bulk toolbar) should use `$--destructive` / `$--destructive-foreground`.
   - `montte.pen:14997` & `15010` — `"fill": "#dbeafe"` / `"fill": "#1e40af"` (tag chip background and text) should use tokens such as `$--accent` / `$--accent-foreground`.
   - `montte.pen:21374` onwards — The entire **"Telas Lançamentos"** canvas section uses raw Tailwind slate values (`#e2e8f0`, `#f1f5f9`, `#334155`, `#64748b`, `#94a3b8`, `#475569`, `#10b981`, `#ffffff`) with no design token references at all.

   Please replace these with the appropriate `$--` design tokens to keep theming consistent and maintainable.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `montte.pen`, line 21373-21374 ([link](https://github.com/f-o-t/montte-nx/blob/0d2a239d958d217e3a7813bd0b3d3b521f84683d/montte.pen#L21373-L21374)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **"Telas Lançamentos" frame uses no design tokens**

   The entire `Telas Lançamentos` canvas section (starting at line 21368) uses exclusively hardcoded Tailwind slate hex values (e.g. `#e2e8f0`, `#f1f5f9`, `#334155`, `#64748b`) and also switches back to `Inter` as the font family, whereas the rest of the newly added content (Transactions List, sidebar) uses `Sora`. 

   This frame appears to be a legacy or exploratory canvas that was never migrated to the token/Sora system. Consider either:
   1. Migrating it to use `$--*` tokens + Sora, matching the rest of the file, or
   2. Removing it if it is no longer a source of truth for the design.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: montte.pen
   Line: 21373-21374

   Comment:
   **"Telas Lançamentos" frame uses no design tokens**

   The entire `Telas Lançamentos` canvas section (starting at line 21368) uses exclusively hardcoded Tailwind slate hex values (e.g. `#e2e8f0`, `#f1f5f9`, `#334155`, `#64748b`) and also switches back to `Inter` as the font family, whereas the rest of the newly added content (Transactions List, sidebar) uses `Sora`. 

   This frame appears to be a legacy or exploratory canvas that was never migrated to the token/Sora system. Consider either:
   1. Migrating it to use `$--*` tokens + Sora, matching the rest of the file, or
   2. Removing it if it is no longer a source of truth for the design.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <sub>Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!</sub>


3. `montte.pen`, line 5905-5911 ([link](https://github.com/f-o-t/montte-nx/blob/0d2a239d958d217e3a7813bd0b3d3b521f84683d/montte.pen#L5905-L5911)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Canvas wrapper frames use hardcoded background fills**

   The top-level canvas grouping frames (`Modais de Lançamento` at line 5911, `Modais de Contas Bancárias` at line 41940, `Contas Financeiras` at line 62646) use hardcoded hex values (`#f8fafc`, `#f8fafc`, `#f1f5f9`) as their background fill instead of design tokens. While these are visual-only canvas frames, keeping them consistent (e.g. using `$--muted` or `$--background`) avoids confusion when the theme palette changes.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: montte.pen
   Line: 5905-5911

   Comment:
   **Canvas wrapper frames use hardcoded background fills**

   The top-level canvas grouping frames (`Modais de Lançamento` at line 5911, `Modais de Contas Bancárias` at line 41940, `Contas Financeiras` at line 62646) use hardcoded hex values (`#f8fafc`, `#f8fafc`, `#f1f5f9`) as their background fill instead of design tokens. While these are visual-only canvas frames, keeping them consistent (e.g. using `$--muted` or `$--background`) avoids confusion when the theme palette changes.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <sub>Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: montte.pen
Line: 4597

Comment:
**Hardcoded hex colors bypass design token system**

Several newly introduced frames use raw hex color values instead of the established `$--*` design token system used throughout the rest of the file. This means these elements will **not** respond to theme changes (e.g. dark mode) and are inconsistent with the rest of the design.

Occurrences in this PR:

- `montte.pen:4597` — `"fill": "#ffffff14"` (bulk action buttons — `bulkCategorize`, `bulkDelete`, `bulkConfirm`) should use a token like `$--background` with opacity, or a dedicated `$--primary-foreground/10` token.
- `montte.pen:4679` & `4684` — `"fill": "#ff9d9d"` / `"fill": "#ffb6b6"` (delete icon + label in bulk toolbar) should use `$--destructive` / `$--destructive-foreground`.
- `montte.pen:14997` & `15010` — `"fill": "#dbeafe"` / `"fill": "#1e40af"` (tag chip background and text) should use tokens such as `$--accent` / `$--accent-foreground`.
- `montte.pen:21374` onwards — The entire **"Telas Lançamentos"** canvas section uses raw Tailwind slate values (`#e2e8f0`, `#f1f5f9`, `#334155`, `#64748b`, `#94a3b8`, `#475569`, `#10b981`, `#ffffff`) with no design token references at all.

Please replace these with the appropriate `$--` design tokens to keep theming consistent and maintainable.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: montte.pen
Line: 21373-21374

Comment:
**"Telas Lançamentos" frame uses no design tokens**

The entire `Telas Lançamentos` canvas section (starting at line 21368) uses exclusively hardcoded Tailwind slate hex values (e.g. `#e2e8f0`, `#f1f5f9`, `#334155`, `#64748b`) and also switches back to `Inter` as the font family, whereas the rest of the newly added content (Transactions List, sidebar) uses `Sora`. 

This frame appears to be a legacy or exploratory canvas that was never migrated to the token/Sora system. Consider either:
1. Migrating it to use `$--*` tokens + Sora, matching the rest of the file, or
2. Removing it if it is no longer a source of truth for the design.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: montte.pen
Line: 5905-5911

Comment:
**Canvas wrapper frames use hardcoded background fills**

The top-level canvas grouping frames (`Modais de Lançamento` at line 5911, `Modais de Contas Bancárias` at line 41940, `Contas Financeiras` at line 62646) use hardcoded hex values (`#f8fafc`, `#f8fafc`, `#f1f5f9`) as their background fill instead of design tokens. While these are visual-only canvas frames, keeping them consistent (e.g. using `$--muted` or `$--background`) avoids confusion when the theme palette changes.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 0d2a239</sub>

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->