### PR TITLE
Manoelnetocarvalho03/mon 227 tanstack form uso no maximo potencial server validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,17 +168,32 @@ Zod schemas belong in the backend. Frontend only imports inferred types via `Inp
 - **`isInvalid` check** — `field.state.meta.isTouched && field.state.meta.errors.length > 0`.
 - **Accessibility** — always set `id`, `name`, `aria-invalid` on inputs; `htmlFor` on `<FieldLabel>`.
 - **`children` prop** — always use `children={(field) => ...}` as explicit JSX prop.
-- **Server validation via `onSubmitAsync`** — use `validators: { onSubmitAsync }` with `useMutation` defined outside the form. Call `mutation.mutateAsync({...})` inside the async validator. Return `{ form: "error" }` or `{ fields: { fieldName: "error" } }` or `null`. Catch `ORPCError` from `@orpc/client` for typed error codes (e.g. `err.code === "CONFLICT"`).
-- **Form-level error display** — use `form.Subscribe` reading from `state.errorMap.onSubmit`:
+- **`onSubmitAsync` — only when inline field errors matter** — use only for forms where a server conflict maps to a specific visible field (e.g. duplicate CPF/CNPJ on contacts, duplicate apelido on bank accounts). For generic CRUD forms, use plain `onSubmit` + `toast.error`. Define mutations with `useMutation` outside the form; call `mutateAsync` inside the validator. Use `fromPromise` from `neverthrow` instead of try/catch:
   ```tsx
-  selector={(state) =>
-     typeof state.errorMap.onSubmit === "object" &&
-     state.errorMap.onSubmit !== null &&
-     "form" in state.errorMap.onSubmit
-        ? String(state.errorMap.onSubmit.form)
-        : null
-  }
+  import { fromPromise } from "neverthrow";
+
+  const createMutation = useMutation(orpc.x.create.mutationOptions());
+
+  const form = useForm({
+    validators: {
+      onSubmitAsync: async ({ value }) => {
+        const result = await fromPromise(createMutation.mutateAsync(value), (e) => e);
+        if (result.isErr()) {
+          const err = result.error;
+          if (err instanceof ORPCError && err.code === "CONFLICT") {
+            return { fields: { fieldName: "Já existe um registro com esse valor." } };
+          }
+          return err instanceof Error ? err.message : "Erro inesperado.";
+        }
+        toast.success("Criado com sucesso.");
+        onSuccess();
+        return null;
+      },
+    },
+  });
   ```
+- **Field error from server** — return `{ fields: { fieldName: "message" } }` from `onSubmitAsync`; TanStack Form injects into `field.state.meta.errors`. Set `isInvalid = field.state.meta.errors.length > 0` (drop `isTouched` check) so the error shows immediately without prior user interaction.
+- **No footer error display** — don't render a footer error paragraph. Errors go on the field they belong to. Generic errors (non-CONFLICT) return a plain string which TanStack Form stores in `state.errorMap.onSubmit` — but prefer `toast.error` for those instead.
 - **Multi-step forms with nested components** — use a local React context so step components defined outside the parent can access the form without prop drilling:
   ```tsx
   const FormCtx = createContext<FormApi | null>(null);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -536,14 +536,48 @@ SSR-safe hook library — import each from its own subpath. Never use `@uidotdev
 | localStorage (fixed key, syncs tabs) | `foxact/create-local-storage-state` |
 | sessionStorage | `foxact/use-session-storage` |
 | Media queries | `foxact/use-media-query` |
-| Debounce (derived values only) | `foxact/use-debounced-value` — **deprecated: use `useDebouncedCallback` from `@tanstack/react-pacer` instead** |
 | Context guard | `foxact/invariant` |
 | Merge refs | `foxact/merge-refs` |
 | SSR-safe layout effect | `foxact/use-isomorphic-layout-effect` |
 
 - All localStorage keys prefixed `montte:`.
 - Prefer `createClientOnlyFn` / `createIsomorphicFn` from `@tanstack/react-start` over `typeof window === 'undefined'` guards.
-- For debouncing callbacks (side effects), use `useDebouncedCallback` from `@tanstack/react-pacer`. Never use `foxact/use-debounced-value` + `useEffect` for debounced callbacks.
+
+---
+
+## TanStack Pacer
+
+Use `@tanstack/react-pacer` for all debounce, throttle, and rate-limiting needs. Never use `foxact/use-debounced-value`.
+
+| Hook | Use for |
+| ---- | ------- |
+| `useDebouncedCallback` | Sync callbacks (search input → URL/state update) |
+| `useAsyncDebouncedCallback` | Async callbacks (fetch, `mutateAsync`) — handles race conditions |
+| `useThrottledCallback` | Callbacks with limited frequency (scroll, resize handlers) |
+| `useThrottledValue` | Throttled derived values (scroll position for animations) |
+| `useRateLimiter` | Hard limit on action frequency (e.g. 3 exports per minute) |
+
+**Key rules:**
+- If the debounced function is `async` or calls `mutateAsync`, always use `useAsyncDebouncedCallback` — not `useDebouncedCallback`.
+- Never combine `foxact/use-debounced-value` + `useEffect` to debounce a callback. Use `useDebouncedCallback` directly.
+- Options object syntax: `{ wait: 350 }` (not positional).
+
+```typescript
+// ✅ Sync callback (search input)
+const handleSearch = useDebouncedCallback(
+   (value: string) => navigate({ search: (p) => ({ ...p, q: value }) }),
+   { wait: 350 },
+);
+
+// ✅ Async callback (CNPJ lookup, duplicate check)
+const fetchData = useAsyncDebouncedCallback(
+   async (value: string) => {
+      const result = await someMutation.mutateAsync({ value });
+      setResult(result);
+   },
+   { wait: 400 },
+);
+```
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,26 @@ export const bulkRemove = protectedProcedure
 - `input` goes INSIDE `queryOptions()`. Mutation callbacks go INSIDE `mutationOptions()`.
 - Global `MutationCache` in `root-provider.tsx` invalidates all queries after every mutation — per-mutation invalidation only needed for cross-tree queries.
 
+**Hook selection:**
+
+| Need | Hook |
+| ---- | ---- |
+| Single query (default) | `useSuspenseQuery` |
+| Multiple independent queries in same component | `useSuspenseQueries` — avoids waterfall |
+| Conditional query (depends on user input/state) | `useSuspenseQuery` + `skipToken` |
+| Paginated query (no flicker on page change) | `useSuspenseQuery` + `placeholderData: keepPreviousData` |
+| Subscribe to partial query data | `useSuspenseQuery` + `select` option |
+| Prefetch before render | `queryClient.prefetchQuery` in route loader |
+| Track mutation state cross-component | `useMutationState` + `orpc.procedure.mutationKey()` |
+
+**Key rules:**
+- **Never `useQuery`** — always `useSuspenseQuery`. Exception: only when rendering outside a `<Suspense>` and a loading state is intentional (rare).
+- **Never `useQuery + enabled`** — use `skipToken + useSuspenseQuery` instead.
+- **`useSuspenseQueries`** for 2+ independent queries in the same component — prevents React from suspending sequentially (waterfall).
+- **`placeholderData: keepPreviousData`** is mandatory on all queries with `page`/`pageSize` input — prevents content from disappearing while navigating pages.
+- **`select`** — when a component only needs one field from a large query response; prevents re-renders when unrelated fields change.
+- **`orpc.procedure.mutationKey()` / `orpc.procedure.queryKey()`** — always use oRPC-generated keys; never define manual string arrays.
+
 **Type inference** — never define manual interfaces for router data:
 
 ```typescript

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,28 @@ export const bulkRemove = protectedProcedure
 - **Never `useQuery + enabled`** — use the child component pattern instead (see below).
 - **Never `skipToken + useSuspenseQuery`** — `UseSuspenseQueryOptions` does not support `skipToken`. Use child component pattern.
 - **`useSuspenseQueries`** for 2+ independent queries in the same component — prevents React from suspending sequentially (waterfall).
-- **`select`** — when a component only needs one field from a large query response; prevents re-renders when unrelated fields change.
+- **`select` aggressively** — whenever a component needs only part of a query response, use `select` to derive the exact shape needed. This eliminates `useState` for derived values, prevents re-renders from unrelated field changes, and removes the need for intermediate variables or `useMemo`. Prefer `select` over storing values in separate state:
+  ```tsx
+  // ❌ Redundant state derived from query
+  const { data: service } = useSuspenseQuery(orpc.services.getById.queryOptions({ input: { id } }));
+  const [price, setPrice] = useState(service.basePrice);
+
+  // ✅ select gives you exactly what you need — no extra state
+  const { data: price } = useSuspenseQuery({
+     ...orpc.services.getById.queryOptions({ input: { id } }),
+     select: (s) => s.basePrice,
+  });
+  ```
+- **URL search params over `useState` for any shareable UI state** — filters, sort, pagination, selected tab, open/closed panels, active IDs — anything that benefits from being bookmarkable or surviving a refresh belongs in `validateSearch`. Use `navigate({ search: (prev) => ({ ...prev, key: value }), replace: true })` to update. This eliminates entire classes of local state and keeps components stateless:
+  ```tsx
+  // ❌ Local state lost on refresh, not shareable
+  const [activeTab, setActiveTab] = useState("overview");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  // ✅ URL params — survives refresh, shareable, drives loaders
+  const { activeTab, selectedId } = Route.useSearch();
+  navigate({ search: (prev) => ({ ...prev, activeTab: "details" }), replace: true });
+  ```
 - **`orpc.procedure.mutationKey()` / `orpc.procedure.queryKey()`** — always use oRPC-generated keys; never define manual string arrays.
 
 **Type inference** — never define manual interfaces for router data:
@@ -294,7 +315,7 @@ orpc.procedure.queryOptions({ input: condition ? { id } : skipToken })
 - **Early returns over if/else** — always guard and return early; never use `else` after a `return`.
 - **Minimize `useEffect`** — derive state, use event handlers. Only for external system sync.
 - **Dates** — always `dayjs`. Never raw `Date` math or manual string formatting.
-- **URL search params over local state** — filters, sort, pagination live in `validateSearch` on the route.
+- **URL search params over local state** — filters, sort, pagination, active tabs, selected IDs live in `validateSearch` on the route. See oRPC + TanStack Query section for the full pattern.
 - **Files:** kebab-case. **Components:** PascalCase `[Feature][Action][Type]`. **Hooks:** `use[Feature][Action]`.
 - **oxlint suppression:** `// oxlint-ignore <rule-name>` above the triggering line.
 - **Array index keys:** `` key={`step-${index + 1}`} `` over suppressing `noArrayIndexKey`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,22 +148,65 @@ Zod schemas belong in the backend. Frontend only imports inferred types via `Inp
 - **`isInvalid` check** — `field.state.meta.isTouched && field.state.meta.errors.length > 0`.
 - **Accessibility** — always set `id`, `name`, `aria-invalid` on inputs; `htmlFor` on `<FieldLabel>`.
 - **`children` prop** — always use `children={(field) => ...}` as explicit JSX prop.
+- **Server validation via `onSubmitAsync`** — use `validators: { onSubmitAsync }` instead of `useMutation`. Call `orpc.procedure.call({...})` directly. Return `{ form: "error" }` or `{ fields: { fieldName: "error" } }` or `null`. Catch `ORPCError` from `@orpc/client` for typed error codes (e.g. `err.code === "CONFLICT"`).
+- **Form-level error display** — use `form.Subscribe` with `flatMap` selector to extract `.form` key from `state.errors`:
+  ```tsx
+  selector={(state) =>
+     state.errors.flatMap((e) => {
+        if (!e) return [];
+        if (typeof e === "string") return [e];
+        if ("form" in e && typeof e.form === "string") return [e.form];
+        return [];
+     })
+  }
+  ```
+- **Selective `form.Subscribe`** — always use a specific selector, never `selector={(state) => state}`. For submit buttons use `[state.canSubmit, state.isSubmitting] as const` and destructure.
+- **Navigation guard** — add `useBlocker` from `@tanstack/react-router` to edit forms. Use `withResolver: true` and `shouldBlockFn`. Render a pt-BR AlertDialog when `blocker.status === "blocked"`:
+  ```tsx
+  const blocker = useBlocker({
+     withResolver: true,
+     shouldBlockFn: () => form.store.state.isDirty && !form.store.state.isSubmitted,
+     disabled: isCreate, // skip for create-only forms
+  });
+  ```
 
 ---
 
 ## Suspense, Error Boundaries & Empty States
 
-Every `useSuspenseQuery` component must be wrapped in `<ErrorBoundary>` (outer) + `<Suspense>` (inner):
+Every `useSuspenseQuery` component must be wrapped in `<QueryBoundary>` from `@/components/query-boundary` — never raw `ErrorBoundary + Suspense`:
 
 ```tsx
-<ErrorBoundary FallbackComponent={createErrorFallback({ errorTitle: "Erro ao carregar" })}>
-   <Suspense fallback={<MyPageSkeleton />}>
-      <MyPageContent />
-   </Suspense>
-</ErrorBoundary>
+<QueryBoundary fallback={<MyPageSkeleton />} errorTitle="Erro ao carregar">
+   <MyPageContent />
+</QueryBoundary>
 ```
 
-`createErrorFallback` from `@packages/ui/components/error-fallback`. `fallback={null}` only for invisible-while-loading components.
+`QueryBoundary` wraps `QueryErrorResetBoundary` + `ErrorBoundary` + `Suspense` internally. Use `errorFallback` prop for custom fallback components. `fallback={null}` only for invisible-while-loading components.
+
+**Parallel queries** — replace multiple sequential `useSuspenseQuery` calls with `useSuspenseQueries` to eliminate waterfall:
+```tsx
+const [{ data: session }, { data: teams }] = useSuspenseQueries({
+   queries: [orpc.session.getSession.queryOptions({}), orpc.organization.getOrganizationTeams.queryOptions({})],
+});
+```
+
+**Conditional queries** — replace `useQuery + enabled` with `skipToken + useSuspenseQuery`:
+```tsx
+const { data } = useSuspenseQuery(
+   condition
+      ? orpc.procedure.queryOptions({ input: { id } })
+      : { queryKey: ["disabled-key"], queryFn: skipToken },
+);
+```
+
+**Paginated queries** — add `placeholderData: keepPreviousData` to prevent flicker when navigating pages:
+```tsx
+const { data } = useSuspenseQuery({
+   ...orpc.procedure.queryOptions({ input: { page, pageSize } }),
+   placeholderData: keepPreviousData,
+});
+```
 
 **Empty states** — always use `Empty`/`EmptyHeader`/`EmptyMedia`/`EmptyTitle`/`EmptyDescription`/`EmptyContent` from `@packages/ui/components/empty`. Never build custom empty states with raw divs.
 
@@ -493,14 +536,14 @@ SSR-safe hook library — import each from its own subpath. Never use `@uidotdev
 | localStorage (fixed key, syncs tabs) | `foxact/create-local-storage-state` |
 | sessionStorage | `foxact/use-session-storage` |
 | Media queries | `foxact/use-media-query` |
-| Debounce (derived values only) | `foxact/use-debounced-value` |
+| Debounce (derived values only) | `foxact/use-debounced-value` — **deprecated: use `useDebouncedCallback` from `@tanstack/react-pacer` instead** |
 | Context guard | `foxact/invariant` |
 | Merge refs | `foxact/merge-refs` |
 | SSR-safe layout effect | `foxact/use-isomorphic-layout-effect` |
 
 - All localStorage keys prefixed `montte:`.
 - Prefer `createClientOnlyFn` / `createIsomorphicFn` from `@tanstack/react-start` over `typeof window === 'undefined'` guards.
-- For debouncing callbacks (side effects), use `useDebouncedCallback` from `@tanstack/react-pacer`.
+- For debouncing callbacks (side effects), use `useDebouncedCallback` from `@tanstack/react-pacer`. Never use `foxact/use-debounced-value` + `useEffect` for debounced callbacks.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,17 +136,16 @@ export const bulkRemove = protectedProcedure
 | ---- | ---- |
 | Single query (default) | `useSuspenseQuery` |
 | Multiple independent queries in same component | `useSuspenseQueries` — avoids waterfall |
-| Conditional query (depends on user input/state) | `useSuspenseQuery` + `skipToken` |
-| Paginated query (no flicker on page change) | `useSuspenseQuery` + `placeholderData: keepPreviousData` |
+| Conditional query (depends on user input/state) | Child component pattern — see below |
 | Subscribe to partial query data | `useSuspenseQuery` + `select` option |
 | Prefetch before render | `queryClient.prefetchQuery` in route loader |
 | Track mutation state cross-component | `useMutationState` + `orpc.procedure.mutationKey()` |
 
 **Key rules:**
-- **Never `useQuery`** — always `useSuspenseQuery`. Exception: only when rendering outside a `<Suspense>` and a loading state is intentional (rare).
-- **Never `useQuery + enabled`** — use `skipToken + useSuspenseQuery` instead.
+- **Never `useQuery`** — always `useSuspenseQuery`. No exceptions.
+- **Never `useQuery + enabled`** — use the child component pattern instead (see below).
+- **Never `skipToken + useSuspenseQuery`** — `UseSuspenseQueryOptions` does not support `skipToken`. Use child component pattern.
 - **`useSuspenseQueries`** for 2+ independent queries in the same component — prevents React from suspending sequentially (waterfall).
-- **`placeholderData: keepPreviousData`** is mandatory on all queries with `page`/`pageSize` input — prevents content from disappearing while navigating pages.
 - **`select`** — when a component only needs one field from a large query response; prevents re-renders when unrelated fields change.
 - **`orpc.procedure.mutationKey()` / `orpc.procedure.queryKey()`** — always use oRPC-generated keys; never define manual string arrays.
 
@@ -165,7 +164,7 @@ Zod schemas belong in the backend. Frontend only imports inferred types via `Inp
 ## TanStack Form Pattern
 
 - **Schema at module level** — never define `z.object({...})` inside a component.
-- **`isInvalid` check** — `field.state.meta.isTouched && field.state.meta.errors.length > 0`.
+- **`isInvalid` check** — `field.state.meta.isTouched && field.state.meta.errors.length > 0` for client-validated fields. For fields that receive server errors via `onSubmitAsync` (e.g. the conflict field), drop `isTouched`: `field.state.meta.errors.length > 0` — so the injected error shows immediately without prior interaction.
 - **Accessibility** — always set `id`, `name`, `aria-invalid` on inputs; `htmlFor` on `<FieldLabel>`.
 - **`children` prop** — always use `children={(field) => ...}` as explicit JSX prop.
 - **`onSubmitAsync` — only when inline field errors matter** — use only for forms where a server conflict maps to a specific visible field (e.g. duplicate CPF/CNPJ on contacts, duplicate apelido on bank accounts). For generic CRUD forms, use plain `onSubmit` + `toast.error`. Define mutations with `useMutation` outside the form; call `mutateAsync` inside the validator. Use `fromPromise` from `neverthrow` instead of try/catch:
@@ -194,9 +193,14 @@ Zod schemas belong in the backend. Frontend only imports inferred types via `Inp
   ```
 - **Field error from server** — return `{ fields: { fieldName: "message" } }` from `onSubmitAsync`; TanStack Form injects into `field.state.meta.errors`. Set `isInvalid = field.state.meta.errors.length > 0` (drop `isTouched` check) so the error shows immediately without prior user interaction.
 - **No footer error display** — don't render a footer error paragraph. Errors go on the field they belong to. Generic errors (non-CONFLICT) return a plain string which TanStack Form stores in `state.errorMap.onSubmit` — but prefer `toast.error` for those instead.
-- **Multi-step forms with nested components** — use a local React context so step components defined outside the parent can access the form without prop drilling:
+- **Multi-step forms with nested components** — use a local React context so step components defined outside the parent can access the form without prop drilling. To type the context, use a factory function (never `ReturnType<typeof useForm<T>>` — TypeScript does not allow generic type arguments on `typeof` references):
   ```tsx
-  const FormCtx = createContext<FormApi | null>(null);
+  function createMyForm() {
+    return useForm({ defaultValues: { ... }, validators: { ... } });
+  }
+  type MyFormApi = ReturnType<typeof createMyForm>;
+
+  const FormCtx = createContext<MyFormApi | null>(null);
   function useMyForm() {
      const f = useContext(FormCtx);
      if (!f) throw new Error("...");
@@ -206,11 +210,24 @@ Zod schemas belong in the backend. Frontend only imports inferred types via `Inp
   // Parent wraps: <FormCtx.Provider value={form}>...</FormCtx.Provider>
   ```
 - **Selective `form.Subscribe`** — always use a specific selector, never `selector={(state) => state}`. For submit buttons use `[state.canSubmit, state.isSubmitting] as const` and destructure.
-- **Navigation guard** — add `useBlocker` from `@tanstack/react-router` to edit forms. Use `withResolver: true` and `shouldBlockFn`. Render a pt-BR AlertDialog when `blocker.status === "blocked"`:
+- **Navigation guard** — add `useBlocker` from `@tanstack/react-router` to edit forms. Use `withResolver: true` and `shouldBlockFn`. Always use optional chaining on `blocker.proceed?.()` and `blocker.reset?.()` — they are only defined when the blocker is in `"blocked"` state (TS2722 otherwise). Use `useAlertDialog` to prompt the user:
   ```tsx
   const blocker = useBlocker({
      withResolver: true,
-     shouldBlockFn: () => form.store.state.isDirty && !form.store.state.isSubmitted,
+     shouldBlockFn: () => {
+       if (form.store.state.isDirty && !form.store.state.isSubmitted) {
+         openAlertDialog({
+           title: "Descartar alterações?",
+           description: "Você tem alterações não salvas. Tem certeza que deseja sair sem salvar?",
+           actionLabel: "Descartar alterações",
+           cancelLabel: "Continuar editando",
+           onAction: () => blocker.proceed?.(),
+           onCancel: () => blocker.reset?.(),
+         });
+         return true;
+       }
+       return false;
+     },
      disabled: isCreate, // skip for create-only forms
   });
   ```
@@ -236,21 +253,27 @@ const [{ data: session }, { data: teams }] = useSuspenseQueries({
 });
 ```
 
-**Conditional queries** — replace `useQuery + enabled` with `skipToken + useSuspenseQuery`:
+**Conditional queries** — extract a child component that calls `useSuspenseQuery` unconditionally; the parent renders it only when the input is ready:
 ```tsx
-const { data } = useSuspenseQuery(
-   condition
-      ? orpc.procedure.queryOptions({ input: { id } })
-      : { queryKey: ["disabled-key"], queryFn: skipToken },
-);
-```
+function ItemDetails({ id }: { id: string }) {
+   const { data } = useSuspenseQuery(
+      orpc.procedure.queryOptions({ input: { id } }),
+   );
+   return <div>{data.name}</div>;
+}
 
-**Paginated queries** — add `placeholderData: keepPreviousData` to prevent flicker when navigating pages:
+// Parent:
+{selectedId && (
+   <Suspense fallback={<Skeleton />}>
+      <ItemDetails id={selectedId} />
+   </Suspense>
+)}
+```
+Never use `skipToken` with `useSuspenseQuery` — it is not supported in TanStack Query v5.
+
+**`skipToken` with oRPC** — only valid inside `queryOptions` as the `input` value when using `useQuery` (rare):
 ```tsx
-const { data } = useSuspenseQuery({
-   ...orpc.procedure.queryOptions({ input: { page, pageSize } }),
-   placeholderData: keepPreviousData,
-});
+orpc.procedure.queryOptions({ input: condition ? { id } : skipToken })
 ```
 
 **Empty states** — always use `Empty`/`EmptyHeader`/`EmptyMedia`/`EmptyTitle`/`EmptyDescription`/`EmptyContent` from `@packages/ui/components/empty`. Never build custom empty states with raw divs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,17 +168,27 @@ Zod schemas belong in the backend. Frontend only imports inferred types via `Inp
 - **`isInvalid` check** — `field.state.meta.isTouched && field.state.meta.errors.length > 0`.
 - **Accessibility** — always set `id`, `name`, `aria-invalid` on inputs; `htmlFor` on `<FieldLabel>`.
 - **`children` prop** — always use `children={(field) => ...}` as explicit JSX prop.
-- **Server validation via `onSubmitAsync`** — use `validators: { onSubmitAsync }` instead of `useMutation`. Call `orpc.procedure.call({...})` directly. Return `{ form: "error" }` or `{ fields: { fieldName: "error" } }` or `null`. Catch `ORPCError` from `@orpc/client` for typed error codes (e.g. `err.code === "CONFLICT"`).
-- **Form-level error display** — use `form.Subscribe` with `flatMap` selector to extract `.form` key from `state.errors`:
+- **Server validation via `onSubmitAsync`** — use `validators: { onSubmitAsync }` with `useMutation` defined outside the form. Call `mutation.mutateAsync({...})` inside the async validator. Return `{ form: "error" }` or `{ fields: { fieldName: "error" } }` or `null`. Catch `ORPCError` from `@orpc/client` for typed error codes (e.g. `err.code === "CONFLICT"`).
+- **Form-level error display** — use `form.Subscribe` reading from `state.errorMap.onSubmit`:
   ```tsx
   selector={(state) =>
-     state.errors.flatMap((e) => {
-        if (!e) return [];
-        if (typeof e === "string") return [e];
-        if ("form" in e && typeof e.form === "string") return [e.form];
-        return [];
-     })
+     typeof state.errorMap.onSubmit === "object" &&
+     state.errorMap.onSubmit !== null &&
+     "form" in state.errorMap.onSubmit
+        ? String(state.errorMap.onSubmit.form)
+        : null
   }
+  ```
+- **Multi-step forms with nested components** — use a local React context so step components defined outside the parent can access the form without prop drilling:
+  ```tsx
+  const FormCtx = createContext<FormApi | null>(null);
+  function useMyForm() {
+     const f = useContext(FormCtx);
+     if (!f) throw new Error("...");
+     return f;
+  }
+  // Step components call useMyForm() — no props needed
+  // Parent wraps: <FormCtx.Provider value={form}>...</FormCtx.Provider>
   ```
 - **Selective `form.Subscribe`** — always use a specific selector, never `selector={(state) => state}`. For submit buttons use `[state.canSubmit, state.isSubmitting] as const` and destructure.
 - **Navigation guard** — add `useBlocker` from `@tanstack/react-router` to edit forms. Use `withResolver: true` and `shouldBlockFn`. Render a pt-BR AlertDialog when `blocker.status === "blocked"`:

--- a/apps/web/src/features/analytics/hooks/use-insight-config.ts
+++ b/apps/web/src/features/analytics/hooks/use-insight-config.ts
@@ -4,8 +4,8 @@ import type {
    KpiConfig,
    TimeSeriesConfig,
 } from "@packages/analytics/types";
-import { useDebouncedValue } from "foxact/use-debounced-value";
-import { useCallback, useEffect, useState } from "react";
+import { useDebouncedCallback } from "@tanstack/react-pacer";
+import { useCallback, useState } from "react";
 
 export type InsightType = "kpi" | "time_series" | "breakdown";
 
@@ -44,17 +44,13 @@ const DEFAULT_BREAKDOWN_CONFIG: BreakdownConfig = {
 export function useInsightConfig(initialType: InsightType = "kpi") {
    const [type, setType] = useState<InsightType>(initialType);
    const [config, setConfig] = useState<InsightConfig>(DEFAULT_KPI_CONFIG);
-   const [pendingUpdates, setPendingUpdates] = useState<Partial<InsightConfig>>(
-      {},
-   );
-   const debouncedUpdates = useDebouncedValue(pendingUpdates, 500);
 
-   useEffect(() => {
-      if (Object.keys(debouncedUpdates).length > 0) {
-         setConfig((c) => ({ ...c, ...debouncedUpdates }) as InsightConfig);
-         setPendingUpdates({});
-      }
-   }, [debouncedUpdates]);
+   const debouncedSetConfig = useDebouncedCallback(
+      (updates: Partial<InsightConfig>) => {
+         setConfig((c) => ({ ...c, ...updates }) as InsightConfig);
+      },
+      { wait: 500 },
+   );
 
    const handleTypeChange = useCallback((newType: InsightType) => {
       setType(newType);
@@ -71,9 +67,12 @@ export function useInsightConfig(initialType: InsightType = "kpi") {
       }
    }, []);
 
-   const updateConfig = useCallback((updates: Partial<InsightConfig>) => {
-      setPendingUpdates((prev) => ({ ...prev, ...updates }));
-   }, []);
+   const updateConfig = useCallback(
+      (updates: Partial<InsightConfig>) => {
+         debouncedSetConfig(updates);
+      },
+      [debouncedSetConfig],
+   );
 
    const updateConfigImmediate = useCallback(
       (updates: Partial<InsightConfig>) => {

--- a/apps/web/src/features/analytics/hooks/use-insight-config.ts
+++ b/apps/web/src/features/analytics/hooks/use-insight-config.ts
@@ -4,6 +4,7 @@ import type {
    KpiConfig,
    TimeSeriesConfig,
 } from "@packages/analytics/types";
+import { Store, useStore } from "@tanstack/react-store";
 import { useDebouncedCallback } from "@tanstack/react-pacer";
 import { useCallback, useState } from "react";
 
@@ -41,50 +42,87 @@ const DEFAULT_BREAKDOWN_CONFIG: BreakdownConfig = {
    limit: 10,
 };
 
-export function useInsightConfig(initialType: InsightType = "kpi") {
-   const [type, setType] = useState<InsightType>(initialType);
-   const [config, setConfig] = useState<InsightConfig>(DEFAULT_KPI_CONFIG);
+type InsightState =
+   | { type: "kpi"; config: KpiConfig }
+   | { type: "time_series"; config: TimeSeriesConfig }
+   | { type: "breakdown"; config: BreakdownConfig };
 
-   const debouncedSetConfig = useDebouncedCallback(
+function buildInitialState(initialConfig?: InsightConfig): InsightState {
+   if (initialConfig?.type === "kpi")
+      return { type: "kpi", config: initialConfig };
+   if (initialConfig?.type === "time_series")
+      return { type: "time_series", config: initialConfig };
+   if (initialConfig?.type === "breakdown")
+      return { type: "breakdown", config: initialConfig };
+   return { type: "kpi", config: DEFAULT_KPI_CONFIG };
+}
+
+function mergeConfig(
+   state: InsightState,
+   updates: Partial<InsightConfig>,
+): InsightState {
+   if (state.type === "kpi")
+      return {
+         type: "kpi",
+         config: { ...state.config, ...updates } as KpiConfig,
+      };
+   if (state.type === "time_series")
+      return {
+         type: "time_series",
+         config: { ...state.config, ...updates } as TimeSeriesConfig,
+      };
+   return {
+      type: "breakdown",
+      config: { ...state.config, ...updates } as BreakdownConfig,
+   };
+}
+
+export function useInsightConfig(initialConfig?: InsightConfig) {
+   const [store] = useState(
+      () => new Store<InsightState>(buildInitialState(initialConfig)),
+   );
+
+   const state = useStore(store, (s) => s);
+
+   const setType = useCallback(
+      (newType: InsightType) => {
+         if (newType === "kpi") {
+            store.setState(() => ({ type: "kpi", config: DEFAULT_KPI_CONFIG }));
+            return;
+         }
+         if (newType === "time_series") {
+            store.setState(() => ({
+               type: "time_series",
+               config: DEFAULT_TIME_SERIES_CONFIG,
+            }));
+            return;
+         }
+         store.setState(() => ({
+            type: "breakdown",
+            config: DEFAULT_BREAKDOWN_CONFIG,
+         }));
+      },
+      [store],
+   );
+
+   const updateConfig = useDebouncedCallback(
       (updates: Partial<InsightConfig>) => {
-         setConfig((c) => ({ ...c, ...updates }) as InsightConfig);
+         store.setState((prev) => mergeConfig(prev, updates));
       },
       { wait: 500 },
    );
 
-   const handleTypeChange = useCallback((newType: InsightType) => {
-      setType(newType);
-      switch (newType) {
-         case "kpi":
-            setConfig(DEFAULT_KPI_CONFIG);
-            break;
-         case "time_series":
-            setConfig(DEFAULT_TIME_SERIES_CONFIG);
-            break;
-         case "breakdown":
-            setConfig(DEFAULT_BREAKDOWN_CONFIG);
-            break;
-      }
-   }, []);
-
-   const updateConfig = useCallback(
-      (updates: Partial<InsightConfig>) => {
-         debouncedSetConfig(updates);
-      },
-      [debouncedSetConfig],
-   );
-
    const updateConfigImmediate = useCallback(
       (updates: Partial<InsightConfig>) => {
-         setConfig((prev) => ({ ...prev, ...updates }) as InsightConfig);
+         store.setState((prev) => mergeConfig(prev, updates));
       },
-      [],
+      [store],
    );
 
    return {
-      type,
-      config,
-      setType: handleTypeChange,
+      type: state.type,
+      config: state.config,
+      setType,
       updateConfig,
       updateConfigImmediate,
    };

--- a/apps/web/src/features/analytics/ui/dashboard-tile.tsx
+++ b/apps/web/src/features/analytics/ui/dashboard-tile.tsx
@@ -18,7 +18,7 @@ import {
 import { Skeleton } from "@packages/ui/components/skeleton";
 import { cn } from "@packages/ui/lib/utils";
 import {
-   skipToken,
+   useQuery,
    useQueryClient,
    useSuspenseQuery,
 } from "@tanstack/react-query";
@@ -198,11 +198,10 @@ function useInsightMetadata(
    insightId?: string,
    globalDateRange?: DashboardDateRange,
 ) {
-   const { data: insight } = useSuspenseQuery(
-      insightId && !insightName
-         ? orpc.insights.getById.queryOptions({ input: { id: insightId } })
-         : { queryKey: ["disabled-insight", insightId], queryFn: skipToken },
-   );
+   const { data: insight } = useQuery({
+      ...orpc.insights.getById.queryOptions({ input: { id: insightId! } }),
+      enabled: !!insightId && !insightName,
+   });
 
    const name = insightName || insight?.name || "";
    const description = insight?.description || "";

--- a/apps/web/src/features/analytics/ui/dashboard-tile.tsx
+++ b/apps/web/src/features/analytics/ui/dashboard-tile.tsx
@@ -17,11 +17,7 @@ import {
 } from "@packages/ui/components/dropdown-menu";
 import { Skeleton } from "@packages/ui/components/skeleton";
 import { cn } from "@packages/ui/lib/utils";
-import {
-   useQuery,
-   useQueryClient,
-   useSuspenseQuery,
-} from "@tanstack/react-query";
+import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import {
    AlertCircle,
@@ -190,25 +186,23 @@ function DashboardInsightContent({
    return <InsightPreview config={config} />;
 }
 
-/**
- * Resolve insight metadata for the tile header.
- */
-function useInsightMetadata(
-   insightName?: string,
-   insightId?: string,
-   globalDateRange?: DashboardDateRange,
-) {
-   const { data: insight } = useQuery({
-      ...orpc.insights.getById.queryOptions({ input: { id: insightId! } }),
-      enabled: !!insightId && !insightName,
-   });
+function InsightTileMeta({
+   insightId,
+   insightName,
+   globalDateRange,
+}: {
+   insightId: string;
+   insightName?: string;
+   globalDateRange?: DashboardDateRange;
+}) {
+   const { data: insight } = useSuspenseQuery(
+      orpc.insights.getById.queryOptions({ input: { id: insightId } }),
+   );
 
-   const name = insightName || insight?.name || "";
-   const description = insight?.description || "";
-   const type = insight?.type || "kpi";
-   const lastComputedAt = insight?.lastComputedAt ?? null;
+   const name = insightName || insight.name || "";
+   const description = insight.description || "";
+   const type = insight.type || "kpi";
 
-   // ERP insight type label
    const typeLabel =
       type === "kpi"
          ? "KPI"
@@ -218,8 +212,7 @@ function useInsightMetadata(
              ? "DISTRIBUIÇÃO"
              : "INSIGHT";
 
-   // Extract date range from config if available
-   const config = insight?.config as Record<string, unknown> | undefined;
+   const config = insight.config as Record<string, unknown> | undefined;
    const dateRange = config?.dateRange as
       | { type: string; value: string }
       | undefined;
@@ -228,7 +221,47 @@ function useInsightMetadata(
       ? formatDateRange(effectiveDateRange.value)
       : "ÚLTIMOS 30 DIAS";
 
-   return { name, description, typeLabel, dateRangeLabel, lastComputedAt };
+   return (
+      <div className="min-w-0 flex-1 space-y-1">
+         <p className="text-[11px] font-medium tracking-wider text-muted-foreground uppercase">
+            {typeLabel} &bull; {dateRangeLabel}
+         </p>
+         <h3 className="text-sm font-semibold leading-snug">{name}</h3>
+         {description && (
+            <p className="text-xs text-muted-foreground leading-relaxed">
+               {description}
+            </p>
+         )}
+      </div>
+   );
+}
+
+function InsightRefreshMenuItem({
+   insightId,
+   onRefresh,
+}: {
+   insightId: string;
+   onRefresh: () => void;
+}) {
+   const { data: insight } = useSuspenseQuery(
+      orpc.insights.getById.queryOptions({ input: { id: insightId } }),
+   );
+
+   const lastComputedAt = insight.lastComputedAt ?? null;
+
+   return (
+      <DropdownMenuItem onClick={onRefresh}>
+         <RefreshCw className="mr-2 size-4" />
+         <div className="flex flex-col">
+            <span>Atualizar dados</span>
+            {lastComputedAt && (
+               <span className="text-[11px] text-muted-foreground">
+                  {formatLastComputed(new Date(lastComputedAt))}
+               </span>
+            )}
+         </div>
+      </DropdownMenuItem>
+   );
 }
 
 function formatDateRange(value: string): string {
@@ -312,8 +345,6 @@ export function DashboardTile({
    };
 
    const { slug, teamSlug } = useDashboardSlugs();
-   const { name, description, typeLabel, dateRangeLabel, lastComputedAt } =
-      useInsightMetadata(insightName, insightId, globalDateRange);
 
    const handleRefresh = () => {
       if (!insightId) return;
@@ -351,22 +382,31 @@ export function DashboardTile({
                            <GripVertical className="size-4" />
                         </Button>
                      )}
-                     <div className="min-w-0 flex-1 space-y-1">
-                        {/* Type + Date range badge */}
-                        <p className="text-[11px] font-medium tracking-wider text-muted-foreground uppercase">
-                           {typeLabel} &bull; {dateRangeLabel}
-                        </p>
-                        {/* Title */}
-                        <h3 className="text-sm font-semibold leading-snug">
-                           {name}
-                        </h3>
-                        {/* Description */}
-                        {description && (
-                           <p className="text-xs text-muted-foreground leading-relaxed">
-                              {description}
+                     {insightId ? (
+                        <Suspense
+                           fallback={
+                              <div className="min-w-0 flex-1 space-y-1">
+                                 <Skeleton className="h-3 w-20" />
+                                 <Skeleton className="h-4 w-36" />
+                              </div>
+                           }
+                        >
+                           <InsightTileMeta
+                              globalDateRange={globalDateRange}
+                              insightId={insightId}
+                              insightName={insightName}
+                           />
+                        </Suspense>
+                     ) : (
+                        <div className="min-w-0 flex-1 space-y-1">
+                           <p className="text-[11px] font-medium tracking-wider text-muted-foreground uppercase">
+                              INSIGHT
                            </p>
-                        )}
-                     </div>
+                           <h3 className="text-sm font-semibold leading-snug">
+                              {insightName ?? ""}
+                           </h3>
+                        </div>
+                     )}
                   </div>
                   <div className="flex items-center gap-0.5 shrink-0">
                      <DropdownMenu>
@@ -423,19 +463,19 @@ export function DashboardTile({
 
                            {/* Refresh data */}
                            {insightId && (
-                              <DropdownMenuItem onClick={handleRefresh}>
-                                 <RefreshCw className="mr-2 size-4" />
-                                 <div className="flex flex-col">
-                                    <span>Atualizar dados</span>
-                                    {lastComputedAt && (
-                                       <span className="text-[11px] text-muted-foreground">
-                                          {formatLastComputed(
-                                             new Date(lastComputedAt),
-                                          )}
-                                       </span>
-                                    )}
-                                 </div>
-                              </DropdownMenuItem>
+                              <Suspense
+                                 fallback={
+                                    <DropdownMenuItem disabled>
+                                       <RefreshCw className="mr-2 size-4" />
+                                       Atualizar dados
+                                    </DropdownMenuItem>
+                                 }
+                              >
+                                 <InsightRefreshMenuItem
+                                    insightId={insightId}
+                                    onRefresh={handleRefresh}
+                                 />
+                              </Suspense>
                            )}
 
                            {/* Remove from dashboard */}

--- a/apps/web/src/features/analytics/ui/dashboard-tile.tsx
+++ b/apps/web/src/features/analytics/ui/dashboard-tile.tsx
@@ -18,7 +18,7 @@ import {
 import { Skeleton } from "@packages/ui/components/skeleton";
 import { cn } from "@packages/ui/lib/utils";
 import {
-   useQuery,
+   skipToken,
    useQueryClient,
    useSuspenseQuery,
 } from "@tanstack/react-query";
@@ -198,12 +198,11 @@ function useInsightMetadata(
    insightId?: string,
    globalDateRange?: DashboardDateRange,
 ) {
-   const { data: insight } = useQuery({
-      ...orpc.insights.getById.queryOptions({
-         input: { id: insightId ?? "" },
-      }),
-      enabled: !!insightId && !insightName,
-   });
+   const { data: insight } = useSuspenseQuery(
+      insightId && !insightName
+         ? orpc.insights.getById.queryOptions({ input: { id: insightId } })
+         : { queryKey: ["disabled-insight", insightId], queryFn: skipToken },
+   );
 
    const name = insightName || insight?.name || "";
    const description = insight?.description || "";

--- a/apps/web/src/features/analytics/ui/insight-edit-dialog-stack.tsx
+++ b/apps/web/src/features/analytics/ui/insight-edit-dialog-stack.tsx
@@ -1,10 +1,10 @@
 import type {
    BreakdownConfig,
-   InsightConfig,
    KpiConfig,
    TimeSeriesConfig,
 } from "@packages/analytics/types";
 import { insightConfigSchema } from "@packages/analytics/types";
+import type { InsightType } from "@/features/analytics/hooks/use-insight-config";
 import { Button } from "@packages/ui/components/button";
 import {
    CredenzaBody,
@@ -21,10 +21,9 @@ import {
    useQueryClient,
 } from "@tanstack/react-query";
 import { BarChart3, Hash, Loader2, TrendingUp } from "lucide-react";
-import { Suspense, useCallback, useEffect, useState } from "react";
+import { Suspense, useCallback, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { toast } from "sonner";
-import type { InsightType } from "@/features/analytics/hooks/use-insight-config";
 import { useInsightConfig } from "@/features/analytics/hooks/use-insight-config";
 import { useCredenza } from "@/hooks/use-credenza";
 import { orpc } from "@/integrations/orpc/client";
@@ -61,23 +60,13 @@ function InsightEditDialogStackContent({
       orpc.insights.getById.queryOptions({ input: { id: insightId } }),
    );
 
-   const { type, config, setType, updateConfigImmediate } = useInsightConfig();
-   const [name, setName] = useState("");
-   const [initialized, setInitialized] = useState(false);
+   const parsed = insightConfigSchema.safeParse(insight.config);
 
-   useEffect(() => {
-      if (insight && !initialized) {
-         setName(insight.name);
-         const parsed = insightConfigSchema.safeParse(insight.config);
-         if (parsed.success) {
-            setType(parsed.data.type as InsightType);
-            queueMicrotask(() => {
-               updateConfigImmediate(parsed.data);
-            });
-         }
-         setInitialized(true);
-      }
-   }, [insight, initialized, setType, updateConfigImmediate]);
+   const { type, config, setType, updateConfigImmediate } = useInsightConfig(
+      parsed.success ? parsed.data : undefined,
+   );
+
+   const [name, setName] = useState(insight.name);
 
    const updateMutation = useMutation(
       orpc.insights.update.mutationOptions({
@@ -102,16 +91,14 @@ function InsightEditDialogStackContent({
       updateMutation.mutate({
          id: insightId,
          name: name.trim(),
-         config: config as InsightConfig,
+         config,
       });
    }, [insightId, name, config, updateMutation]);
 
    return (
       <>
          <CredenzaHeader className="pb-3">
-            <CredenzaTitle className="text-base">
-               {insight?.name ?? "Configurar insight"}
-            </CredenzaTitle>
+            <CredenzaTitle className="text-base">{insight.name}</CredenzaTitle>
             <CredenzaDescription>
                Ajuste as configurações do insight.
             </CredenzaDescription>

--- a/apps/web/src/features/bank-accounts/ui/bank-accounts-form.tsx
+++ b/apps/web/src/features/bank-accounts/ui/bank-accounts-form.tsx
@@ -49,8 +49,19 @@ import { Textarea } from "@packages/ui/components/textarea";
 import { cn } from "@packages/ui/lib/utils";
 import { useMaskito } from "@maskito/react";
 import type { MaskitoOptions } from "@maskito/core";
+import {
+   AlertDialog,
+   AlertDialogAction,
+   AlertDialogCancel,
+   AlertDialogContent,
+   AlertDialogDescription,
+   AlertDialogFooter,
+   AlertDialogHeader,
+   AlertDialogTitle,
+} from "@packages/ui/components/alert-dialog";
 import { ORPCError } from "@orpc/client";
 import { useForm } from "@tanstack/react-form";
+import { useBlocker } from "@tanstack/react-router";
 import Color from "color";
 import dayjs from "dayjs";
 import {
@@ -246,518 +257,565 @@ export function BankAccountForm({
       },
    });
 
+   const blocker = useBlocker({
+      withResolver: true,
+      shouldBlockFn: () =>
+         form.store.state.isDirty && !form.store.state.isSubmitted,
+      disabled: isCreate,
+   });
+
    return (
-      <form
-         className="h-full flex flex-col"
-         onSubmit={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            form.handleSubmit();
-         }}
-      >
-         <CredenzaHeader>
-            <CredenzaTitle>
-               {isCreate ? "Nova Conta Bancária" : "Editar Conta Bancária"}
-            </CredenzaTitle>
-            <CredenzaDescription>
-               {isCreate
-                  ? "Preencha os dados da nova conta bancária."
-                  : "Atualize as informações da conta bancária."}
-            </CredenzaDescription>
-         </CredenzaHeader>
+      <>
+         {blocker.status === "blocked" && (
+            <AlertDialog open>
+               <AlertDialogContent>
+                  <AlertDialogHeader>
+                     <AlertDialogTitle>Descartar alterações?</AlertDialogTitle>
+                     <AlertDialogDescription>
+                        Você tem alterações não salvas. Tem certeza que deseja
+                        sair sem salvar?
+                     </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                     <AlertDialogCancel onClick={() => blocker.reset()}>
+                        Continuar editando
+                     </AlertDialogCancel>
+                     <AlertDialogAction onClick={() => blocker.proceed()}>
+                        Descartar alterações
+                     </AlertDialogAction>
+                  </AlertDialogFooter>
+               </AlertDialogContent>
+            </AlertDialog>
+         )}
+         <form
+            className="h-full flex flex-col"
+            onSubmit={(e) => {
+               e.preventDefault();
+               e.stopPropagation();
+               form.handleSubmit();
+            }}
+         >
+            <CredenzaHeader>
+               <CredenzaTitle>
+                  {isCreate ? "Nova Conta Bancária" : "Editar Conta Bancária"}
+               </CredenzaTitle>
+               <CredenzaDescription>
+                  {isCreate
+                     ? "Preencha os dados da nova conta bancária."
+                     : "Atualize as informações da conta bancária."}
+               </CredenzaDescription>
+            </CredenzaHeader>
 
-         <CredenzaBody>
-            <FieldGroup>
-               <div className="grid grid-cols-2 gap-4">
-                  <form.Field
-                     name="type"
-                     children={(field) => {
-                        const selected = TYPE_OPTIONS.find(
-                           (o) => o.value === field.state.value,
-                        );
-                        return (
-                           <Field>
-                              <FieldLabel>Tipo de conta</FieldLabel>
-                              <Popover
-                                 onOpenChange={setTypeOpen}
-                                 open={typeOpen}
-                              >
-                                 <PopoverTrigger asChild>
-                                    <Button
-                                       aria-expanded={typeOpen}
-                                       className="w-full justify-between"
-                                       onBlur={field.handleBlur}
-                                       role="combobox"
-                                       type="button"
-                                       variant="outline"
-                                    >
-                                       <span className="flex items-center gap-2">
-                                          {selected?.icon}
-                                          {selected?.label ??
-                                             "Selecione o tipo"}
-                                       </span>
-                                       <ChevronsUpDownIcon className="size-4 shrink-0 opacity-50" />
-                                    </Button>
-                                 </PopoverTrigger>
-                                 <PopoverContent
-                                    align="start"
-                                    className="p-0 w-[var(--radix-popover-trigger-width)]"
-                                 >
-                                    <Command>
-                                       <CommandList>
-                                          <CommandEmpty>
-                                             Nenhum tipo encontrado.
-                                          </CommandEmpty>
-                                          <CommandGroup>
-                                             {TYPE_OPTIONS.map((opt) => (
-                                                <CommandItem
-                                                   key={opt.value}
-                                                   onSelect={() => {
-                                                      field.handleChange(
-                                                         opt.value,
-                                                      );
-                                                      setTypeOpen(false);
-                                                   }}
-                                                   value={opt.value}
-                                                >
-                                                   <span className="flex items-center gap-2 flex-1">
-                                                      {opt.icon}
-                                                      {opt.label}
-                                                   </span>
-                                                   <CheckIcon
-                                                      className={cn(
-                                                         "size-4 shrink-0",
-                                                         field.state.value ===
-                                                            opt.value
-                                                            ? "opacity-100"
-                                                            : "opacity-0",
-                                                      )}
-                                                   />
-                                                </CommandItem>
-                                             ))}
-                                          </CommandGroup>
-                                       </CommandList>
-                                    </Command>
-                                 </PopoverContent>
-                              </Popover>
-                           </Field>
-                        );
-                     }}
-                  />
-
-                  <form.Field
-                     name="color"
-                     children={(field) => (
-                        <Field>
-                           <FieldLabel>Cor</FieldLabel>
-                           <Popover>
-                              <PopoverTrigger asChild>
-                                 <Button
-                                    className="w-full justify-start gap-2"
-                                    type="button"
-                                    variant="outline"
-                                 >
-                                    <div
-                                       className="size-4 rounded border border-border shrink-0"
-                                       style={{
-                                          backgroundColor: field.state.value,
-                                       }}
-                                    />
-                                    <span className="font-mono text-xs">
-                                       {field.state.value}
-                                    </span>
-                                 </Button>
-                              </PopoverTrigger>
-                              <PopoverContent
-                                 align="end"
-                                 className="rounded-md border bg-background"
-                              >
-                                 <ColorPicker
-                                    className="flex flex-col gap-4"
-                                    onChange={(rgba) => {
-                                       if (Array.isArray(rgba)) {
-                                          field.handleChange(
-                                             Color.rgb(
-                                                rgba[0],
-                                                rgba[1],
-                                                rgba[2],
-                                             ).hex(),
-                                          );
-                                       }
-                                    }}
-                                    value={field.state.value || "#000000"}
-                                 >
-                                    <div className="h-24">
-                                       <ColorPickerSelection />
-                                    </div>
-                                    <div className="flex items-center gap-4">
-                                       <ColorPickerEyeDropper />
-                                       <div className="grid w-full gap-2">
-                                          <ColorPickerHue />
-                                          <ColorPickerAlpha />
-                                       </div>
-                                    </div>
-                                    <div className="flex items-center gap-2">
-                                       <ColorPickerOutput />
-                                       <ColorPickerFormat />
-                                    </div>
-                                 </ColorPicker>
-                              </PopoverContent>
-                           </Popover>
-                        </Field>
-                     )}
-                  />
-               </div>
-
-               <form.Subscribe selector={(s) => s.values.type}>
-                  {(type) =>
-                     type !== "cash" ? (
-                        <>
-                           <div className="grid grid-cols-2 gap-4">
-                              <form.Field
-                                 name="bankCode"
-                                 children={(field) => {
-                                    const isInvalid =
-                                       field.state.meta.isTouched &&
-                                       field.state.meta.errors.length > 0;
-                                    return (
-                                       <Field data-invalid={isInvalid}>
-                                          <FieldLabel>Banco</FieldLabel>
-                                          <Combobox
-                                             className="w-full"
-                                             emptyMessage="Nenhum banco encontrado."
-                                             onBlur={field.handleBlur}
-                                             onValueChange={(v) =>
-                                                field.handleChange(v)
-                                             }
-                                             options={bankOptions}
-                                             placeholder="Selecionar..."
-                                             searchPlaceholder="Pesquisar"
-                                             value={field.state.value}
-                                          />
-                                          {isInvalid && (
-                                             <FieldError
-                                                errors={field.state.meta.errors}
-                                             />
-                                          )}
-                                       </Field>
-                                    );
-                                 }}
-                              />
-
-                              <form.Field
-                                 name="nickname"
-                                 children={(field) => {
-                                    const isInvalid =
-                                       field.state.meta.isTouched &&
-                                       field.state.meta.errors.length > 0;
-                                    return (
-                                       <Field data-invalid={isInvalid}>
-                                          <FieldLabel htmlFor={field.name}>
-                                             Apelido
-                                          </FieldLabel>
-                                          <Input
-                                             id={field.name}
-                                             name={field.name}
-                                             aria-invalid={isInvalid}
-                                             onBlur={field.handleBlur}
-                                             onChange={(e) =>
-                                                field.handleChange(
-                                                   e.target.value,
-                                                )
-                                             }
-                                             placeholder="Ex: Conta principal"
-                                             value={field.state.value}
-                                          />
-                                          {isInvalid && (
-                                             <FieldError
-                                                errors={field.state.meta.errors}
-                                             />
-                                          )}
-                                       </Field>
-                                    );
-                                 }}
-                              />
-                           </div>
-
-                           <div className="grid grid-cols-2 gap-4">
-                              <form.Field
-                                 name="branch"
-                                 children={(field) => {
-                                    const isInvalid =
-                                       field.state.meta.isTouched &&
-                                       field.state.meta.errors.length > 0;
-                                    return (
-                                       <Field data-invalid={isInvalid}>
-                                          <FieldLabel htmlFor={field.name}>
-                                             Agência
-                                          </FieldLabel>
-                                          <Input
-                                             ref={branchRef}
-                                             aria-invalid={isInvalid}
-                                             defaultValue={field.state.value}
-                                             id={field.name}
-                                             inputMode="numeric"
-                                             name={field.name}
-                                             onBlur={field.handleBlur}
-                                             onInput={(e) =>
-                                                field.handleChange(
-                                                   (
-                                                      e.target as HTMLInputElement
-                                                   ).value,
-                                                )
-                                             }
-                                             placeholder="00000"
-                                          />
-                                          {isInvalid && (
-                                             <FieldError
-                                                errors={field.state.meta.errors}
-                                             />
-                                          )}
-                                       </Field>
-                                    );
-                                 }}
-                              />
-
-                              <form.Field
-                                 name="accountNumber"
-                                 children={(field) => {
-                                    const isInvalid =
-                                       field.state.meta.isTouched &&
-                                       field.state.meta.errors.length > 0;
-                                    return (
-                                       <Field data-invalid={isInvalid}>
-                                          <FieldLabel htmlFor={field.name}>
-                                             Conta
-                                          </FieldLabel>
-                                          <Input
-                                             ref={accountRef}
-                                             aria-invalid={isInvalid}
-                                             defaultValue={field.state.value}
-                                             id={field.name}
-                                             inputMode="numeric"
-                                             name={field.name}
-                                             onBlur={field.handleBlur}
-                                             onInput={(e) =>
-                                                field.handleChange(
-                                                   (
-                                                      e.target as HTMLInputElement
-                                                   ).value,
-                                                )
-                                             }
-                                             placeholder="000000000000-0"
-                                          />
-                                          {isInvalid && (
-                                             <FieldError
-                                                errors={field.state.meta.errors}
-                                             />
-                                          )}
-                                       </Field>
-                                    );
-                                 }}
-                              />
-                           </div>
-                        </>
-                     ) : null
-                  }
-               </form.Subscribe>
-
-               {isCreate && (
+            <CredenzaBody>
+               <FieldGroup>
                   <div className="grid grid-cols-2 gap-4">
                      <form.Field
-                        name="initialBalance"
+                        name="type"
                         children={(field) => {
-                           const isInvalid =
-                              field.state.meta.isTouched &&
-                              field.state.meta.errors.length > 0;
-                           return (
-                              <Field data-invalid={isInvalid}>
-                                 <FieldLabel>Saldo inicial</FieldLabel>
-                                 <MoneyInput
-                                    onChange={(v) =>
-                                       field.handleChange(String(v ?? 0))
-                                    }
-                                    value={field.state.value}
-                                    valueInCents={false}
-                                 />
-                                 {isInvalid && (
-                                    <FieldError
-                                       errors={field.state.meta.errors}
-                                    />
-                                 )}
-                              </Field>
+                           const selected = TYPE_OPTIONS.find(
+                              (o) => o.value === field.state.value,
                            );
-                        }}
-                     />
-
-                     <form.Field
-                        name="initialBalanceDate"
-                        children={(field) => {
-                           const selectedDate = toDate(field.state.value);
                            return (
                               <Field>
-                                 <FieldLabel>Data do saldo inicial</FieldLabel>
+                                 <FieldLabel>Tipo de conta</FieldLabel>
                                  <Popover
-                                    open={dateOpen}
-                                    onOpenChange={setDateOpen}
+                                    onOpenChange={setTypeOpen}
+                                    open={typeOpen}
                                  >
                                     <PopoverTrigger asChild>
                                        <Button
-                                          className={cn(
-                                             "w-full justify-start gap-2 font-normal",
-                                             !selectedDate &&
-                                                "text-muted-foreground",
-                                          )}
+                                          aria-expanded={typeOpen}
+                                          className="w-full justify-between"
+                                          onBlur={field.handleBlur}
+                                          role="combobox"
                                           type="button"
                                           variant="outline"
                                        >
-                                          <CalendarIcon className="size-4 shrink-0" />
-                                          {selectedDate
-                                             ? dayjs(selectedDate).format(
-                                                  "DD/MM/YYYY",
-                                               )
-                                             : "Selecionar data"}
+                                          <span className="flex items-center gap-2">
+                                             {selected?.icon}
+                                             {selected?.label ??
+                                                "Selecione o tipo"}
+                                          </span>
+                                          <ChevronsUpDownIcon className="size-4 shrink-0 opacity-50" />
                                        </Button>
                                     </PopoverTrigger>
                                     <PopoverContent
                                        align="start"
-                                       className="w-auto p-0"
+                                       className="p-0 w-[var(--radix-popover-trigger-width)]"
                                     >
-                                       <Calendar
-                                          captionLayout="dropdown"
-                                          components={{
-                                             MonthCaption: (props) => (
-                                                <>{props.children}</>
-                                             ),
-                                             DropdownNav: (props) => (
-                                                <div className="flex w-full items-center gap-2">
-                                                   {props.children}
-                                                </div>
-                                             ),
-                                             Dropdown: (props) => (
-                                                <Select
-                                                   onValueChange={(value) => {
-                                                      if (props.onChange) {
-                                                         const ev = {
-                                                            target: {
-                                                               value: String(
-                                                                  value,
-                                                               ),
-                                                            },
-                                                         } as React.ChangeEvent<HTMLSelectElement>;
-                                                         props.onChange(ev);
-                                                      }
-                                                   }}
-                                                   value={String(props.value)}
-                                                >
-                                                   <SelectTrigger className="first:flex-1 last:shrink-0">
-                                                      <SelectValue />
-                                                   </SelectTrigger>
-                                                   <SelectContent>
-                                                      {props.options?.map(
-                                                         (option) => (
-                                                            <SelectItem
-                                                               disabled={
-                                                                  option.disabled
-                                                               }
-                                                               key={
-                                                                  option.value
-                                                               }
-                                                               value={String(
-                                                                  option.value,
-                                                               )}
-                                                            >
-                                                               {option.label}
-                                                            </SelectItem>
-                                                         ),
-                                                      )}
-                                                   </SelectContent>
-                                                </Select>
-                                             ),
-                                          }}
-                                          fromDate={minDate}
-                                          toDate={new Date()}
-                                          hideNavigation
-                                          mode="single"
-                                          selected={selectedDate}
-                                          onSelect={(date) => {
-                                             field.handleChange(
-                                                date
-                                                   ? dayjs(date).format(
-                                                        "YYYY-MM-DD",
-                                                     )
-                                                   : "",
-                                             );
-                                             setDateOpen(false);
-                                          }}
-                                       />
+                                       <Command>
+                                          <CommandList>
+                                             <CommandEmpty>
+                                                Nenhum tipo encontrado.
+                                             </CommandEmpty>
+                                             <CommandGroup>
+                                                {TYPE_OPTIONS.map((opt) => (
+                                                   <CommandItem
+                                                      key={opt.value}
+                                                      onSelect={() => {
+                                                         field.handleChange(
+                                                            opt.value,
+                                                         );
+                                                         setTypeOpen(false);
+                                                      }}
+                                                      value={opt.value}
+                                                   >
+                                                      <span className="flex items-center gap-2 flex-1">
+                                                         {opt.icon}
+                                                         {opt.label}
+                                                      </span>
+                                                      <CheckIcon
+                                                         className={cn(
+                                                            "size-4 shrink-0",
+                                                            field.state
+                                                               .value ===
+                                                               opt.value
+                                                               ? "opacity-100"
+                                                               : "opacity-0",
+                                                         )}
+                                                      />
+                                                   </CommandItem>
+                                                ))}
+                                             </CommandGroup>
+                                          </CommandList>
+                                       </Command>
                                     </PopoverContent>
                                  </Popover>
                               </Field>
                            );
                         }}
                      />
+
+                     <form.Field
+                        name="color"
+                        children={(field) => (
+                           <Field>
+                              <FieldLabel>Cor</FieldLabel>
+                              <Popover>
+                                 <PopoverTrigger asChild>
+                                    <Button
+                                       className="w-full justify-start gap-2"
+                                       type="button"
+                                       variant="outline"
+                                    >
+                                       <div
+                                          className="size-4 rounded border border-border shrink-0"
+                                          style={{
+                                             backgroundColor: field.state.value,
+                                          }}
+                                       />
+                                       <span className="font-mono text-xs">
+                                          {field.state.value}
+                                       </span>
+                                    </Button>
+                                 </PopoverTrigger>
+                                 <PopoverContent
+                                    align="end"
+                                    className="rounded-md border bg-background"
+                                 >
+                                    <ColorPicker
+                                       className="flex flex-col gap-4"
+                                       onChange={(rgba) => {
+                                          if (Array.isArray(rgba)) {
+                                             field.handleChange(
+                                                Color.rgb(
+                                                   rgba[0],
+                                                   rgba[1],
+                                                   rgba[2],
+                                                ).hex(),
+                                             );
+                                          }
+                                       }}
+                                       value={field.state.value || "#000000"}
+                                    >
+                                       <div className="h-24">
+                                          <ColorPickerSelection />
+                                       </div>
+                                       <div className="flex items-center gap-4">
+                                          <ColorPickerEyeDropper />
+                                          <div className="grid w-full gap-2">
+                                             <ColorPickerHue />
+                                             <ColorPickerAlpha />
+                                          </div>
+                                       </div>
+                                       <div className="flex items-center gap-2">
+                                          <ColorPickerOutput />
+                                          <ColorPickerFormat />
+                                       </div>
+                                    </ColorPicker>
+                                 </PopoverContent>
+                              </Popover>
+                           </Field>
+                        )}
+                     />
                   </div>
-               )}
 
-               <form.Field
-                  name="notes"
-                  children={(field) => (
-                     <Field>
-                        <FieldLabel htmlFor={field.name}>
-                           Observações{" "}
-                           <span className="text-muted-foreground font-normal">
-                              (opcional)
-                           </span>
-                        </FieldLabel>
-                        <Textarea
-                           id={field.name}
-                           name={field.name}
-                           onBlur={field.handleBlur}
-                           onChange={(e) => field.handleChange(e.target.value)}
-                           placeholder="Informações adicionais sobre a conta..."
-                           rows={2}
-                           value={field.state.value}
+                  <form.Subscribe selector={(s) => s.values.type}>
+                     {(type) =>
+                        type !== "cash" ? (
+                           <>
+                              <div className="grid grid-cols-2 gap-4">
+                                 <form.Field
+                                    name="bankCode"
+                                    children={(field) => {
+                                       const isInvalid =
+                                          field.state.meta.isTouched &&
+                                          field.state.meta.errors.length > 0;
+                                       return (
+                                          <Field data-invalid={isInvalid}>
+                                             <FieldLabel>Banco</FieldLabel>
+                                             <Combobox
+                                                className="w-full"
+                                                emptyMessage="Nenhum banco encontrado."
+                                                onBlur={field.handleBlur}
+                                                onValueChange={(v) =>
+                                                   field.handleChange(v)
+                                                }
+                                                options={bankOptions}
+                                                placeholder="Selecionar..."
+                                                searchPlaceholder="Pesquisar"
+                                                value={field.state.value}
+                                             />
+                                             {isInvalid && (
+                                                <FieldError
+                                                   errors={
+                                                      field.state.meta.errors
+                                                   }
+                                                />
+                                             )}
+                                          </Field>
+                                       );
+                                    }}
+                                 />
+
+                                 <form.Field
+                                    name="nickname"
+                                    children={(field) => {
+                                       const isInvalid =
+                                          field.state.meta.isTouched &&
+                                          field.state.meta.errors.length > 0;
+                                       return (
+                                          <Field data-invalid={isInvalid}>
+                                             <FieldLabel htmlFor={field.name}>
+                                                Apelido
+                                             </FieldLabel>
+                                             <Input
+                                                id={field.name}
+                                                name={field.name}
+                                                aria-invalid={isInvalid}
+                                                onBlur={field.handleBlur}
+                                                onChange={(e) =>
+                                                   field.handleChange(
+                                                      e.target.value,
+                                                   )
+                                                }
+                                                placeholder="Ex: Conta principal"
+                                                value={field.state.value}
+                                             />
+                                             {isInvalid && (
+                                                <FieldError
+                                                   errors={
+                                                      field.state.meta.errors
+                                                   }
+                                                />
+                                             )}
+                                          </Field>
+                                       );
+                                    }}
+                                 />
+                              </div>
+
+                              <div className="grid grid-cols-2 gap-4">
+                                 <form.Field
+                                    name="branch"
+                                    children={(field) => {
+                                       const isInvalid =
+                                          field.state.meta.isTouched &&
+                                          field.state.meta.errors.length > 0;
+                                       return (
+                                          <Field data-invalid={isInvalid}>
+                                             <FieldLabel htmlFor={field.name}>
+                                                Agência
+                                             </FieldLabel>
+                                             <Input
+                                                ref={branchRef}
+                                                aria-invalid={isInvalid}
+                                                defaultValue={field.state.value}
+                                                id={field.name}
+                                                inputMode="numeric"
+                                                name={field.name}
+                                                onBlur={field.handleBlur}
+                                                onInput={(e) =>
+                                                   field.handleChange(
+                                                      (
+                                                         e.target as HTMLInputElement
+                                                      ).value,
+                                                   )
+                                                }
+                                                placeholder="00000"
+                                             />
+                                             {isInvalid && (
+                                                <FieldError
+                                                   errors={
+                                                      field.state.meta.errors
+                                                   }
+                                                />
+                                             )}
+                                          </Field>
+                                       );
+                                    }}
+                                 />
+
+                                 <form.Field
+                                    name="accountNumber"
+                                    children={(field) => {
+                                       const isInvalid =
+                                          field.state.meta.isTouched &&
+                                          field.state.meta.errors.length > 0;
+                                       return (
+                                          <Field data-invalid={isInvalid}>
+                                             <FieldLabel htmlFor={field.name}>
+                                                Conta
+                                             </FieldLabel>
+                                             <Input
+                                                ref={accountRef}
+                                                aria-invalid={isInvalid}
+                                                defaultValue={field.state.value}
+                                                id={field.name}
+                                                inputMode="numeric"
+                                                name={field.name}
+                                                onBlur={field.handleBlur}
+                                                onInput={(e) =>
+                                                   field.handleChange(
+                                                      (
+                                                         e.target as HTMLInputElement
+                                                      ).value,
+                                                   )
+                                                }
+                                                placeholder="000000000000-0"
+                                             />
+                                             {isInvalid && (
+                                                <FieldError
+                                                   errors={
+                                                      field.state.meta.errors
+                                                   }
+                                                />
+                                             )}
+                                          </Field>
+                                       );
+                                    }}
+                                 />
+                              </div>
+                           </>
+                        ) : null
+                     }
+                  </form.Subscribe>
+
+                  {isCreate && (
+                     <div className="grid grid-cols-2 gap-4">
+                        <form.Field
+                           name="initialBalance"
+                           children={(field) => {
+                              const isInvalid =
+                                 field.state.meta.isTouched &&
+                                 field.state.meta.errors.length > 0;
+                              return (
+                                 <Field data-invalid={isInvalid}>
+                                    <FieldLabel>Saldo inicial</FieldLabel>
+                                    <MoneyInput
+                                       onChange={(v) =>
+                                          field.handleChange(String(v ?? 0))
+                                       }
+                                       value={field.state.value}
+                                       valueInCents={false}
+                                    />
+                                    {isInvalid && (
+                                       <FieldError
+                                          errors={field.state.meta.errors}
+                                       />
+                                    )}
+                                 </Field>
+                              );
+                           }}
                         />
-                     </Field>
-                  )}
-               />
-            </FieldGroup>
-         </CredenzaBody>
 
-         <CredenzaFooter className="flex flex-col gap-2">
-            <form.Subscribe
-               selector={(state) =>
-                  state.errors.flatMap((e) => {
-                     if (!e) return [];
-                     if (typeof e === "string") return [e];
-                     if ("form" in e && typeof e.form === "string")
-                        return [e.form];
-                     return [];
-                  })
-               }
-            >
-               {(messages) =>
-                  messages.length > 0 && <FieldError errors={messages} />
-               }
-            </form.Subscribe>
-            <form.Subscribe
-               selector={(state) =>
-                  [state.canSubmit, state.isSubmitting] as const
-               }
-            >
-               {([canSubmit, isSubmitting]) => (
-                  <Button
-                     className="w-full gap-2"
-                     disabled={!canSubmit}
-                     type="submit"
-                  >
-                     {isSubmitting && <Spinner className="size-4" />}
-                     {isCreate ? "Criar conta" : "Salvar alterações"}
-                  </Button>
-               )}
-            </form.Subscribe>
-         </CredenzaFooter>
-      </form>
+                        <form.Field
+                           name="initialBalanceDate"
+                           children={(field) => {
+                              const selectedDate = toDate(field.state.value);
+                              return (
+                                 <Field>
+                                    <FieldLabel>
+                                       Data do saldo inicial
+                                    </FieldLabel>
+                                    <Popover
+                                       open={dateOpen}
+                                       onOpenChange={setDateOpen}
+                                    >
+                                       <PopoverTrigger asChild>
+                                          <Button
+                                             className={cn(
+                                                "w-full justify-start gap-2 font-normal",
+                                                !selectedDate &&
+                                                   "text-muted-foreground",
+                                             )}
+                                             type="button"
+                                             variant="outline"
+                                          >
+                                             <CalendarIcon className="size-4 shrink-0" />
+                                             {selectedDate
+                                                ? dayjs(selectedDate).format(
+                                                     "DD/MM/YYYY",
+                                                  )
+                                                : "Selecionar data"}
+                                          </Button>
+                                       </PopoverTrigger>
+                                       <PopoverContent
+                                          align="start"
+                                          className="w-auto p-0"
+                                       >
+                                          <Calendar
+                                             captionLayout="dropdown"
+                                             components={{
+                                                MonthCaption: (props) => (
+                                                   <>{props.children}</>
+                                                ),
+                                                DropdownNav: (props) => (
+                                                   <div className="flex w-full items-center gap-2">
+                                                      {props.children}
+                                                   </div>
+                                                ),
+                                                Dropdown: (props) => (
+                                                   <Select
+                                                      onValueChange={(
+                                                         value,
+                                                      ) => {
+                                                         if (props.onChange) {
+                                                            const ev = {
+                                                               target: {
+                                                                  value: String(
+                                                                     value,
+                                                                  ),
+                                                               },
+                                                            } as React.ChangeEvent<HTMLSelectElement>;
+                                                            props.onChange(ev);
+                                                         }
+                                                      }}
+                                                      value={String(
+                                                         props.value,
+                                                      )}
+                                                   >
+                                                      <SelectTrigger className="first:flex-1 last:shrink-0">
+                                                         <SelectValue />
+                                                      </SelectTrigger>
+                                                      <SelectContent>
+                                                         {props.options?.map(
+                                                            (option) => (
+                                                               <SelectItem
+                                                                  disabled={
+                                                                     option.disabled
+                                                                  }
+                                                                  key={
+                                                                     option.value
+                                                                  }
+                                                                  value={String(
+                                                                     option.value,
+                                                                  )}
+                                                               >
+                                                                  {option.label}
+                                                               </SelectItem>
+                                                            ),
+                                                         )}
+                                                      </SelectContent>
+                                                   </Select>
+                                                ),
+                                             }}
+                                             fromDate={minDate}
+                                             toDate={new Date()}
+                                             hideNavigation
+                                             mode="single"
+                                             selected={selectedDate}
+                                             onSelect={(date) => {
+                                                field.handleChange(
+                                                   date
+                                                      ? dayjs(date).format(
+                                                           "YYYY-MM-DD",
+                                                        )
+                                                      : "",
+                                                );
+                                                setDateOpen(false);
+                                             }}
+                                          />
+                                       </PopoverContent>
+                                    </Popover>
+                                 </Field>
+                              );
+                           }}
+                        />
+                     </div>
+                  )}
+
+                  <form.Field
+                     name="notes"
+                     children={(field) => (
+                        <Field>
+                           <FieldLabel htmlFor={field.name}>
+                              Observações{" "}
+                              <span className="text-muted-foreground font-normal">
+                                 (opcional)
+                              </span>
+                           </FieldLabel>
+                           <Textarea
+                              id={field.name}
+                              name={field.name}
+                              onBlur={field.handleBlur}
+                              onChange={(e) =>
+                                 field.handleChange(e.target.value)
+                              }
+                              placeholder="Informações adicionais sobre a conta..."
+                              rows={2}
+                              value={field.state.value}
+                           />
+                        </Field>
+                     )}
+                  />
+               </FieldGroup>
+            </CredenzaBody>
+
+            <CredenzaFooter className="flex flex-col gap-2">
+               <form.Subscribe
+                  selector={(state) =>
+                     state.errors.flatMap((e) => {
+                        if (!e) return [];
+                        if (typeof e === "string") return [e];
+                        if ("form" in e && typeof e.form === "string")
+                           return [e.form];
+                        return [];
+                     })
+                  }
+               >
+                  {(messages) =>
+                     messages.length > 0 && <FieldError errors={messages} />
+                  }
+               </form.Subscribe>
+               <form.Subscribe
+                  selector={(state) =>
+                     [state.canSubmit, state.isSubmitting] as const
+                  }
+               >
+                  {([canSubmit, isSubmitting]) => (
+                     <Button
+                        className="w-full gap-2"
+                        disabled={!canSubmit}
+                        type="submit"
+                     >
+                        {isSubmitting && <Spinner className="size-4" />}
+                        {isCreate ? "Criar conta" : "Salvar alterações"}
+                     </Button>
+                  )}
+               </form.Subscribe>
+            </CredenzaFooter>
+         </form>
+      </>
    );
 }

--- a/apps/web/src/features/bank-accounts/ui/bank-accounts-form.tsx
+++ b/apps/web/src/features/bank-accounts/ui/bank-accounts-form.tsx
@@ -277,8 +277,8 @@ export function BankAccountForm({
                   "Você tem alterações não salvas. Tem certeza que deseja sair sem salvar?",
                actionLabel: "Descartar alterações",
                cancelLabel: "Continuar editando",
-               onAction: () => blocker.proceed(),
-               onCancel: () => blocker.reset(),
+               onAction: () => blocker.proceed?.(),
+               onCancel: () => blocker.reset?.(),
             });
             return true;
          }

--- a/apps/web/src/features/bank-accounts/ui/bank-accounts-form.tsx
+++ b/apps/web/src/features/bank-accounts/ui/bank-accounts-form.tsx
@@ -49,16 +49,6 @@ import { Textarea } from "@packages/ui/components/textarea";
 import { cn } from "@packages/ui/lib/utils";
 import { useMaskito } from "@maskito/react";
 import type { MaskitoOptions } from "@maskito/core";
-import {
-   AlertDialog,
-   AlertDialogAction,
-   AlertDialogCancel,
-   AlertDialogContent,
-   AlertDialogDescription,
-   AlertDialogFooter,
-   AlertDialogHeader,
-   AlertDialogTitle,
-} from "@packages/ui/components/alert-dialog";
 import { ORPCError } from "@orpc/client";
 import { useForm } from "@tanstack/react-form";
 import { useBlocker } from "@tanstack/react-router";
@@ -77,6 +67,7 @@ import {
 import { useState } from "react";
 import { toast } from "sonner";
 import { orpc } from "@/integrations/orpc/client";
+import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import { useActiveTeam } from "@/hooks/use-active-team";
 import { useCnpj } from "@/hooks/use-cnpj";
 import { useBrazilianBanks } from "../hooks/use-brazilian-banks";
@@ -257,565 +248,540 @@ export function BankAccountForm({
       },
    });
 
+   const { openAlertDialog } = useAlertDialog();
+
    const blocker = useBlocker({
       withResolver: true,
-      shouldBlockFn: () =>
-         form.store.state.isDirty && !form.store.state.isSubmitted,
+      shouldBlockFn: () => {
+         if (form.store.state.isDirty && !form.store.state.isSubmitted) {
+            openAlertDialog({
+               title: "Descartar alterações?",
+               description:
+                  "Você tem alterações não salvas. Tem certeza que deseja sair sem salvar?",
+               actionLabel: "Descartar alterações",
+               cancelLabel: "Continuar editando",
+               onAction: () => blocker.proceed(),
+               onCancel: () => blocker.reset(),
+            });
+            return true;
+         }
+         return false;
+      },
       disabled: isCreate,
    });
 
    return (
-      <>
-         {blocker.status === "blocked" && (
-            <AlertDialog open>
-               <AlertDialogContent>
-                  <AlertDialogHeader>
-                     <AlertDialogTitle>Descartar alterações?</AlertDialogTitle>
-                     <AlertDialogDescription>
-                        Você tem alterações não salvas. Tem certeza que deseja
-                        sair sem salvar?
-                     </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                     <AlertDialogCancel onClick={() => blocker.reset()}>
-                        Continuar editando
-                     </AlertDialogCancel>
-                     <AlertDialogAction onClick={() => blocker.proceed()}>
-                        Descartar alterações
-                     </AlertDialogAction>
-                  </AlertDialogFooter>
-               </AlertDialogContent>
-            </AlertDialog>
-         )}
-         <form
-            className="h-full flex flex-col"
-            onSubmit={(e) => {
-               e.preventDefault();
-               e.stopPropagation();
-               form.handleSubmit();
-            }}
-         >
-            <CredenzaHeader>
-               <CredenzaTitle>
-                  {isCreate ? "Nova Conta Bancária" : "Editar Conta Bancária"}
-               </CredenzaTitle>
-               <CredenzaDescription>
-                  {isCreate
-                     ? "Preencha os dados da nova conta bancária."
-                     : "Atualize as informações da conta bancária."}
-               </CredenzaDescription>
-            </CredenzaHeader>
+      <form
+         className="h-full flex flex-col"
+         onSubmit={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            form.handleSubmit();
+         }}
+      >
+         <CredenzaHeader>
+            <CredenzaTitle>
+               {isCreate ? "Nova Conta Bancária" : "Editar Conta Bancária"}
+            </CredenzaTitle>
+            <CredenzaDescription>
+               {isCreate
+                  ? "Preencha os dados da nova conta bancária."
+                  : "Atualize as informações da conta bancária."}
+            </CredenzaDescription>
+         </CredenzaHeader>
 
-            <CredenzaBody>
-               <FieldGroup>
+         <CredenzaBody>
+            <FieldGroup>
+               <div className="grid grid-cols-2 gap-4">
+                  <form.Field
+                     name="type"
+                     children={(field) => {
+                        const selected = TYPE_OPTIONS.find(
+                           (o) => o.value === field.state.value,
+                        );
+                        return (
+                           <Field>
+                              <FieldLabel>Tipo de conta</FieldLabel>
+                              <Popover
+                                 onOpenChange={setTypeOpen}
+                                 open={typeOpen}
+                              >
+                                 <PopoverTrigger asChild>
+                                    <Button
+                                       aria-expanded={typeOpen}
+                                       className="w-full justify-between"
+                                       onBlur={field.handleBlur}
+                                       role="combobox"
+                                       type="button"
+                                       variant="outline"
+                                    >
+                                       <span className="flex items-center gap-2">
+                                          {selected?.icon}
+                                          {selected?.label ??
+                                             "Selecione o tipo"}
+                                       </span>
+                                       <ChevronsUpDownIcon className="size-4 shrink-0 opacity-50" />
+                                    </Button>
+                                 </PopoverTrigger>
+                                 <PopoverContent
+                                    align="start"
+                                    className="p-0 w-[var(--radix-popover-trigger-width)]"
+                                 >
+                                    <Command>
+                                       <CommandList>
+                                          <CommandEmpty>
+                                             Nenhum tipo encontrado.
+                                          </CommandEmpty>
+                                          <CommandGroup>
+                                             {TYPE_OPTIONS.map((opt) => (
+                                                <CommandItem
+                                                   key={opt.value}
+                                                   onSelect={() => {
+                                                      field.handleChange(
+                                                         opt.value,
+                                                      );
+                                                      setTypeOpen(false);
+                                                   }}
+                                                   value={opt.value}
+                                                >
+                                                   <span className="flex items-center gap-2 flex-1">
+                                                      {opt.icon}
+                                                      {opt.label}
+                                                   </span>
+                                                   <CheckIcon
+                                                      className={cn(
+                                                         "size-4 shrink-0",
+                                                         field.state.value ===
+                                                            opt.value
+                                                            ? "opacity-100"
+                                                            : "opacity-0",
+                                                      )}
+                                                   />
+                                                </CommandItem>
+                                             ))}
+                                          </CommandGroup>
+                                       </CommandList>
+                                    </Command>
+                                 </PopoverContent>
+                              </Popover>
+                           </Field>
+                        );
+                     }}
+                  />
+
+                  <form.Field
+                     name="color"
+                     children={(field) => (
+                        <Field>
+                           <FieldLabel>Cor</FieldLabel>
+                           <Popover>
+                              <PopoverTrigger asChild>
+                                 <Button
+                                    className="w-full justify-start gap-2"
+                                    type="button"
+                                    variant="outline"
+                                 >
+                                    <div
+                                       className="size-4 rounded border border-border shrink-0"
+                                       style={{
+                                          backgroundColor: field.state.value,
+                                       }}
+                                    />
+                                    <span className="font-mono text-xs">
+                                       {field.state.value}
+                                    </span>
+                                 </Button>
+                              </PopoverTrigger>
+                              <PopoverContent
+                                 align="end"
+                                 className="rounded-md border bg-background"
+                              >
+                                 <ColorPicker
+                                    className="flex flex-col gap-4"
+                                    onChange={(rgba) => {
+                                       if (Array.isArray(rgba)) {
+                                          field.handleChange(
+                                             Color.rgb(
+                                                rgba[0],
+                                                rgba[1],
+                                                rgba[2],
+                                             ).hex(),
+                                          );
+                                       }
+                                    }}
+                                    value={field.state.value || "#000000"}
+                                 >
+                                    <div className="h-24">
+                                       <ColorPickerSelection />
+                                    </div>
+                                    <div className="flex items-center gap-4">
+                                       <ColorPickerEyeDropper />
+                                       <div className="grid w-full gap-2">
+                                          <ColorPickerHue />
+                                          <ColorPickerAlpha />
+                                       </div>
+                                    </div>
+                                    <div className="flex items-center gap-2">
+                                       <ColorPickerOutput />
+                                       <ColorPickerFormat />
+                                    </div>
+                                 </ColorPicker>
+                              </PopoverContent>
+                           </Popover>
+                        </Field>
+                     )}
+                  />
+               </div>
+
+               <form.Subscribe selector={(s) => s.values.type}>
+                  {(type) =>
+                     type !== "cash" ? (
+                        <>
+                           <div className="grid grid-cols-2 gap-4">
+                              <form.Field
+                                 name="bankCode"
+                                 children={(field) => {
+                                    const isInvalid =
+                                       field.state.meta.isTouched &&
+                                       field.state.meta.errors.length > 0;
+                                    return (
+                                       <Field data-invalid={isInvalid}>
+                                          <FieldLabel>Banco</FieldLabel>
+                                          <Combobox
+                                             className="w-full"
+                                             emptyMessage="Nenhum banco encontrado."
+                                             onBlur={field.handleBlur}
+                                             onValueChange={(v) =>
+                                                field.handleChange(v)
+                                             }
+                                             options={bankOptions}
+                                             placeholder="Selecionar..."
+                                             searchPlaceholder="Pesquisar"
+                                             value={field.state.value}
+                                          />
+                                          {isInvalid && (
+                                             <FieldError
+                                                errors={field.state.meta.errors}
+                                             />
+                                          )}
+                                       </Field>
+                                    );
+                                 }}
+                              />
+
+                              <form.Field
+                                 name="nickname"
+                                 children={(field) => {
+                                    const isInvalid =
+                                       field.state.meta.isTouched &&
+                                       field.state.meta.errors.length > 0;
+                                    return (
+                                       <Field data-invalid={isInvalid}>
+                                          <FieldLabel htmlFor={field.name}>
+                                             Apelido
+                                          </FieldLabel>
+                                          <Input
+                                             id={field.name}
+                                             name={field.name}
+                                             aria-invalid={isInvalid}
+                                             onBlur={field.handleBlur}
+                                             onChange={(e) =>
+                                                field.handleChange(
+                                                   e.target.value,
+                                                )
+                                             }
+                                             placeholder="Ex: Conta principal"
+                                             value={field.state.value}
+                                          />
+                                          {isInvalid && (
+                                             <FieldError
+                                                errors={field.state.meta.errors}
+                                             />
+                                          )}
+                                       </Field>
+                                    );
+                                 }}
+                              />
+                           </div>
+
+                           <div className="grid grid-cols-2 gap-4">
+                              <form.Field
+                                 name="branch"
+                                 children={(field) => {
+                                    const isInvalid =
+                                       field.state.meta.isTouched &&
+                                       field.state.meta.errors.length > 0;
+                                    return (
+                                       <Field data-invalid={isInvalid}>
+                                          <FieldLabel htmlFor={field.name}>
+                                             Agência
+                                          </FieldLabel>
+                                          <Input
+                                             ref={branchRef}
+                                             aria-invalid={isInvalid}
+                                             defaultValue={field.state.value}
+                                             id={field.name}
+                                             inputMode="numeric"
+                                             name={field.name}
+                                             onBlur={field.handleBlur}
+                                             onInput={(e) =>
+                                                field.handleChange(
+                                                   (
+                                                      e.target as HTMLInputElement
+                                                   ).value,
+                                                )
+                                             }
+                                             placeholder="00000"
+                                          />
+                                          {isInvalid && (
+                                             <FieldError
+                                                errors={field.state.meta.errors}
+                                             />
+                                          )}
+                                       </Field>
+                                    );
+                                 }}
+                              />
+
+                              <form.Field
+                                 name="accountNumber"
+                                 children={(field) => {
+                                    const isInvalid =
+                                       field.state.meta.isTouched &&
+                                       field.state.meta.errors.length > 0;
+                                    return (
+                                       <Field data-invalid={isInvalid}>
+                                          <FieldLabel htmlFor={field.name}>
+                                             Conta
+                                          </FieldLabel>
+                                          <Input
+                                             ref={accountRef}
+                                             aria-invalid={isInvalid}
+                                             defaultValue={field.state.value}
+                                             id={field.name}
+                                             inputMode="numeric"
+                                             name={field.name}
+                                             onBlur={field.handleBlur}
+                                             onInput={(e) =>
+                                                field.handleChange(
+                                                   (
+                                                      e.target as HTMLInputElement
+                                                   ).value,
+                                                )
+                                             }
+                                             placeholder="000000000000-0"
+                                          />
+                                          {isInvalid && (
+                                             <FieldError
+                                                errors={field.state.meta.errors}
+                                             />
+                                          )}
+                                       </Field>
+                                    );
+                                 }}
+                              />
+                           </div>
+                        </>
+                     ) : null
+                  }
+               </form.Subscribe>
+
+               {isCreate && (
                   <div className="grid grid-cols-2 gap-4">
                      <form.Field
-                        name="type"
+                        name="initialBalance"
                         children={(field) => {
-                           const selected = TYPE_OPTIONS.find(
-                              (o) => o.value === field.state.value,
-                           );
+                           const isInvalid =
+                              field.state.meta.isTouched &&
+                              field.state.meta.errors.length > 0;
                            return (
-                              <Field>
-                                 <FieldLabel>Tipo de conta</FieldLabel>
-                                 <Popover
-                                    onOpenChange={setTypeOpen}
-                                    open={typeOpen}
-                                 >
-                                    <PopoverTrigger asChild>
-                                       <Button
-                                          aria-expanded={typeOpen}
-                                          className="w-full justify-between"
-                                          onBlur={field.handleBlur}
-                                          role="combobox"
-                                          type="button"
-                                          variant="outline"
-                                       >
-                                          <span className="flex items-center gap-2">
-                                             {selected?.icon}
-                                             {selected?.label ??
-                                                "Selecione o tipo"}
-                                          </span>
-                                          <ChevronsUpDownIcon className="size-4 shrink-0 opacity-50" />
-                                       </Button>
-                                    </PopoverTrigger>
-                                    <PopoverContent
-                                       align="start"
-                                       className="p-0 w-[var(--radix-popover-trigger-width)]"
-                                    >
-                                       <Command>
-                                          <CommandList>
-                                             <CommandEmpty>
-                                                Nenhum tipo encontrado.
-                                             </CommandEmpty>
-                                             <CommandGroup>
-                                                {TYPE_OPTIONS.map((opt) => (
-                                                   <CommandItem
-                                                      key={opt.value}
-                                                      onSelect={() => {
-                                                         field.handleChange(
-                                                            opt.value,
-                                                         );
-                                                         setTypeOpen(false);
-                                                      }}
-                                                      value={opt.value}
-                                                   >
-                                                      <span className="flex items-center gap-2 flex-1">
-                                                         {opt.icon}
-                                                         {opt.label}
-                                                      </span>
-                                                      <CheckIcon
-                                                         className={cn(
-                                                            "size-4 shrink-0",
-                                                            field.state
-                                                               .value ===
-                                                               opt.value
-                                                               ? "opacity-100"
-                                                               : "opacity-0",
-                                                         )}
-                                                      />
-                                                   </CommandItem>
-                                                ))}
-                                             </CommandGroup>
-                                          </CommandList>
-                                       </Command>
-                                    </PopoverContent>
-                                 </Popover>
+                              <Field data-invalid={isInvalid}>
+                                 <FieldLabel>Saldo inicial</FieldLabel>
+                                 <MoneyInput
+                                    onChange={(v) =>
+                                       field.handleChange(String(v ?? 0))
+                                    }
+                                    value={field.state.value}
+                                    valueInCents={false}
+                                 />
+                                 {isInvalid && (
+                                    <FieldError
+                                       errors={field.state.meta.errors}
+                                    />
+                                 )}
                               </Field>
                            );
                         }}
                      />
 
                      <form.Field
-                        name="color"
-                        children={(field) => (
-                           <Field>
-                              <FieldLabel>Cor</FieldLabel>
-                              <Popover>
-                                 <PopoverTrigger asChild>
-                                    <Button
-                                       className="w-full justify-start gap-2"
-                                       type="button"
-                                       variant="outline"
+                        name="initialBalanceDate"
+                        children={(field) => {
+                           const selectedDate = toDate(field.state.value);
+                           return (
+                              <Field>
+                                 <FieldLabel>Data do saldo inicial</FieldLabel>
+                                 <Popover
+                                    open={dateOpen}
+                                    onOpenChange={setDateOpen}
+                                 >
+                                    <PopoverTrigger asChild>
+                                       <Button
+                                          className={cn(
+                                             "w-full justify-start gap-2 font-normal",
+                                             !selectedDate &&
+                                                "text-muted-foreground",
+                                          )}
+                                          type="button"
+                                          variant="outline"
+                                       >
+                                          <CalendarIcon className="size-4 shrink-0" />
+                                          {selectedDate
+                                             ? dayjs(selectedDate).format(
+                                                  "DD/MM/YYYY",
+                                               )
+                                             : "Selecionar data"}
+                                       </Button>
+                                    </PopoverTrigger>
+                                    <PopoverContent
+                                       align="start"
+                                       className="w-auto p-0"
                                     >
-                                       <div
-                                          className="size-4 rounded border border-border shrink-0"
-                                          style={{
-                                             backgroundColor: field.state.value,
+                                       <Calendar
+                                          captionLayout="dropdown"
+                                          components={{
+                                             MonthCaption: (props) => (
+                                                <>{props.children}</>
+                                             ),
+                                             DropdownNav: (props) => (
+                                                <div className="flex w-full items-center gap-2">
+                                                   {props.children}
+                                                </div>
+                                             ),
+                                             Dropdown: (props) => (
+                                                <Select
+                                                   onValueChange={(value) => {
+                                                      if (props.onChange) {
+                                                         const ev = {
+                                                            target: {
+                                                               value: String(
+                                                                  value,
+                                                               ),
+                                                            },
+                                                         } as React.ChangeEvent<HTMLSelectElement>;
+                                                         props.onChange(ev);
+                                                      }
+                                                   }}
+                                                   value={String(props.value)}
+                                                >
+                                                   <SelectTrigger className="first:flex-1 last:shrink-0">
+                                                      <SelectValue />
+                                                   </SelectTrigger>
+                                                   <SelectContent>
+                                                      {props.options?.map(
+                                                         (option) => (
+                                                            <SelectItem
+                                                               disabled={
+                                                                  option.disabled
+                                                               }
+                                                               key={
+                                                                  option.value
+                                                               }
+                                                               value={String(
+                                                                  option.value,
+                                                               )}
+                                                            >
+                                                               {option.label}
+                                                            </SelectItem>
+                                                         ),
+                                                      )}
+                                                   </SelectContent>
+                                                </Select>
+                                             ),
+                                          }}
+                                          fromDate={minDate}
+                                          toDate={new Date()}
+                                          hideNavigation
+                                          mode="single"
+                                          selected={selectedDate}
+                                          onSelect={(date) => {
+                                             field.handleChange(
+                                                date
+                                                   ? dayjs(date).format(
+                                                        "YYYY-MM-DD",
+                                                     )
+                                                   : "",
+                                             );
+                                             setDateOpen(false);
                                           }}
                                        />
-                                       <span className="font-mono text-xs">
-                                          {field.state.value}
-                                       </span>
-                                    </Button>
-                                 </PopoverTrigger>
-                                 <PopoverContent
-                                    align="end"
-                                    className="rounded-md border bg-background"
-                                 >
-                                    <ColorPicker
-                                       className="flex flex-col gap-4"
-                                       onChange={(rgba) => {
-                                          if (Array.isArray(rgba)) {
-                                             field.handleChange(
-                                                Color.rgb(
-                                                   rgba[0],
-                                                   rgba[1],
-                                                   rgba[2],
-                                                ).hex(),
-                                             );
-                                          }
-                                       }}
-                                       value={field.state.value || "#000000"}
-                                    >
-                                       <div className="h-24">
-                                          <ColorPickerSelection />
-                                       </div>
-                                       <div className="flex items-center gap-4">
-                                          <ColorPickerEyeDropper />
-                                          <div className="grid w-full gap-2">
-                                             <ColorPickerHue />
-                                             <ColorPickerAlpha />
-                                          </div>
-                                       </div>
-                                       <div className="flex items-center gap-2">
-                                          <ColorPickerOutput />
-                                          <ColorPickerFormat />
-                                       </div>
-                                    </ColorPicker>
-                                 </PopoverContent>
-                              </Popover>
-                           </Field>
-                        )}
+                                    </PopoverContent>
+                                 </Popover>
+                              </Field>
+                           );
+                        }}
                      />
                   </div>
+               )}
 
-                  <form.Subscribe selector={(s) => s.values.type}>
-                     {(type) =>
-                        type !== "cash" ? (
-                           <>
-                              <div className="grid grid-cols-2 gap-4">
-                                 <form.Field
-                                    name="bankCode"
-                                    children={(field) => {
-                                       const isInvalid =
-                                          field.state.meta.isTouched &&
-                                          field.state.meta.errors.length > 0;
-                                       return (
-                                          <Field data-invalid={isInvalid}>
-                                             <FieldLabel>Banco</FieldLabel>
-                                             <Combobox
-                                                className="w-full"
-                                                emptyMessage="Nenhum banco encontrado."
-                                                onBlur={field.handleBlur}
-                                                onValueChange={(v) =>
-                                                   field.handleChange(v)
-                                                }
-                                                options={bankOptions}
-                                                placeholder="Selecionar..."
-                                                searchPlaceholder="Pesquisar"
-                                                value={field.state.value}
-                                             />
-                                             {isInvalid && (
-                                                <FieldError
-                                                   errors={
-                                                      field.state.meta.errors
-                                                   }
-                                                />
-                                             )}
-                                          </Field>
-                                       );
-                                    }}
-                                 />
-
-                                 <form.Field
-                                    name="nickname"
-                                    children={(field) => {
-                                       const isInvalid =
-                                          field.state.meta.isTouched &&
-                                          field.state.meta.errors.length > 0;
-                                       return (
-                                          <Field data-invalid={isInvalid}>
-                                             <FieldLabel htmlFor={field.name}>
-                                                Apelido
-                                             </FieldLabel>
-                                             <Input
-                                                id={field.name}
-                                                name={field.name}
-                                                aria-invalid={isInvalid}
-                                                onBlur={field.handleBlur}
-                                                onChange={(e) =>
-                                                   field.handleChange(
-                                                      e.target.value,
-                                                   )
-                                                }
-                                                placeholder="Ex: Conta principal"
-                                                value={field.state.value}
-                                             />
-                                             {isInvalid && (
-                                                <FieldError
-                                                   errors={
-                                                      field.state.meta.errors
-                                                   }
-                                                />
-                                             )}
-                                          </Field>
-                                       );
-                                    }}
-                                 />
-                              </div>
-
-                              <div className="grid grid-cols-2 gap-4">
-                                 <form.Field
-                                    name="branch"
-                                    children={(field) => {
-                                       const isInvalid =
-                                          field.state.meta.isTouched &&
-                                          field.state.meta.errors.length > 0;
-                                       return (
-                                          <Field data-invalid={isInvalid}>
-                                             <FieldLabel htmlFor={field.name}>
-                                                Agência
-                                             </FieldLabel>
-                                             <Input
-                                                ref={branchRef}
-                                                aria-invalid={isInvalid}
-                                                defaultValue={field.state.value}
-                                                id={field.name}
-                                                inputMode="numeric"
-                                                name={field.name}
-                                                onBlur={field.handleBlur}
-                                                onInput={(e) =>
-                                                   field.handleChange(
-                                                      (
-                                                         e.target as HTMLInputElement
-                                                      ).value,
-                                                   )
-                                                }
-                                                placeholder="00000"
-                                             />
-                                             {isInvalid && (
-                                                <FieldError
-                                                   errors={
-                                                      field.state.meta.errors
-                                                   }
-                                                />
-                                             )}
-                                          </Field>
-                                       );
-                                    }}
-                                 />
-
-                                 <form.Field
-                                    name="accountNumber"
-                                    children={(field) => {
-                                       const isInvalid =
-                                          field.state.meta.isTouched &&
-                                          field.state.meta.errors.length > 0;
-                                       return (
-                                          <Field data-invalid={isInvalid}>
-                                             <FieldLabel htmlFor={field.name}>
-                                                Conta
-                                             </FieldLabel>
-                                             <Input
-                                                ref={accountRef}
-                                                aria-invalid={isInvalid}
-                                                defaultValue={field.state.value}
-                                                id={field.name}
-                                                inputMode="numeric"
-                                                name={field.name}
-                                                onBlur={field.handleBlur}
-                                                onInput={(e) =>
-                                                   field.handleChange(
-                                                      (
-                                                         e.target as HTMLInputElement
-                                                      ).value,
-                                                   )
-                                                }
-                                                placeholder="000000000000-0"
-                                             />
-                                             {isInvalid && (
-                                                <FieldError
-                                                   errors={
-                                                      field.state.meta.errors
-                                                   }
-                                                />
-                                             )}
-                                          </Field>
-                                       );
-                                    }}
-                                 />
-                              </div>
-                           </>
-                        ) : null
-                     }
-                  </form.Subscribe>
-
-                  {isCreate && (
-                     <div className="grid grid-cols-2 gap-4">
-                        <form.Field
-                           name="initialBalance"
-                           children={(field) => {
-                              const isInvalid =
-                                 field.state.meta.isTouched &&
-                                 field.state.meta.errors.length > 0;
-                              return (
-                                 <Field data-invalid={isInvalid}>
-                                    <FieldLabel>Saldo inicial</FieldLabel>
-                                    <MoneyInput
-                                       onChange={(v) =>
-                                          field.handleChange(String(v ?? 0))
-                                       }
-                                       value={field.state.value}
-                                       valueInCents={false}
-                                    />
-                                    {isInvalid && (
-                                       <FieldError
-                                          errors={field.state.meta.errors}
-                                       />
-                                    )}
-                                 </Field>
-                              );
-                           }}
+               <form.Field
+                  name="notes"
+                  children={(field) => (
+                     <Field>
+                        <FieldLabel htmlFor={field.name}>
+                           Observações{" "}
+                           <span className="text-muted-foreground font-normal">
+                              (opcional)
+                           </span>
+                        </FieldLabel>
+                        <Textarea
+                           id={field.name}
+                           name={field.name}
+                           onBlur={field.handleBlur}
+                           onChange={(e) => field.handleChange(e.target.value)}
+                           placeholder="Informações adicionais sobre a conta..."
+                           rows={2}
+                           value={field.state.value}
                         />
-
-                        <form.Field
-                           name="initialBalanceDate"
-                           children={(field) => {
-                              const selectedDate = toDate(field.state.value);
-                              return (
-                                 <Field>
-                                    <FieldLabel>
-                                       Data do saldo inicial
-                                    </FieldLabel>
-                                    <Popover
-                                       open={dateOpen}
-                                       onOpenChange={setDateOpen}
-                                    >
-                                       <PopoverTrigger asChild>
-                                          <Button
-                                             className={cn(
-                                                "w-full justify-start gap-2 font-normal",
-                                                !selectedDate &&
-                                                   "text-muted-foreground",
-                                             )}
-                                             type="button"
-                                             variant="outline"
-                                          >
-                                             <CalendarIcon className="size-4 shrink-0" />
-                                             {selectedDate
-                                                ? dayjs(selectedDate).format(
-                                                     "DD/MM/YYYY",
-                                                  )
-                                                : "Selecionar data"}
-                                          </Button>
-                                       </PopoverTrigger>
-                                       <PopoverContent
-                                          align="start"
-                                          className="w-auto p-0"
-                                       >
-                                          <Calendar
-                                             captionLayout="dropdown"
-                                             components={{
-                                                MonthCaption: (props) => (
-                                                   <>{props.children}</>
-                                                ),
-                                                DropdownNav: (props) => (
-                                                   <div className="flex w-full items-center gap-2">
-                                                      {props.children}
-                                                   </div>
-                                                ),
-                                                Dropdown: (props) => (
-                                                   <Select
-                                                      onValueChange={(
-                                                         value,
-                                                      ) => {
-                                                         if (props.onChange) {
-                                                            const ev = {
-                                                               target: {
-                                                                  value: String(
-                                                                     value,
-                                                                  ),
-                                                               },
-                                                            } as React.ChangeEvent<HTMLSelectElement>;
-                                                            props.onChange(ev);
-                                                         }
-                                                      }}
-                                                      value={String(
-                                                         props.value,
-                                                      )}
-                                                   >
-                                                      <SelectTrigger className="first:flex-1 last:shrink-0">
-                                                         <SelectValue />
-                                                      </SelectTrigger>
-                                                      <SelectContent>
-                                                         {props.options?.map(
-                                                            (option) => (
-                                                               <SelectItem
-                                                                  disabled={
-                                                                     option.disabled
-                                                                  }
-                                                                  key={
-                                                                     option.value
-                                                                  }
-                                                                  value={String(
-                                                                     option.value,
-                                                                  )}
-                                                               >
-                                                                  {option.label}
-                                                               </SelectItem>
-                                                            ),
-                                                         )}
-                                                      </SelectContent>
-                                                   </Select>
-                                                ),
-                                             }}
-                                             fromDate={minDate}
-                                             toDate={new Date()}
-                                             hideNavigation
-                                             mode="single"
-                                             selected={selectedDate}
-                                             onSelect={(date) => {
-                                                field.handleChange(
-                                                   date
-                                                      ? dayjs(date).format(
-                                                           "YYYY-MM-DD",
-                                                        )
-                                                      : "",
-                                                );
-                                                setDateOpen(false);
-                                             }}
-                                          />
-                                       </PopoverContent>
-                                    </Popover>
-                                 </Field>
-                              );
-                           }}
-                        />
-                     </div>
+                     </Field>
                   )}
+               />
+            </FieldGroup>
+         </CredenzaBody>
 
-                  <form.Field
-                     name="notes"
-                     children={(field) => (
-                        <Field>
-                           <FieldLabel htmlFor={field.name}>
-                              Observações{" "}
-                              <span className="text-muted-foreground font-normal">
-                                 (opcional)
-                              </span>
-                           </FieldLabel>
-                           <Textarea
-                              id={field.name}
-                              name={field.name}
-                              onBlur={field.handleBlur}
-                              onChange={(e) =>
-                                 field.handleChange(e.target.value)
-                              }
-                              placeholder="Informações adicionais sobre a conta..."
-                              rows={2}
-                              value={field.state.value}
-                           />
-                        </Field>
-                     )}
-                  />
-               </FieldGroup>
-            </CredenzaBody>
-
-            <CredenzaFooter className="flex flex-col gap-2">
-               <form.Subscribe
-                  selector={(state) =>
-                     state.errors.flatMap((e) => {
-                        if (!e) return [];
-                        if (typeof e === "string") return [e];
-                        if ("form" in e && typeof e.form === "string")
-                           return [e.form];
-                        return [];
-                     })
-                  }
-               >
-                  {(messages) =>
-                     messages.length > 0 && <FieldError errors={messages} />
-                  }
-               </form.Subscribe>
-               <form.Subscribe
-                  selector={(state) =>
-                     [state.canSubmit, state.isSubmitting] as const
-                  }
-               >
-                  {([canSubmit, isSubmitting]) => (
-                     <Button
-                        className="w-full gap-2"
-                        disabled={!canSubmit}
-                        type="submit"
-                     >
-                        {isSubmitting && <Spinner className="size-4" />}
-                        {isCreate ? "Criar conta" : "Salvar alterações"}
-                     </Button>
-                  )}
-               </form.Subscribe>
-            </CredenzaFooter>
-         </form>
-      </>
+         <CredenzaFooter className="flex flex-col gap-2">
+            <form.Subscribe
+               selector={(state) =>
+                  state.errors.flatMap((e) => {
+                     if (!e) return [];
+                     if (typeof e === "string") return [e];
+                     if ("form" in e && typeof e.form === "string")
+                        return [e.form];
+                     return [];
+                  })
+               }
+            >
+               {(messages) =>
+                  messages.length > 0 && <FieldError errors={messages} />
+               }
+            </form.Subscribe>
+            <form.Subscribe
+               selector={(state) =>
+                  [state.canSubmit, state.isSubmitting] as const
+               }
+            >
+               {([canSubmit, isSubmitting]) => (
+                  <Button
+                     className="w-full gap-2"
+                     disabled={!canSubmit}
+                     type="submit"
+                  >
+                     {isSubmitting && <Spinner className="size-4" />}
+                     {isCreate ? "Criar conta" : "Salvar alterações"}
+                  </Button>
+               )}
+            </form.Subscribe>
+         </CredenzaFooter>
+      </form>
    );
 }

--- a/apps/web/src/features/bank-accounts/ui/bank-accounts-form.tsx
+++ b/apps/web/src/features/bank-accounts/ui/bank-accounts-form.tsx
@@ -51,6 +51,8 @@ import { useMaskito } from "@maskito/react";
 import type { MaskitoOptions } from "@maskito/core";
 import { ORPCError } from "@orpc/client";
 import { useForm } from "@tanstack/react-form";
+import { useMutation } from "@tanstack/react-query";
+import { fromPromise } from "neverthrow";
 import { useBlocker } from "@tanstack/react-router";
 import Color from "color";
 import dayjs from "dayjs";
@@ -169,6 +171,13 @@ export function BankAccountForm({
 }: BankAccountFormProps) {
    const isCreate = mode === "create";
    const [typeOpen, setTypeOpen] = useState(false);
+
+   const createMutation = useMutation(
+      orpc.bankAccounts.create.mutationOptions(),
+   );
+   const updateMutation = useMutation(
+      orpc.bankAccounts.update.mutationOptions(),
+   );
    const [dateOpen, setDateOpen] = useState(false);
    const { bankOptions } = useBrazilianBanks();
 
@@ -223,27 +232,35 @@ export function BankAccountForm({
                notes: value.notes || null,
             };
 
-            try {
-               if (isCreate) {
-                  await orpc.bankAccounts.create.call(payload);
-                  toast.success("Conta bancária criada com sucesso.");
-               } else if (account) {
-                  await orpc.bankAccounts.update.call({
-                     id: account.id,
-                     ...payload,
-                  });
-                  toast.success("Conta bancária atualizada com sucesso.");
-               }
-               onSuccess();
-               return null;
-            } catch (err) {
+            const promise = isCreate
+               ? createMutation.mutateAsync(payload)
+               : account
+                 ? updateMutation.mutateAsync({ id: account.id, ...payload })
+                 : null;
+
+            if (!promise) return null;
+
+            const result = await fromPromise(promise, (e) => e);
+
+            if (result.isErr()) {
+               const err = result.error;
                if (err instanceof ORPCError && err.code === "CONFLICT") {
-                  return { form: "Já existe uma conta com esses dados." };
+                  return {
+                     fields: {
+                        nickname: "Já existe uma conta com esse apelido.",
+                     },
+                  };
                }
-               return {
-                  form: err instanceof Error ? err.message : "Erro inesperado.",
-               };
+               return err instanceof Error ? err.message : "Erro inesperado.";
             }
+
+            toast.success(
+               isCreate
+                  ? "Conta bancária criada com sucesso."
+                  : "Conta bancária atualizada com sucesso.",
+            );
+            onSuccess();
+            return null;
          },
       },
    });
@@ -473,7 +490,6 @@ export function BankAccountForm({
                                  name="nickname"
                                  children={(field) => {
                                     const isInvalid =
-                                       field.state.meta.isTouched &&
                                        field.state.meta.errors.length > 0;
                                     return (
                                        <Field data-invalid={isInvalid}>
@@ -750,21 +766,6 @@ export function BankAccountForm({
          </CredenzaBody>
 
          <CredenzaFooter className="flex flex-col gap-2">
-            <form.Subscribe
-               selector={(state) =>
-                  state.errors.flatMap((e) => {
-                     if (!e) return [];
-                     if (typeof e === "string") return [e];
-                     if ("form" in e && typeof e.form === "string")
-                        return [e.form];
-                     return [];
-                  })
-               }
-            >
-               {(messages) =>
-                  messages.length > 0 && <FieldError errors={messages} />
-               }
-            </form.Subscribe>
             <form.Subscribe
                selector={(state) =>
                   [state.canSubmit, state.isSubmitting] as const

--- a/apps/web/src/features/bank-accounts/ui/bank-accounts-form.tsx
+++ b/apps/web/src/features/bank-accounts/ui/bank-accounts-form.tsx
@@ -49,8 +49,8 @@ import { Textarea } from "@packages/ui/components/textarea";
 import { cn } from "@packages/ui/lib/utils";
 import { useMaskito } from "@maskito/react";
 import type { MaskitoOptions } from "@maskito/core";
+import { ORPCError } from "@orpc/client";
 import { useForm } from "@tanstack/react-form";
-import { useMutation } from "@tanstack/react-query";
 import Color from "color";
 import dayjs from "dayjs";
 import {
@@ -176,29 +176,7 @@ export function BankAccountForm({
    const branchRef = useMaskito({ options: branchMaskOptions });
    const accountRef = useMaskito({ options: accountMaskOptions });
 
-   const createMutation = useMutation(
-      orpc.bankAccounts.create.mutationOptions({
-         onSuccess: () => {
-            toast.success("Conta bancária criada com sucesso.");
-            onSuccess();
-         },
-         onError: (error) => {
-            toast.error(error.message || "Erro ao criar conta bancária.");
-         },
-      }),
-   );
-
-   const updateMutation = useMutation(
-      orpc.bankAccounts.update.mutationOptions({
-         onSuccess: () => {
-            toast.success("Conta bancária atualizada com sucesso.");
-            onSuccess();
-         },
-         onError: (error) => {
-            toast.error(error.message || "Erro ao atualizar conta bancária.");
-         },
-      }),
-   );
+   const accountTypeDefault: BankAccountType = account?.type ?? "checking";
 
    const form = useForm({
       defaultValues: {
@@ -208,41 +186,63 @@ export function BankAccountForm({
             ? dayjs(account.initialBalanceDate).format("YYYY-MM-DD")
             : dayjs().format("YYYY-MM-DD"),
          name: account?.name ?? "",
-         type: (account?.type ?? "checking") as BankAccountType,
+         type: accountTypeDefault,
          bankCode: account?.bankCode ?? "",
          nickname: account?.nickname ?? "",
          branch: account?.branch ?? "",
          accountNumber: account?.accountNumber ?? "",
          notes: account?.notes ?? "",
       },
-      onSubmit: async ({ value }) => {
-         const selectedBank = bankOptions.find(
-            (b) => b.value === value.bankCode,
-         );
-         const resolvedName =
-            value.type === "cash"
-               ? "Caixa Físico"
-               : (value.nickname || selectedBank?.label || value.name).trim();
+      validators: {
+         onSubmitAsync: async ({ value }) => {
+            const selectedBank = bankOptions.find(
+               (b) => b.value === value.bankCode,
+            );
+            const resolvedName =
+               value.type === "cash"
+                  ? "Caixa Físico"
+                  : (
+                       value.nickname ||
+                       selectedBank?.label ||
+                       value.name
+                    ).trim();
 
-         const payload = {
-            color: value.color,
-            initialBalance: value.initialBalance,
-            initialBalanceDate: value.initialBalanceDate || undefined,
-            name: resolvedName,
-            type: value.type,
-            bankCode: value.bankCode || null,
-            bankName: selectedBank?.label || null,
-            nickname: value.nickname || null,
-            branch: value.branch || null,
-            accountNumber: value.accountNumber || null,
-            notes: value.notes || null,
-         };
+            const payload = {
+               color: value.color,
+               initialBalance: value.initialBalance,
+               initialBalanceDate: value.initialBalanceDate || undefined,
+               name: resolvedName,
+               type: value.type,
+               bankCode: value.bankCode || null,
+               bankName: selectedBank?.label || null,
+               nickname: value.nickname || null,
+               branch: value.branch || null,
+               accountNumber: value.accountNumber || null,
+               notes: value.notes || null,
+            };
 
-         if (isCreate) {
-            createMutation.mutate(payload);
-         } else if (account) {
-            updateMutation.mutate({ id: account.id, ...payload });
-         }
+            try {
+               if (isCreate) {
+                  await orpc.bankAccounts.create.call(payload);
+                  toast.success("Conta bancária criada com sucesso.");
+               } else if (account) {
+                  await orpc.bankAccounts.update.call({
+                     id: account.id,
+                     ...payload,
+                  });
+                  toast.success("Conta bancária atualizada com sucesso.");
+               }
+               onSuccess();
+               return null;
+            } catch (err) {
+               if (err instanceof ORPCError && err.code === "CONFLICT") {
+                  return { form: "Já existe uma conta com esses dados." };
+               }
+               return {
+                  form: err instanceof Error ? err.message : "Erro inesperado.",
+               };
+            }
+         },
       },
    });
 
@@ -725,24 +725,34 @@ export function BankAccountForm({
             </FieldGroup>
          </CredenzaBody>
 
-         <CredenzaFooter>
-            <form.Subscribe selector={(state) => state}>
-               {(state) => (
+         <CredenzaFooter className="flex flex-col gap-2">
+            <form.Subscribe
+               selector={(state) =>
+                  state.errors.flatMap((e) => {
+                     if (!e) return [];
+                     if (typeof e === "string") return [e];
+                     if ("form" in e && typeof e.form === "string")
+                        return [e.form];
+                     return [];
+                  })
+               }
+            >
+               {(messages) =>
+                  messages.length > 0 && <FieldError errors={messages} />
+               }
+            </form.Subscribe>
+            <form.Subscribe
+               selector={(state) =>
+                  [state.canSubmit, state.isSubmitting] as const
+               }
+            >
+               {([canSubmit, isSubmitting]) => (
                   <Button
                      className="w-full gap-2"
-                     disabled={
-                        !state.canSubmit ||
-                        state.isSubmitting ||
-                        createMutation.isPending ||
-                        updateMutation.isPending
-                     }
+                     disabled={!canSubmit}
                      type="submit"
                   >
-                     {(state.isSubmitting ||
-                        createMutation.isPending ||
-                        updateMutation.isPending) && (
-                        <Spinner className="size-4" />
-                     )}
+                     {isSubmitting && <Spinner className="size-4" />}
                      {isCreate ? "Criar conta" : "Salvar alterações"}
                   </Button>
                )}

--- a/apps/web/src/features/billing/ui/billing-overview.tsx
+++ b/apps/web/src/features/billing/ui/billing-overview.tsx
@@ -29,7 +29,7 @@ import {
    TooltipProvider,
    TooltipTrigger,
 } from "@packages/ui/components/tooltip";
-import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { useSuspenseQueries } from "@tanstack/react-query";
 import {
    Briefcase,
    Calendar,
@@ -241,10 +241,7 @@ function BillingPeriodSection() {
    );
 }
 
-function AddCardBanner() {
-   const { data, isLoading } = useQuery(
-      orpc.billing.getPaymentStatus.queryOptions({}),
-   );
+function AddCardBanner({ hasPaymentMethod }: { hasPaymentMethod: boolean }) {
    const { activeOrganization } = useActiveOrganization();
    const [isPending, startTransition] = useTransition();
 
@@ -264,7 +261,7 @@ function AddCardBanner() {
       });
    };
 
-   if (isLoading || data?.hasPaymentMethod) return null;
+   if (hasPaymentMethod) return null;
 
    return (
       <div className="rounded-lg border border-dashed bg-muted/40 p-5 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -660,16 +657,15 @@ function InvoicesPreviewContent() {
 }
 
 export function BillingOverview() {
-   const { data: meterUsage } = useSuspenseQuery(
-      orpc.billing.getMeterUsage.queryOptions({}),
-   );
-   const { data: catalog } = useSuspenseQuery(
-      orpc.billing.getEventCatalog.queryOptions({}),
-   );
-   const { data: paymentStatus } = useQuery(
-      orpc.billing.getPaymentStatus.queryOptions({}),
-   );
-   const hasPaymentMethod = paymentStatus?.hasPaymentMethod ?? false;
+   const [{ data: meterUsage }, { data: catalog }, { data: paymentStatus }] =
+      useSuspenseQueries({
+         queries: [
+            orpc.billing.getMeterUsage.queryOptions({}),
+            orpc.billing.getEventCatalog.queryOptions({}),
+            orpc.billing.getPaymentStatus.queryOptions({}),
+         ],
+      });
+   const hasPaymentMethod = paymentStatus.hasPaymentMethod;
 
    const categorySummaries = buildCategorySummaries(catalog, meterUsage);
    const monthToDate = categorySummaries.reduce(
@@ -685,10 +681,8 @@ export function BillingOverview() {
       <div className="space-y-6">
          <CurrentBillHeader monthToDate={monthToDate} />
          <BillingPeriodSection />
-         <AddCardBanner />
-         {paymentStatus !== undefined && (
-            <AddonsSection hasPaymentMethod={hasPaymentMethod} />
-         )}
+         <AddCardBanner hasPaymentMethod={hasPaymentMethod} />
+         <AddonsSection hasPaymentMethod={hasPaymentMethod} />
 
          <div>
             <h2 className="text-lg font-semibold mb-4">Produtos</h2>

--- a/apps/web/src/features/billing/ui/billing-overview.tsx
+++ b/apps/web/src/features/billing/ui/billing-overview.tsx
@@ -29,7 +29,7 @@ import {
    TooltipProvider,
    TooltipTrigger,
 } from "@packages/ui/components/tooltip";
-import { useSuspenseQueries } from "@tanstack/react-query";
+import { useSuspenseQueries, useSuspenseQuery } from "@tanstack/react-query";
 import {
    Briefcase,
    Calendar,
@@ -563,7 +563,7 @@ function InvoicesPreviewSkeleton() {
 
 function InvoicesPreviewContent() {
    const { data: invoices } = useSuspenseQuery(
-      orpc.billing.getInvoices.queryOptions({ limit: 5 }),
+      orpc.billing.getInvoices.queryOptions({ input: { limit: 5 } }),
    );
 
    if (!invoices || invoices.length === 0) {

--- a/apps/web/src/features/bills/ui/bill-from-transaction-dialog-stack.tsx
+++ b/apps/web/src/features/bills/ui/bill-from-transaction-dialog-stack.tsx
@@ -327,18 +327,22 @@ function BillFromTransactionDialogStackInner({
          </CredenzaBody>
 
          <CredenzaFooter>
-            <form.Subscribe selector={(state) => state}>
-               {(state) => (
+            <form.Subscribe
+               selector={(state) =>
+                  [state.canSubmit, state.isSubmitting] as const
+               }
+            >
+               {([canSubmit, isSubmitting]) => (
                   <Button
                      disabled={
-                        !state.canSubmit ||
-                        state.isSubmitting ||
+                        !canSubmit ||
+                        isSubmitting ||
                         createFromTransactionMutation.isPending
                      }
                      form="bill-from-transaction-form"
                      type="submit"
                   >
-                     {(state.isSubmitting ||
+                     {(isSubmitting ||
                         createFromTransactionMutation.isPending) && (
                         <Spinner className="size-4 mr-2" />
                      )}

--- a/apps/web/src/features/bills/ui/bill-from-transaction-dialog-stack.tsx
+++ b/apps/web/src/features/bills/ui/bill-from-transaction-dialog-stack.tsx
@@ -26,9 +26,7 @@ import { Spinner } from "@packages/ui/components/spinner";
 import { useForm } from "@tanstack/react-form";
 import { useMutation } from "@tanstack/react-query";
 import { useStore } from "@tanstack/react-store";
-import { Suspense } from "react";
-import { ErrorBoundary } from "react-error-boundary";
-import { createErrorFallback } from "@/components/query-boundary";
+import { QueryBoundary } from "@/components/query-boundary";
 import { toast } from "sonner";
 import { orpc } from "@/integrations/orpc/client";
 import { BillInstallmentPreview } from "./bill-installment-preview";
@@ -370,14 +368,11 @@ export function BillFromTransactionDialogStack(
    props: BillFromTransactionDialogStackProps,
 ) {
    return (
-      <ErrorBoundary
-         FallbackComponent={createErrorFallback({
-            errorTitle: "Erro ao carregar transação",
-         })}
+      <QueryBoundary
+         fallback={<BillFromTransactionDialogSkeleton />}
+         errorTitle="Erro ao carregar transação"
       >
-         <Suspense fallback={<BillFromTransactionDialogSkeleton />}>
-            <BillFromTransactionDialogStackInner {...props} />
-         </Suspense>
-      </ErrorBoundary>
+         <BillFromTransactionDialogStackInner {...props} />
+      </QueryBoundary>
    );
 }

--- a/apps/web/src/features/bills/ui/bill-pay-dialog-stack.tsx
+++ b/apps/web/src/features/bills/ui/bill-pay-dialog-stack.tsx
@@ -239,10 +239,10 @@ function BillPayDialogStackInner({ bill, onSuccess }: BillPayDialogStackProps) {
             </form>
          </CredenzaBody>
          <CredenzaFooter>
-            <form.Subscribe selector={(state) => state}>
-               {(state) => (
+            <form.Subscribe selector={(state) => state.canSubmit}>
+               {(canSubmit) => (
                   <Button
-                     disabled={!state.canSubmit || payMutation.isPending}
+                     disabled={!canSubmit || payMutation.isPending}
                      form="bill-pay-form"
                      type="submit"
                   >

--- a/apps/web/src/features/bills/ui/bill-pay-dialog-stack.tsx
+++ b/apps/web/src/features/bills/ui/bill-pay-dialog-stack.tsx
@@ -26,9 +26,7 @@ import { Spinner } from "@packages/ui/components/spinner";
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import dayjs from "dayjs";
-import { Suspense } from "react";
-import { ErrorBoundary } from "react-error-boundary";
-import { createErrorFallback } from "@/components/query-boundary";
+import { QueryBoundary } from "@/components/query-boundary";
 import { toast } from "sonner";
 import { orpc } from "@/integrations/orpc/client";
 import type { BillRow } from "./bills-columns";
@@ -272,14 +270,11 @@ function BillPayDialogSkeleton() {
 
 export function BillPayDialogStack(props: BillPayDialogStackProps) {
    return (
-      <ErrorBoundary
-         FallbackComponent={createErrorFallback({
-            errorTitle: "Erro ao carregar conta",
-         })}
+      <QueryBoundary
+         fallback={<BillPayDialogSkeleton />}
+         errorTitle="Erro ao carregar conta"
       >
-         <Suspense fallback={<BillPayDialogSkeleton />}>
-            <BillPayDialogStackInner {...props} />
-         </Suspense>
-      </ErrorBoundary>
+         <BillPayDialogStackInner {...props} />
+      </QueryBoundary>
    );
 }

--- a/apps/web/src/features/bills/ui/bills-form.tsx
+++ b/apps/web/src/features/bills/ui/bills-form.tsx
@@ -29,9 +29,7 @@ import { useForm } from "@tanstack/react-form";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { ORPCError } from "@orpc/client";
 import dayjs from "dayjs";
-import { Suspense } from "react";
-import { ErrorBoundary } from "react-error-boundary";
-import { createErrorFallback } from "@/components/query-boundary";
+import { QueryBoundary } from "@/components/query-boundary";
 import { toast } from "sonner";
 import { orpc } from "@/integrations/orpc/client";
 import type { BillRow } from "./bills-columns";
@@ -367,14 +365,11 @@ function BillFormSkeleton() {
 
 export function BillForm(props: BillFormProps) {
    return (
-      <ErrorBoundary
-         FallbackComponent={createErrorFallback({
-            errorTitle: "Erro ao carregar conta",
-         })}
+      <QueryBoundary
+         fallback={<BillFormSkeleton />}
+         errorTitle="Erro ao carregar conta"
       >
-         <Suspense fallback={<BillFormSkeleton />}>
-            <BillFormInner {...props} />
-         </Suspense>
-      </ErrorBoundary>
+         <BillFormInner {...props} />
+      </QueryBoundary>
    );
 }

--- a/apps/web/src/features/bills/ui/bills-form.tsx
+++ b/apps/web/src/features/bills/ui/bills-form.tsx
@@ -104,8 +104,8 @@ function BillFormInner({ bill, onSuccess }: BillFormProps) {
                   "Você tem alterações não salvas. Tem certeza que deseja sair sem salvar?",
                actionLabel: "Descartar alterações",
                cancelLabel: "Continuar editando",
-               onAction: () => blocker.proceed(),
-               onCancel: () => blocker.reset(),
+               onAction: () => blocker.proceed?.(),
+               onCancel: () => blocker.reset?.(),
             });
             return true;
          }

--- a/apps/web/src/features/bills/ui/bills-form.tsx
+++ b/apps/web/src/features/bills/ui/bills-form.tsx
@@ -63,18 +63,24 @@ function BillFormInner({ bill, onSuccess }: BillFormProps) {
          description: "",
       },
       onSubmit: async ({ value }) => {
-         await updateMutation.mutateAsync({
-            id: bill.id,
-            type: value.type,
-            name: value.name.trim(),
-            amount: value.amount,
-            dueDate: value.dueDate,
-            bankAccountId: value.bankAccountId || null,
-            categoryId: value.categoryId || null,
-            description: value.description?.trim() || null,
-         });
-         toast.success("Conta atualizada com sucesso.");
-         onSuccess();
+         try {
+            await updateMutation.mutateAsync({
+               id: bill.id,
+               type: value.type,
+               name: value.name.trim(),
+               amount: value.amount,
+               dueDate: value.dueDate,
+               bankAccountId: value.bankAccountId || null,
+               categoryId: value.categoryId || null,
+               description: value.description?.trim() || null,
+            });
+            toast.success("Conta atualizada com sucesso.");
+            onSuccess();
+         } catch (err) {
+            toast.error(
+               err instanceof Error ? err.message : "Erro ao atualizar conta.",
+            );
+         }
       },
    });
 

--- a/apps/web/src/features/bills/ui/bills-form.tsx
+++ b/apps/web/src/features/bills/ui/bills-form.tsx
@@ -26,7 +26,8 @@ import { Skeleton } from "@packages/ui/components/skeleton";
 import { Spinner } from "@packages/ui/components/spinner";
 import { Textarea } from "@packages/ui/components/textarea";
 import { useForm } from "@tanstack/react-form";
-import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { ORPCError } from "@orpc/client";
 import dayjs from "dayjs";
 import { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
@@ -51,18 +52,6 @@ function BillFormInner({ bill, onSuccess }: BillFormProps) {
    );
    const categories = categoriesResult;
 
-   const updateMutation = useMutation(
-      orpc.bills.update.mutationOptions({
-         onSuccess: () => {
-            toast.success("Conta atualizada com sucesso.");
-            onSuccess();
-         },
-         onError: (error) => {
-            toast.error(error.message || "Erro ao atualizar conta.");
-         },
-      }),
-   );
-
    const form = useForm({
       defaultValues: {
          type: bill.type as "payable" | "receivable",
@@ -73,21 +62,36 @@ function BillFormInner({ bill, onSuccess }: BillFormProps) {
          categoryId: bill.category?.id ?? "",
          description: "",
       },
-      onSubmit: async ({ value }) => {
-         await updateMutation.mutateAsync({
-            id: bill.id,
-            type: value.type,
-            name: value.name.trim(),
-            amount: value.amount,
-            dueDate: value.dueDate,
-            bankAccountId: value.bankAccountId || null,
-            categoryId: value.categoryId || null,
-            description: value.description?.trim() || null,
-         });
+      validators: {
+         onSubmitAsync: async ({ value }) => {
+            try {
+               await orpc.bills.update.call({
+                  id: bill.id,
+                  type: value.type,
+                  name: value.name.trim(),
+                  amount: value.amount,
+                  dueDate: value.dueDate,
+                  bankAccountId: value.bankAccountId || null,
+                  categoryId: value.categoryId || null,
+                  description: value.description?.trim() || null,
+               });
+               toast.success("Conta atualizada com sucesso.");
+               onSuccess();
+               return null;
+            } catch (err) {
+               if (err instanceof ORPCError && err.code === "CONFLICT") {
+                  return { form: "Já existe uma conta com esses dados." };
+               }
+               return {
+                  form:
+                     err instanceof Error
+                        ? err.message
+                        : "Erro ao atualizar conta.",
+               };
+            }
+         },
       },
    });
-
-   const isPending = updateMutation.isPending;
 
    return (
       <form
@@ -311,19 +315,34 @@ function BillFormInner({ bill, onSuccess }: BillFormProps) {
             </FieldGroup>
          </CredenzaBody>
 
-         <CredenzaFooter>
-            <form.Subscribe selector={(state) => state}>
-               {(state) => (
+         <CredenzaFooter className="flex flex-col gap-2">
+            <form.Subscribe
+               selector={(state) =>
+                  state.errors.flatMap((e) => {
+                     if (!e) return [];
+                     if (typeof e === "string") return [e];
+                     if ("form" in e && typeof e.form === "string")
+                        return [e.form];
+                     return [];
+                  })
+               }
+            >
+               {(messages) =>
+                  messages.length > 0 && <FieldError errors={messages} />
+               }
+            </form.Subscribe>
+            <form.Subscribe
+               selector={(state) =>
+                  [state.canSubmit, state.isSubmitting] as const
+               }
+            >
+               {([canSubmit, isSubmitting]) => (
                   <Button
                      className="w-full"
-                     disabled={
-                        !state.canSubmit || state.isSubmitting || isPending
-                     }
+                     disabled={!canSubmit}
                      type="submit"
                   >
-                     {(state.isSubmitting || isPending) && (
-                        <Spinner className="size-4 mr-2" />
-                     )}
+                     {isSubmitting && <Spinner className="size-4" />}
                      Salvar alterações
                   </Button>
                )}

--- a/apps/web/src/features/bills/ui/bills-form.tsx
+++ b/apps/web/src/features/bills/ui/bills-form.tsx
@@ -120,11 +120,11 @@ function BillFormInner({ bill, onSuccess }: BillFormProps) {
                         <Field data-invalid={isInvalid}>
                            <FieldLabel>Tipo</FieldLabel>
                            <Select
-                              onValueChange={(v) =>
-                                 field.handleChange(
-                                    v as "payable" | "receivable",
-                                 )
-                              }
+                              onValueChange={(v) => {
+                                 if (v === "payable" || v === "receivable") {
+                                    field.handleChange(v);
+                                 }
+                              }}
                               value={field.state.value}
                            >
                               <SelectTrigger>

--- a/apps/web/src/features/bills/ui/bills-form.tsx
+++ b/apps/web/src/features/bills/ui/bills-form.tsx
@@ -25,9 +25,20 @@ import {
 import { Skeleton } from "@packages/ui/components/skeleton";
 import { Spinner } from "@packages/ui/components/spinner";
 import { Textarea } from "@packages/ui/components/textarea";
+import {
+   AlertDialog,
+   AlertDialogAction,
+   AlertDialogCancel,
+   AlertDialogContent,
+   AlertDialogDescription,
+   AlertDialogFooter,
+   AlertDialogHeader,
+   AlertDialogTitle,
+} from "@packages/ui/components/alert-dialog";
+import { ORPCError } from "@orpc/client";
 import { useForm } from "@tanstack/react-form";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { ORPCError } from "@orpc/client";
+import { useBlocker } from "@tanstack/react-router";
 import dayjs from "dayjs";
 import { QueryBoundary } from "@/components/query-boundary";
 import { toast } from "sonner";
@@ -91,262 +102,293 @@ function BillFormInner({ bill, onSuccess }: BillFormProps) {
       },
    });
 
+   const blocker = useBlocker({
+      withResolver: true,
+      shouldBlockFn: () =>
+         form.store.state.isDirty && !form.store.state.isSubmitted,
+   });
+
    return (
-      <form
-         onSubmit={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            form.handleSubmit();
-         }}
-      >
-         <CredenzaHeader>
-            <CredenzaTitle>Editar Conta</CredenzaTitle>
-            <CredenzaDescription>
-               Atualize as informações da conta.
-            </CredenzaDescription>
-         </CredenzaHeader>
+      <>
+         {blocker.status === "blocked" && (
+            <AlertDialog open>
+               <AlertDialogContent>
+                  <AlertDialogHeader>
+                     <AlertDialogTitle>Descartar alterações?</AlertDialogTitle>
+                     <AlertDialogDescription>
+                        Você tem alterações não salvas. Tem certeza que deseja
+                        sair sem salvar?
+                     </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                     <AlertDialogCancel onClick={() => blocker.reset()}>
+                        Continuar editando
+                     </AlertDialogCancel>
+                     <AlertDialogAction onClick={() => blocker.proceed()}>
+                        Descartar alterações
+                     </AlertDialogAction>
+                  </AlertDialogFooter>
+               </AlertDialogContent>
+            </AlertDialog>
+         )}
+         <form
+            onSubmit={(e) => {
+               e.preventDefault();
+               e.stopPropagation();
+               form.handleSubmit();
+            }}
+         >
+            <CredenzaHeader>
+               <CredenzaTitle>Editar Conta</CredenzaTitle>
+               <CredenzaDescription>
+                  Atualize as informações da conta.
+               </CredenzaDescription>
+            </CredenzaHeader>
 
-         <CredenzaBody className="px-4">
-            <FieldGroup>
-               <form.Field
-                  name="type"
-                  children={(field) => {
-                     const isInvalid =
-                        field.state.meta.isTouched &&
-                        field.state.meta.errors.length > 0;
-                     return (
-                        <Field data-invalid={isInvalid}>
-                           <FieldLabel>Tipo</FieldLabel>
-                           <Select
-                              onValueChange={(v) => {
-                                 if (v === "payable" || v === "receivable") {
-                                    field.handleChange(v);
-                                 }
-                              }}
-                              value={field.state.value}
-                           >
-                              <SelectTrigger>
-                                 <SelectValue placeholder="Selecione o tipo" />
-                              </SelectTrigger>
-                              <SelectContent>
-                                 <SelectItem value="payable">
-                                    A Pagar
-                                 </SelectItem>
-                                 <SelectItem value="receivable">
-                                    A Receber
-                                 </SelectItem>
-                              </SelectContent>
-                           </Select>
-                           {isInvalid && (
-                              <FieldError errors={field.state.meta.errors} />
-                           )}
-                        </Field>
-                     );
-                  }}
-               />
-
-               <form.Field
-                  name="name"
-                  children={(field) => {
-                     const isInvalid =
-                        field.state.meta.isTouched &&
-                        field.state.meta.errors.length > 0;
-                     return (
-                        <Field data-invalid={isInvalid}>
-                           <FieldLabel htmlFor={field.name}>Nome</FieldLabel>
-                           <Input
-                              id={field.name}
-                              name={field.name}
-                              aria-invalid={isInvalid}
-                              onBlur={field.handleBlur}
-                              onChange={(e) =>
-                                 field.handleChange(e.target.value)
-                              }
-                              placeholder="Ex: Aluguel, Energia Elétrica"
-                              value={field.state.value}
-                           />
-                           {isInvalid && (
-                              <FieldError errors={field.state.meta.errors} />
-                           )}
-                        </Field>
-                     );
-                  }}
-               />
-
-               <form.Field
-                  name="amount"
-                  children={(field) => (
-                     <Field>
-                        <FieldLabel>Valor</FieldLabel>
-                        <MoneyInput
-                           onChange={(v) =>
-                              field.handleChange(
-                                 v !== undefined ? String(v / 100) : "",
-                              )
-                           }
-                           value={
-                              field.state.value
-                                 ? Math.round(Number(field.state.value) * 100)
-                                 : 0
-                           }
-                           valueInCents={true}
-                        />
-                        <FieldError errors={field.state.meta.errors} />
-                     </Field>
-                  )}
-               />
-
-               <form.Field
-                  name="dueDate"
-                  children={(field) => (
-                     <Field>
-                        <FieldLabel>Data de Vencimento</FieldLabel>
-                        <DatePicker
-                           date={
-                              field.state.value
-                                 ? dayjs(field.state.value).toDate()
-                                 : undefined
-                           }
-                           onSelect={(d) =>
-                              field.handleChange(
-                                 d?.toISOString().substring(0, 10) ?? today,
-                              )
-                           }
-                        />
-                        <FieldError errors={field.state.meta.errors} />
-                     </Field>
-                  )}
-               />
-
-               {accounts.length > 0 && (
+            <CredenzaBody className="px-4">
+               <FieldGroup>
                   <form.Field
-                     name="bankAccountId"
+                     name="type"
+                     children={(field) => {
+                        const isInvalid =
+                           field.state.meta.isTouched &&
+                           field.state.meta.errors.length > 0;
+                        return (
+                           <Field data-invalid={isInvalid}>
+                              <FieldLabel>Tipo</FieldLabel>
+                              <Select
+                                 onValueChange={(v) => {
+                                    if (v === "payable" || v === "receivable") {
+                                       field.handleChange(v);
+                                    }
+                                 }}
+                                 value={field.state.value}
+                              >
+                                 <SelectTrigger>
+                                    <SelectValue placeholder="Selecione o tipo" />
+                                 </SelectTrigger>
+                                 <SelectContent>
+                                    <SelectItem value="payable">
+                                       A Pagar
+                                    </SelectItem>
+                                    <SelectItem value="receivable">
+                                       A Receber
+                                    </SelectItem>
+                                 </SelectContent>
+                              </Select>
+                              {isInvalid && (
+                                 <FieldError errors={field.state.meta.errors} />
+                              )}
+                           </Field>
+                        );
+                     }}
+                  />
+
+                  <form.Field
+                     name="name"
+                     children={(field) => {
+                        const isInvalid =
+                           field.state.meta.isTouched &&
+                           field.state.meta.errors.length > 0;
+                        return (
+                           <Field data-invalid={isInvalid}>
+                              <FieldLabel htmlFor={field.name}>Nome</FieldLabel>
+                              <Input
+                                 id={field.name}
+                                 name={field.name}
+                                 aria-invalid={isInvalid}
+                                 onBlur={field.handleBlur}
+                                 onChange={(e) =>
+                                    field.handleChange(e.target.value)
+                                 }
+                                 placeholder="Ex: Aluguel, Energia Elétrica"
+                                 value={field.state.value}
+                              />
+                              {isInvalid && (
+                                 <FieldError errors={field.state.meta.errors} />
+                              )}
+                           </Field>
+                        );
+                     }}
+                  />
+
+                  <form.Field
+                     name="amount"
                      children={(field) => (
                         <Field>
-                           <FieldLabel>Conta Bancária</FieldLabel>
-                           <Select
-                              onValueChange={field.handleChange}
-                              value={field.state.value}
-                           >
-                              <SelectTrigger>
-                                 <SelectValue placeholder="Selecione uma conta (opcional)" />
-                              </SelectTrigger>
-                              <SelectContent>
-                                 {accounts.map((acc) => (
-                                    <SelectItem key={acc.id} value={acc.id}>
-                                       {acc.name}
-                                    </SelectItem>
-                                 ))}
-                              </SelectContent>
-                           </Select>
+                           <FieldLabel>Valor</FieldLabel>
+                           <MoneyInput
+                              onChange={(v) =>
+                                 field.handleChange(
+                                    v !== undefined ? String(v / 100) : "",
+                                 )
+                              }
+                              value={
+                                 field.state.value
+                                    ? Math.round(
+                                         Number(field.state.value) * 100,
+                                      )
+                                    : 0
+                              }
+                              valueInCents={true}
+                           />
+                           <FieldError errors={field.state.meta.errors} />
                         </Field>
                      )}
                   />
-               )}
 
-               <form.Subscribe selector={(s) => s.values.type}>
-                  {(billType) => {
-                     const categoryType =
-                        billType === "receivable" ? "income" : "expense";
-                     const filtered = categories.filter(
-                        (cat) => cat.type === categoryType,
-                     );
-                     if (filtered.length === 0) return null;
-                     return (
-                        <form.Field
-                           name="categoryId"
-                           children={(field) => (
-                              <Field>
-                                 <FieldLabel>Categoria</FieldLabel>
-                                 <Select
-                                    onValueChange={field.handleChange}
-                                    value={field.state.value}
-                                 >
-                                    <SelectTrigger>
-                                       <SelectValue placeholder="Selecione uma categoria (opcional)" />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                       {filtered.map((cat) => (
-                                          <SelectItem
-                                             key={cat.id}
-                                             value={cat.id}
-                                          >
-                                             {cat.name}
-                                          </SelectItem>
-                                       ))}
-                                    </SelectContent>
-                                 </Select>
-                              </Field>
-                           )}
-                        />
-                     );
-                  }}
-               </form.Subscribe>
-
-               <form.Field
-                  name="description"
-                  children={(field) => {
-                     const isInvalid =
-                        field.state.meta.isTouched &&
-                        field.state.meta.errors.length > 0;
-                     return (
-                        <Field data-invalid={isInvalid}>
-                           <FieldLabel htmlFor={field.name}>
-                              Descrição (opcional)
-                           </FieldLabel>
-                           <Textarea
-                              id={field.name}
-                              name={field.name}
-                              aria-invalid={isInvalid}
-                              onBlur={field.handleBlur}
-                              onChange={(e) =>
-                                 field.handleChange(e.target.value)
+                  <form.Field
+                     name="dueDate"
+                     children={(field) => (
+                        <Field>
+                           <FieldLabel>Data de Vencimento</FieldLabel>
+                           <DatePicker
+                              date={
+                                 field.state.value
+                                    ? dayjs(field.state.value).toDate()
+                                    : undefined
                               }
-                              placeholder="Observações sobre esta conta..."
-                              rows={2}
-                              value={field.state.value}
+                              onSelect={(d) =>
+                                 field.handleChange(
+                                    d?.toISOString().substring(0, 10) ?? today,
+                                 )
+                              }
                            />
+                           <FieldError errors={field.state.meta.errors} />
                         </Field>
-                     );
-                  }}
-               />
-            </FieldGroup>
-         </CredenzaBody>
+                     )}
+                  />
 
-         <CredenzaFooter className="flex flex-col gap-2">
-            <form.Subscribe
-               selector={(state) =>
-                  state.errors.flatMap((e) => {
-                     if (!e) return [];
-                     if (typeof e === "string") return [e];
-                     if ("form" in e && typeof e.form === "string")
-                        return [e.form];
-                     return [];
-                  })
-               }
-            >
-               {(messages) =>
-                  messages.length > 0 && <FieldError errors={messages} />
-               }
-            </form.Subscribe>
-            <form.Subscribe
-               selector={(state) =>
-                  [state.canSubmit, state.isSubmitting] as const
-               }
-            >
-               {([canSubmit, isSubmitting]) => (
-                  <Button
-                     className="w-full"
-                     disabled={!canSubmit}
-                     type="submit"
-                  >
-                     {isSubmitting && <Spinner className="size-4" />}
-                     Salvar alterações
-                  </Button>
-               )}
-            </form.Subscribe>
-         </CredenzaFooter>
-      </form>
+                  {accounts.length > 0 && (
+                     <form.Field
+                        name="bankAccountId"
+                        children={(field) => (
+                           <Field>
+                              <FieldLabel>Conta Bancária</FieldLabel>
+                              <Select
+                                 onValueChange={field.handleChange}
+                                 value={field.state.value}
+                              >
+                                 <SelectTrigger>
+                                    <SelectValue placeholder="Selecione uma conta (opcional)" />
+                                 </SelectTrigger>
+                                 <SelectContent>
+                                    {accounts.map((acc) => (
+                                       <SelectItem key={acc.id} value={acc.id}>
+                                          {acc.name}
+                                       </SelectItem>
+                                    ))}
+                                 </SelectContent>
+                              </Select>
+                           </Field>
+                        )}
+                     />
+                  )}
+
+                  <form.Subscribe selector={(s) => s.values.type}>
+                     {(billType) => {
+                        const categoryType =
+                           billType === "receivable" ? "income" : "expense";
+                        const filtered = categories.filter(
+                           (cat) => cat.type === categoryType,
+                        );
+                        if (filtered.length === 0) return null;
+                        return (
+                           <form.Field
+                              name="categoryId"
+                              children={(field) => (
+                                 <Field>
+                                    <FieldLabel>Categoria</FieldLabel>
+                                    <Select
+                                       onValueChange={field.handleChange}
+                                       value={field.state.value}
+                                    >
+                                       <SelectTrigger>
+                                          <SelectValue placeholder="Selecione uma categoria (opcional)" />
+                                       </SelectTrigger>
+                                       <SelectContent>
+                                          {filtered.map((cat) => (
+                                             <SelectItem
+                                                key={cat.id}
+                                                value={cat.id}
+                                             >
+                                                {cat.name}
+                                             </SelectItem>
+                                          ))}
+                                       </SelectContent>
+                                    </Select>
+                                 </Field>
+                              )}
+                           />
+                        );
+                     }}
+                  </form.Subscribe>
+
+                  <form.Field
+                     name="description"
+                     children={(field) => {
+                        const isInvalid =
+                           field.state.meta.isTouched &&
+                           field.state.meta.errors.length > 0;
+                        return (
+                           <Field data-invalid={isInvalid}>
+                              <FieldLabel htmlFor={field.name}>
+                                 Descrição (opcional)
+                              </FieldLabel>
+                              <Textarea
+                                 id={field.name}
+                                 name={field.name}
+                                 aria-invalid={isInvalid}
+                                 onBlur={field.handleBlur}
+                                 onChange={(e) =>
+                                    field.handleChange(e.target.value)
+                                 }
+                                 placeholder="Observações sobre esta conta..."
+                                 rows={2}
+                                 value={field.state.value}
+                              />
+                           </Field>
+                        );
+                     }}
+                  />
+               </FieldGroup>
+            </CredenzaBody>
+
+            <CredenzaFooter className="flex flex-col gap-2">
+               <form.Subscribe
+                  selector={(state) =>
+                     state.errors.flatMap((e) => {
+                        if (!e) return [];
+                        if (typeof e === "string") return [e];
+                        if ("form" in e && typeof e.form === "string")
+                           return [e.form];
+                        return [];
+                     })
+                  }
+               >
+                  {(messages) =>
+                     messages.length > 0 && <FieldError errors={messages} />
+                  }
+               </form.Subscribe>
+               <form.Subscribe
+                  selector={(state) =>
+                     [state.canSubmit, state.isSubmitting] as const
+                  }
+               >
+                  {([canSubmit, isSubmitting]) => (
+                     <Button
+                        className="w-full"
+                        disabled={!canSubmit}
+                        type="submit"
+                     >
+                        {isSubmitting && <Spinner className="size-4" />}
+                        Salvar alterações
+                     </Button>
+                  )}
+               </form.Subscribe>
+            </CredenzaFooter>
+         </form>
+      </>
    );
 }
 

--- a/apps/web/src/features/bills/ui/bills-form.tsx
+++ b/apps/web/src/features/bills/ui/bills-form.tsx
@@ -25,9 +25,8 @@ import {
 import { Skeleton } from "@packages/ui/components/skeleton";
 import { Spinner } from "@packages/ui/components/spinner";
 import { Textarea } from "@packages/ui/components/textarea";
-import { ORPCError } from "@orpc/client";
 import { useForm } from "@tanstack/react-form";
-import { useSuspenseQueries } from "@tanstack/react-query";
+import { useMutation, useSuspenseQueries } from "@tanstack/react-query";
 import { useBlocker } from "@tanstack/react-router";
 import dayjs from "dayjs";
 import { QueryBoundary } from "@/components/query-boundary";
@@ -51,6 +50,8 @@ function BillFormInner({ bill, onSuccess }: BillFormProps) {
       ],
    });
 
+   const updateMutation = useMutation(orpc.bills.update.mutationOptions());
+
    const form = useForm({
       defaultValues: {
          type: bill.type as "payable" | "receivable",
@@ -61,34 +62,19 @@ function BillFormInner({ bill, onSuccess }: BillFormProps) {
          categoryId: bill.category?.id ?? "",
          description: "",
       },
-      validators: {
-         onSubmitAsync: async ({ value }) => {
-            try {
-               await orpc.bills.update.call({
-                  id: bill.id,
-                  type: value.type,
-                  name: value.name.trim(),
-                  amount: value.amount,
-                  dueDate: value.dueDate,
-                  bankAccountId: value.bankAccountId || null,
-                  categoryId: value.categoryId || null,
-                  description: value.description?.trim() || null,
-               });
-               toast.success("Conta atualizada com sucesso.");
-               onSuccess();
-               return null;
-            } catch (err) {
-               if (err instanceof ORPCError && err.code === "CONFLICT") {
-                  return { form: "Já existe uma conta com esses dados." };
-               }
-               return {
-                  form:
-                     err instanceof Error
-                        ? err.message
-                        : "Erro ao atualizar conta.",
-               };
-            }
-         },
+      onSubmit: async ({ value }) => {
+         await updateMutation.mutateAsync({
+            id: bill.id,
+            type: value.type,
+            name: value.name.trim(),
+            amount: value.amount,
+            dueDate: value.dueDate,
+            bankAccountId: value.bankAccountId || null,
+            categoryId: value.categoryId || null,
+            description: value.description?.trim() || null,
+         });
+         toast.success("Conta atualizada com sucesso.");
+         onSuccess();
       },
    });
 
@@ -336,21 +322,6 @@ function BillFormInner({ bill, onSuccess }: BillFormProps) {
          </CredenzaBody>
 
          <CredenzaFooter className="flex flex-col gap-2">
-            <form.Subscribe
-               selector={(state) =>
-                  state.errors.flatMap((e) => {
-                     if (!e) return [];
-                     if (typeof e === "string") return [e];
-                     if ("form" in e && typeof e.form === "string")
-                        return [e.form];
-                     return [];
-                  })
-               }
-            >
-               {(messages) =>
-                  messages.length > 0 && <FieldError errors={messages} />
-               }
-            </form.Subscribe>
             <form.Subscribe
                selector={(state) =>
                   [state.canSubmit, state.isSubmitting] as const

--- a/apps/web/src/features/bills/ui/bills-form.tsx
+++ b/apps/web/src/features/bills/ui/bills-form.tsx
@@ -27,7 +27,7 @@ import { Spinner } from "@packages/ui/components/spinner";
 import { Textarea } from "@packages/ui/components/textarea";
 import { ORPCError } from "@orpc/client";
 import { useForm } from "@tanstack/react-form";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useSuspenseQueries } from "@tanstack/react-query";
 import { useBlocker } from "@tanstack/react-router";
 import dayjs from "dayjs";
 import { QueryBoundary } from "@/components/query-boundary";
@@ -44,13 +44,12 @@ interface BillFormProps {
 function BillFormInner({ bill, onSuccess }: BillFormProps) {
    const today = dayjs().format("YYYY-MM-DD");
 
-   const { data: accounts } = useSuspenseQuery(
-      orpc.bankAccounts.getAll.queryOptions({}),
-   );
-   const { data: categoriesResult } = useSuspenseQuery(
-      orpc.categories.getAll.queryOptions({}),
-   );
-   const categories = categoriesResult;
+   const [{ data: accounts }, { data: categories }] = useSuspenseQueries({
+      queries: [
+         orpc.bankAccounts.getAll.queryOptions({}),
+         orpc.categories.getAll.queryOptions({}),
+      ],
+   });
 
    const form = useForm({
       defaultValues: {

--- a/apps/web/src/features/bills/ui/bills-form.tsx
+++ b/apps/web/src/features/bills/ui/bills-form.tsx
@@ -25,16 +25,6 @@ import {
 import { Skeleton } from "@packages/ui/components/skeleton";
 import { Spinner } from "@packages/ui/components/spinner";
 import { Textarea } from "@packages/ui/components/textarea";
-import {
-   AlertDialog,
-   AlertDialogAction,
-   AlertDialogCancel,
-   AlertDialogContent,
-   AlertDialogDescription,
-   AlertDialogFooter,
-   AlertDialogHeader,
-   AlertDialogTitle,
-} from "@packages/ui/components/alert-dialog";
 import { ORPCError } from "@orpc/client";
 import { useForm } from "@tanstack/react-form";
 import { useSuspenseQuery } from "@tanstack/react-query";
@@ -43,6 +33,7 @@ import dayjs from "dayjs";
 import { QueryBoundary } from "@/components/query-boundary";
 import { toast } from "sonner";
 import { orpc } from "@/integrations/orpc/client";
+import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import type { BillRow } from "./bills-columns";
 
 interface BillFormProps {
@@ -102,293 +93,283 @@ function BillFormInner({ bill, onSuccess }: BillFormProps) {
       },
    });
 
+   const { openAlertDialog } = useAlertDialog();
+
    const blocker = useBlocker({
       withResolver: true,
-      shouldBlockFn: () =>
-         form.store.state.isDirty && !form.store.state.isSubmitted,
+      shouldBlockFn: () => {
+         if (form.store.state.isDirty && !form.store.state.isSubmitted) {
+            openAlertDialog({
+               title: "Descartar alterações?",
+               description:
+                  "Você tem alterações não salvas. Tem certeza que deseja sair sem salvar?",
+               actionLabel: "Descartar alterações",
+               cancelLabel: "Continuar editando",
+               onAction: () => blocker.proceed(),
+               onCancel: () => blocker.reset(),
+            });
+            return true;
+         }
+         return false;
+      },
    });
 
    return (
-      <>
-         {blocker.status === "blocked" && (
-            <AlertDialog open>
-               <AlertDialogContent>
-                  <AlertDialogHeader>
-                     <AlertDialogTitle>Descartar alterações?</AlertDialogTitle>
-                     <AlertDialogDescription>
-                        Você tem alterações não salvas. Tem certeza que deseja
-                        sair sem salvar?
-                     </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                     <AlertDialogCancel onClick={() => blocker.reset()}>
-                        Continuar editando
-                     </AlertDialogCancel>
-                     <AlertDialogAction onClick={() => blocker.proceed()}>
-                        Descartar alterações
-                     </AlertDialogAction>
-                  </AlertDialogFooter>
-               </AlertDialogContent>
-            </AlertDialog>
-         )}
-         <form
-            onSubmit={(e) => {
-               e.preventDefault();
-               e.stopPropagation();
-               form.handleSubmit();
-            }}
-         >
-            <CredenzaHeader>
-               <CredenzaTitle>Editar Conta</CredenzaTitle>
-               <CredenzaDescription>
-                  Atualize as informações da conta.
-               </CredenzaDescription>
-            </CredenzaHeader>
+      <form
+         onSubmit={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            form.handleSubmit();
+         }}
+      >
+         <CredenzaHeader>
+            <CredenzaTitle>Editar Conta</CredenzaTitle>
+            <CredenzaDescription>
+               Atualize as informações da conta.
+            </CredenzaDescription>
+         </CredenzaHeader>
 
-            <CredenzaBody className="px-4">
-               <FieldGroup>
-                  <form.Field
-                     name="type"
-                     children={(field) => {
-                        const isInvalid =
-                           field.state.meta.isTouched &&
-                           field.state.meta.errors.length > 0;
-                        return (
-                           <Field data-invalid={isInvalid}>
-                              <FieldLabel>Tipo</FieldLabel>
-                              <Select
-                                 onValueChange={(v) => {
-                                    if (v === "payable" || v === "receivable") {
-                                       field.handleChange(v);
-                                    }
-                                 }}
-                                 value={field.state.value}
-                              >
-                                 <SelectTrigger>
-                                    <SelectValue placeholder="Selecione o tipo" />
-                                 </SelectTrigger>
-                                 <SelectContent>
-                                    <SelectItem value="payable">
-                                       A Pagar
-                                    </SelectItem>
-                                    <SelectItem value="receivable">
-                                       A Receber
-                                    </SelectItem>
-                                 </SelectContent>
-                              </Select>
-                              {isInvalid && (
-                                 <FieldError errors={field.state.meta.errors} />
-                              )}
-                           </Field>
-                        );
-                     }}
-                  />
-
-                  <form.Field
-                     name="name"
-                     children={(field) => {
-                        const isInvalid =
-                           field.state.meta.isTouched &&
-                           field.state.meta.errors.length > 0;
-                        return (
-                           <Field data-invalid={isInvalid}>
-                              <FieldLabel htmlFor={field.name}>Nome</FieldLabel>
-                              <Input
-                                 id={field.name}
-                                 name={field.name}
-                                 aria-invalid={isInvalid}
-                                 onBlur={field.handleBlur}
-                                 onChange={(e) =>
-                                    field.handleChange(e.target.value)
+         <CredenzaBody className="px-4">
+            <FieldGroup>
+               <form.Field
+                  name="type"
+                  children={(field) => {
+                     const isInvalid =
+                        field.state.meta.isTouched &&
+                        field.state.meta.errors.length > 0;
+                     return (
+                        <Field data-invalid={isInvalid}>
+                           <FieldLabel>Tipo</FieldLabel>
+                           <Select
+                              onValueChange={(v) => {
+                                 if (v === "payable" || v === "receivable") {
+                                    field.handleChange(v);
                                  }
-                                 placeholder="Ex: Aluguel, Energia Elétrica"
-                                 value={field.state.value}
-                              />
-                              {isInvalid && (
-                                 <FieldError errors={field.state.meta.errors} />
-                              )}
-                           </Field>
-                        );
-                     }}
-                  />
+                              }}
+                              value={field.state.value}
+                           >
+                              <SelectTrigger>
+                                 <SelectValue placeholder="Selecione o tipo" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                 <SelectItem value="payable">
+                                    A Pagar
+                                 </SelectItem>
+                                 <SelectItem value="receivable">
+                                    A Receber
+                                 </SelectItem>
+                              </SelectContent>
+                           </Select>
+                           {isInvalid && (
+                              <FieldError errors={field.state.meta.errors} />
+                           )}
+                        </Field>
+                     );
+                  }}
+               />
 
+               <form.Field
+                  name="name"
+                  children={(field) => {
+                     const isInvalid =
+                        field.state.meta.isTouched &&
+                        field.state.meta.errors.length > 0;
+                     return (
+                        <Field data-invalid={isInvalid}>
+                           <FieldLabel htmlFor={field.name}>Nome</FieldLabel>
+                           <Input
+                              id={field.name}
+                              name={field.name}
+                              aria-invalid={isInvalid}
+                              onBlur={field.handleBlur}
+                              onChange={(e) =>
+                                 field.handleChange(e.target.value)
+                              }
+                              placeholder="Ex: Aluguel, Energia Elétrica"
+                              value={field.state.value}
+                           />
+                           {isInvalid && (
+                              <FieldError errors={field.state.meta.errors} />
+                           )}
+                        </Field>
+                     );
+                  }}
+               />
+
+               <form.Field
+                  name="amount"
+                  children={(field) => (
+                     <Field>
+                        <FieldLabel>Valor</FieldLabel>
+                        <MoneyInput
+                           onChange={(v) =>
+                              field.handleChange(
+                                 v !== undefined ? String(v / 100) : "",
+                              )
+                           }
+                           value={
+                              field.state.value
+                                 ? Math.round(Number(field.state.value) * 100)
+                                 : 0
+                           }
+                           valueInCents={true}
+                        />
+                        <FieldError errors={field.state.meta.errors} />
+                     </Field>
+                  )}
+               />
+
+               <form.Field
+                  name="dueDate"
+                  children={(field) => (
+                     <Field>
+                        <FieldLabel>Data de Vencimento</FieldLabel>
+                        <DatePicker
+                           date={
+                              field.state.value
+                                 ? dayjs(field.state.value).toDate()
+                                 : undefined
+                           }
+                           onSelect={(d) =>
+                              field.handleChange(
+                                 d?.toISOString().substring(0, 10) ?? today,
+                              )
+                           }
+                        />
+                        <FieldError errors={field.state.meta.errors} />
+                     </Field>
+                  )}
+               />
+
+               {accounts.length > 0 && (
                   <form.Field
-                     name="amount"
+                     name="bankAccountId"
                      children={(field) => (
                         <Field>
-                           <FieldLabel>Valor</FieldLabel>
-                           <MoneyInput
-                              onChange={(v) =>
-                                 field.handleChange(
-                                    v !== undefined ? String(v / 100) : "",
-                                 )
-                              }
-                              value={
-                                 field.state.value
-                                    ? Math.round(
-                                         Number(field.state.value) * 100,
-                                      )
-                                    : 0
-                              }
-                              valueInCents={true}
-                           />
-                           <FieldError errors={field.state.meta.errors} />
+                           <FieldLabel>Conta Bancária</FieldLabel>
+                           <Select
+                              onValueChange={field.handleChange}
+                              value={field.state.value}
+                           >
+                              <SelectTrigger>
+                                 <SelectValue placeholder="Selecione uma conta (opcional)" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                 {accounts.map((acc) => (
+                                    <SelectItem key={acc.id} value={acc.id}>
+                                       {acc.name}
+                                    </SelectItem>
+                                 ))}
+                              </SelectContent>
+                           </Select>
                         </Field>
                      )}
                   />
+               )}
 
-                  <form.Field
-                     name="dueDate"
-                     children={(field) => (
-                        <Field>
-                           <FieldLabel>Data de Vencimento</FieldLabel>
-                           <DatePicker
-                              date={
-                                 field.state.value
-                                    ? dayjs(field.state.value).toDate()
-                                    : undefined
+               <form.Subscribe selector={(s) => s.values.type}>
+                  {(billType) => {
+                     const categoryType =
+                        billType === "receivable" ? "income" : "expense";
+                     const filtered = categories.filter(
+                        (cat) => cat.type === categoryType,
+                     );
+                     if (filtered.length === 0) return null;
+                     return (
+                        <form.Field
+                           name="categoryId"
+                           children={(field) => (
+                              <Field>
+                                 <FieldLabel>Categoria</FieldLabel>
+                                 <Select
+                                    onValueChange={field.handleChange}
+                                    value={field.state.value}
+                                 >
+                                    <SelectTrigger>
+                                       <SelectValue placeholder="Selecione uma categoria (opcional)" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                       {filtered.map((cat) => (
+                                          <SelectItem
+                                             key={cat.id}
+                                             value={cat.id}
+                                          >
+                                             {cat.name}
+                                          </SelectItem>
+                                       ))}
+                                    </SelectContent>
+                                 </Select>
+                              </Field>
+                           )}
+                        />
+                     );
+                  }}
+               </form.Subscribe>
+
+               <form.Field
+                  name="description"
+                  children={(field) => {
+                     const isInvalid =
+                        field.state.meta.isTouched &&
+                        field.state.meta.errors.length > 0;
+                     return (
+                        <Field data-invalid={isInvalid}>
+                           <FieldLabel htmlFor={field.name}>
+                              Descrição (opcional)
+                           </FieldLabel>
+                           <Textarea
+                              id={field.name}
+                              name={field.name}
+                              aria-invalid={isInvalid}
+                              onBlur={field.handleBlur}
+                              onChange={(e) =>
+                                 field.handleChange(e.target.value)
                               }
-                              onSelect={(d) =>
-                                 field.handleChange(
-                                    d?.toISOString().substring(0, 10) ?? today,
-                                 )
-                              }
+                              placeholder="Observações sobre esta conta..."
+                              rows={2}
+                              value={field.state.value}
                            />
-                           <FieldError errors={field.state.meta.errors} />
                         </Field>
-                     )}
-                  />
+                     );
+                  }}
+               />
+            </FieldGroup>
+         </CredenzaBody>
 
-                  {accounts.length > 0 && (
-                     <form.Field
-                        name="bankAccountId"
-                        children={(field) => (
-                           <Field>
-                              <FieldLabel>Conta Bancária</FieldLabel>
-                              <Select
-                                 onValueChange={field.handleChange}
-                                 value={field.state.value}
-                              >
-                                 <SelectTrigger>
-                                    <SelectValue placeholder="Selecione uma conta (opcional)" />
-                                 </SelectTrigger>
-                                 <SelectContent>
-                                    {accounts.map((acc) => (
-                                       <SelectItem key={acc.id} value={acc.id}>
-                                          {acc.name}
-                                       </SelectItem>
-                                    ))}
-                                 </SelectContent>
-                              </Select>
-                           </Field>
-                        )}
-                     />
-                  )}
-
-                  <form.Subscribe selector={(s) => s.values.type}>
-                     {(billType) => {
-                        const categoryType =
-                           billType === "receivable" ? "income" : "expense";
-                        const filtered = categories.filter(
-                           (cat) => cat.type === categoryType,
-                        );
-                        if (filtered.length === 0) return null;
-                        return (
-                           <form.Field
-                              name="categoryId"
-                              children={(field) => (
-                                 <Field>
-                                    <FieldLabel>Categoria</FieldLabel>
-                                    <Select
-                                       onValueChange={field.handleChange}
-                                       value={field.state.value}
-                                    >
-                                       <SelectTrigger>
-                                          <SelectValue placeholder="Selecione uma categoria (opcional)" />
-                                       </SelectTrigger>
-                                       <SelectContent>
-                                          {filtered.map((cat) => (
-                                             <SelectItem
-                                                key={cat.id}
-                                                value={cat.id}
-                                             >
-                                                {cat.name}
-                                             </SelectItem>
-                                          ))}
-                                       </SelectContent>
-                                    </Select>
-                                 </Field>
-                              )}
-                           />
-                        );
-                     }}
-                  </form.Subscribe>
-
-                  <form.Field
-                     name="description"
-                     children={(field) => {
-                        const isInvalid =
-                           field.state.meta.isTouched &&
-                           field.state.meta.errors.length > 0;
-                        return (
-                           <Field data-invalid={isInvalid}>
-                              <FieldLabel htmlFor={field.name}>
-                                 Descrição (opcional)
-                              </FieldLabel>
-                              <Textarea
-                                 id={field.name}
-                                 name={field.name}
-                                 aria-invalid={isInvalid}
-                                 onBlur={field.handleBlur}
-                                 onChange={(e) =>
-                                    field.handleChange(e.target.value)
-                                 }
-                                 placeholder="Observações sobre esta conta..."
-                                 rows={2}
-                                 value={field.state.value}
-                              />
-                           </Field>
-                        );
-                     }}
-                  />
-               </FieldGroup>
-            </CredenzaBody>
-
-            <CredenzaFooter className="flex flex-col gap-2">
-               <form.Subscribe
-                  selector={(state) =>
-                     state.errors.flatMap((e) => {
-                        if (!e) return [];
-                        if (typeof e === "string") return [e];
-                        if ("form" in e && typeof e.form === "string")
-                           return [e.form];
-                        return [];
-                     })
-                  }
-               >
-                  {(messages) =>
-                     messages.length > 0 && <FieldError errors={messages} />
-                  }
-               </form.Subscribe>
-               <form.Subscribe
-                  selector={(state) =>
-                     [state.canSubmit, state.isSubmitting] as const
-                  }
-               >
-                  {([canSubmit, isSubmitting]) => (
-                     <Button
-                        className="w-full"
-                        disabled={!canSubmit}
-                        type="submit"
-                     >
-                        {isSubmitting && <Spinner className="size-4" />}
-                        Salvar alterações
-                     </Button>
-                  )}
-               </form.Subscribe>
-            </CredenzaFooter>
-         </form>
-      </>
+         <CredenzaFooter className="flex flex-col gap-2">
+            <form.Subscribe
+               selector={(state) =>
+                  state.errors.flatMap((e) => {
+                     if (!e) return [];
+                     if (typeof e === "string") return [e];
+                     if ("form" in e && typeof e.form === "string")
+                        return [e.form];
+                     return [];
+                  })
+               }
+            >
+               {(messages) =>
+                  messages.length > 0 && <FieldError errors={messages} />
+               }
+            </form.Subscribe>
+            <form.Subscribe
+               selector={(state) =>
+                  [state.canSubmit, state.isSubmitting] as const
+               }
+            >
+               {([canSubmit, isSubmitting]) => (
+                  <Button
+                     className="w-full"
+                     disabled={!canSubmit}
+                     type="submit"
+                  >
+                     {isSubmitting && <Spinner className="size-4" />}
+                     Salvar alterações
+                  </Button>
+               )}
+            </form.Subscribe>
+         </CredenzaFooter>
+      </form>
    );
 }
 

--- a/apps/web/src/features/budget-goals/ui/budget-goal-dialog-stack.tsx
+++ b/apps/web/src/features/budget-goals/ui/budget-goal-dialog-stack.tsx
@@ -394,19 +394,23 @@ export function BudgetGoalDialogStack({
          </CredenzaBody>
 
          <CredenzaFooter>
-            <form.Subscribe selector={(state) => state}>
-               {(state) => (
+            <form.Subscribe
+               selector={(state) =>
+                  [state.canSubmit, state.isSubmitting] as const
+               }
+            >
+               {([canSubmit, isSubmitting]) => (
                   <Button
                      className="w-full"
                      disabled={
-                        !state.canSubmit ||
-                        state.isSubmitting ||
+                        !canSubmit ||
+                        isSubmitting ||
                         createMutation.isPending ||
                         updateMutation.isPending
                      }
                      type="submit"
                   >
-                     {(state.isSubmitting ||
+                     {(isSubmitting ||
                         createMutation.isPending ||
                         updateMutation.isPending) && (
                         <Spinner className="size-4 mr-2" />

--- a/apps/web/src/features/contacts/ui/contacts-form.tsx
+++ b/apps/web/src/features/contacts/ui/contacts-form.tsx
@@ -1,3 +1,13 @@
+import {
+   AlertDialog,
+   AlertDialogAction,
+   AlertDialogCancel,
+   AlertDialogContent,
+   AlertDialogDescription,
+   AlertDialogFooter,
+   AlertDialogHeader,
+   AlertDialogTitle,
+} from "@packages/ui/components/alert-dialog";
 import { Button } from "@packages/ui/components/button";
 import {
    CredenzaBody,
@@ -27,6 +37,7 @@ import { useMaskito } from "@maskito/react";
 import { ORPCError } from "@orpc/client";
 import { useForm } from "@tanstack/react-form";
 import { useStore } from "@tanstack/react-store";
+import { useBlocker } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { toast } from "sonner";
 import { orpc } from "@/integrations/orpc/client";
@@ -170,129 +181,230 @@ export function ContactForm({ mode, contact, onSuccess }: ContactFormProps) {
    const phoneRef = useMaskito({ options: phoneMaskOptions });
    const documentRef = useMaskito({ options: documentMaskOptions });
 
+   const blocker = useBlocker({
+      withResolver: true,
+      shouldBlockFn: () =>
+         form.store.state.isDirty && !form.store.state.isSubmitted,
+      disabled: isCreate,
+   });
+
    return (
-      <form
-         onSubmit={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            form.handleSubmit();
-         }}
-      >
-         <CredenzaHeader>
-            <CredenzaTitle>
-               {isCreate ? "Novo Contato" : "Editar Contato"}
-            </CredenzaTitle>
-            <CredenzaDescription>
-               {isCreate
-                  ? "Cadastre um cliente ou fornecedor."
-                  : "Atualize as informações do contato."}
-            </CredenzaDescription>
-         </CredenzaHeader>
+      <>
+         {blocker.status === "blocked" && (
+            <AlertDialog open>
+               <AlertDialogContent>
+                  <AlertDialogHeader>
+                     <AlertDialogTitle>Descartar alterações?</AlertDialogTitle>
+                     <AlertDialogDescription>
+                        Você tem alterações não salvas. Tem certeza que deseja
+                        sair sem salvar?
+                     </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                     <AlertDialogCancel onClick={() => blocker.reset()}>
+                        Continuar editando
+                     </AlertDialogCancel>
+                     <AlertDialogAction onClick={() => blocker.proceed()}>
+                        Descartar alterações
+                     </AlertDialogAction>
+                  </AlertDialogFooter>
+               </AlertDialogContent>
+            </AlertDialog>
+         )}
+         <form
+            onSubmit={(e) => {
+               e.preventDefault();
+               e.stopPropagation();
+               form.handleSubmit();
+            }}
+         >
+            <CredenzaHeader>
+               <CredenzaTitle>
+                  {isCreate ? "Novo Contato" : "Editar Contato"}
+               </CredenzaTitle>
+               <CredenzaDescription>
+                  {isCreate
+                     ? "Cadastre um cliente ou fornecedor."
+                     : "Atualize as informações do contato."}
+               </CredenzaDescription>
+            </CredenzaHeader>
 
-         <CredenzaBody className="px-4">
-            <FieldGroup>
-               <form.Field
-                  name="name"
-                  children={(field) => {
-                     const isInvalid =
-                        field.state.meta.isTouched &&
-                        field.state.meta.errors.length > 0;
-                     return (
-                        <Field data-invalid={isInvalid}>
-                           <FieldLabel htmlFor={field.name}>Nome *</FieldLabel>
-                           <Input
-                              id={field.name}
-                              name={field.name}
-                              aria-invalid={isInvalid}
-                              onBlur={field.handleBlur}
-                              onChange={(e) =>
-                                 field.handleChange(e.target.value)
-                              }
-                              placeholder="Ex: Empresa XYZ"
-                              value={field.state.value}
-                           />
-                           {isInvalid && (
-                              <FieldError errors={field.state.meta.errors} />
-                           )}
-                        </Field>
-                     );
-                  }}
-               />
-
-               <form.Field
-                  name="type"
-                  children={(field) => (
-                     <Field>
-                        <FieldLabel>Tipo *</FieldLabel>
-                        <Select
-                           onValueChange={(v) => {
-                              if (
-                                 v === "cliente" ||
-                                 v === "fornecedor" ||
-                                 v === "ambos"
-                              ) {
-                                 field.handleChange(v);
-                              }
-                           }}
-                           value={field.state.value}
-                        >
-                           <SelectTrigger>
-                              <SelectValue placeholder="Selecione o tipo" />
-                           </SelectTrigger>
-                           <SelectContent>
-                              <SelectItem value="cliente">Cliente</SelectItem>
-                              <SelectItem value="fornecedor">
-                                 Fornecedor
-                              </SelectItem>
-                              <SelectItem value="ambos">Ambos</SelectItem>
-                           </SelectContent>
-                        </Select>
-                     </Field>
-                  )}
-               />
-
-               <div className="grid grid-cols-3 gap-2">
+            <CredenzaBody className="px-4">
+               <FieldGroup>
                   <form.Field
-                     name="documentType"
+                     name="name"
+                     children={(field) => {
+                        const isInvalid =
+                           field.state.meta.isTouched &&
+                           field.state.meta.errors.length > 0;
+                        return (
+                           <Field data-invalid={isInvalid}>
+                              <FieldLabel htmlFor={field.name}>
+                                 Nome *
+                              </FieldLabel>
+                              <Input
+                                 id={field.name}
+                                 name={field.name}
+                                 aria-invalid={isInvalid}
+                                 onBlur={field.handleBlur}
+                                 onChange={(e) =>
+                                    field.handleChange(e.target.value)
+                                 }
+                                 placeholder="Ex: Empresa XYZ"
+                                 value={field.state.value}
+                              />
+                              {isInvalid && (
+                                 <FieldError errors={field.state.meta.errors} />
+                              )}
+                           </Field>
+                        );
+                     }}
+                  />
+
+                  <form.Field
+                     name="type"
                      children={(field) => (
                         <Field>
-                           <FieldLabel>Tipo Doc.</FieldLabel>
+                           <FieldLabel>Tipo *</FieldLabel>
                            <Select
                               onValueChange={(v) => {
-                                 if (v === "" || v === "cpf" || v === "cnpj") {
+                                 if (
+                                    v === "cliente" ||
+                                    v === "fornecedor" ||
+                                    v === "ambos"
+                                 ) {
                                     field.handleChange(v);
                                  }
                               }}
                               value={field.state.value}
                            >
                               <SelectTrigger>
-                                 <SelectValue placeholder="—" />
+                                 <SelectValue placeholder="Selecione o tipo" />
                               </SelectTrigger>
                               <SelectContent>
-                                 <SelectItem value="cpf">CPF</SelectItem>
-                                 <SelectItem value="cnpj">CNPJ</SelectItem>
+                                 <SelectItem value="cliente">
+                                    Cliente
+                                 </SelectItem>
+                                 <SelectItem value="fornecedor">
+                                    Fornecedor
+                                 </SelectItem>
+                                 <SelectItem value="ambos">Ambos</SelectItem>
                               </SelectContent>
                            </Select>
                         </Field>
                      )}
                   />
 
+                  <div className="grid grid-cols-3 gap-2">
+                     <form.Field
+                        name="documentType"
+                        children={(field) => (
+                           <Field>
+                              <FieldLabel>Tipo Doc.</FieldLabel>
+                              <Select
+                                 onValueChange={(v) => {
+                                    if (
+                                       v === "" ||
+                                       v === "cpf" ||
+                                       v === "cnpj"
+                                    ) {
+                                       field.handleChange(v);
+                                    }
+                                 }}
+                                 value={field.state.value}
+                              >
+                                 <SelectTrigger>
+                                    <SelectValue placeholder="—" />
+                                 </SelectTrigger>
+                                 <SelectContent>
+                                    <SelectItem value="cpf">CPF</SelectItem>
+                                    <SelectItem value="cnpj">CNPJ</SelectItem>
+                                 </SelectContent>
+                              </Select>
+                           </Field>
+                        )}
+                     />
+
+                     <form.Field
+                        name="document"
+                        children={(field) => {
+                           const isInvalid =
+                              field.state.meta.isTouched &&
+                              field.state.meta.errors.length > 0;
+                           return (
+                              <Field
+                                 className="col-span-2"
+                                 data-invalid={isInvalid}
+                              >
+                                 <FieldLabel htmlFor={field.name}>
+                                    Número
+                                 </FieldLabel>
+                                 <Input
+                                    ref={documentRef}
+                                    aria-invalid={isInvalid}
+                                    defaultValue={field.state.value}
+                                    id={field.name}
+                                    inputMode="numeric"
+                                    name={field.name}
+                                    onBlur={field.handleBlur}
+                                    onInput={(e) =>
+                                       field.handleChange(
+                                          (e.target as HTMLInputElement).value,
+                                       )
+                                    }
+                                    placeholder={
+                                       docType === "cnpj"
+                                          ? "00.000.000/0000-00"
+                                          : "000.000.000-00"
+                                    }
+                                 />
+                              </Field>
+                           );
+                        }}
+                     />
+                  </div>
+
                   <form.Field
-                     name="document"
+                     name="email"
                      children={(field) => {
                         const isInvalid =
                            field.state.meta.isTouched &&
                            field.state.meta.errors.length > 0;
                         return (
-                           <Field
-                              className="col-span-2"
-                              data-invalid={isInvalid}
-                           >
+                           <Field data-invalid={isInvalid}>
                               <FieldLabel htmlFor={field.name}>
-                                 Número
+                                 Email
                               </FieldLabel>
                               <Input
-                                 ref={documentRef}
+                                 id={field.name}
+                                 name={field.name}
+                                 aria-invalid={isInvalid}
+                                 onBlur={field.handleBlur}
+                                 onChange={(e) =>
+                                    field.handleChange(e.target.value)
+                                 }
+                                 placeholder="contato@empresa.com"
+                                 type="email"
+                                 value={field.state.value}
+                              />
+                           </Field>
+                        );
+                     }}
+                  />
+
+                  <form.Field
+                     name="phone"
+                     children={(field) => {
+                        const isInvalid =
+                           field.state.meta.isTouched &&
+                           field.state.meta.errors.length > 0;
+                        return (
+                           <Field data-invalid={isInvalid}>
+                              <FieldLabel htmlFor={field.name}>
+                                 Telefone
+                              </FieldLabel>
+                              <Input
+                                 ref={phoneRef}
                                  aria-invalid={isInvalid}
                                  defaultValue={field.state.value}
                                  id={field.name}
@@ -304,138 +416,77 @@ export function ContactForm({ mode, contact, onSuccess }: ContactFormProps) {
                                        (e.target as HTMLInputElement).value,
                                     )
                                  }
-                                 placeholder={
-                                    docType === "cnpj"
-                                       ? "00.000.000/0000-00"
-                                       : "000.000.000-00"
-                                 }
+                                 placeholder="(11) 99999-9999"
                               />
                            </Field>
                         );
                      }}
                   />
-               </div>
 
-               <form.Field
-                  name="email"
-                  children={(field) => {
-                     const isInvalid =
-                        field.state.meta.isTouched &&
-                        field.state.meta.errors.length > 0;
-                     return (
-                        <Field data-invalid={isInvalid}>
-                           <FieldLabel htmlFor={field.name}>Email</FieldLabel>
-                           <Input
-                              id={field.name}
-                              name={field.name}
-                              aria-invalid={isInvalid}
-                              onBlur={field.handleBlur}
-                              onChange={(e) =>
-                                 field.handleChange(e.target.value)
-                              }
-                              placeholder="contato@empresa.com"
-                              type="email"
-                              value={field.state.value}
-                           />
-                        </Field>
-                     );
-                  }}
-               />
+                  <form.Field
+                     name="notes"
+                     children={(field) => {
+                        const isInvalid =
+                           field.state.meta.isTouched &&
+                           field.state.meta.errors.length > 0;
+                        return (
+                           <Field data-invalid={isInvalid}>
+                              <FieldLabel htmlFor={field.name}>
+                                 Observações
+                              </FieldLabel>
+                              <Textarea
+                                 id={field.name}
+                                 name={field.name}
+                                 aria-invalid={isInvalid}
+                                 onBlur={field.handleBlur}
+                                 onChange={(e) =>
+                                    field.handleChange(e.target.value)
+                                 }
+                                 placeholder="Informações adicionais..."
+                                 rows={3}
+                                 value={field.state.value}
+                              />
+                           </Field>
+                        );
+                     }}
+                  />
+               </FieldGroup>
+            </CredenzaBody>
 
-               <form.Field
-                  name="phone"
-                  children={(field) => {
-                     const isInvalid =
-                        field.state.meta.isTouched &&
-                        field.state.meta.errors.length > 0;
-                     return (
-                        <Field data-invalid={isInvalid}>
-                           <FieldLabel htmlFor={field.name}>
-                              Telefone
-                           </FieldLabel>
-                           <Input
-                              ref={phoneRef}
-                              aria-invalid={isInvalid}
-                              defaultValue={field.state.value}
-                              id={field.name}
-                              inputMode="numeric"
-                              name={field.name}
-                              onBlur={field.handleBlur}
-                              onInput={(e) =>
-                                 field.handleChange(
-                                    (e.target as HTMLInputElement).value,
-                                 )
-                              }
-                              placeholder="(11) 99999-9999"
-                           />
-                        </Field>
-                     );
-                  }}
-               />
-
-               <form.Field
-                  name="notes"
-                  children={(field) => {
-                     const isInvalid =
-                        field.state.meta.isTouched &&
-                        field.state.meta.errors.length > 0;
-                     return (
-                        <Field data-invalid={isInvalid}>
-                           <FieldLabel htmlFor={field.name}>
-                              Observações
-                           </FieldLabel>
-                           <Textarea
-                              id={field.name}
-                              name={field.name}
-                              aria-invalid={isInvalid}
-                              onBlur={field.handleBlur}
-                              onChange={(e) =>
-                                 field.handleChange(e.target.value)
-                              }
-                              placeholder="Informações adicionais..."
-                              rows={3}
-                              value={field.state.value}
-                           />
-                        </Field>
-                     );
-                  }}
-               />
-            </FieldGroup>
-         </CredenzaBody>
-
-         <CredenzaFooter className="flex flex-col gap-2">
-            <form.Subscribe
-               selector={(state) =>
-                  state.errors.flatMap((e) => {
-                     if (!e) return [];
-                     if (typeof e === "string") return [e];
-                     if ("form" in e && typeof e.form === "string")
-                        return [e.form];
-                     return [];
-                  })
-               }
-            >
-               {(messages) =>
-                  messages.length > 0 && <FieldError errors={messages} />
-               }
-            </form.Subscribe>
-            <form.Subscribe
-               selector={(state) =>
-                  [state.canSubmit, state.isSubmitting] as const
-               }
-            >
-               {([canSubmit, isSubmitting]) => (
-                  <Button
-                     className="w-full gap-2"
-                     disabled={!canSubmit}
-                     type="submit"
-                  >
-                     {isSubmitting && <Spinner className="size-4" />}
-                     {isCreate ? "Criar contato" : "Salvar alterações"}
-                  </Button>
-               )}
-            </form.Subscribe>
-         </CredenzaFooter>
-      </form>
+            <CredenzaFooter className="flex flex-col gap-2">
+               <form.Subscribe
+                  selector={(state) =>
+                     state.errors.flatMap((e) => {
+                        if (!e) return [];
+                        if (typeof e === "string") return [e];
+                        if ("form" in e && typeof e.form === "string")
+                           return [e.form];
+                        return [];
+                     })
+                  }
+               >
+                  {(messages) =>
+                     messages.length > 0 && <FieldError errors={messages} />
+                  }
+               </form.Subscribe>
+               <form.Subscribe
+                  selector={(state) =>
+                     [state.canSubmit, state.isSubmitting] as const
+                  }
+               >
+                  {([canSubmit, isSubmitting]) => (
+                     <Button
+                        className="w-full gap-2"
+                        disabled={!canSubmit}
+                        type="submit"
+                     >
+                        {isSubmitting && <Spinner className="size-4" />}
+                        {isCreate ? "Criar contato" : "Salvar alterações"}
+                     </Button>
+                  )}
+               </form.Subscribe>
+            </CredenzaFooter>
+         </form>
+      </>
    );
 }

--- a/apps/web/src/features/contacts/ui/contacts-form.tsx
+++ b/apps/web/src/features/contacts/ui/contacts-form.tsx
@@ -24,8 +24,8 @@ import { Spinner } from "@packages/ui/components/spinner";
 import { Textarea } from "@packages/ui/components/textarea";
 import type { MaskitoOptions } from "@maskito/core";
 import { useMaskito } from "@maskito/react";
+import { ORPCError } from "@orpc/client";
 import { useForm } from "@tanstack/react-form";
-import { useMutation } from "@tanstack/react-query";
 import { useStore } from "@tanstack/react-store";
 import { useMemo } from "react";
 import { toast } from "sonner";
@@ -105,31 +105,54 @@ interface ContactFormProps {
 export function ContactForm({ mode, contact, onSuccess }: ContactFormProps) {
    const isCreate = mode === "create";
 
+   const documentTypeDefault: "" | "cpf" | "cnpj" = contact?.documentType ?? "";
+
    const form = useForm({
       defaultValues: {
          name: contact?.name ?? "",
-         type: contact?.type ?? ("cliente" as ContactRow["type"]),
+         type: contact?.type ?? ("cliente" satisfies ContactRow["type"]),
          email: contact?.email ?? "",
          phone: contact?.phone ?? "",
          document: contact?.document ?? "",
-         documentType: contact?.documentType ?? ("" as "" | "cpf" | "cnpj"),
+         documentType: documentTypeDefault,
          notes: contact?.notes ?? "",
       },
-      onSubmit: async ({ value }) => {
-         const payload = {
-            name: value.name.trim(),
-            type: value.type,
-            email: value.email?.trim() || null,
-            phone: value.phone?.trim() || null,
-            document: value.document?.trim() || null,
-            documentType: (value.documentType || null) as "cpf" | "cnpj" | null,
-            notes: value.notes?.trim() || null,
-         };
-         if (isCreate) {
-            createMutation.mutate(payload);
-         } else if (contact) {
-            updateMutation.mutate({ id: contact.id, ...payload });
-         }
+      validators: {
+         onSubmitAsync: async ({ value }) => {
+            const payload = {
+               name: value.name.trim(),
+               type: value.type,
+               email: value.email?.trim() || null,
+               phone: value.phone?.trim() || null,
+               document: value.document?.trim() || null,
+               documentType:
+                  value.documentType === "" ? null : value.documentType,
+               notes: value.notes?.trim() || null,
+            };
+            try {
+               if (isCreate) {
+                  await orpc.contacts.create.call(payload);
+                  toast.success("Contato criado com sucesso.");
+               } else if (contact) {
+                  await orpc.contacts.update.call({
+                     id: contact.id,
+                     ...payload,
+                  });
+                  toast.success("Contato atualizado com sucesso.");
+               }
+               onSuccess();
+               return null;
+            } catch (err) {
+               if (err instanceof ORPCError && err.code === "CONFLICT") {
+                  return {
+                     fields: { document: "CNPJ/CPF já cadastrado." },
+                  };
+               }
+               return {
+                  form: err instanceof Error ? err.message : "Erro inesperado.",
+               };
+            }
+         },
       },
    });
 
@@ -146,32 +169,6 @@ export function ContactForm({ mode, contact, onSuccess }: ContactFormProps) {
 
    const phoneRef = useMaskito({ options: phoneMaskOptions });
    const documentRef = useMaskito({ options: documentMaskOptions });
-
-   const createMutation = useMutation(
-      orpc.contacts.create.mutationOptions({
-         onSuccess: () => {
-            toast.success("Contato criado com sucesso.");
-            onSuccess();
-         },
-         onError: (error) => {
-            toast.error(error.message || "Erro ao criar contato.");
-         },
-      }),
-   );
-
-   const updateMutation = useMutation(
-      orpc.contacts.update.mutationOptions({
-         onSuccess: () => {
-            toast.success("Contato atualizado com sucesso.");
-            onSuccess();
-         },
-         onError: (error) => {
-            toast.error(error.message || "Erro ao atualizar contato.");
-         },
-      }),
-   );
-
-   const isPending = createMutation.isPending || updateMutation.isPending;
 
    return (
       <form
@@ -228,9 +225,15 @@ export function ContactForm({ mode, contact, onSuccess }: ContactFormProps) {
                      <Field>
                         <FieldLabel>Tipo *</FieldLabel>
                         <Select
-                           onValueChange={(v) =>
-                              field.handleChange(v as ContactRow["type"])
-                           }
+                           onValueChange={(v) => {
+                              if (
+                                 v === "cliente" ||
+                                 v === "fornecedor" ||
+                                 v === "ambos"
+                              ) {
+                                 field.handleChange(v);
+                              }
+                           }}
                            value={field.state.value}
                         >
                            <SelectTrigger>
@@ -255,9 +258,11 @@ export function ContactForm({ mode, contact, onSuccess }: ContactFormProps) {
                         <Field>
                            <FieldLabel>Tipo Doc.</FieldLabel>
                            <Select
-                              onValueChange={(v) =>
-                                 field.handleChange(v as "" | "cpf" | "cnpj")
-                              }
+                              onValueChange={(v) => {
+                                 if (v === "" || v === "cpf" || v === "cnpj") {
+                                    field.handleChange(v);
+                                 }
+                              }}
                               value={field.state.value}
                            >
                               <SelectTrigger>
@@ -398,19 +403,34 @@ export function ContactForm({ mode, contact, onSuccess }: ContactFormProps) {
             </FieldGroup>
          </CredenzaBody>
 
-         <CredenzaFooter>
-            <form.Subscribe selector={(state) => state}>
-               {(state) => (
+         <CredenzaFooter className="flex flex-col gap-2">
+            <form.Subscribe
+               selector={(state) =>
+                  state.errors.flatMap((e) => {
+                     if (!e) return [];
+                     if (typeof e === "string") return [e];
+                     if ("form" in e && typeof e.form === "string")
+                        return [e.form];
+                     return [];
+                  })
+               }
+            >
+               {(messages) =>
+                  messages.length > 0 && <FieldError errors={messages} />
+               }
+            </form.Subscribe>
+            <form.Subscribe
+               selector={(state) =>
+                  [state.canSubmit, state.isSubmitting] as const
+               }
+            >
+               {([canSubmit, isSubmitting]) => (
                   <Button
                      className="w-full gap-2"
-                     disabled={
-                        !state.canSubmit || state.isSubmitting || isPending
-                     }
+                     disabled={!canSubmit}
                      type="submit"
                   >
-                     {(state.isSubmitting || isPending) && (
-                        <Spinner className="size-4" />
-                     )}
+                     {isSubmitting && <Spinner className="size-4" />}
                      {isCreate ? "Criar contato" : "Salvar alterações"}
                   </Button>
                )}

--- a/apps/web/src/features/contacts/ui/contacts-form.tsx
+++ b/apps/web/src/features/contacts/ui/contacts-form.tsx
@@ -334,6 +334,9 @@ export function ContactForm({ mode, contact, onSuccess }: ContactFormProps) {
                                        : "000.000.000-00"
                                  }
                               />
+                              {isInvalid && (
+                                 <FieldError errors={field.state.meta.errors} />
+                              )}
                            </Field>
                         );
                      }}

--- a/apps/web/src/features/contacts/ui/contacts-form.tsx
+++ b/apps/web/src/features/contacts/ui/contacts-form.tsx
@@ -191,8 +191,8 @@ export function ContactForm({ mode, contact, onSuccess }: ContactFormProps) {
                   "Você tem alterações não salvas. Tem certeza que deseja sair sem salvar?",
                actionLabel: "Descartar alterações",
                cancelLabel: "Continuar editando",
-               onAction: () => blocker.proceed(),
-               onCancel: () => blocker.reset(),
+               onAction: () => blocker.proceed?.(),
+               onCancel: () => blocker.reset?.(),
             });
             return true;
          }

--- a/apps/web/src/features/contacts/ui/contacts-form.tsx
+++ b/apps/web/src/features/contacts/ui/contacts-form.tsx
@@ -1,13 +1,3 @@
-import {
-   AlertDialog,
-   AlertDialogAction,
-   AlertDialogCancel,
-   AlertDialogContent,
-   AlertDialogDescription,
-   AlertDialogFooter,
-   AlertDialogHeader,
-   AlertDialogTitle,
-} from "@packages/ui/components/alert-dialog";
 import { Button } from "@packages/ui/components/button";
 import {
    CredenzaBody,
@@ -41,6 +31,7 @@ import { useBlocker } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { toast } from "sonner";
 import { orpc } from "@/integrations/orpc/client";
+import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import type { ContactRow } from "./contacts-columns";
 
 const phoneMaskOptions: MaskitoOptions = {
@@ -181,230 +172,151 @@ export function ContactForm({ mode, contact, onSuccess }: ContactFormProps) {
    const phoneRef = useMaskito({ options: phoneMaskOptions });
    const documentRef = useMaskito({ options: documentMaskOptions });
 
+   const { openAlertDialog } = useAlertDialog();
+
    const blocker = useBlocker({
       withResolver: true,
-      shouldBlockFn: () =>
-         form.store.state.isDirty && !form.store.state.isSubmitted,
+      shouldBlockFn: () => {
+         if (form.store.state.isDirty && !form.store.state.isSubmitted) {
+            openAlertDialog({
+               title: "Descartar alterações?",
+               description:
+                  "Você tem alterações não salvas. Tem certeza que deseja sair sem salvar?",
+               actionLabel: "Descartar alterações",
+               cancelLabel: "Continuar editando",
+               onAction: () => blocker.proceed(),
+               onCancel: () => blocker.reset(),
+            });
+            return true;
+         }
+         return false;
+      },
       disabled: isCreate,
    });
 
    return (
-      <>
-         {blocker.status === "blocked" && (
-            <AlertDialog open>
-               <AlertDialogContent>
-                  <AlertDialogHeader>
-                     <AlertDialogTitle>Descartar alterações?</AlertDialogTitle>
-                     <AlertDialogDescription>
-                        Você tem alterações não salvas. Tem certeza que deseja
-                        sair sem salvar?
-                     </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                     <AlertDialogCancel onClick={() => blocker.reset()}>
-                        Continuar editando
-                     </AlertDialogCancel>
-                     <AlertDialogAction onClick={() => blocker.proceed()}>
-                        Descartar alterações
-                     </AlertDialogAction>
-                  </AlertDialogFooter>
-               </AlertDialogContent>
-            </AlertDialog>
-         )}
-         <form
-            onSubmit={(e) => {
-               e.preventDefault();
-               e.stopPropagation();
-               form.handleSubmit();
-            }}
-         >
-            <CredenzaHeader>
-               <CredenzaTitle>
-                  {isCreate ? "Novo Contato" : "Editar Contato"}
-               </CredenzaTitle>
-               <CredenzaDescription>
-                  {isCreate
-                     ? "Cadastre um cliente ou fornecedor."
-                     : "Atualize as informações do contato."}
-               </CredenzaDescription>
-            </CredenzaHeader>
+      <form
+         onSubmit={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            form.handleSubmit();
+         }}
+      >
+         <CredenzaHeader>
+            <CredenzaTitle>
+               {isCreate ? "Novo Contato" : "Editar Contato"}
+            </CredenzaTitle>
+            <CredenzaDescription>
+               {isCreate
+                  ? "Cadastre um cliente ou fornecedor."
+                  : "Atualize as informações do contato."}
+            </CredenzaDescription>
+         </CredenzaHeader>
 
-            <CredenzaBody className="px-4">
-               <FieldGroup>
-                  <form.Field
-                     name="name"
-                     children={(field) => {
-                        const isInvalid =
-                           field.state.meta.isTouched &&
-                           field.state.meta.errors.length > 0;
-                        return (
-                           <Field data-invalid={isInvalid}>
-                              <FieldLabel htmlFor={field.name}>
-                                 Nome *
-                              </FieldLabel>
-                              <Input
-                                 id={field.name}
-                                 name={field.name}
-                                 aria-invalid={isInvalid}
-                                 onBlur={field.handleBlur}
-                                 onChange={(e) =>
-                                    field.handleChange(e.target.value)
-                                 }
-                                 placeholder="Ex: Empresa XYZ"
-                                 value={field.state.value}
-                              />
-                              {isInvalid && (
-                                 <FieldError errors={field.state.meta.errors} />
-                              )}
-                           </Field>
-                        );
-                     }}
-                  />
+         <CredenzaBody className="px-4">
+            <FieldGroup>
+               <form.Field
+                  name="name"
+                  children={(field) => {
+                     const isInvalid =
+                        field.state.meta.isTouched &&
+                        field.state.meta.errors.length > 0;
+                     return (
+                        <Field data-invalid={isInvalid}>
+                           <FieldLabel htmlFor={field.name}>Nome *</FieldLabel>
+                           <Input
+                              id={field.name}
+                              name={field.name}
+                              aria-invalid={isInvalid}
+                              onBlur={field.handleBlur}
+                              onChange={(e) =>
+                                 field.handleChange(e.target.value)
+                              }
+                              placeholder="Ex: Empresa XYZ"
+                              value={field.state.value}
+                           />
+                           {isInvalid && (
+                              <FieldError errors={field.state.meta.errors} />
+                           )}
+                        </Field>
+                     );
+                  }}
+               />
 
+               <form.Field
+                  name="type"
+                  children={(field) => (
+                     <Field>
+                        <FieldLabel>Tipo *</FieldLabel>
+                        <Select
+                           onValueChange={(v) => {
+                              if (
+                                 v === "cliente" ||
+                                 v === "fornecedor" ||
+                                 v === "ambos"
+                              ) {
+                                 field.handleChange(v);
+                              }
+                           }}
+                           value={field.state.value}
+                        >
+                           <SelectTrigger>
+                              <SelectValue placeholder="Selecione o tipo" />
+                           </SelectTrigger>
+                           <SelectContent>
+                              <SelectItem value="cliente">Cliente</SelectItem>
+                              <SelectItem value="fornecedor">
+                                 Fornecedor
+                              </SelectItem>
+                              <SelectItem value="ambos">Ambos</SelectItem>
+                           </SelectContent>
+                        </Select>
+                     </Field>
+                  )}
+               />
+
+               <div className="grid grid-cols-3 gap-2">
                   <form.Field
-                     name="type"
+                     name="documentType"
                      children={(field) => (
                         <Field>
-                           <FieldLabel>Tipo *</FieldLabel>
+                           <FieldLabel>Tipo Doc.</FieldLabel>
                            <Select
                               onValueChange={(v) => {
-                                 if (
-                                    v === "cliente" ||
-                                    v === "fornecedor" ||
-                                    v === "ambos"
-                                 ) {
+                                 if (v === "" || v === "cpf" || v === "cnpj") {
                                     field.handleChange(v);
                                  }
                               }}
                               value={field.state.value}
                            >
                               <SelectTrigger>
-                                 <SelectValue placeholder="Selecione o tipo" />
+                                 <SelectValue placeholder="—" />
                               </SelectTrigger>
                               <SelectContent>
-                                 <SelectItem value="cliente">
-                                    Cliente
-                                 </SelectItem>
-                                 <SelectItem value="fornecedor">
-                                    Fornecedor
-                                 </SelectItem>
-                                 <SelectItem value="ambos">Ambos</SelectItem>
+                                 <SelectItem value="cpf">CPF</SelectItem>
+                                 <SelectItem value="cnpj">CNPJ</SelectItem>
                               </SelectContent>
                            </Select>
                         </Field>
                      )}
                   />
 
-                  <div className="grid grid-cols-3 gap-2">
-                     <form.Field
-                        name="documentType"
-                        children={(field) => (
-                           <Field>
-                              <FieldLabel>Tipo Doc.</FieldLabel>
-                              <Select
-                                 onValueChange={(v) => {
-                                    if (
-                                       v === "" ||
-                                       v === "cpf" ||
-                                       v === "cnpj"
-                                    ) {
-                                       field.handleChange(v);
-                                    }
-                                 }}
-                                 value={field.state.value}
-                              >
-                                 <SelectTrigger>
-                                    <SelectValue placeholder="—" />
-                                 </SelectTrigger>
-                                 <SelectContent>
-                                    <SelectItem value="cpf">CPF</SelectItem>
-                                    <SelectItem value="cnpj">CNPJ</SelectItem>
-                                 </SelectContent>
-                              </Select>
-                           </Field>
-                        )}
-                     />
-
-                     <form.Field
-                        name="document"
-                        children={(field) => {
-                           const isInvalid =
-                              field.state.meta.isTouched &&
-                              field.state.meta.errors.length > 0;
-                           return (
-                              <Field
-                                 className="col-span-2"
-                                 data-invalid={isInvalid}
-                              >
-                                 <FieldLabel htmlFor={field.name}>
-                                    Número
-                                 </FieldLabel>
-                                 <Input
-                                    ref={documentRef}
-                                    aria-invalid={isInvalid}
-                                    defaultValue={field.state.value}
-                                    id={field.name}
-                                    inputMode="numeric"
-                                    name={field.name}
-                                    onBlur={field.handleBlur}
-                                    onInput={(e) =>
-                                       field.handleChange(
-                                          (e.target as HTMLInputElement).value,
-                                       )
-                                    }
-                                    placeholder={
-                                       docType === "cnpj"
-                                          ? "00.000.000/0000-00"
-                                          : "000.000.000-00"
-                                    }
-                                 />
-                              </Field>
-                           );
-                        }}
-                     />
-                  </div>
-
                   <form.Field
-                     name="email"
+                     name="document"
                      children={(field) => {
                         const isInvalid =
                            field.state.meta.isTouched &&
                            field.state.meta.errors.length > 0;
                         return (
-                           <Field data-invalid={isInvalid}>
+                           <Field
+                              className="col-span-2"
+                              data-invalid={isInvalid}
+                           >
                               <FieldLabel htmlFor={field.name}>
-                                 Email
+                                 Número
                               </FieldLabel>
                               <Input
-                                 id={field.name}
-                                 name={field.name}
-                                 aria-invalid={isInvalid}
-                                 onBlur={field.handleBlur}
-                                 onChange={(e) =>
-                                    field.handleChange(e.target.value)
-                                 }
-                                 placeholder="contato@empresa.com"
-                                 type="email"
-                                 value={field.state.value}
-                              />
-                           </Field>
-                        );
-                     }}
-                  />
-
-                  <form.Field
-                     name="phone"
-                     children={(field) => {
-                        const isInvalid =
-                           field.state.meta.isTouched &&
-                           field.state.meta.errors.length > 0;
-                        return (
-                           <Field data-invalid={isInvalid}>
-                              <FieldLabel htmlFor={field.name}>
-                                 Telefone
-                              </FieldLabel>
-                              <Input
-                                 ref={phoneRef}
+                                 ref={documentRef}
                                  aria-invalid={isInvalid}
                                  defaultValue={field.state.value}
                                  id={field.name}
@@ -416,77 +328,138 @@ export function ContactForm({ mode, contact, onSuccess }: ContactFormProps) {
                                        (e.target as HTMLInputElement).value,
                                     )
                                  }
-                                 placeholder="(11) 99999-9999"
-                              />
-                           </Field>
-                        );
-                     }}
-                  />
-
-                  <form.Field
-                     name="notes"
-                     children={(field) => {
-                        const isInvalid =
-                           field.state.meta.isTouched &&
-                           field.state.meta.errors.length > 0;
-                        return (
-                           <Field data-invalid={isInvalid}>
-                              <FieldLabel htmlFor={field.name}>
-                                 Observações
-                              </FieldLabel>
-                              <Textarea
-                                 id={field.name}
-                                 name={field.name}
-                                 aria-invalid={isInvalid}
-                                 onBlur={field.handleBlur}
-                                 onChange={(e) =>
-                                    field.handleChange(e.target.value)
+                                 placeholder={
+                                    docType === "cnpj"
+                                       ? "00.000.000/0000-00"
+                                       : "000.000.000-00"
                                  }
-                                 placeholder="Informações adicionais..."
-                                 rows={3}
-                                 value={field.state.value}
                               />
                            </Field>
                         );
                      }}
                   />
-               </FieldGroup>
-            </CredenzaBody>
+               </div>
 
-            <CredenzaFooter className="flex flex-col gap-2">
-               <form.Subscribe
-                  selector={(state) =>
-                     state.errors.flatMap((e) => {
-                        if (!e) return [];
-                        if (typeof e === "string") return [e];
-                        if ("form" in e && typeof e.form === "string")
-                           return [e.form];
-                        return [];
-                     })
-                  }
-               >
-                  {(messages) =>
-                     messages.length > 0 && <FieldError errors={messages} />
-                  }
-               </form.Subscribe>
-               <form.Subscribe
-                  selector={(state) =>
-                     [state.canSubmit, state.isSubmitting] as const
-                  }
-               >
-                  {([canSubmit, isSubmitting]) => (
-                     <Button
-                        className="w-full gap-2"
-                        disabled={!canSubmit}
-                        type="submit"
-                     >
-                        {isSubmitting && <Spinner className="size-4" />}
-                        {isCreate ? "Criar contato" : "Salvar alterações"}
-                     </Button>
-                  )}
-               </form.Subscribe>
-            </CredenzaFooter>
-         </form>
-      </>
+               <form.Field
+                  name="email"
+                  children={(field) => {
+                     const isInvalid =
+                        field.state.meta.isTouched &&
+                        field.state.meta.errors.length > 0;
+                     return (
+                        <Field data-invalid={isInvalid}>
+                           <FieldLabel htmlFor={field.name}>Email</FieldLabel>
+                           <Input
+                              id={field.name}
+                              name={field.name}
+                              aria-invalid={isInvalid}
+                              onBlur={field.handleBlur}
+                              onChange={(e) =>
+                                 field.handleChange(e.target.value)
+                              }
+                              placeholder="contato@empresa.com"
+                              type="email"
+                              value={field.state.value}
+                           />
+                        </Field>
+                     );
+                  }}
+               />
+
+               <form.Field
+                  name="phone"
+                  children={(field) => {
+                     const isInvalid =
+                        field.state.meta.isTouched &&
+                        field.state.meta.errors.length > 0;
+                     return (
+                        <Field data-invalid={isInvalid}>
+                           <FieldLabel htmlFor={field.name}>
+                              Telefone
+                           </FieldLabel>
+                           <Input
+                              ref={phoneRef}
+                              aria-invalid={isInvalid}
+                              defaultValue={field.state.value}
+                              id={field.name}
+                              inputMode="numeric"
+                              name={field.name}
+                              onBlur={field.handleBlur}
+                              onInput={(e) =>
+                                 field.handleChange(
+                                    (e.target as HTMLInputElement).value,
+                                 )
+                              }
+                              placeholder="(11) 99999-9999"
+                           />
+                        </Field>
+                     );
+                  }}
+               />
+
+               <form.Field
+                  name="notes"
+                  children={(field) => {
+                     const isInvalid =
+                        field.state.meta.isTouched &&
+                        field.state.meta.errors.length > 0;
+                     return (
+                        <Field data-invalid={isInvalid}>
+                           <FieldLabel htmlFor={field.name}>
+                              Observações
+                           </FieldLabel>
+                           <Textarea
+                              id={field.name}
+                              name={field.name}
+                              aria-invalid={isInvalid}
+                              onBlur={field.handleBlur}
+                              onChange={(e) =>
+                                 field.handleChange(e.target.value)
+                              }
+                              placeholder="Informações adicionais..."
+                              rows={3}
+                              value={field.state.value}
+                           />
+                        </Field>
+                     );
+                  }}
+               />
+            </FieldGroup>
+         </CredenzaBody>
+
+         <CredenzaFooter className="flex flex-col gap-2">
+            <form.Subscribe
+               selector={(state) =>
+                  state.errors.flatMap((e) => {
+                     if (!e) return [];
+                     if (typeof e === "string") return [e];
+                     if ("form" in e && typeof e.form === "string")
+                        return [e.form];
+                     return [];
+                  })
+               }
+            >
+               {(messages) =>
+                  messages.length > 0 && <FieldError errors={messages} />
+               }
+            </form.Subscribe>
+            <form.Subscribe
+               selector={(state) =>
+                  [state.canSubmit, state.isSubmitting] as const
+               }
+            >
+               {([canSubmit, isSubmitting]) => (
+                  <Button
+                     className="w-full gap-2"
+                     disabled={!canSubmit}
+                     type="submit"
+                  >
+                     {isSubmitting && <Spinner className="size-4" />}
+                     {isCreate ? "Criar contato" : "Salvar alterações"}
+                  </Button>
+               )}
+            </form.Subscribe>
+         </CredenzaFooter>
+      </form>
    );
 }

--- a/apps/web/src/features/contacts/ui/contacts-form.tsx
+++ b/apps/web/src/features/contacts/ui/contacts-form.tsx
@@ -26,6 +26,8 @@ import type { MaskitoOptions } from "@maskito/core";
 import { useMaskito } from "@maskito/react";
 import { ORPCError } from "@orpc/client";
 import { useForm } from "@tanstack/react-form";
+import { useMutation } from "@tanstack/react-query";
+import { fromPromise } from "neverthrow";
 import { useStore } from "@tanstack/react-store";
 import { useBlocker } from "@tanstack/react-router";
 import { useMemo } from "react";
@@ -109,6 +111,9 @@ export function ContactForm({ mode, contact, onSuccess }: ContactFormProps) {
 
    const documentTypeDefault: "" | "cpf" | "cnpj" = contact?.documentType ?? "";
 
+   const createMutation = useMutation(orpc.contacts.create.mutationOptions());
+   const updateMutation = useMutation(orpc.contacts.update.mutationOptions());
+
    const form = useForm({
       defaultValues: {
          name: contact?.name ?? "",
@@ -131,29 +136,31 @@ export function ContactForm({ mode, contact, onSuccess }: ContactFormProps) {
                   value.documentType === "" ? null : value.documentType,
                notes: value.notes?.trim() || null,
             };
-            try {
-               if (isCreate) {
-                  await orpc.contacts.create.call(payload);
-                  toast.success("Contato criado com sucesso.");
-               } else if (contact) {
-                  await orpc.contacts.update.call({
-                     id: contact.id,
-                     ...payload,
-                  });
-                  toast.success("Contato atualizado com sucesso.");
-               }
-               onSuccess();
-               return null;
-            } catch (err) {
+            const promise = isCreate
+               ? createMutation.mutateAsync(payload)
+               : contact
+                 ? updateMutation.mutateAsync({ id: contact.id, ...payload })
+                 : null;
+
+            if (!promise) return null;
+
+            const result = await fromPromise(promise, (e) => e);
+
+            if (result.isErr()) {
+               const err = result.error;
                if (err instanceof ORPCError && err.code === "CONFLICT") {
-                  return {
-                     fields: { document: "CNPJ/CPF já cadastrado." },
-                  };
+                  return { fields: { document: "CNPJ/CPF já cadastrado." } };
                }
-               return {
-                  form: err instanceof Error ? err.message : "Erro inesperado.",
-               };
+               return err instanceof Error ? err.message : "Erro inesperado.";
             }
+
+            toast.success(
+               isCreate
+                  ? "Contato criado com sucesso."
+                  : "Contato atualizado com sucesso.",
+            );
+            onSuccess();
+            return null;
          },
       },
    });
@@ -304,9 +311,7 @@ export function ContactForm({ mode, contact, onSuccess }: ContactFormProps) {
                   <form.Field
                      name="document"
                      children={(field) => {
-                        const isInvalid =
-                           field.state.meta.isTouched &&
-                           field.state.meta.errors.length > 0;
+                        const isInvalid = field.state.meta.errors.length > 0;
                         return (
                            <Field
                               className="col-span-2"
@@ -431,21 +436,6 @@ export function ContactForm({ mode, contact, onSuccess }: ContactFormProps) {
          </CredenzaBody>
 
          <CredenzaFooter className="flex flex-col gap-2">
-            <form.Subscribe
-               selector={(state) =>
-                  state.errors.flatMap((e) => {
-                     if (!e) return [];
-                     if (typeof e === "string") return [e];
-                     if ("form" in e && typeof e.form === "string")
-                        return [e.form];
-                     return [];
-                  })
-               }
-            >
-               {(messages) =>
-                  messages.length > 0 && <FieldError errors={messages} />
-               }
-            </form.Subscribe>
             <form.Subscribe
                selector={(state) =>
                   [state.canSubmit, state.isSubmitting] as const

--- a/apps/web/src/features/credit-cards/ui/credit-cards-form.tsx
+++ b/apps/web/src/features/credit-cards/ui/credit-cards-form.tsx
@@ -32,9 +32,11 @@ import {
 import { Spinner } from "@packages/ui/components/spinner";
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { useBlocker } from "@tanstack/react-router";
 import Color from "color";
 import { toast } from "sonner";
 import { orpc } from "@/integrations/orpc/client";
+import { useAlertDialog } from "@/hooks/use-alert-dialog";
 
 interface CreditCardFormProps {
    mode: "create" | "edit";
@@ -58,30 +60,13 @@ export function CreditCardForm({ mode, card, onSuccess }: CreditCardFormProps) {
       orpc.bankAccounts.getAll.queryOptions({}),
    );
 
-   const createMutation = useMutation(
-      orpc.creditCards.create.mutationOptions({
-         onSuccess: () => {
-            toast.success("Cartão de crédito criado com sucesso.");
-            onSuccess();
-         },
-         onError: (error) => {
-            toast.error(error.message || "Erro ao criar cartão de crédito.");
-         },
-      }),
-   );
+   const { openAlertDialog } = useAlertDialog();
 
+   const createMutation = useMutation(
+      orpc.creditCards.create.mutationOptions(),
+   );
    const updateMutation = useMutation(
-      orpc.creditCards.update.mutationOptions({
-         onSuccess: () => {
-            toast.success("Cartão de crédito atualizado com sucesso.");
-            onSuccess();
-         },
-         onError: (error) => {
-            toast.error(
-               error.message || "Erro ao atualizar cartão de crédito.",
-            );
-         },
-      }),
+      orpc.creditCards.update.mutationOptions(),
    );
 
    const form = useForm({
@@ -93,28 +78,60 @@ export function CreditCardForm({ mode, card, onSuccess }: CreditCardFormProps) {
          dueDay: card?.dueDay ?? 10,
          bankAccountId: card?.bankAccountId ?? "",
       },
-      onSubmit: async ({ value }) => {
-         if (isCreate) {
-            createMutation.mutate({
-               name: value.name.trim(),
-               color: value.color,
-               creditLimit: value.creditLimit,
-               closingDay: value.closingDay,
-               dueDay: value.dueDay,
-               bankAccountId: value.bankAccountId || "",
-            });
-         } else if (card) {
-            updateMutation.mutate({
-               id: card.id,
-               name: value.name.trim(),
-               color: value.color,
-               creditLimit: value.creditLimit,
-               closingDay: value.closingDay,
-               dueDay: value.dueDay,
-               bankAccountId: value.bankAccountId || undefined,
-            });
-         }
+      validators: {
+         onSubmitAsync: async ({ value }) => {
+            try {
+               if (isCreate) {
+                  await createMutation.mutateAsync({
+                     name: value.name.trim(),
+                     color: value.color,
+                     creditLimit: value.creditLimit,
+                     closingDay: value.closingDay,
+                     dueDay: value.dueDay,
+                     bankAccountId: value.bankAccountId || "",
+                  });
+                  toast.success("Cartão de crédito criado com sucesso.");
+               } else if (card) {
+                  await updateMutation.mutateAsync({
+                     id: card.id,
+                     name: value.name.trim(),
+                     color: value.color,
+                     creditLimit: value.creditLimit,
+                     closingDay: value.closingDay,
+                     dueDay: value.dueDay,
+                     bankAccountId: value.bankAccountId || undefined,
+                  });
+                  toast.success("Cartão de crédito atualizado com sucesso.");
+               }
+               onSuccess();
+               return null;
+            } catch (err) {
+               return {
+                  form: err instanceof Error ? err.message : "Erro inesperado.",
+               };
+            }
+         },
       },
+   });
+
+   const blocker = useBlocker({
+      withResolver: true,
+      shouldBlockFn: () => {
+         if (form.store.state.isDirty && !form.store.state.isSubmitted) {
+            openAlertDialog({
+               title: "Descartar alterações?",
+               description:
+                  "Você tem alterações não salvas. Tem certeza que deseja sair sem salvar?",
+               actionLabel: "Descartar alterações",
+               cancelLabel: "Continuar editando",
+               onAction: () => blocker.proceed(),
+               onCancel: () => blocker.reset(),
+            });
+            return true;
+         }
+         return false;
+      },
+      disabled: isCreate,
    });
 
    return (
@@ -348,7 +365,24 @@ export function CreditCardForm({ mode, card, onSuccess }: CreditCardFormProps) {
             </FieldGroup>
          </CredenzaBody>
 
-         <CredenzaFooter>
+         <CredenzaFooter className="flex flex-col gap-2">
+            <form.Subscribe
+               selector={(state) =>
+                  typeof state.errorMap.onSubmit === "object" &&
+                  state.errorMap.onSubmit !== null &&
+                  "form" in state.errorMap.onSubmit
+                     ? String(state.errorMap.onSubmit.form)
+                     : null
+               }
+            >
+               {(formError) =>
+                  formError && (
+                     <p className="text-sm text-destructive text-center">
+                        {formError}
+                     </p>
+                  )
+               }
+            </form.Subscribe>
             <form.Subscribe
                selector={(state) =>
                   [state.canSubmit, state.isSubmitting] as const
@@ -357,19 +391,10 @@ export function CreditCardForm({ mode, card, onSuccess }: CreditCardFormProps) {
                {([canSubmit, isSubmitting]) => (
                   <Button
                      className="w-full gap-2"
-                     disabled={
-                        !canSubmit ||
-                        isSubmitting ||
-                        createMutation.isPending ||
-                        updateMutation.isPending
-                     }
+                     disabled={!canSubmit || isSubmitting}
                      type="submit"
                   >
-                     {(isSubmitting ||
-                        createMutation.isPending ||
-                        updateMutation.isPending) && (
-                        <Spinner className="size-4" />
-                     )}
+                     {isSubmitting && <Spinner className="size-4" />}
                      {isCreate ? "Criar cartão" : "Salvar alterações"}
                   </Button>
                )}

--- a/apps/web/src/features/credit-cards/ui/credit-cards-form.tsx
+++ b/apps/web/src/features/credit-cards/ui/credit-cards-form.tsx
@@ -124,8 +124,8 @@ export function CreditCardForm({ mode, card, onSuccess }: CreditCardFormProps) {
                   "Você tem alterações não salvas. Tem certeza que deseja sair sem salvar?",
                actionLabel: "Descartar alterações",
                cancelLabel: "Continuar editando",
-               onAction: () => blocker.proceed(),
-               onCancel: () => blocker.reset(),
+               onAction: () => blocker.proceed?.(),
+               onCancel: () => blocker.reset?.(),
             });
             return true;
          }

--- a/apps/web/src/features/credit-cards/ui/credit-cards-form.tsx
+++ b/apps/web/src/features/credit-cards/ui/credit-cards-form.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@packages/ui/components/button";
+import { Spinner } from "@packages/ui/components/spinner";
 import {
    ColorPicker,
    ColorPickerAlpha,
@@ -369,13 +370,18 @@ export function CreditCardForm({ mode, card, onSuccess }: CreditCardFormProps) {
          </CredenzaBody>
 
          <CredenzaFooter className="flex flex-col gap-2">
-            <form.Subscribe selector={(state) => state.canSubmit}>
-               {(canSubmit) => (
+            <form.Subscribe
+               selector={(state) =>
+                  [state.canSubmit, state.isSubmitting] as const
+               }
+            >
+               {([canSubmit, isSubmitting]) => (
                   <Button
                      className="w-full gap-2"
-                     disabled={!canSubmit}
+                     disabled={!canSubmit || isSubmitting}
                      type="submit"
                   >
+                     {isSubmitting && <Spinner className="size-4" />}
                      {isCreate ? "Criar cartão" : "Salvar alterações"}
                   </Button>
                )}

--- a/apps/web/src/features/credit-cards/ui/credit-cards-form.tsx
+++ b/apps/web/src/features/credit-cards/ui/credit-cards-form.tsx
@@ -367,18 +367,20 @@ export function CreditCardForm({ mode, card, onSuccess }: CreditCardFormProps) {
 
          <CredenzaFooter className="flex flex-col gap-2">
             <form.Subscribe
-               selector={(state) =>
-                  typeof state.errorMap.onSubmit === "object" &&
-                  state.errorMap.onSubmit !== null &&
-                  "form" in state.errorMap.onSubmit
-                     ? String(state.errorMap.onSubmit.form)
-                     : null
+               selector={(state): string[] =>
+                  state.errors.flatMap((e) => {
+                     if (!e) return [];
+                     if (typeof e === "string") return [e];
+                     if ("form" in e && typeof e.form === "string")
+                        return [e.form];
+                     return [];
+                  })
                }
             >
-               {(formError) =>
-                  formError && (
+               {(errors) =>
+                  errors.length > 0 && (
                      <p className="text-sm text-destructive text-center">
-                        {formError}
+                        {errors.join(", ")}
                      </p>
                   )
                }

--- a/apps/web/src/features/credit-cards/ui/credit-cards-form.tsx
+++ b/apps/web/src/features/credit-cards/ui/credit-cards-form.tsx
@@ -165,9 +165,7 @@ export function CreditCardForm({ mode, card, onSuccess }: CreditCardFormProps) {
                               value={field.state.value}
                            />
                            {isInvalid && (
-                              <FieldError
-                                 errors={field.state.meta.errors as any}
-                              />
+                              <FieldError errors={field.state.meta.errors} />
                            )}
                         </Field>
                      );
@@ -281,9 +279,7 @@ export function CreditCardForm({ mode, card, onSuccess }: CreditCardFormProps) {
                               value={field.state.value}
                            />
                            {isInvalid && (
-                              <FieldError
-                                 errors={field.state.meta.errors as any}
-                              />
+                              <FieldError errors={field.state.meta.errors} />
                            )}
                         </Field>
                      );
@@ -322,9 +318,7 @@ export function CreditCardForm({ mode, card, onSuccess }: CreditCardFormProps) {
                               value={field.state.value}
                            />
                            {isInvalid && (
-                              <FieldError
-                                 errors={field.state.meta.errors as any}
-                              />
+                              <FieldError errors={field.state.meta.errors} />
                            )}
                         </Field>
                      );
@@ -362,7 +356,7 @@ export function CreditCardForm({ mode, card, onSuccess }: CreditCardFormProps) {
             >
                {([canSubmit, isSubmitting]) => (
                   <Button
-                     className="w-full"
+                     className="w-full gap-2"
                      disabled={
                         !canSubmit ||
                         isSubmitting ||
@@ -374,7 +368,7 @@ export function CreditCardForm({ mode, card, onSuccess }: CreditCardFormProps) {
                      {(isSubmitting ||
                         createMutation.isPending ||
                         updateMutation.isPending) && (
-                        <Spinner className="size-4 mr-2" />
+                        <Spinner className="size-4" />
                      )}
                      {isCreate ? "Criar cartão" : "Salvar alterações"}
                   </Button>

--- a/apps/web/src/features/credit-cards/ui/credit-cards-form.tsx
+++ b/apps/web/src/features/credit-cards/ui/credit-cards-form.tsx
@@ -34,6 +34,7 @@ import { useForm } from "@tanstack/react-form";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { useBlocker } from "@tanstack/react-router";
 import Color from "color";
+import { fromPromise } from "neverthrow";
 import { toast } from "sonner";
 import { orpc } from "@/integrations/orpc/client";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
@@ -80,36 +81,39 @@ export function CreditCardForm({ mode, card, onSuccess }: CreditCardFormProps) {
       },
       validators: {
          onSubmitAsync: async ({ value }) => {
-            try {
-               if (isCreate) {
-                  await createMutation.mutateAsync({
-                     name: value.name.trim(),
-                     color: value.color,
-                     creditLimit: value.creditLimit,
-                     closingDay: value.closingDay,
-                     dueDay: value.dueDay,
-                     bankAccountId: value.bankAccountId || "",
-                  });
-                  toast.success("Cartão de crédito criado com sucesso.");
-               } else if (card) {
-                  await updateMutation.mutateAsync({
-                     id: card.id,
-                     name: value.name.trim(),
-                     color: value.color,
-                     creditLimit: value.creditLimit,
-                     closingDay: value.closingDay,
-                     dueDay: value.dueDay,
-                     bankAccountId: value.bankAccountId || undefined,
-                  });
-                  toast.success("Cartão de crédito atualizado com sucesso.");
-               }
-               onSuccess();
-               return null;
-            } catch (err) {
-               return {
-                  form: err instanceof Error ? err.message : "Erro inesperado.",
-               };
+            const promise = isCreate
+               ? createMutation.mutateAsync({
+                    name: value.name.trim(),
+                    color: value.color,
+                    creditLimit: value.creditLimit,
+                    closingDay: value.closingDay,
+                    dueDay: value.dueDay,
+                    bankAccountId: value.bankAccountId || "",
+                 })
+               : card
+                 ? updateMutation.mutateAsync({
+                      id: card.id,
+                      name: value.name.trim(),
+                      color: value.color,
+                      creditLimit: value.creditLimit,
+                      closingDay: value.closingDay,
+                      dueDay: value.dueDay,
+                      bankAccountId: value.bankAccountId || undefined,
+                   })
+                 : null;
+            if (!promise) return null;
+            const result = await fromPromise(promise, (e) => e);
+            if (result.isErr()) {
+               const err = result.error;
+               return err instanceof Error ? err.message : "Erro inesperado.";
             }
+            toast.success(
+               isCreate
+                  ? "Cartão de crédito criado com sucesso."
+                  : "Cartão de crédito atualizado com sucesso.",
+            );
+            onSuccess();
+            return null;
          },
       },
    });
@@ -366,25 +370,6 @@ export function CreditCardForm({ mode, card, onSuccess }: CreditCardFormProps) {
          </CredenzaBody>
 
          <CredenzaFooter className="flex flex-col gap-2">
-            <form.Subscribe
-               selector={(state): string[] =>
-                  state.errors.flatMap((e) => {
-                     if (!e) return [];
-                     if (typeof e === "string") return [e];
-                     if ("form" in e && typeof e.form === "string")
-                        return [e.form];
-                     return [];
-                  })
-               }
-            >
-               {(errors) =>
-                  errors.length > 0 && (
-                     <p className="text-sm text-destructive text-center">
-                        {errors.join(", ")}
-                     </p>
-                  )
-               }
-            </form.Subscribe>
             <form.Subscribe
                selector={(state) =>
                   [state.canSubmit, state.isSubmitting] as const

--- a/apps/web/src/features/credit-cards/ui/credit-cards-form.tsx
+++ b/apps/web/src/features/credit-cards/ui/credit-cards-form.tsx
@@ -29,7 +29,6 @@ import {
    PopoverContent,
    PopoverTrigger,
 } from "@packages/ui/components/popover";
-import { Spinner } from "@packages/ui/components/spinner";
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { useBlocker } from "@tanstack/react-router";
@@ -370,18 +369,13 @@ export function CreditCardForm({ mode, card, onSuccess }: CreditCardFormProps) {
          </CredenzaBody>
 
          <CredenzaFooter className="flex flex-col gap-2">
-            <form.Subscribe
-               selector={(state) =>
-                  [state.canSubmit, state.isSubmitting] as const
-               }
-            >
-               {([canSubmit, isSubmitting]) => (
+            <form.Subscribe selector={(state) => state.canSubmit}>
+               {(canSubmit) => (
                   <Button
                      className="w-full gap-2"
-                     disabled={!canSubmit || isSubmitting}
+                     disabled={!canSubmit}
                      type="submit"
                   >
-                     {isSubmitting && <Spinner className="size-4" />}
                      {isCreate ? "Criar cartão" : "Salvar alterações"}
                   </Button>
                )}

--- a/apps/web/src/features/credit-cards/ui/credit-cards-form.tsx
+++ b/apps/web/src/features/credit-cards/ui/credit-cards-form.tsx
@@ -355,19 +355,23 @@ export function CreditCardForm({ mode, card, onSuccess }: CreditCardFormProps) {
          </CredenzaBody>
 
          <CredenzaFooter>
-            <form.Subscribe selector={(state) => state}>
-               {(state) => (
+            <form.Subscribe
+               selector={(state) =>
+                  [state.canSubmit, state.isSubmitting] as const
+               }
+            >
+               {([canSubmit, isSubmitting]) => (
                   <Button
                      className="w-full"
                      disabled={
-                        !state.canSubmit ||
-                        state.isSubmitting ||
+                        !canSubmit ||
+                        isSubmitting ||
                         createMutation.isPending ||
                         updateMutation.isPending
                      }
                      type="submit"
                   >
-                     {(state.isSubmitting ||
+                     {(isSubmitting ||
                         createMutation.isPending ||
                         updateMutation.isPending) && (
                         <Spinner className="size-4 mr-2" />

--- a/apps/web/src/features/services/ui/services-form.tsx
+++ b/apps/web/src/features/services/ui/services-form.tsx
@@ -456,19 +456,23 @@ export function ServiceForm({ mode, service, onSuccess }: ServiceFormProps) {
          </CredenzaBody>
 
          <CredenzaFooter>
-            <form.Subscribe selector={(state) => state}>
-               {(state) => (
+            <form.Subscribe
+               selector={(state) =>
+                  [state.canSubmit, state.isSubmitting] as const
+               }
+            >
+               {([canSubmit, isSubmitting]) => (
                   <Button
                      className="w-full"
                      disabled={
-                        !state.canSubmit ||
-                        state.isSubmitting ||
+                        !canSubmit ||
+                        isSubmitting ||
                         isPending ||
                         mutationsPending
                      }
                      type="submit"
                   >
-                     {(state.isSubmitting || isPending || mutationsPending) && (
+                     {(isSubmitting || isPending || mutationsPending) && (
                         <Spinner className="size-4 mr-2" />
                      )}
                      {isCreate ? "Criar serviço" : "Salvar alterações"}

--- a/apps/web/src/features/services/ui/services-form.tsx
+++ b/apps/web/src/features/services/ui/services-form.tsx
@@ -471,18 +471,20 @@ export function ServiceForm({ mode, service, onSuccess }: ServiceFormProps) {
 
          <CredenzaFooter className="flex flex-col gap-2">
             <form.Subscribe
-               selector={(state) =>
-                  typeof state.errorMap.onSubmit === "object" &&
-                  state.errorMap.onSubmit !== null &&
-                  "form" in state.errorMap.onSubmit
-                     ? String(state.errorMap.onSubmit.form)
-                     : null
+               selector={(state): string[] =>
+                  state.errors.flatMap((e) => {
+                     if (!e) return [];
+                     if (typeof e === "string") return [e];
+                     if ("form" in e && typeof e.form === "string")
+                        return [e.form];
+                     return [];
+                  })
                }
             >
-               {(formError) =>
-                  formError && (
+               {(errors) =>
+                  errors.length > 0 && (
                      <p className="text-sm text-destructive text-center">
-                        {formError}
+                        {errors.join(", ")}
                      </p>
                   )
                }

--- a/apps/web/src/features/services/ui/services-form.tsx
+++ b/apps/web/src/features/services/ui/services-form.tsx
@@ -28,6 +28,7 @@ import {
 import { useBlocker } from "@tanstack/react-router";
 import { PlusCircle, Trash2 } from "lucide-react";
 import { toast } from "sonner";
+import { QueryBoundary } from "@/components/query-boundary";
 import { orpc } from "@/integrations/orpc/client";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import type { ServiceRow } from "./services-columns";
@@ -353,7 +354,12 @@ export function ServiceForm({ mode, service, onSuccess }: ServiceFormProps) {
                </div>
 
                {!isCreate && service?.id && (
-                  <ExistingVariants serviceId={service.id} />
+                  <QueryBoundary
+                     errorTitle="Erro ao carregar variantes"
+                     fallback={null}
+                  >
+                     <ExistingVariants serviceId={service.id} />
+                  </QueryBoundary>
                )}
 
                <form.Field

--- a/apps/web/src/features/services/ui/services-form.tsx
+++ b/apps/web/src/features/services/ui/services-form.tsx
@@ -21,9 +21,9 @@ import { Spinner } from "@packages/ui/components/spinner";
 import { Textarea } from "@packages/ui/components/textarea";
 import { useForm } from "@tanstack/react-form";
 import {
-   skipToken,
    useMutation,
    useSuspenseQueries,
+   useSuspenseQuery,
 } from "@tanstack/react-query";
 import { useBlocker } from "@tanstack/react-router";
 import { PlusCircle, Trash2 } from "lucide-react";
@@ -60,24 +60,41 @@ interface ServiceFormProps {
    onSuccess: () => void;
 }
 
+function ExistingVariants({ serviceId }: { serviceId: string }) {
+   const { data } = useSuspenseQuery(
+      orpc.services.getVariants.queryOptions({ input: { serviceId } }),
+   );
+   if (!data || data.length === 0) return null;
+   return (
+      <div className="flex flex-col gap-2">
+         <span className="text-xs text-muted-foreground">
+            Variantes existentes
+         </span>
+         {data.map((v) => (
+            <div
+               className="flex items-center justify-between p-2 border rounded-md text-sm"
+               key={v.id}
+            >
+               <span>{v.name}</span>
+               <span className="text-muted-foreground text-xs">
+                  {BILLING_CYCLE_LABELS[v.billingCycle as BillingCycle] ??
+                     v.billingCycle}
+               </span>
+            </div>
+         ))}
+      </div>
+   );
+}
+
 export function ServiceForm({ mode, service, onSuccess }: ServiceFormProps) {
    const isCreate = mode === "create";
 
-   const [{ data: categories }, { data: tags }, { data: existingVariants }] =
-      useSuspenseQueries({
-         queries: [
-            orpc.categories.getAll.queryOptions({}),
-            orpc.tags.getAll.queryOptions({}),
-            !isCreate && service?.id
-               ? orpc.services.getVariants.queryOptions({
-                    input: { serviceId: service.id },
-                 })
-               : {
-                    queryKey: ["disabled-variants", service?.id],
-                    queryFn: skipToken,
-                 },
-         ],
-      });
+   const [{ data: categories }, { data: tags }] = useSuspenseQueries({
+      queries: [
+         orpc.categories.getAll.queryOptions({}),
+         orpc.tags.getAll.queryOptions({}),
+      ],
+   });
 
    const { openAlertDialog } = useAlertDialog();
 
@@ -159,8 +176,8 @@ export function ServiceForm({ mode, service, onSuccess }: ServiceFormProps) {
                   "Você tem alterações não salvas. Tem certeza que deseja sair sem salvar?",
                actionLabel: "Descartar alterações",
                cancelLabel: "Continuar editando",
-               onAction: () => blocker.proceed(),
-               onCancel: () => blocker.reset(),
+               onAction: () => blocker.proceed?.(),
+               onCancel: () => blocker.reset?.(),
             });
             return true;
          }
@@ -335,28 +352,9 @@ export function ServiceForm({ mode, service, onSuccess }: ServiceFormProps) {
                   />
                </div>
 
-               {!isCreate &&
-                  existingVariants &&
-                  existingVariants.length > 0 && (
-                     <div className="flex flex-col gap-2">
-                        <span className="text-xs text-muted-foreground">
-                           Variantes existentes
-                        </span>
-                        {existingVariants.map((v) => (
-                           <div
-                              className="flex items-center justify-between p-2 border rounded-md text-sm"
-                              key={v.id}
-                           >
-                              <span>{v.name}</span>
-                              <span className="text-muted-foreground text-xs">
-                                 {BILLING_CYCLE_LABELS[
-                                    v.billingCycle as BillingCycle
-                                 ] ?? v.billingCycle}
-                              </span>
-                           </div>
-                        ))}
-                     </div>
-                  )}
+               {!isCreate && service?.id && (
+                  <ExistingVariants serviceId={service.id} />
+               )}
 
                <form.Field
                   mode="array"

--- a/apps/web/src/features/services/ui/services-form.tsx
+++ b/apps/web/src/features/services/ui/services-form.tsx
@@ -20,7 +20,11 @@ import { Separator } from "@packages/ui/components/separator";
 import { Spinner } from "@packages/ui/components/spinner";
 import { Textarea } from "@packages/ui/components/textarea";
 import { useForm } from "@tanstack/react-form";
-import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import {
+   skipToken,
+   useMutation,
+   useSuspenseQuery,
+} from "@tanstack/react-query";
 import { PlusCircle, Trash2 } from "lucide-react";
 import { useTransition } from "react";
 import { toast } from "sonner";
@@ -65,11 +69,12 @@ export function ServiceForm({ mode, service, onSuccess }: ServiceFormProps) {
 
    const { data: tags } = useSuspenseQuery(orpc.tags.getAll.queryOptions({}));
 
-   const { data: existingVariants } = useQuery(
-      orpc.services.getVariants.queryOptions({
-         input: { serviceId: service?.id ?? "" },
-         enabled: !isCreate && !!service?.id,
-      }),
+   const { data: existingVariants } = useSuspenseQuery(
+      !isCreate && service?.id
+         ? orpc.services.getVariants.queryOptions({
+              input: { serviceId: service.id },
+           })
+         : { queryKey: ["disabled-variants", service?.id], queryFn: skipToken },
    );
 
    const createMutation = useMutation(

--- a/apps/web/src/features/services/ui/services-form.tsx
+++ b/apps/web/src/features/services/ui/services-form.tsx
@@ -307,7 +307,7 @@ export function ServiceForm({ mode, service, onSuccess }: ServiceFormProps) {
                      name="variants"
                      children={(field) => (
                         <Button
-                           className="h-7 text-xs"
+                           className="h-7 text-xs gap-2"
                            onClick={() =>
                               field.pushValue({
                                  name: "",
@@ -319,7 +319,7 @@ export function ServiceForm({ mode, service, onSuccess }: ServiceFormProps) {
                            type="button"
                            variant="outline"
                         >
-                           <PlusCircle className="size-3.5 mr-1" />
+                           <PlusCircle className="size-3.5" />
                            Adicionar
                         </Button>
                      )}
@@ -468,7 +468,7 @@ export function ServiceForm({ mode, service, onSuccess }: ServiceFormProps) {
             >
                {([canSubmit, isSubmitting]) => (
                   <Button
-                     className="w-full"
+                     className="w-full gap-2"
                      disabled={
                         !canSubmit ||
                         isSubmitting ||
@@ -478,7 +478,7 @@ export function ServiceForm({ mode, service, onSuccess }: ServiceFormProps) {
                      type="submit"
                   >
                      {(isSubmitting || isPending || mutationsPending) && (
-                        <Spinner className="size-4 mr-2" />
+                        <Spinner className="size-4" />
                      )}
                      {isCreate ? "Criar serviço" : "Salvar alterações"}
                   </Button>

--- a/apps/web/src/features/services/ui/services-form.tsx
+++ b/apps/web/src/features/services/ui/services-form.tsx
@@ -25,10 +25,11 @@ import {
    useMutation,
    useSuspenseQueries,
 } from "@tanstack/react-query";
+import { useBlocker } from "@tanstack/react-router";
 import { PlusCircle, Trash2 } from "lucide-react";
-import { useTransition } from "react";
 import { toast } from "sonner";
 import { orpc } from "@/integrations/orpc/client";
+import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import type { ServiceRow } from "./services-columns";
 
 type BillingCycle = "hourly" | "monthly" | "annual" | "one_time";
@@ -61,7 +62,6 @@ interface ServiceFormProps {
 
 export function ServiceForm({ mode, service, onSuccess }: ServiceFormProps) {
    const isCreate = mode === "create";
-   const [isPending, startTransition] = useTransition();
 
    const [{ data: categories }, { data: tags }, { data: existingVariants }] =
       useSuspenseQueries({
@@ -79,29 +79,15 @@ export function ServiceForm({ mode, service, onSuccess }: ServiceFormProps) {
          ],
       });
 
-   const createMutation = useMutation(
-      orpc.services.create.mutationOptions({
-         onError: (error) => {
-            toast.error(error.message || "Erro ao criar serviço.");
-         },
-      }),
-   );
+   const { openAlertDialog } = useAlertDialog();
 
-   const updateMutation = useMutation(
-      orpc.services.update.mutationOptions({
-         onError: (error) => {
-            toast.error(error.message || "Erro ao atualizar serviço.");
-         },
-      }),
-   );
-
+   const createMutation = useMutation(orpc.services.create.mutationOptions());
+   const updateMutation = useMutation(orpc.services.update.mutationOptions());
    const createVariantMutation = useMutation(
-      orpc.services.createVariant.mutationOptions({
-         onError: (error) => {
-            toast.error(error.message || "Erro ao criar variante.");
-         },
-      }),
+      orpc.services.createVariant.mutationOptions(),
    );
+
+   const emptyVariants: VariantFormValue[] = [];
 
    const form = useForm({
       defaultValues: {
@@ -110,62 +96,83 @@ export function ServiceForm({ mode, service, onSuccess }: ServiceFormProps) {
          basePrice: service?.basePrice ?? "0",
          categoryId: service?.categoryId ?? "",
          tagId: service?.tagId ?? "",
-         variants: [] as VariantFormValue[],
+         variants: emptyVariants,
       },
-      onSubmit: async ({ value }) => {
-         const categoryId = value.categoryId.trim() || undefined;
-         const tagId = value.tagId.trim() || undefined;
+      validators: {
+         onSubmitAsync: async ({ value }) => {
+            const categoryId = value.categoryId.trim() || undefined;
+            const tagId = value.tagId.trim() || undefined;
 
-         if (isCreate) {
-            const created = await createMutation.mutateAsync({
-               name: value.name.trim(),
-               description: value.description.trim() || undefined,
-               basePrice: value.basePrice,
-               categoryId,
-               tagId,
-            });
+            try {
+               if (isCreate) {
+                  const created = await createMutation.mutateAsync({
+                     name: value.name.trim(),
+                     description: value.description.trim() || undefined,
+                     basePrice: value.basePrice,
+                     categoryId,
+                     tagId,
+                  });
 
-            if (value.variants.length > 0) {
-               await Promise.all(
-                  value.variants.map((v) =>
-                     createVariantMutation.mutateAsync({
-                        serviceId: created.id,
-                        name: v.name.trim(),
-                        basePrice: v.basePrice,
-                        billingCycle: v.billingCycle as BillingCycle,
-                     }),
-                  ),
-               );
+                  if (value.variants.length > 0) {
+                     await Promise.all(
+                        value.variants.map((v) =>
+                           createVariantMutation.mutateAsync({
+                              serviceId: created.id,
+                              name: v.name.trim(),
+                              basePrice: v.basePrice,
+                              billingCycle: v.billingCycle,
+                           }),
+                        ),
+                     );
+                  }
+
+                  toast.success("Serviço criado.");
+               } else if (service) {
+                  await updateMutation.mutateAsync({
+                     id: service.id,
+                     name: value.name.trim(),
+                     description: value.description.trim() || undefined,
+                     basePrice: value.basePrice,
+                     categoryId,
+                     tagId,
+                  });
+                  toast.success("Serviço atualizado.");
+               }
+               onSuccess();
+               return null;
+            } catch (err) {
+               return {
+                  form: err instanceof Error ? err.message : "Erro inesperado.",
+               };
             }
-
-            toast.success("Serviço criado.");
-         } else if (service) {
-            await updateMutation.mutateAsync({
-               id: service.id,
-               name: value.name.trim(),
-               description: value.description.trim() || undefined,
-               basePrice: value.basePrice,
-               categoryId,
-               tagId,
-            });
-            toast.success("Serviço atualizado.");
-         }
-
-         onSuccess();
+         },
       },
    });
 
-   const mutationsPending =
-      createMutation.isPending ||
-      updateMutation.isPending ||
-      createVariantMutation.isPending;
+   const blocker = useBlocker({
+      withResolver: true,
+      shouldBlockFn: () => {
+         if (form.store.state.isDirty && !form.store.state.isSubmitted) {
+            openAlertDialog({
+               title: "Descartar alterações?",
+               description:
+                  "Você tem alterações não salvas. Tem certeza que deseja sair sem salvar?",
+               actionLabel: "Descartar alterações",
+               cancelLabel: "Continuar editando",
+               onAction: () => blocker.proceed(),
+               onCancel: () => blocker.reset(),
+            });
+            return true;
+         }
+         return false;
+      },
+      disabled: isCreate,
+   });
 
    const handleSubmit = (e: React.FormEvent) => {
       e.preventDefault();
       e.stopPropagation();
-      startTransition(async () => {
-         await form.handleSubmit();
-      });
+      form.handleSubmit();
    };
 
    return (
@@ -462,7 +469,24 @@ export function ServiceForm({ mode, service, onSuccess }: ServiceFormProps) {
             </div>
          </CredenzaBody>
 
-         <CredenzaFooter>
+         <CredenzaFooter className="flex flex-col gap-2">
+            <form.Subscribe
+               selector={(state) =>
+                  typeof state.errorMap.onSubmit === "object" &&
+                  state.errorMap.onSubmit !== null &&
+                  "form" in state.errorMap.onSubmit
+                     ? String(state.errorMap.onSubmit.form)
+                     : null
+               }
+            >
+               {(formError) =>
+                  formError && (
+                     <p className="text-sm text-destructive text-center">
+                        {formError}
+                     </p>
+                  )
+               }
+            </form.Subscribe>
             <form.Subscribe
                selector={(state) =>
                   [state.canSubmit, state.isSubmitting] as const
@@ -471,17 +495,10 @@ export function ServiceForm({ mode, service, onSuccess }: ServiceFormProps) {
                {([canSubmit, isSubmitting]) => (
                   <Button
                      className="w-full gap-2"
-                     disabled={
-                        !canSubmit ||
-                        isSubmitting ||
-                        isPending ||
-                        mutationsPending
-                     }
+                     disabled={!canSubmit || isSubmitting}
                      type="submit"
                   >
-                     {(isSubmitting || isPending || mutationsPending) && (
-                        <Spinner className="size-4" />
-                     )}
+                     {isSubmitting && <Spinner className="size-4" />}
                      {isCreate ? "Criar serviço" : "Salvar alterações"}
                   </Button>
                )}

--- a/apps/web/src/features/services/ui/services-form.tsx
+++ b/apps/web/src/features/services/ui/services-form.tsx
@@ -23,7 +23,7 @@ import { useForm } from "@tanstack/react-form";
 import {
    skipToken,
    useMutation,
-   useSuspenseQuery,
+   useSuspenseQueries,
 } from "@tanstack/react-query";
 import { PlusCircle, Trash2 } from "lucide-react";
 import { useTransition } from "react";
@@ -63,19 +63,21 @@ export function ServiceForm({ mode, service, onSuccess }: ServiceFormProps) {
    const isCreate = mode === "create";
    const [isPending, startTransition] = useTransition();
 
-   const { data: categories } = useSuspenseQuery(
-      orpc.categories.getAll.queryOptions({}),
-   );
-
-   const { data: tags } = useSuspenseQuery(orpc.tags.getAll.queryOptions({}));
-
-   const { data: existingVariants } = useSuspenseQuery(
-      !isCreate && service?.id
-         ? orpc.services.getVariants.queryOptions({
-              input: { serviceId: service.id },
-           })
-         : { queryKey: ["disabled-variants", service?.id], queryFn: skipToken },
-   );
+   const [{ data: categories }, { data: tags }, { data: existingVariants }] =
+      useSuspenseQueries({
+         queries: [
+            orpc.categories.getAll.queryOptions({}),
+            orpc.tags.getAll.queryOptions({}),
+            !isCreate && service?.id
+               ? orpc.services.getVariants.queryOptions({
+                    input: { serviceId: service.id },
+                 })
+               : {
+                    queryKey: ["disabled-variants", service?.id],
+                    queryFn: skipToken,
+                 },
+         ],
+      });
 
    const createMutation = useMutation(
       orpc.services.create.mutationOptions({

--- a/apps/web/src/features/services/ui/services-form.tsx
+++ b/apps/web/src/features/services/ui/services-form.tsx
@@ -27,6 +27,7 @@ import {
 } from "@tanstack/react-query";
 import { useBlocker } from "@tanstack/react-router";
 import { PlusCircle, Trash2 } from "lucide-react";
+import { fromPromise } from "neverthrow";
 import { toast } from "sonner";
 import { QueryBoundary } from "@/components/query-boundary";
 import { orpc } from "@/integrations/orpc/client";
@@ -121,48 +122,69 @@ export function ServiceForm({ mode, service, onSuccess }: ServiceFormProps) {
             const categoryId = value.categoryId.trim() || undefined;
             const tagId = value.tagId.trim() || undefined;
 
-            try {
-               if (isCreate) {
-                  const created = await createMutation.mutateAsync({
+            if (isCreate) {
+               const createResult = await fromPromise(
+                  createMutation.mutateAsync({
                      name: value.name.trim(),
                      description: value.description.trim() || undefined,
                      basePrice: value.basePrice,
                      categoryId,
                      tagId,
-                  });
-
-                  if (value.variants.length > 0) {
-                     await Promise.all(
-                        value.variants.map((v) =>
-                           createVariantMutation.mutateAsync({
-                              serviceId: created.id,
-                              name: v.name.trim(),
-                              basePrice: v.basePrice,
-                              billingCycle: v.billingCycle,
-                           }),
-                        ),
+                  }),
+                  (e) => e,
+               );
+               if (createResult.isErr()) {
+                  const err = createResult.error;
+                  return err instanceof Error
+                     ? err.message
+                     : "Erro inesperado.";
+               }
+               if (value.variants.length > 0) {
+                  const results = await Promise.allSettled(
+                     value.variants.map((v) =>
+                        createVariantMutation.mutateAsync({
+                           serviceId: createResult.value.id,
+                           name: v.name.trim(),
+                           basePrice: v.basePrice,
+                           billingCycle: v.billingCycle,
+                        }),
+                     ),
+                  );
+                  const failed = results.filter(
+                     (r) => r.status === "rejected",
+                  ).length;
+                  if (failed > 0) {
+                     toast.warning(
+                        `Serviço criado, mas ${failed} variante(s) falharam.`,
                      );
+                  } else {
+                     toast.success("Serviço criado.");
                   }
-
+               } else {
                   toast.success("Serviço criado.");
-               } else if (service) {
-                  await updateMutation.mutateAsync({
+               }
+            } else if (service) {
+               const updateResult = await fromPromise(
+                  updateMutation.mutateAsync({
                      id: service.id,
                      name: value.name.trim(),
                      description: value.description.trim() || undefined,
                      basePrice: value.basePrice,
                      categoryId,
                      tagId,
-                  });
-                  toast.success("Serviço atualizado.");
+                  }),
+                  (e) => e,
+               );
+               if (updateResult.isErr()) {
+                  const err = updateResult.error;
+                  return err instanceof Error
+                     ? err.message
+                     : "Erro inesperado.";
                }
-               onSuccess();
-               return null;
-            } catch (err) {
-               return {
-                  form: err instanceof Error ? err.message : "Erro inesperado.",
-               };
+               toast.success("Serviço atualizado.");
             }
+            onSuccess();
+            return null;
          },
       },
    });
@@ -474,25 +496,6 @@ export function ServiceForm({ mode, service, onSuccess }: ServiceFormProps) {
          </CredenzaBody>
 
          <CredenzaFooter className="flex flex-col gap-2">
-            <form.Subscribe
-               selector={(state): string[] =>
-                  state.errors.flatMap((e) => {
-                     if (!e) return [];
-                     if (typeof e === "string") return [e];
-                     if ("form" in e && typeof e.form === "string")
-                        return [e.form];
-                     return [];
-                  })
-               }
-            >
-               {(errors) =>
-                  errors.length > 0 && (
-                     <p className="text-sm text-destructive text-center">
-                        {errors.join(", ")}
-                     </p>
-                  )
-               }
-            </form.Subscribe>
             <form.Subscribe
                selector={(state) =>
                   [state.canSubmit, state.isSubmitting] as const

--- a/apps/web/src/features/services/ui/subscription-form.tsx
+++ b/apps/web/src/features/services/ui/subscription-form.tsx
@@ -27,7 +27,8 @@ import { Spinner } from "@packages/ui/components/spinner";
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import dayjs from "dayjs";
-import { useMemo, useState, useTransition } from "react";
+import { Suspense, useMemo, useState, useTransition } from "react";
+import { Skeleton } from "@packages/ui/components/skeleton";
 import { toast } from "sonner";
 import type { AnyFieldMeta } from "@tanstack/react-form";
 import type { Outputs } from "@/integrations/orpc/client";
@@ -214,14 +215,18 @@ export function SubscriptionForm({
                            field.state.meta.isTouched &&
                            field.state.meta.errors.length > 0;
                         return (
-                           <VariantSelectField
-                              errors={field.state.meta.errors}
-                              isInvalid={isInvalid}
-                              onValueChange={(v) => field.handleChange(v)}
-                              onVariantChange={setSelectedVariant}
-                              serviceId={selectedServiceId}
-                              value={field.state.value}
-                           />
+                           <Suspense
+                              fallback={<Skeleton className="h-10 w-full" />}
+                           >
+                              <VariantSelectField
+                                 errors={field.state.meta.errors}
+                                 isInvalid={isInvalid}
+                                 onValueChange={(v) => field.handleChange(v)}
+                                 onVariantChange={setSelectedVariant}
+                                 serviceId={selectedServiceId}
+                                 value={field.state.value}
+                              />
+                           </Suspense>
                         );
                      }}
                   />

--- a/apps/web/src/features/services/ui/subscription-form.tsx
+++ b/apps/web/src/features/services/ui/subscription-form.tsx
@@ -25,19 +25,67 @@ import {
 } from "@packages/ui/components/select";
 import { Spinner } from "@packages/ui/components/spinner";
 import { useForm } from "@tanstack/react-form";
-import {
-   skipToken,
-   useMutation,
-   useSuspenseQuery,
-} from "@tanstack/react-query";
+import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import dayjs from "dayjs";
 import { useMemo, useState, useTransition } from "react";
 import { toast } from "sonner";
+import type { AnyFieldMeta } from "@tanstack/react-form";
+import type { Outputs } from "@/integrations/orpc/client";
 import { orpc } from "@/integrations/orpc/client";
+
+type ServiceVariant = Outputs["services"]["getVariants"][number];
 
 interface SubscriptionFormProps {
    contactId: string;
    onSuccess: () => void;
+}
+
+interface VariantSelectFieldProps {
+   serviceId: string;
+   value: string;
+   onValueChange: (variantId: string) => void;
+   onVariantChange: (variant: ServiceVariant | null) => void;
+   isInvalid: boolean;
+   errors: AnyFieldMeta["errors"];
+}
+
+function VariantSelectField({
+   serviceId,
+   value,
+   onValueChange,
+   onVariantChange,
+   isInvalid,
+   errors,
+}: VariantSelectFieldProps) {
+   const { data: variants } = useSuspenseQuery(
+      orpc.services.getVariants.queryOptions({ input: { serviceId } }),
+   );
+
+   return (
+      <Field data-invalid={isInvalid}>
+         <FieldLabel>Variante *</FieldLabel>
+         <Select
+            onValueChange={(v) => {
+               onValueChange(v);
+               onVariantChange(variants.find((vt) => vt.id === v) ?? null);
+            }}
+            value={value}
+         >
+            <SelectTrigger>
+               <SelectValue placeholder="Selecione a variante" />
+            </SelectTrigger>
+            <SelectContent>
+               {variants.map((variant) => (
+                  <SelectItem key={variant.id} value={variant.id}>
+                     {variant.name} —{" "}
+                     {format(of(variant.basePrice, "BRL"), "pt-BR")}
+                  </SelectItem>
+               ))}
+            </SelectContent>
+         </Select>
+         {isInvalid && <FieldError errors={errors} />}
+      </Field>
+   );
 }
 
 export function SubscriptionForm({
@@ -85,21 +133,9 @@ export function SubscriptionForm({
    });
 
    const [selectedServiceId, setSelectedServiceId] = useState("");
-   const [selectedVariantId, setSelectedVariantId] = useState("");
+   const [selectedVariant, setSelectedVariant] =
+      useState<ServiceVariant | null>(null);
    const [negotiatedPrice, setNegotiatedPrice] = useState("0");
-
-   const { data: variants = [] } = useSuspenseQuery(
-      selectedServiceId
-         ? orpc.services.getVariants.queryOptions({
-              input: { serviceId: selectedServiceId },
-           })
-         : { queryKey: ["disabled-variants"], queryFn: skipToken },
-   );
-
-   const selectedVariant = useMemo(
-      () => variants.find((v) => v.id === selectedVariantId) ?? null,
-      [variants, selectedVariantId],
-   );
 
    const discountPercent = useMemo(() => {
       const neg = Number(negotiatedPrice);
@@ -142,7 +178,7 @@ export function SubscriptionForm({
                                  field.handleChange(v);
                                  setSelectedServiceId(v);
                                  form.setFieldValue("variantId", "");
-                                 setSelectedVariantId("");
+                                 setSelectedVariant(null);
                               }}
                               value={field.state.value}
                            >
@@ -178,37 +214,14 @@ export function SubscriptionForm({
                            field.state.meta.isTouched &&
                            field.state.meta.errors.length > 0;
                         return (
-                           <Field data-invalid={isInvalid}>
-                              <FieldLabel>Variante *</FieldLabel>
-                              <Select
-                                 onValueChange={(v) => {
-                                    field.handleChange(v);
-                                    setSelectedVariantId(v);
-                                 }}
-                                 value={field.state.value}
-                              >
-                                 <SelectTrigger>
-                                    <SelectValue placeholder="Selecione a variante" />
-                                 </SelectTrigger>
-                                 <SelectContent>
-                                    {variants.map((variant) => (
-                                       <SelectItem
-                                          key={variant.id}
-                                          value={variant.id}
-                                       >
-                                          {variant.name} —{" "}
-                                          {format(
-                                             of(variant.basePrice, "BRL"),
-                                             "pt-BR",
-                                          )}
-                                       </SelectItem>
-                                    ))}
-                                 </SelectContent>
-                              </Select>
-                              {isInvalid && (
-                                 <FieldError errors={field.state.meta.errors} />
-                              )}
-                           </Field>
+                           <VariantSelectField
+                              errors={field.state.meta.errors}
+                              isInvalid={isInvalid}
+                              onValueChange={(v) => field.handleChange(v)}
+                              onVariantChange={setSelectedVariant}
+                              serviceId={selectedServiceId}
+                              value={field.state.value}
+                           />
                         );
                      }}
                   />

--- a/apps/web/src/features/services/ui/subscription-form.tsx
+++ b/apps/web/src/features/services/ui/subscription-form.tsx
@@ -25,7 +25,11 @@ import {
 } from "@packages/ui/components/select";
 import { Spinner } from "@packages/ui/components/spinner";
 import { useForm } from "@tanstack/react-form";
-import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import {
+   skipToken,
+   useMutation,
+   useSuspenseQuery,
+} from "@tanstack/react-query";
 import dayjs from "dayjs";
 import { useMemo, useState, useTransition } from "react";
 import { toast } from "sonner";
@@ -84,12 +88,13 @@ export function SubscriptionForm({
    const [selectedVariantId, setSelectedVariantId] = useState("");
    const [negotiatedPrice, setNegotiatedPrice] = useState("0");
 
-   const { data: variants = [] } = useQuery({
-      ...orpc.services.getVariants.queryOptions({
-         input: { serviceId: selectedServiceId },
-      }),
-      enabled: !!selectedServiceId,
-   });
+   const { data: variants = [] } = useSuspenseQuery(
+      selectedServiceId
+         ? orpc.services.getVariants.queryOptions({
+              input: { serviceId: selectedServiceId },
+           })
+         : { queryKey: ["disabled-variants"], queryFn: skipToken },
+   );
 
    const selectedVariant = useMemo(
       () => variants.find((v) => v.id === selectedVariantId) ?? null,

--- a/apps/web/src/features/services/ui/subscription-form.tsx
+++ b/apps/web/src/features/services/ui/subscription-form.tsx
@@ -350,7 +350,7 @@ export function SubscriptionForm({
             >
                {([canSubmit, isSubmitting]) => (
                   <Button
-                     className="w-full"
+                     className="w-full gap-2"
                      disabled={
                         !canSubmit ||
                         isSubmitting ||
@@ -362,7 +362,7 @@ export function SubscriptionForm({
                      {(isSubmitting ||
                         isPending ||
                         createMutation.isPending) && (
-                        <Spinner className="size-4 mr-2" />
+                        <Spinner className="size-4" />
                      )}
                      Criar assinatura
                   </Button>

--- a/apps/web/src/features/services/ui/subscription-form.tsx
+++ b/apps/web/src/features/services/ui/subscription-form.tsx
@@ -338,19 +338,23 @@ export function SubscriptionForm({
          </CredenzaBody>
 
          <CredenzaFooter>
-            <form.Subscribe selector={(state) => state}>
-               {(state) => (
+            <form.Subscribe
+               selector={(state) =>
+                  [state.canSubmit, state.isSubmitting] as const
+               }
+            >
+               {([canSubmit, isSubmitting]) => (
                   <Button
                      className="w-full"
                      disabled={
-                        !state.canSubmit ||
-                        state.isSubmitting ||
+                        !canSubmit ||
+                        isSubmitting ||
                         isPending ||
                         createMutation.isPending
                      }
                      type="submit"
                   >
-                     {(state.isSubmitting ||
+                     {(isSubmitting ||
                         isPending ||
                         createMutation.isPending) && (
                         <Spinner className="size-4 mr-2" />

--- a/apps/web/src/features/transactions/ui/transaction-dialog-stack.tsx
+++ b/apps/web/src/features/transactions/ui/transaction-dialog-stack.tsx
@@ -861,8 +861,8 @@ function TransactionDialogStackContent({
                   "Você tem alterações não salvas. Tem certeza que deseja sair sem salvar?",
                actionLabel: "Descartar alterações",
                cancelLabel: "Continuar editando",
-               onAction: () => blocker.proceed(),
-               onCancel: () => blocker.reset(),
+               onAction: () => blocker.proceed?.(),
+               onCancel: () => blocker.reset?.(),
             });
             return true;
          }

--- a/apps/web/src/features/transactions/ui/transaction-dialog-stack.tsx
+++ b/apps/web/src/features/transactions/ui/transaction-dialog-stack.tsx
@@ -1949,27 +1949,29 @@ function TransactionDialogStackContent({
             </FieldGroup>
          </CredenzaBody>
          <CredenzaFooter>
-            <form.Subscribe selector={(state) => state}>
-               {(formState) => {
-                  const createAsBill =
+            <form.Subscribe
+               selector={(state) => ({
+                  canSubmit: state.canSubmit,
+                  createAsBill:
                      isCreate &&
-                     formState.values.createAsBill &&
-                     formState.values.type === "expense";
-                  return (
-                     <Button
-                        className="w-full"
-                        disabled={!formState.canSubmit || isPending}
-                        type="submit"
-                     >
-                        {isPending ? <Spinner className="size-4 mr-2" /> : null}
-                        {createAsBill
-                           ? "Criar conta a pagar"
-                           : isCreate
-                             ? "Criar lançamento"
-                             : "Salvar alterações"}
-                     </Button>
-                  );
-               }}
+                     state.values.createAsBill &&
+                     state.values.type === "expense",
+               })}
+            >
+               {({ canSubmit, createAsBill }) => (
+                  <Button
+                     className="w-full"
+                     disabled={!canSubmit || isPending}
+                     type="submit"
+                  >
+                     {isPending ? <Spinner className="size-4 mr-2" /> : null}
+                     {createAsBill
+                        ? "Criar conta a pagar"
+                        : isCreate
+                          ? "Criar lançamento"
+                          : "Salvar alterações"}
+                  </Button>
+               )}
             </form.Subscribe>
          </CredenzaFooter>
       </form>

--- a/apps/web/src/features/transactions/ui/transaction-dialog-stack.tsx
+++ b/apps/web/src/features/transactions/ui/transaction-dialog-stack.tsx
@@ -32,12 +32,14 @@ import { Switch } from "@packages/ui/components/switch";
 import { Textarea } from "@packages/ui/components/textarea";
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { useBlocker } from "@tanstack/react-router";
 import dayjs from "dayjs";
 import { ChevronLeft, Plus } from "lucide-react";
 import { Suspense, useState } from "react";
 import { toast } from "sonner";
 import { z } from "zod";
 import { orpc } from "@/integrations/orpc/client";
+import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import type { TransactionRow } from "./transactions-columns";
 
 type TransactionType = "income" | "expense" | "transfer";
@@ -730,46 +732,15 @@ function TransactionDialogStackContent({
       orpc.creditCards.getAll.queryOptions({}),
    );
 
+   const { openAlertDialog } = useAlertDialog();
+
    const createMutation = useMutation(
-      orpc.transactions.create.mutationOptions({
-         onSuccess: () => {
-            toast.success("Lançamento criado com sucesso.");
-            onSuccess();
-         },
-         onError: (error) => {
-            toast.error(error.message || "Erro ao criar lançamento.");
-         },
-      }),
+      orpc.transactions.create.mutationOptions(),
    );
-
    const updateMutation = useMutation(
-      orpc.transactions.update.mutationOptions({
-         onSuccess: () => {
-            toast.success("Lançamento atualizado com sucesso.");
-            onSuccess();
-         },
-         onError: (error) => {
-            toast.error(error.message || "Erro ao atualizar lançamento.");
-         },
-      }),
+      orpc.transactions.update.mutationOptions(),
    );
-
-   const billCreateMutation = useMutation(
-      orpc.bills.create.mutationOptions({
-         onSuccess: () => {
-            toast.success("Conta a pagar criada com sucesso.");
-            onSuccess();
-         },
-         onError: (error) => {
-            toast.error(error.message || "Erro ao criar conta a pagar.");
-         },
-      }),
-   );
-
-   const isPending =
-      createMutation.isPending ||
-      updateMutation.isPending ||
-      billCreateMutation.isPending;
+   const billCreateMutation = useMutation(orpc.bills.create.mutationOptions());
 
    const emptyTagIds: string[] = [];
 
@@ -800,62 +771,104 @@ function TransactionDialogStackContent({
          recurringFrequency: null as string | null,
          recurringCount: null as number | null,
       },
-      onSubmit: ({ value }) => {
-         const dateStr = value.date
-            ? dayjs(value.date).format("YYYY-MM-DD")
-            : "";
-         const isTransfer = value.type === "transfer";
+      validators: {
+         onSubmitAsync: async ({ value }) => {
+            const dateStr = value.date
+               ? dayjs(value.date).format("YYYY-MM-DD")
+               : "";
+            const isTransfer = value.type === "transfer";
 
-         if (isCreate && value.createAsBill && value.type === "expense") {
-            billCreateMutation.mutate({
-               bill: {
-                  name: value.name?.trim() || "Despesa",
-                  type: "payable",
+            try {
+               if (isCreate && value.createAsBill && value.type === "expense") {
+                  await billCreateMutation.mutateAsync({
+                     bill: {
+                        name: value.name?.trim() || "Despesa",
+                        type: "payable",
+                        amount: value.amount,
+                        dueDate: dateStr,
+                        bankAccountId: value.bankAccountId || null,
+                        categoryId: value.categoryId || null,
+                        description: value.description || null,
+                     },
+                  });
+                  toast.success("Conta a pagar criada com sucesso.");
+                  onSuccess();
+                  return null;
+               }
+
+               const tagIdsTouched =
+                  form.getFieldMeta("tagIds")?.isTouched ?? false;
+
+               const payload = {
+                  type: value.type,
+                  name: value.name?.trim() || null,
                   amount: value.amount,
-                  dueDate: dateStr,
+                  date: dateStr,
                   bankAccountId: value.bankAccountId || null,
-                  categoryId: value.categoryId || null,
+                  destinationBankAccountId: isTransfer
+                     ? value.destinationBankAccountId || null
+                     : null,
+                  categoryId: isTransfer ? null : value.categoryId || null,
+                  subcategoryId: isTransfer
+                     ? null
+                     : value.subcategoryId || null,
+                  attachments: [] as Attachment[],
+                  tagIds: isCreate || tagIdsTouched ? value.tagIds : undefined,
                   description: value.description || null,
-               },
-            });
-            return;
-         }
+                  contactId: value.contactId,
+                  creditCardId:
+                     value.type === "expense"
+                        ? value.creditCardId || null
+                        : null,
+                  paymentMethod: (isTransfer
+                     ? null
+                     : value.paymentMethod || null) as PaymentMethod | null,
+                  isInstallment: isTransfer ? false : value.isInstallment,
+                  installmentCount:
+                     !isTransfer && value.isInstallment
+                        ? value.installmentCount
+                        : null,
+               };
 
-         const tagIdsTouched = form.getFieldMeta("tagIds")?.isTouched ?? false;
-
-         const payload = {
-            type: value.type,
-            name: value.name?.trim() || null,
-            amount: value.amount,
-            date: dateStr,
-            bankAccountId: value.bankAccountId || null,
-            destinationBankAccountId: isTransfer
-               ? value.destinationBankAccountId || null
-               : null,
-            categoryId: isTransfer ? null : value.categoryId || null,
-            subcategoryId: isTransfer ? null : value.subcategoryId || null,
-            attachments: [] as Attachment[],
-            tagIds: isCreate || tagIdsTouched ? value.tagIds : undefined,
-            description: value.description || null,
-            contactId: value.contactId,
-            creditCardId:
-               value.type === "expense" ? value.creditCardId || null : null,
-            paymentMethod: (isTransfer
-               ? null
-               : value.paymentMethod || null) as PaymentMethod | null,
-            isInstallment: isTransfer ? false : value.isInstallment,
-            installmentCount:
-               !isTransfer && value.isInstallment
-                  ? value.installmentCount
-                  : null,
-         };
-
-         if (isCreate) {
-            createMutation.mutate(payload);
-         } else if (transaction) {
-            updateMutation.mutate({ id: transaction.id, ...payload });
-         }
+               if (isCreate) {
+                  await createMutation.mutateAsync(payload);
+                  toast.success("Lançamento criado com sucesso.");
+               } else if (transaction) {
+                  await updateMutation.mutateAsync({
+                     id: transaction.id,
+                     ...payload,
+                  });
+                  toast.success("Lançamento atualizado com sucesso.");
+               }
+               onSuccess();
+               return null;
+            } catch (err) {
+               return {
+                  form: err instanceof Error ? err.message : "Erro inesperado.",
+               };
+            }
+         },
       },
+   });
+
+   const blocker = useBlocker({
+      withResolver: true,
+      shouldBlockFn: () => {
+         if (form.store.state.isDirty && !form.store.state.isSubmitted) {
+            openAlertDialog({
+               title: "Descartar alterações?",
+               description:
+                  "Você tem alterações não salvas. Tem certeza que deseja sair sem salvar?",
+               actionLabel: "Descartar alterações",
+               cancelLabel: "Continuar editando",
+               onAction: () => blocker.proceed(),
+               onCancel: () => blocker.reset(),
+            });
+            return true;
+         }
+         return false;
+      },
+      disabled: isCreate,
    });
 
    if (secondaryForm) {
@@ -1106,7 +1119,7 @@ function TransactionDialogStackContent({
                                                    </span>
                                                 </FieldLabel>
                                                 <MoneyInput
-                                                   disabled={isPending}
+                                                   disabled={false}
                                                    onChange={(value) =>
                                                       field.handleChange(
                                                          String(value ?? 0),
@@ -1324,7 +1337,7 @@ function TransactionDialogStackContent({
                                                    </span>
                                                 </FieldLabel>
                                                 <MoneyInput
-                                                   disabled={isPending}
+                                                   disabled={false}
                                                    onChange={(value) =>
                                                       field.handleChange(
                                                          String(value ?? 0),
@@ -1948,23 +1961,41 @@ function TransactionDialogStackContent({
                )}
             </FieldGroup>
          </CredenzaBody>
-         <CredenzaFooter>
+         <CredenzaFooter className="flex flex-col gap-2">
+            <form.Subscribe
+               selector={(state) =>
+                  typeof state.errorMap.onSubmit === "object" &&
+                  state.errorMap.onSubmit !== null &&
+                  "form" in state.errorMap.onSubmit
+                     ? String(state.errorMap.onSubmit.form)
+                     : null
+               }
+            >
+               {(formError) =>
+                  formError && (
+                     <p className="text-sm text-destructive text-center">
+                        {formError}
+                     </p>
+                  )
+               }
+            </form.Subscribe>
             <form.Subscribe
                selector={(state) => ({
                   canSubmit: state.canSubmit,
+                  isSubmitting: state.isSubmitting,
                   createAsBill:
                      isCreate &&
                      state.values.createAsBill &&
                      state.values.type === "expense",
                })}
             >
-               {({ canSubmit, createAsBill }) => (
+               {({ canSubmit, isSubmitting, createAsBill }) => (
                   <Button
-                     className="w-full"
-                     disabled={!canSubmit || isPending}
+                     className="w-full gap-2"
+                     disabled={!canSubmit || isSubmitting}
                      type="submit"
                   >
-                     {isPending ? <Spinner className="size-4 mr-2" /> : null}
+                     {isSubmitting ? <Spinner className="size-4" /> : null}
                      {createAsBill
                         ? "Criar conta a pagar"
                         : isCreate

--- a/apps/web/src/features/transactions/ui/transaction-export-credenza.tsx
+++ b/apps/web/src/features/transactions/ui/transaction-export-credenza.tsx
@@ -431,15 +431,15 @@ function ExportForm({
                      Cancelar
                   </Button>
                   <Button
-                     className="flex-1"
+                     className="flex-1 gap-2"
                      disabled={!canDownload || isPending}
                      onClick={handleDownload}
                      type="button"
                   >
                      {isPending ? (
-                        <Spinner className="size-4 mr-2" />
+                        <Spinner className="size-4" />
                      ) : (
-                        <Download className="size-4 mr-2" />
+                        <Download className="size-4" />
                      )}
                      Baixar
                   </Button>

--- a/apps/web/src/features/transactions/ui/transaction-filter-bar.tsx
+++ b/apps/web/src/features/transactions/ui/transaction-filter-bar.tsx
@@ -11,8 +11,8 @@ import {
 } from "@packages/ui/components/select";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Search, X } from "lucide-react";
-import { useDebouncedValue } from "foxact/use-debounced-value";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useDebouncedCallback } from "@tanstack/react-pacer";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { orpc } from "@/integrations/orpc/client";
 import { TransactionFilterPopover } from "./transaction-filter-popover";
 
@@ -141,31 +141,22 @@ export function TransactionFilterBar({
    );
 
    const [searchInput, setSearchInput] = useState(filters.search);
-   const debouncedSearch = useDebouncedValue(searchInput, 350);
 
-   const stableOnFiltersChange = useCallback(onFiltersChange, [
-      onFiltersChange,
-   ]);
    const filtersRef = useRef(filters);
    useEffect(() => {
       filtersRef.current = filters;
    });
 
-   const isMounted = useRef(false);
-   useEffect(() => {
-      if (!isMounted.current) {
-         isMounted.current = true;
-         return;
-      }
-      stableOnFiltersChange({
-         ...filtersRef.current,
-         search: debouncedSearch,
-         page: 1,
-      });
-   }, [debouncedSearch, stableOnFiltersChange]);
+   const debouncedFilterUpdate = useDebouncedCallback(
+      (value: string) => {
+         onFiltersChange({ ...filtersRef.current, search: value, page: 1 });
+      },
+      { wait: 350 },
+   );
 
    const handleSearchChange = (value: string) => {
       setSearchInput(value);
+      debouncedFilterUpdate(value);
    };
 
    const hasDateFilter = !!(filters.dateFrom || filters.dateTo);

--- a/apps/web/src/features/transactions/ui/transactions-list.tsx
+++ b/apps/web/src/features/transactions/ui/transactions-list.tsx
@@ -25,7 +25,11 @@ import {
    SelectionActionButton,
 } from "@packages/ui/components/selection-action-bar";
 import { useRowSelection } from "@packages/ui/hooks/use-row-selection";
-import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import {
+   keepPreviousData,
+   useMutation,
+   useSuspenseQuery,
+} from "@tanstack/react-query";
 import {
    ArrowLeftRight,
    FolderOpen,
@@ -99,8 +103,8 @@ export function TransactionsList({
       onClear,
    } = useRowSelection();
 
-   const { data: result } = useSuspenseQuery(
-      orpc.transactions.getAll.queryOptions({
+   const { data: result } = useSuspenseQuery({
+      ...orpc.transactions.getAll.queryOptions({
          input: {
             type: filters.type,
             dateFrom: filters.dateFrom,
@@ -115,7 +119,8 @@ export function TransactionsList({
             pageSize: filters.pageSize,
          },
       }),
-   );
+      placeholderData: keepPreviousData,
+   });
 
    const { data: summary } = useSuspenseQuery(
       orpc.transactions.getSummary.queryOptions({

--- a/apps/web/src/features/transactions/ui/transactions-list.tsx
+++ b/apps/web/src/features/transactions/ui/transactions-list.tsx
@@ -25,11 +25,7 @@ import {
    SelectionActionButton,
 } from "@packages/ui/components/selection-action-bar";
 import { useRowSelection } from "@packages/ui/hooks/use-row-selection";
-import {
-   keepPreviousData,
-   useMutation,
-   useSuspenseQuery,
-} from "@tanstack/react-query";
+import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import {
    ArrowLeftRight,
    FolderOpen,
@@ -119,7 +115,6 @@ export function TransactionsList({
             pageSize: filters.pageSize,
          },
       }),
-      placeholderData: keepPreviousData,
    });
 
    const { data: summary } = useSuspenseQuery(

--- a/apps/web/src/hooks/use-active-team.ts
+++ b/apps/web/src/hooks/use-active-team.ts
@@ -1,14 +1,13 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useSuspenseQueries } from "@tanstack/react-query";
 import { orpc } from "@/integrations/orpc/client";
 
 export function useActiveTeam() {
-   const { data: session } = useSuspenseQuery(
-      orpc.session.getSession.queryOptions({}),
-   );
-
-   const { data: teams } = useSuspenseQuery(
-      orpc.organization.getOrganizationTeams.queryOptions({}),
-   );
+   const [{ data: session }, { data: teams }] = useSuspenseQueries({
+      queries: [
+         orpc.session.getSession.queryOptions({}),
+         orpc.organization.getOrganizationTeams.queryOptions({}),
+      ],
+   });
 
    const activeTeamId = session?.session.activeTeamId ?? null;
    const activeTeam = teams.find((team) => team.id === activeTeamId) ?? null;

--- a/apps/web/src/hooks/use-alert-dialog.tsx
+++ b/apps/web/src/hooks/use-alert-dialog.tsx
@@ -22,6 +22,7 @@ interface AlertDialogState {
    actionLabel: string;
    cancelLabel: string;
    onAction: () => void | Promise<void>;
+   onCancel?: () => void;
    variant: "default" | "destructive";
 }
 
@@ -31,6 +32,7 @@ const initialState: AlertDialogState = {
    description: "",
    isOpen: false,
    onAction: () => {},
+   onCancel: undefined,
    title: "",
    variant: "default",
 };
@@ -41,6 +43,7 @@ interface OpenAlertDialogOptions {
    title: string;
    description: string;
    onAction: () => void | Promise<void>;
+   onCancel?: () => void;
    actionLabel?: string;
    cancelLabel?: string;
    variant?: "default" | "destructive";
@@ -56,6 +59,7 @@ export const useAlertDialog = () => {
             description: options.description,
             isOpen: true,
             onAction: options.onAction,
+            onCancel: options.onCancel,
             title: options.title,
             variant: options.variant ?? "default",
          })),
@@ -73,6 +77,7 @@ export function GlobalAlertDialog() {
 
    const handleOpenChange = (open: boolean) => {
       if (!open) {
+         state.onCancel?.();
          alertDialogStore.setState(() => initialState);
       }
    };

--- a/apps/web/src/hooks/use-alert-dialog.tsx
+++ b/apps/web/src/hooks/use-alert-dialog.tsx
@@ -71,6 +71,7 @@ export function GlobalAlertDialog() {
    const [isPending, startTransition] = useTransition();
 
    const handleAction = async () => {
+      alertDialogStore.setState((s) => ({ ...s, onCancel: undefined }));
       await state.onAction();
       alertDialogStore.setState(() => initialState);
    };

--- a/apps/web/src/layout/dashboard/ui/-sidebar-scope-switcher/create-team-form.tsx
+++ b/apps/web/src/layout/dashboard/ui/-sidebar-scope-switcher/create-team-form.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@packages/ui/components/button";
-import { createErrorFallback } from "@/components/query-boundary";
+import { QueryBoundary } from "@/components/query-boundary";
 import {
    CredenzaBody,
    CredenzaDescription,
@@ -13,8 +13,7 @@ import { Skeleton } from "@packages/ui/components/skeleton";
 import { Textarea } from "@packages/ui/components/textarea";
 import { useForm } from "@tanstack/react-form";
 import type { FC, FormEvent } from "react";
-import { Suspense, useCallback, useTransition } from "react";
-import { ErrorBoundary } from "react-error-boundary";
+import { useCallback, useTransition } from "react";
 import { toast } from "sonner";
 import { z } from "zod";
 import { useActiveOrganization } from "@/hooks/use-active-organization";
@@ -212,15 +211,12 @@ export const CreateTeamForm: FC = () => {
                Crie um novo espaço para organizar os membros da sua organização
             </CredenzaDescription>
          </CredenzaHeader>
-         <ErrorBoundary
-            FallbackComponent={createErrorFallback({
-               errorTitle: "Erro ao carregar dados da organização",
-            })}
+         <QueryBoundary
+            fallback={<CreateTeamSkeleton />}
+            errorTitle="Erro ao carregar dados da organização"
          >
-            <Suspense fallback={<CreateTeamSkeleton />}>
-               <CreateTeamFormContent />
-            </Suspense>
-         </ErrorBoundary>
+            <CreateTeamFormContent />
+         </QueryBoundary>
       </>
    );
 };

--- a/apps/web/src/layout/dashboard/ui/-sidebar-scope-switcher/create-team-form.tsx
+++ b/apps/web/src/layout/dashboard/ui/-sidebar-scope-switcher/create-team-form.tsx
@@ -179,14 +179,14 @@ const CreateTeamFormContent = () => {
             <Button onClick={closeCredenza} type="button" variant="outline">
                Cancelar
             </Button>
-            <form.Subscribe selector={(state) => state}>
-               {(formState) => (
+            <form.Subscribe
+               selector={(state) =>
+                  [state.canSubmit, state.isSubmitting] as const
+               }
+            >
+               {([canSubmit, isSubmitting]) => (
                   <Button
-                     disabled={
-                        !formState.canSubmit ||
-                        formState.isSubmitting ||
-                        isPending
-                     }
+                     disabled={!canSubmit || isSubmitting || isPending}
                      onClick={() => {
                         startTransition(async () => {
                            await form.handleSubmit();

--- a/apps/web/src/layout/dashboard/ui/-sidebar-scope-switcher/manage-organization-form.tsx
+++ b/apps/web/src/layout/dashboard/ui/-sidebar-scope-switcher/manage-organization-form.tsx
@@ -306,16 +306,18 @@ export function ManageOrganizationForm({
             </CredenzaBody>
 
             <CredenzaFooter>
-               <form.Subscribe selector={(state) => state}>
-                  {(state) => (
+               <form.Subscribe
+                  selector={(state) =>
+                     [state.canSubmit, state.isSubmitting] as const
+                  }
+               >
+                  {([canSubmit, isSubmitting]) => (
                      <Button
                         className="w-full"
-                        disabled={
-                           !state.canSubmit || state.isSubmitting || isPending
-                        }
+                        disabled={!canSubmit || isSubmitting || isPending}
                         type="submit"
                      >
-                        {state.isSubmitting || isPending
+                        {isSubmitting || isPending
                            ? isEditMode
                               ? "Saving..."
                               : "Creating..."

--- a/apps/web/src/layout/dashboard/ui/sidebar-scope-switcher.tsx
+++ b/apps/web/src/layout/dashboard/ui/sidebar-scope-switcher.tsx
@@ -40,9 +40,8 @@ import {
    Settings,
    UserPlus,
 } from "lucide-react";
-import { Suspense, useCallback, useTransition } from "react";
-import { ErrorBoundary } from "react-error-boundary";
-import { createErrorFallback } from "@/components/query-boundary";
+import { useCallback, useTransition } from "react";
+import { QueryBoundary } from "@/components/query-boundary";
 import { toast } from "sonner";
 import { CreateTeamForm } from "./-sidebar-scope-switcher/create-team-form";
 import { ManageOrganizationForm } from "./-sidebar-scope-switcher/manage-organization-form";
@@ -528,14 +527,11 @@ function SidebarScopeSwitcherContent() {
 
 export function SidebarScopeSwitcher() {
    return (
-      <ErrorBoundary
-         FallbackComponent={createErrorFallback({
-            errorTitle: "Erro ao carregar menu",
-         })}
+      <QueryBoundary
+         fallback={<SidebarScopeSwitcherSkeleton />}
+         errorTitle="Erro ao carregar menu"
       >
-         <Suspense fallback={<SidebarScopeSwitcherSkeleton />}>
-            <SidebarScopeSwitcherContent />
-         </Suspense>
-      </ErrorBoundary>
+         <SidebarScopeSwitcherContent />
+      </QueryBoundary>
    );
 }

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-categories/category-filter-bar.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-categories/category-filter-bar.tsx
@@ -5,9 +5,9 @@ import { Label } from "@packages/ui/components/label";
 import { Switch } from "@packages/ui/components/switch";
 import { cn } from "@packages/ui/lib/utils";
 import { Link, useRouter } from "@tanstack/react-router";
-import { useDebouncedValue } from "foxact/use-debounced-value";
+import { useDebouncedCallback } from "@tanstack/react-pacer";
 import { LayoutList, Search, X } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 interface CategoryFilterBarProps {
    search: string;
@@ -41,16 +41,10 @@ export function CategoryFilterBar({
 }: CategoryFilterBarProps) {
    const router = useRouter();
    const [inputValue, setInputValue] = useState(search);
-   const debouncedSearch = useDebouncedValue(inputValue, 300);
-   const isMounted = useRef(false);
 
-   useEffect(() => {
-      if (!isMounted.current) {
-         isMounted.current = true;
-         return;
-      }
-      onSearchChange(debouncedSearch);
-   }, [debouncedSearch]); // eslint-disable-line react-hooks/exhaustive-deps
+   const debouncedOnSearchChange = useDebouncedCallback(onSearchChange, {
+      wait: 300,
+   });
 
    useEffect(() => {
       if (search === "") setInputValue("");
@@ -65,7 +59,10 @@ export function CategoryFilterBar({
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
             <Input
                className="pl-9"
-               onChange={(e) => setInputValue(e.target.value)}
+               onChange={(e) => {
+                  setInputValue(e.target.value);
+                  debouncedOnSearchChange(e.target.value);
+               }}
                placeholder="Buscar por nome ou palavra-chave..."
                value={inputValue}
             />

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-form.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-form.tsx
@@ -249,19 +249,23 @@ export function TagForm({ mode, tag, onSuccess }: TagFormProps) {
          </CredenzaBody>
 
          <CredenzaFooter>
-            <form.Subscribe selector={(state) => state}>
-               {(state) => (
+            <form.Subscribe
+               selector={(state) =>
+                  [state.canSubmit, state.isSubmitting] as const
+               }
+            >
+               {([canSubmit, isSubmitting]) => (
                   <Button
                      className="w-full"
                      disabled={
-                        !state.canSubmit ||
-                        state.isSubmitting ||
+                        !canSubmit ||
+                        isSubmitting ||
                         createMutation.isPending ||
                         updateMutation.isPending
                      }
                      type="submit"
                   >
-                     {(state.isSubmitting ||
+                     {(isSubmitting ||
                         createMutation.isPending ||
                         updateMutation.isPending) && (
                         <Spinner className="size-4" />

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/statement-import-credenza.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/statement-import-credenza.tsx
@@ -47,7 +47,7 @@ import {
    DropzoneEmptyState,
 } from "@packages/ui/components/dropzone";
 import { defineStepper } from "@packages/ui/components/stepper";
-import { createErrorFallback } from "@/components/query-boundary";
+import { QueryBoundary } from "@/components/query-boundary";
 import {
    Tooltip,
    TooltipContent,
@@ -68,8 +68,7 @@ import {
    Undo2,
    X,
 } from "lucide-react";
-import { Suspense, useRef, useState, useTransition } from "react";
-import { ErrorBoundary } from "react-error-boundary";
+import { useRef, useState, useTransition } from "react";
 import { toast } from "sonner";
 import { orpc } from "@/integrations/orpc/client";
 import { useCredenza } from "@/hooks/use-credenza";
@@ -1482,39 +1481,29 @@ function ImportWizard({
    return (
       <>
          {currentId === "upload" && (
-            <ErrorBoundary
-               FallbackComponent={createErrorFallback({
-                  errorTitle: "Erro ao carregar contas",
-               })}
+            <QueryBoundary
+               fallback={
+                  <div className="flex items-center justify-center p-4">
+                     <Loader2 className="size-4 animate-spin text-muted-foreground" />
+                  </div>
+               }
+               errorTitle="Erro ao carregar contas"
             >
-               <Suspense
-                  fallback={
-                     <div className="flex items-center justify-center p-4">
-                        <Loader2 className="size-4 animate-spin text-muted-foreground" />
-                     </div>
-                  }
-               >
-                  <UploadStep methods={methods} />
-               </Suspense>
-            </ErrorBoundary>
+               <UploadStep methods={methods} />
+            </QueryBoundary>
          )}
          {currentId === "map" && <MapStep methods={methods} />}
          {currentId === "preview" && (
-            <ErrorBoundary
-               FallbackComponent={createErrorFallback({
-                  errorTitle: "Erro ao carregar categorias",
-               })}
+            <QueryBoundary
+               fallback={
+                  <div className="flex items-center justify-center p-4">
+                     <Loader2 className="size-4 animate-spin text-muted-foreground" />
+                  </div>
+               }
+               errorTitle="Erro ao carregar categorias"
             >
-               <Suspense
-                  fallback={
-                     <div className="flex items-center justify-center p-4">
-                        <Loader2 className="size-4 animate-spin text-muted-foreground" />
-                     </div>
-                  }
-               >
-                  <PreviewStep methods={methods} />
-               </Suspense>
-            </ErrorBoundary>
+               <PreviewStep methods={methods} />
+            </QueryBoundary>
          )}
          {currentId === "confirm" && (
             <ConfirmStep methods={methods} onClose={onClose} />

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/use-statement-import.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/use-statement-import.tsx
@@ -6,7 +6,7 @@ import {
 } from "@f-o-t/money";
 import { parseBufferOrThrow as parseOfx, getTransactions } from "@f-o-t/ofx";
 import { useMutation } from "@tanstack/react-query";
-import { useDebouncedCallback } from "@tanstack/react-pacer";
+import { useAsyncDebouncedCallback } from "@tanstack/react-pacer";
 import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
 import { useLocalStorage } from "foxact/use-local-storage";
@@ -454,7 +454,7 @@ function useStatementImport({
       [onInitSelection],
    );
 
-   const debouncedCheckDuplicates = useDebouncedCallback(
+   const debouncedCheckDuplicates = useAsyncDebouncedCallback(
       async (mapped: ValidatedRow[]) => {
          const validRows = mapped.filter((r) => r.isValid);
          if (!bankAccountId || validRows.length === 0) {

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/$insightId.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/$insightId.tsx
@@ -1,23 +1,22 @@
-import type { InsightConfig } from "@packages/analytics/types";
+import { insightConfigSchema } from "@packages/analytics/types";
 import {
    ContextPanel,
    ContextPanelContent,
    ContextPanelHeader,
    ContextPanelTitle,
 } from "@packages/ui/components/context-panel";
+import { Skeleton } from "@packages/ui/components/skeleton";
 import {
    useMutation,
    useQueryClient,
    useSuspenseQuery,
 } from "@tanstack/react-query";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import { Clock, Copy, RefreshCw, Tag, Trash2, TrendingUp } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { toast } from "sonner";
-import {
-   type InsightType,
-   useInsightConfig,
-} from "@/features/analytics/hooks/use-insight-config";
+import { z } from "zod";
+import { useInsightConfig } from "@/features/analytics/hooks/use-insight-config";
 import { InsightBuilder } from "@/features/analytics/ui/insight-builder";
 import {
    EarlyAccessBanner,
@@ -45,9 +44,26 @@ const ANALYTICS_BANNER: EarlyAccessBannerTemplate = {
    ],
 };
 
+const insightSearchSchema = z.object({
+   type: z
+      .enum(["kpi", "time_series", "breakdown"])
+      .catch("kpi")
+      .default("kpi"),
+});
+
+function InsightSkeleton() {
+   return (
+      <div className="flex flex-col gap-4">
+         <Skeleton className="h-12 w-full" />
+         <Skeleton className="h-64 w-full" />
+      </div>
+   );
+}
+
 export const Route = createFileRoute(
    "/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/$insightId",
 )({
+   validateSearch: insightSearchSchema,
    loader: ({ context, params }) => {
       context.queryClient.prefetchQuery(
          orpc.insights.getById.queryOptions({
@@ -55,42 +71,49 @@ export const Route = createFileRoute(
          }),
       );
    },
+   pendingMs: 300,
+   pendingComponent: InsightSkeleton,
    head: () => ({
       meta: [{ title: "Insight — Montte" }],
    }),
    component: EditInsightPage,
 });
 
+const TYPE_LABELS: Record<string, string> = {
+   kpi: "KPI",
+   time_series: "Série Temporal",
+   breakdown: "Distribuição",
+};
+
 function EditInsightPage() {
    const { insightId, slug, teamSlug } = Route.useParams();
-   const navigate = useNavigate();
+   const navigate = Route.useNavigate();
    const queryClient = useQueryClient();
    const { openAlertDialog } = useAlertDialog();
 
    const { data: insight } = useSuspenseQuery(
-      orpc.insights.getById.queryOptions({
-         input: { id: insightId },
-      }),
+      orpc.insights.getById.queryOptions({ input: { id: insightId } }),
    );
 
-   const { type, config, setType, updateConfigImmediate } = useInsightConfig();
-   const [insightName, setInsightName] = useState("");
-   const [insightDescription, setInsightDescription] = useState("");
-   const [initialized, setInitialized] = useState(false);
+   const parsed = insightConfigSchema.safeParse(insight.config);
 
-   // Populate the builder with the loaded insight data
-   useEffect(() => {
-      if (insight && !initialized) {
-         setInsightName(insight.name);
-         setInsightDescription(insight.description ?? "");
-         const insightConfig = insight.config as InsightConfig;
-         setType(insightConfig.type as InsightType);
-         queueMicrotask(() => {
-            updateConfigImmediate(insightConfig);
+   const { type, config, setType, updateConfigImmediate } = useInsightConfig(
+      parsed.success ? parsed.data : undefined,
+   );
+
+   const [name, setName] = useState(insight.name);
+   const [description, setDescription] = useState(insight.description ?? "");
+
+   const handleTypeChange = useCallback(
+      (newType: "kpi" | "time_series" | "breakdown") => {
+         setType(newType);
+         navigate({
+            search: (prev) => ({ ...prev, type: newType }),
+            replace: true,
          });
-         setInitialized(true);
-      }
-   }, [insight, initialized, setType, updateConfigImmediate]);
+      },
+      [setType, navigate],
+   );
 
    const updateMutation = useMutation(
       orpc.insights.update.mutationOptions({
@@ -148,17 +171,17 @@ function EditInsightPage() {
    );
 
    const handleSave = useCallback(() => {
-      if (!insightName.trim()) {
+      if (!name.trim()) {
          toast.error("O nome do insight é obrigatório");
          return;
       }
       updateMutation.mutate({
          id: insightId,
-         name: insightName.trim(),
-         description: insightDescription.trim() || undefined,
-         config: config as InsightConfig,
+         name: name.trim(),
+         description: description.trim() || undefined,
+         config,
       });
-   }, [insightId, insightName, insightDescription, config, updateMutation]);
+   }, [insightId, name, description, config, updateMutation]);
 
    const handleDelete = useCallback(() => {
       openAlertDialog({
@@ -171,19 +194,20 @@ function EditInsightPage() {
    }, [insightId, deleteMutation, openAlertDialog]);
 
    const handleDuplicate = useCallback(() => {
-      if (!insight) return;
+      if (!parsed.success) return;
       duplicateMutation.mutate({
          name: `${insight.name} (cópia)`,
          description: insight.description ?? undefined,
-         type: insight.type as "kpi" | "time_series" | "breakdown",
-         config: insight.config as InsightConfig,
+         type: parsed.data.type,
+         config: parsed.data,
       });
-   }, [insight, duplicateMutation]);
+   }, [insight.name, insight.description, parsed, duplicateMutation]);
 
    const handleRefresh = useCallback(() => {
+      if (!parsed.success) return;
       queryClient.invalidateQueries({
          queryKey: orpc.analytics.query.queryKey({
-            input: { config: insight?.config as InsightConfig },
+            input: { config: parsed.data },
          }),
       });
       queryClient.invalidateQueries({
@@ -191,65 +215,51 @@ function EditInsightPage() {
             input: { id: insightId },
          }).queryKey,
       });
-   }, [queryClient, insight?.config, insightId]);
-
-   const TYPE_LABELS: Record<string, string> = {
-      trends: "Tendências",
-      funnels: "Funis",
-      retention: "Retenção",
-   };
+   }, [queryClient, parsed, insightId]);
 
    useContextPanelInfo(
-      insight ? (
-         <ContextPanel>
-            <ContextPanelHeader>
-               <ContextPanelTitle>
-                  {insightName || insight.name}
-               </ContextPanelTitle>
-            </ContextPanelHeader>
-            <ContextPanelContent>
-               <ContextPanelMeta
-                  icon={Tag}
-                  label="Tipo"
-                  value={TYPE_LABELS[insight.type] ?? insight.type}
-               />
-               <ContextPanelMeta
-                  icon={Clock}
-                  label="Calculado"
-                  value={
-                     insight.lastComputedAt
-                        ? new Date(insight.lastComputedAt).toLocaleDateString(
-                             "pt-BR",
-                             {
-                                day: "2-digit",
-                                month: "short",
-                                year: "numeric",
-                             },
-                          )
-                        : "—"
-                  }
-               />
-               <ContextPanelDivider />
-               <ContextPanelAction
-                  icon={Copy}
-                  label="Duplicar insight"
-                  onClick={handleDuplicate}
-               />
-               <ContextPanelAction
-                  icon={RefreshCw}
-                  label="Atualizar resultados"
-                  onClick={handleRefresh}
-               />
-               <ContextPanelDivider />
-               <ContextPanelAction
-                  icon={Trash2}
-                  label="Excluir insight"
-                  onClick={handleDelete}
-                  variant="destructive"
-               />
-            </ContextPanelContent>
-         </ContextPanel>
-      ) : null,
+      <ContextPanel>
+         <ContextPanelHeader>
+            <ContextPanelTitle>{name || insight.name}</ContextPanelTitle>
+         </ContextPanelHeader>
+         <ContextPanelContent>
+            <ContextPanelMeta
+               icon={Tag}
+               label="Tipo"
+               value={TYPE_LABELS[type] ?? type}
+            />
+            <ContextPanelMeta
+               icon={Clock}
+               label="Calculado"
+               value={
+                  insight.lastComputedAt
+                     ? new Date(insight.lastComputedAt).toLocaleDateString(
+                          "pt-BR",
+                          { day: "2-digit", month: "short", year: "numeric" },
+                       )
+                     : "—"
+               }
+            />
+            <ContextPanelDivider />
+            <ContextPanelAction
+               icon={Copy}
+               label="Duplicar insight"
+               onClick={handleDuplicate}
+            />
+            <ContextPanelAction
+               icon={RefreshCw}
+               label="Atualizar resultados"
+               onClick={handleRefresh}
+            />
+            <ContextPanelDivider />
+            <ContextPanelAction
+               icon={Trash2}
+               label="Excluir insight"
+               onClick={handleDelete}
+               variant="destructive"
+            />
+         </ContextPanelContent>
+      </ContextPanel>,
    );
 
    return (
@@ -257,18 +267,18 @@ function EditInsightPage() {
          <EarlyAccessBanner template={ANALYTICS_BANNER} />
          <InsightBuilder
             config={config}
-            description={insightDescription}
+            description={description}
             isSaving={updateMutation.isPending}
             lastComputedAt={insight.lastComputedAt}
-            name={insightName}
+            name={name}
             onConfigUpdate={updateConfigImmediate}
             onDelete={handleDelete}
-            onDescriptionChange={setInsightDescription}
+            onDescriptionChange={setDescription}
             onDuplicate={handleDuplicate}
-            onNameChange={setInsightName}
+            onNameChange={setName}
             onRefresh={handleRefresh}
             onSave={handleSave}
-            onTypeChange={setType}
+            onTypeChange={handleTypeChange}
             type={type}
          />
       </>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/bills.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/bills.tsx
@@ -25,6 +25,7 @@ import {
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import type { ColumnFiltersState, SortingState } from "@tanstack/react-table";
 import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
 import { createLocalStorageState } from "foxact/create-local-storage-state";
 import {
    Check,
@@ -63,6 +64,12 @@ const [useBillsReceivableTableState] =
 export const Route = createFileRoute(
    "/_authenticated/$slug/$teamSlug/_dashboard/bills",
 )({
+   validateSearch: z.object({
+      tab: z
+         .enum(["payable", "receivable"])
+         .catch("payable")
+         .default("payable"),
+   }),
    loader: ({ context }) => {
       context.queryClient.prefetchQuery(
          orpc.bills.getAll.queryOptions({ input: { type: "payable" } }),
@@ -351,13 +358,26 @@ function BillsReceivableList() {
 }
 
 function BillsPage() {
+   const { tab } = Route.useSearch();
+   const navigate = Route.useNavigate();
    return (
       <main className="flex flex-col gap-4">
          <DefaultHeader
             description="Gerencie suas contas a pagar e a receber"
             title="Contas"
          />
-         <Tabs defaultValue="payable">
+         <Tabs
+            value={tab}
+            onValueChange={(v) =>
+               navigate({
+                  search: (prev) => ({
+                     ...prev,
+                     tab: v as "payable" | "receivable",
+                  }),
+                  replace: true,
+               })
+            }
+         >
             <TabsList>
                <TabsTrigger value="payable">A Pagar</TabsTrigger>
                <TabsTrigger value="receivable">A Receber</TabsTrigger>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/contacts.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/contacts.tsx
@@ -21,7 +21,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { createLocalStorageState } from "foxact/create-local-storage-state";
 import { Pencil, Plus, Trash2, Users } from "lucide-react";
 
-import { Suspense, useCallback, useState } from "react";
+import { Suspense, useCallback } from "react";
 import { toast } from "sonner";
 import { DefaultHeader } from "@/components/default-header";
 import {
@@ -54,7 +54,12 @@ const [useContactsTableState] =
 export const Route = createFileRoute(
    "/_authenticated/$slug/$teamSlug/_dashboard/contacts",
 )({
-   validateSearch: tableSearchSchema,
+   validateSearch: tableSearchSchema.extend({
+      typeFilter: z
+         .enum(["all", "cliente", "fornecedor", "ambos"])
+         .catch("all")
+         .default("all"),
+   }),
    loader: ({ context }) => {
       context.queryClient.prefetchQuery(orpc.contacts.getAll.queryOptions({}));
    },
@@ -98,13 +103,9 @@ const TYPE_FILTER_LABELS: Record<TypeFilter, string> = {
    ambos: "Ambos",
 };
 
-interface ContactsListProps {
-   typeFilter: TypeFilter;
-}
-
-function ContactsList({ typeFilter }: ContactsListProps) {
+function ContactsList() {
    const navigate = Route.useNavigate();
-   const { sorting, columnFilters } = Route.useSearch();
+   const { sorting, columnFilters, typeFilter } = Route.useSearch();
    const [tableState, setTableState] = useContactsTableState();
    const { openCredenza, closeCredenza } = useCredenza();
    const { openAlertDialog } = useAlertDialog();
@@ -284,7 +285,8 @@ function ContactsList({ typeFilter }: ContactsListProps) {
 
 function ContactsPage() {
    const { openCredenza, closeCredenza } = useCredenza();
-   const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
+   const { typeFilter } = Route.useSearch();
+   const navigate = Route.useNavigate();
 
    const handleCreate = useCallback(() => {
       openCredenza({
@@ -310,7 +312,15 @@ function ContactsPage() {
             {(Object.keys(TYPE_FILTER_LABELS) as TypeFilter[]).map((key) => (
                <Button
                   key={key}
-                  onClick={() => setTypeFilter(key)}
+                  onClick={() =>
+                     navigate({
+                        search: (prev) => ({
+                           ...prev,
+                           typeFilter: key as TypeFilter,
+                        }),
+                        replace: true,
+                     })
+                  }
                   variant={typeFilter === key ? "default" : "outline"}
                >
                   {TYPE_FILTER_LABELS[key]}
@@ -319,7 +329,7 @@ function ContactsPage() {
          </div>
 
          <Suspense fallback={<ContactsSkeleton />}>
-            <ContactsList typeFilter={typeFilter} />
+            <ContactsList />
          </Suspense>
       </main>
    );

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards.tsx
@@ -25,9 +25,7 @@ import type {
 } from "@tanstack/react-table";
 import { createLocalStorageState } from "foxact/create-local-storage-state";
 import { CreditCard, Pencil, Plus, Trash2 } from "lucide-react";
-import { Suspense, useCallback } from "react";
-import { ErrorBoundary } from "react-error-boundary";
-import { createErrorFallback } from "@/components/query-boundary";
+import { useCallback } from "react";
 import { toast } from "sonner";
 import { DefaultHeader } from "@/components/default-header";
 import { QueryBoundary } from "@/components/query-boundary";
@@ -172,19 +170,16 @@ function CreditCardsList() {
       (card: CreditCardRow) => {
          openCredenza({
             children: (
-               <ErrorBoundary
-                  FallbackComponent={createErrorFallback({
-                     errorTitle: "Erro ao carregar cartão",
-                  })}
+               <QueryBoundary
+                  fallback={<CreditCardFormSkeleton />}
+                  errorTitle="Erro ao carregar cartão"
                >
-                  <Suspense fallback={<CreditCardFormSkeleton />}>
-                     <CreditCardForm
-                        card={card}
-                        mode="edit"
-                        onSuccess={closeCredenza}
-                     />
-                  </Suspense>
-               </ErrorBoundary>
+                  <CreditCardForm
+                     card={card}
+                     mode="edit"
+                     onSuccess={closeCredenza}
+                  />
+               </QueryBoundary>
             ),
          });
       },
@@ -299,15 +294,12 @@ function CreditCardsPage() {
    function handleCreate() {
       openCredenza({
          children: (
-            <ErrorBoundary
-               FallbackComponent={createErrorFallback({
-                  errorTitle: "Erro ao carregar formulário",
-               })}
+            <QueryBoundary
+               fallback={<CreditCardFormSkeleton />}
+               errorTitle="Erro ao carregar formulário"
             >
-               <Suspense fallback={<CreditCardFormSkeleton />}>
-                  <CreditCardForm mode="create" onSuccess={closeCredenza} />
-               </Suspense>
-            </ErrorBoundary>
+               <CreditCardForm mode="create" onSuccess={closeCredenza} />
+            </QueryBoundary>
          ),
       });
    }

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/goals.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/goals.tsx
@@ -17,8 +17,13 @@ import {
 } from "@packages/ui/components/empty";
 import { Skeleton } from "@packages/ui/components/skeleton";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
-import type { ColumnFiltersState, SortingState } from "@tanstack/react-table";
+import type {
+   ColumnFiltersState,
+   OnChangeFn,
+   SortingState,
+} from "@tanstack/react-table";
 import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
 import { createLocalStorageState } from "foxact/create-local-storage-state";
 import {
    ChevronLeft,
@@ -31,7 +36,7 @@ import {
    Target,
    Trash2,
 } from "lucide-react";
-import { Suspense, useCallback, useMemo, useState } from "react";
+import { Suspense, useCallback } from "react";
 import { toast } from "sonner";
 import { DefaultHeader } from "@/components/default-header";
 import { BudgetGoalDialogStack } from "@/features/budget-goals/ui/budget-goal-dialog-stack";
@@ -46,14 +51,38 @@ const [useGoalsTableState] =
       null,
    );
 
+const now = new Date();
+
 export const Route = createFileRoute(
    "/_authenticated/$slug/$teamSlug/_dashboard/goals",
 )({
-   loader: ({ context }) => {
-      const now = new Date();
+   validateSearch: z.object({
+      month: z
+         .number()
+         .int()
+         .min(1)
+         .max(12)
+         .catch(now.getMonth() + 1)
+         .default(now.getMonth() + 1),
+      year: z
+         .number()
+         .int()
+         .catch(now.getFullYear())
+         .default(now.getFullYear()),
+      sorting: z
+         .array(z.object({ id: z.string(), desc: z.boolean() }))
+         .catch([])
+         .default([]),
+      columnFilters: z
+         .array(z.object({ id: z.string(), value: z.unknown() }))
+         .catch([])
+         .default([]),
+   }),
+   loaderDeps: ({ search: { month, year } }) => ({ month, year }),
+   loader: ({ context, deps }) => {
       context.queryClient.prefetchQuery(
          orpc.budgetGoals.getAll.queryOptions({
-            input: { month: now.getMonth() + 1, year: now.getFullYear() },
+            input: { month: deps.month, year: deps.year },
          }),
       );
       context.queryClient.prefetchQuery(
@@ -203,15 +232,39 @@ function MonthNavigation({
 // List
 // =============================================================================
 
-interface GoalsListProps {
-   month: number;
-   year: number;
-}
-
-function GoalsList({ month, year }: GoalsListProps) {
-   const [sorting, setSorting] = useState<SortingState>([]);
-   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+function GoalsList() {
+   const navigate = Route.useNavigate();
+   const { month, year, sorting, columnFilters } = Route.useSearch();
    const [tableState, setTableState] = useGoalsTableState();
+
+   const handleSortingChange: OnChangeFn<SortingState> = useCallback(
+      (updater) => {
+         const next =
+            typeof updater === "function"
+               ? updater(sorting as SortingState)
+               : updater;
+         navigate({
+            search: (prev) => ({ ...prev, sorting: next }),
+            replace: true,
+         });
+      },
+      [navigate, sorting],
+   );
+
+   const handleColumnFiltersChange: OnChangeFn<ColumnFiltersState> =
+      useCallback(
+         (updater) => {
+            const next =
+               typeof updater === "function"
+                  ? updater(columnFilters as ColumnFiltersState)
+                  : updater;
+            navigate({
+               search: (prev) => ({ ...prev, columnFilters: next }),
+               replace: true,
+            });
+         },
+         [navigate, columnFilters],
+      );
    const { openCredenza, closeCredenza } = useCredenza();
    const { openAlertDialog } = useAlertDialog();
 
@@ -264,7 +317,7 @@ function GoalsList({ month, year }: GoalsListProps) {
       [openAlertDialog, deleteMutation],
    );
 
-   const columns = useMemo(() => buildBudgetGoalColumns(), []);
+   const columns = buildBudgetGoalColumns();
 
    if (goals.length === 0) {
       return (
@@ -290,10 +343,10 @@ function GoalsList({ month, year }: GoalsListProps) {
             columns={columns}
             data={goals}
             getRowId={(row) => row.id}
-            sorting={sorting}
-            onSortingChange={setSorting}
-            columnFilters={columnFilters}
-            onColumnFiltersChange={setColumnFilters}
+            sorting={sorting as SortingState}
+            onSortingChange={handleSortingChange}
+            columnFilters={columnFilters as ColumnFiltersState}
+            onColumnFiltersChange={handleColumnFiltersChange}
             tableState={tableState}
             onTableStateChange={setTableState}
             renderActions={({ row }) => (
@@ -329,10 +382,8 @@ function GoalsList({ month, year }: GoalsListProps) {
 // =============================================================================
 
 function GoalsPage() {
-   const [monthYear, setMonthYear] = useState({
-      month: new Date().getMonth() + 1,
-      year: new Date().getFullYear(),
-   });
+   const { month, year } = Route.useSearch();
+   const navigate = Route.useNavigate();
    const { openCredenza, closeCredenza } = useCredenza();
 
    const copyMutation = useMutation(
@@ -357,17 +408,17 @@ function GoalsPage() {
          children: (
             <BudgetGoalDialogStack
                mode="create"
-               month={monthYear.month}
+               month={month}
                onSuccess={closeCredenza}
-               year={monthYear.year}
+               year={year}
             />
          ),
       });
-   }, [openCredenza, closeCredenza, monthYear]);
+   }, [openCredenza, closeCredenza, month, year]);
 
    const handleCopyPreviousMonth = useCallback(() => {
-      copyMutation.mutate({ month: monthYear.month, year: monthYear.year });
-   }, [copyMutation, monthYear]);
+      copyMutation.mutate({ month, year });
+   }, [copyMutation, month, year]);
 
    return (
       <main className="flex flex-col gap-4">
@@ -396,12 +447,17 @@ function GoalsPage() {
             title="Metas"
          />
          <MonthNavigation
-            month={monthYear.month}
-            onChange={setMonthYear}
-            year={monthYear.year}
+            month={month}
+            onChange={(v) =>
+               navigate({
+                  search: (prev) => ({ ...prev, ...v }),
+                  replace: true,
+               })
+            }
+            year={year}
          />
          <Suspense fallback={<GoalsSkeleton />}>
-            <GoalsList month={monthYear.month} year={monthYear.year} />
+            <GoalsList />
          </Suspense>
       </main>
    );

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/profile.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/profile.tsx
@@ -576,12 +576,12 @@ function ProfileNameSection({ currentName }: { currentName: string }) {
                   }}
                />
             </FieldGroup>
-            <form.Subscribe selector={(state) => state}>
-               {(formState) => (
+            <form.Subscribe
+               selector={(state) => [state.isDirty, state.canSubmit] as const}
+            >
+               {([isDirty, canSubmit]) => (
                   <Button
-                     disabled={
-                        !formState.isDirty || !formState.canSubmit || isPending
-                     }
+                     disabled={!isDirty || !canSubmit || isPending}
                      type="submit"
                   >
                      {isPending && (
@@ -871,12 +871,9 @@ function ProfilePasswordSection({ hasPassword }: { hasPassword: boolean }) {
                   }}
                />
             </FieldGroup>
-            <form.Subscribe selector={(state) => state}>
-               {(formState) => (
-                  <Button
-                     disabled={!formState.canSubmit || isPending}
-                     type="submit"
-                  >
+            <form.Subscribe selector={(state) => state.canSubmit}>
+               {(canSubmit) => (
+                  <Button disabled={!canSubmit || isPending} type="submit">
                      {isPending && (
                         <Loader2 className="size-4 mr-2 animate-spin" />
                      )}

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/profile.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/profile.tsx
@@ -153,10 +153,12 @@ function AvatarUploadSection({
                disabled={isPending || presignedUpload.isUploading}
                onClick={handleSave}
             >
-               {(isPending || presignedUpload.isUploading) && (
-                  <Loader2 className="size-4 mr-2 animate-spin" />
-               )}
-               Salvar foto
+               <span className="flex items-center gap-2">
+                  {(isPending || presignedUpload.isUploading) && (
+                     <Loader2 className="size-4 animate-spin" />
+                  )}
+                  Salvar foto
+               </span>
             </Button>
          )}
          {(fileUpload.error || presignedUpload.error) && (
@@ -300,10 +302,12 @@ function TwoFactorSection({ twoFactorEnabled }: { twoFactorEnabled: boolean }) {
                         disabled={password.length === 0 || isPending}
                         onClick={handleEnable}
                      >
-                        {isPending && (
-                           <Loader2 className="size-4 mr-2 animate-spin" />
-                        )}
-                        Continuar
+                        <span className="flex items-center gap-2">
+                           {isPending && (
+                              <Loader2 className="size-4 animate-spin" />
+                           )}
+                           Continuar
+                        </span>
                      </Button>
                      <Button onClick={resetState} variant="outline">
                         Cancelar
@@ -349,10 +353,12 @@ function TwoFactorSection({ twoFactorEnabled }: { twoFactorEnabled: boolean }) {
                         disabled={totpCode.length !== 6 || isPending}
                         onClick={handleVerify}
                      >
-                        {isPending && (
-                           <Loader2 className="size-4 mr-2 animate-spin" />
-                        )}
-                        Verificar
+                        <span className="flex items-center gap-2">
+                           {isPending && (
+                              <Loader2 className="size-4 animate-spin" />
+                           )}
+                           Verificar
+                        </span>
                      </Button>
                      <Button onClick={resetState} variant="outline">
                         Cancelar
@@ -406,10 +412,12 @@ function TwoFactorSection({ twoFactorEnabled }: { twoFactorEnabled: boolean }) {
                         onClick={handleDisable}
                         variant="destructive"
                      >
-                        {isPending && (
-                           <Loader2 className="size-4 mr-2 animate-spin" />
-                        )}
-                        Desativar
+                        <span className="flex items-center gap-2">
+                           {isPending && (
+                              <Loader2 className="size-4 animate-spin" />
+                           )}
+                           Desativar
+                        </span>
                      </Button>
                      <Button onClick={resetState} variant="outline">
                         Cancelar
@@ -584,10 +592,12 @@ function ProfileNameSection({ currentName }: { currentName: string }) {
                      disabled={!isDirty || !canSubmit || isPending}
                      type="submit"
                   >
-                     {isPending && (
-                        <Loader2 className="size-4 mr-2 animate-spin" />
-                     )}
-                     Salvar nome
+                     <span className="flex items-center gap-2">
+                        {isPending && (
+                           <Loader2 className="size-4 animate-spin" />
+                        )}
+                        Salvar nome
+                     </span>
                   </Button>
                )}
             </form.Subscribe>
@@ -654,10 +664,10 @@ function ProfileEmailSection({
                      <FieldLabel htmlFor="profile-email">Email</FieldLabel>
                      {emailVerified && (
                         <Badge
-                           className="bg-green-500/10 text-green-500 hover:bg-green-500/20"
+                           className="bg-green-500/10 text-green-500 hover:bg-green-500/20 flex items-center gap-1"
                            variant="outline"
                         >
-                           <ShieldCheck className="size-3 mr-1" />
+                           <ShieldCheck className="size-3" />
                            Verificado
                         </Badge>
                      )}
@@ -675,8 +685,10 @@ function ProfileEmailSection({
                </Field>
             </FieldGroup>
             <Button disabled={!hasChanged || isPending} onClick={handleSave}>
-               {isPending && <Loader2 className="size-4 mr-2 animate-spin" />}
-               Salvar email
+               <span className="flex items-center gap-2">
+                  {isPending && <Loader2 className="size-4 animate-spin" />}
+                  Salvar email
+               </span>
             </Button>
          </div>
       </section>
@@ -874,10 +886,12 @@ function ProfilePasswordSection({ hasPassword }: { hasPassword: boolean }) {
             <form.Subscribe selector={(state) => state.canSubmit}>
                {(canSubmit) => (
                   <Button disabled={!canSubmit || isPending} type="submit">
-                     {isPending && (
-                        <Loader2 className="size-4 mr-2 animate-spin" />
-                     )}
-                     {hasPassword ? "Alterar senha" : "Definir senha"}
+                     <span className="flex items-center gap-2">
+                        {isPending && (
+                           <Loader2 className="size-4 animate-spin" />
+                        )}
+                        {hasPassword ? "Alterar senha" : "Definir senha"}
+                     </span>
                   </Button>
                )}
             </form.Subscribe>

--- a/apps/web/src/routes/_authenticated/-onboarding/cnpj-step.tsx
+++ b/apps/web/src/routes/_authenticated/-onboarding/cnpj-step.tsx
@@ -10,7 +10,7 @@ import type { MaskitoOptions } from "@maskito/core";
 import { useMaskito } from "@maskito/react";
 import { useForm, useStore } from "@tanstack/react-form";
 import { useMutation } from "@tanstack/react-query";
-import { useDebouncedCallback } from "@tanstack/react-pacer";
+import { useAsyncDebouncedCallback } from "@tanstack/react-pacer";
 import dayjs from "dayjs";
 import { Building2, CheckCircle2, MapPin } from "lucide-react";
 import { forwardRef, useEffect, useImperativeHandle } from "react";
@@ -99,7 +99,7 @@ export const CnpjStep = forwardRef<StepHandle, CnpjStepProps>(function CnpjStep(
       onStateChange({ canContinue, isPending });
    }, [canContinue, isPending, onStateChange]);
 
-   const fetchCnpj = useDebouncedCallback(
+   const fetchCnpj = useAsyncDebouncedCallback(
       async () => {
          const digits = form.getFieldValue("cnpj").replace(/\D/g, "");
          if (digits.length !== 14) return;

--- a/apps/web/src/routes/auth/email-verification.tsx
+++ b/apps/web/src/routes/auth/email-verification.tsx
@@ -166,13 +166,15 @@ function EmailVerificationPage() {
                      }}
                   />
                </FieldGroup>
-               <form.Subscribe selector={(state) => state}>
-                  {(formState) => (
+               <form.Subscribe
+                  selector={(state) =>
+                     [state.canSubmit, state.isSubmitting] as const
+                  }
+               >
+                  {([canSubmit, isSubmitting]) => (
                      <Button
                         className="w-full"
-                        disabled={
-                           !formState.canSubmit || formState.isSubmitting
-                        }
+                        disabled={!canSubmit || isSubmitting}
                         type="submit"
                      >
                         Enviar

--- a/apps/web/src/routes/auth/forgot-password.tsx
+++ b/apps/web/src/routes/auth/forgot-password.tsx
@@ -322,14 +322,15 @@ function ForgotPasswordPage() {
                            Voltar
                         </Button>
                         {methods.state.isLast ? (
-                           <form.Subscribe selector={(state) => state}>
-                              {(formState) => (
+                           <form.Subscribe
+                              selector={(state) =>
+                                 [state.canSubmit, state.isSubmitting] as const
+                              }
+                           >
+                              {([canSubmit, isSubmitting]) => (
                                  <Button
                                     className="flex gap-2 items-center justify-center"
-                                    disabled={
-                                       !formState.canSubmit ||
-                                       formState.isSubmitting
-                                    }
+                                    disabled={!canSubmit || isSubmitting}
                                     type="submit"
                                     variant="default"
                                  >

--- a/apps/web/src/routes/auth/forgot-password.tsx
+++ b/apps/web/src/routes/auth/forgot-password.tsx
@@ -30,25 +30,24 @@ const steps = [
 
 const { Stepper } = defineStepper(...steps);
 
+const forgotPasswordSchema = z
+   .object({
+      confirmPassword: z.string(),
+      email: z.email("Insira um endereco de email valido."),
+      otp: z.string().min(6, "O campo deve ter no minimo 6 caracteres."),
+      password: z.string().min(8, "O campo deve ter no minimo 8 caracteres."),
+   })
+   .refine((data) => data.password === data.confirmPassword, {
+      message: "As senhas nao coincidem.",
+      path: ["confirmPassword"],
+   });
+
 export const Route = createFileRoute("/auth/forgot-password")({
    component: ForgotPasswordPage,
 });
 
 function ForgotPasswordPage() {
    const router = useRouter();
-   const schema = z
-      .object({
-         confirmPassword: z.string(),
-         email: z.email("Insira um endereco de email valido."),
-         otp: z.string().min(6, "O campo deve ter no minimo 6 caracteres."),
-         password: z
-            .string()
-            .min(8, "O campo deve ter no minimo 8 caracteres."),
-      })
-      .refine((data) => data.password === data.confirmPassword, {
-         message: "As senhas nao coincidem.",
-         path: ["confirmPassword"],
-      });
 
    const handleSendOtp = useCallback(async (email: string) => {
       await authClient.emailOtp.sendVerificationOtp(
@@ -108,7 +107,7 @@ function ForgotPasswordPage() {
          await handleResetPassword(value.email, value.otp, value.password);
       },
       validators: {
-         onBlur: schema,
+         onBlur: forgotPasswordSchema,
       },
    });
 

--- a/apps/web/src/routes/auth/forgot-password.tsx
+++ b/apps/web/src/routes/auth/forgot-password.tsx
@@ -46,14 +46,18 @@ export const Route = createFileRoute("/auth/forgot-password")({
    component: ForgotPasswordPage,
 });
 
-type ForgotPasswordFormApi = ReturnType<
-   typeof useForm<{
-      confirmPassword: string;
-      email: string;
-      otp: string;
-      password: string;
-   }>
->;
+function createForgotPasswordForm() {
+   return useForm({
+      defaultValues: {
+         confirmPassword: "",
+         email: "",
+         otp: "",
+         password: "",
+      },
+      validators: { onBlur: forgotPasswordSchema },
+   });
+}
+type ForgotPasswordFormApi = ReturnType<typeof createForgotPasswordForm>;
 
 const ForgotPasswordFormContext = createContext<ForgotPasswordFormApi | null>(
    null,
@@ -225,8 +229,12 @@ function ForgotPasswordPage() {
       await authClient.emailOtp.sendVerificationOtp(
          { email, type: "forget-password" },
          {
-            onError: ({ error }) => toast.error(error.message),
-            onRequest: () => toast.loading("Processando..."),
+            onError: ({ error }) => {
+               toast.error(error.message);
+            },
+            onRequest: () => {
+               toast.loading("Processando...");
+            },
             onSuccess: () => {
                toast.success("Codigo enviado!");
                success = true;

--- a/apps/web/src/routes/auth/forgot-password.tsx
+++ b/apps/web/src/routes/auth/forgot-password.tsx
@@ -17,7 +17,7 @@ import { defineStepper } from "@packages/ui/components/stepper";
 import { useForm } from "@tanstack/react-form";
 import { createFileRoute, Link, useRouter } from "@tanstack/react-router";
 import { ArrowLeft } from "lucide-react";
-import { useCallback } from "react";
+import { createContext, useCallback, useContext } from "react";
 import { toast } from "sonner";
 import z from "zod";
 import { authClient } from "@/integrations/better-auth/auth-client";
@@ -45,6 +45,177 @@ const forgotPasswordSchema = z
 export const Route = createFileRoute("/auth/forgot-password")({
    component: ForgotPasswordPage,
 });
+
+type ForgotPasswordFormApi = ReturnType<
+   typeof useForm<{
+      confirmPassword: string;
+      email: string;
+      otp: string;
+      password: string;
+   }>
+>;
+
+const ForgotPasswordFormContext = createContext<ForgotPasswordFormApi | null>(
+   null,
+);
+
+function useForgotPasswordForm() {
+   const form = useContext(ForgotPasswordFormContext);
+   if (!form) throw new Error("useForgotPasswordForm used outside provider");
+   return form;
+}
+
+function EmailStep() {
+   const form = useForgotPasswordForm();
+   return (
+      <FieldGroup>
+         <form.Field
+            name="email"
+            children={(field) => {
+               const isInvalid =
+                  field.state.meta.isTouched &&
+                  field.state.meta.errors.length > 0;
+               return (
+                  <Field data-invalid={isInvalid}>
+                     <FieldLabel htmlFor={field.name}>Email</FieldLabel>
+                     <Input
+                        aria-invalid={isInvalid}
+                        autoComplete="email"
+                        id={field.name}
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                        placeholder="seu@email.com"
+                        type="email"
+                        value={field.state.value}
+                     />
+                     {isInvalid && (
+                        <FieldError errors={field.state.meta.errors} />
+                     )}
+                  </Field>
+               );
+            }}
+         />
+      </FieldGroup>
+   );
+}
+
+function OtpStep() {
+   const form = useForgotPasswordForm();
+   return (
+      <FieldGroup>
+         <form.Field
+            name="otp"
+            children={(field) => {
+               const isInvalid =
+                  field.state.meta.isTouched &&
+                  field.state.meta.errors.length > 0;
+               return (
+                  <Field data-invalid={isInvalid}>
+                     <FieldLabel htmlFor={field.name}>Codigo OTP</FieldLabel>
+                     <InputOTP
+                        aria-invalid={isInvalid}
+                        autoComplete="one-time-code"
+                        id={field.name}
+                        maxLength={6}
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={field.handleChange}
+                        value={field.state.value}
+                     >
+                        <div className="w-full flex justify-center items-center gap-2">
+                           <InputOTPGroup>
+                              <InputOTPSlot index={0} />
+                              <InputOTPSlot index={1} />
+                           </InputOTPGroup>
+                           <InputOTPSeparator />
+                           <InputOTPGroup>
+                              <InputOTPSlot index={2} />
+                              <InputOTPSlot index={3} />
+                           </InputOTPGroup>
+                           <InputOTPSeparator />
+                           <InputOTPGroup>
+                              <InputOTPSlot index={4} />
+                              <InputOTPSlot index={5} />
+                           </InputOTPGroup>
+                        </div>
+                     </InputOTP>
+                     {isInvalid && (
+                        <FieldError errors={field.state.meta.errors} />
+                     )}
+                  </Field>
+               );
+            }}
+         />
+      </FieldGroup>
+   );
+}
+
+function PasswordStep() {
+   const form = useForgotPasswordForm();
+   return (
+      <>
+         <FieldGroup>
+            <form.Field
+               name="password"
+               children={(field) => {
+                  const isInvalid =
+                     field.state.meta.isTouched &&
+                     field.state.meta.errors.length > 0;
+                  return (
+                     <Field data-invalid={isInvalid}>
+                        <FieldLabel htmlFor={field.name}>Senha</FieldLabel>
+                        <PasswordInput
+                           aria-invalid={isInvalid}
+                           autoComplete="new-password"
+                           id={field.name}
+                           name={field.name}
+                           onBlur={field.handleBlur}
+                           onChange={(e) => field.handleChange(e.target.value)}
+                           placeholder="Minimo 8 caracteres"
+                           value={field.state.value}
+                        />
+                        {isInvalid && (
+                           <FieldError errors={field.state.meta.errors} />
+                        )}
+                     </Field>
+                  );
+               }}
+            />
+         </FieldGroup>
+         <FieldGroup>
+            <form.Field
+               name="confirmPassword"
+               children={(field) => {
+                  const isInvalid =
+                     field.state.meta.isTouched &&
+                     field.state.meta.errors.length > 0;
+                  return (
+                     <Field data-invalid={isInvalid}>
+                        <FieldLabel htmlFor={field.name}>
+                           Confirmar Senha
+                        </FieldLabel>
+                        <PasswordInput
+                           aria-invalid={isInvalid}
+                           autoComplete="new-password"
+                           id={field.name}
+                           name={field.name}
+                           onBlur={field.handleBlur}
+                           onChange={(e) => field.handleChange(e.target.value)}
+                           placeholder="Repita a senha"
+                           value={field.state.value}
+                        />
+                        {isInvalid && (
+                           <FieldError errors={field.state.meta.errors} />
+                        )}
+                     </Field>
+                  );
+               }}
+            />
+         </FieldGroup>
+      </>
+   );
+}
 
 function ForgotPasswordPage() {
    const router = useRouter();
@@ -120,268 +291,121 @@ function ForgotPasswordPage() {
       [form],
    );
 
-   function EmailStep() {
-      return (
-         <FieldGroup>
-            <form.Field
-               name="email"
-               children={(field) => {
-                  const isInvalid =
-                     field.state.meta.isTouched &&
-                     field.state.meta.errors.length > 0;
-                  return (
-                     <Field data-invalid={isInvalid}>
-                        <FieldLabel htmlFor={field.name}>Email</FieldLabel>
-                        <Input
-                           aria-invalid={isInvalid}
-                           autoComplete="email"
-                           id={field.name}
-                           name={field.name}
-                           onBlur={field.handleBlur}
-                           onChange={(e) => field.handleChange(e.target.value)}
-                           placeholder="seu@email.com"
-                           type="email"
-                           value={field.state.value}
-                        />
-                        {isInvalid && (
-                           <FieldError errors={field.state.meta.errors} />
-                        )}
-                     </Field>
-                  );
-               }}
-            />
-         </FieldGroup>
-      );
-   }
-
-   function OtpStep() {
-      return (
-         <FieldGroup>
-            <form.Field
-               name="otp"
-               children={(field) => {
-                  const isInvalid =
-                     field.state.meta.isTouched &&
-                     field.state.meta.errors.length > 0;
-                  return (
-                     <Field data-invalid={isInvalid}>
-                        <FieldLabel htmlFor={field.name}>Codigo OTP</FieldLabel>
-                        <InputOTP
-                           aria-invalid={isInvalid}
-                           autoComplete="one-time-code"
-                           id={field.name}
-                           maxLength={6}
-                           name={field.name}
-                           onBlur={field.handleBlur}
-                           onChange={field.handleChange}
-                           value={field.state.value}
-                        >
-                           <div className="w-full flex justify-center items-center gap-2">
-                              <InputOTPGroup>
-                                 <InputOTPSlot index={0} />
-                                 <InputOTPSlot index={1} />
-                              </InputOTPGroup>
-                              <InputOTPSeparator />
-                              <InputOTPGroup>
-                                 <InputOTPSlot index={2} />
-                                 <InputOTPSlot index={3} />
-                              </InputOTPGroup>
-                              <InputOTPSeparator />
-                              <InputOTPGroup>
-                                 <InputOTPSlot index={4} />
-                                 <InputOTPSlot index={5} />
-                              </InputOTPGroup>
-                           </div>
-                        </InputOTP>
-                        {isInvalid && (
-                           <FieldError errors={field.state.meta.errors} />
-                        )}
-                     </Field>
-                  );
-               }}
-            />
-         </FieldGroup>
-      );
-   }
-
-   function PasswordStep() {
-      return (
-         <>
-            <FieldGroup>
-               <form.Field
-                  name="password"
-                  children={(field) => {
-                     const isInvalid =
-                        field.state.meta.isTouched &&
-                        field.state.meta.errors.length > 0;
-                     return (
-                        <Field data-invalid={isInvalid}>
-                           <FieldLabel htmlFor={field.name}>Senha</FieldLabel>
-                           <PasswordInput
-                              aria-invalid={isInvalid}
-                              autoComplete="new-password"
-                              id={field.name}
-                              name={field.name}
-                              onBlur={field.handleBlur}
-                              onChange={(e) =>
-                                 field.handleChange(e.target.value)
-                              }
-                              placeholder="Minimo 8 caracteres"
-                              value={field.state.value}
-                           />
-                           {isInvalid && (
-                              <FieldError errors={field.state.meta.errors} />
-                           )}
-                        </Field>
-                     );
-                  }}
-               />
-            </FieldGroup>
-            <FieldGroup>
-               <form.Field
-                  name="confirmPassword"
-                  children={(field) => {
-                     const isInvalid =
-                        field.state.meta.isTouched &&
-                        field.state.meta.errors.length > 0;
-                     return (
-                        <Field data-invalid={isInvalid}>
-                           <FieldLabel htmlFor={field.name}>
-                              Confirmar Senha
-                           </FieldLabel>
-                           <PasswordInput
-                              aria-invalid={isInvalid}
-                              autoComplete="new-password"
-                              id={field.name}
-                              name={field.name}
-                              onBlur={field.handleBlur}
-                              onChange={(e) =>
-                                 field.handleChange(e.target.value)
-                              }
-                              placeholder="Repita a senha"
-                              value={field.state.value}
-                           />
-                           {isInvalid && (
-                              <FieldError errors={field.state.meta.errors} />
-                           )}
-                        </Field>
-                     );
-                  }}
-               />
-            </FieldGroup>
-         </>
-      );
-   }
-
    return (
-      <Stepper.Provider>
-         {({ methods }) => (
-            <section className="flex flex-col gap-4 w-full">
-               {/* Back Link */}
-               <Button asChild className="gap-2 px-0" variant="link">
-                  <Link to="/auth/sign-in">
-                     <ArrowLeft className="size-4" />
-                     Voltar para login
-                  </Link>
-               </Button>
-
-               {/* Header */}
-               <div className="text-center flex flex-col gap-2">
-                  <h1 className="text-3xl font-semibold font-serif">
-                     Esqueci Minha Senha
-                  </h1>
-                  <p className="text-muted-foreground text-sm">
-                     {methods.state.current.data.id === "enter-email"
-                        ? "Digite seu e-mail para receber o codigo de recuperacao"
-                        : methods.state.current.data.id === "enter-otp"
-                          ? "Digite o codigo enviado para seu e-mail"
-                          : "Digite sua nova senha"}
-                  </p>
-               </div>
-
-               <div className="flex flex-col gap-4">
-                  <Stepper.Navigation className="w-full">
-                     {steps.map((step) => (
-                        <Stepper.Step key={step.id} of={step.id} />
-                     ))}
-                  </Stepper.Navigation>
-                  <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
-                     {methods.flow.switch({
-                        "enter-email": () => <EmailStep />,
-                        "enter-otp": () => <OtpStep />,
-                        "enter-password": () => <PasswordStep />,
-                     })}
-                     <Stepper.Controls className="flex w-full justify-between">
-                        <Button
-                           disabled={methods.state.isFirst}
-                           onClick={() => methods.navigation.prev()}
-                           type="button"
-                           variant="outline"
-                        >
-                           Voltar
-                        </Button>
-                        {methods.state.isLast ? (
-                           <form.Subscribe
-                              selector={(state) =>
-                                 [state.canSubmit, state.isSubmitting] as const
-                              }
-                           >
-                              {([canSubmit, isSubmitting]) => (
-                                 <Button
-                                    className="flex gap-2 items-center justify-center"
-                                    disabled={!canSubmit || isSubmitting}
-                                    type="submit"
-                                    variant="default"
-                                 >
-                                    Redefinir senha
-                                 </Button>
-                              )}
-                           </form.Subscribe>
-                        ) : methods.flow.is("enter-email") ? (
-                           <form.Subscribe
-                              selector={(state) => ({
-                                 emailValid: state.fieldMeta.email?.isValid,
-                                 emailValue: state.values.email,
-                              })}
-                           >
-                              {({ emailValid, emailValue }) => (
-                                 <Button
-                                    disabled={!emailValid}
-                                    onClick={async () => {
-                                       await handleSendOtp(emailValue);
-                                       methods.navigation.next();
-                                    }}
-                                    type="button"
-                                 >
-                                    Proximo
-                                 </Button>
-                              )}
-                           </form.Subscribe>
-                        ) : (
-                           <Button
-                              onClick={() => methods.navigation.next()}
-                              type="button"
-                           >
-                              Proximo
-                           </Button>
-                        )}
-                     </Stepper.Controls>
-                  </form>
-               </div>
-
-               <div className="text-sm text-center">
-                  <div className="flex gap-1 justify-center items-center">
-                     <span>Lembrou sua senha?</span>
-                     <Link
-                        className="text-primary hover:underline"
-                        to="/auth/sign-in"
-                     >
-                        Entrar
+      <ForgotPasswordFormContext.Provider value={form}>
+         <Stepper.Provider>
+            {({ methods }) => (
+               <section className="flex flex-col gap-4 w-full">
+                  <Button asChild className="gap-2 px-0" variant="link">
+                     <Link to="/auth/sign-in">
+                        <ArrowLeft className="size-4" />
+                        Voltar para login
                      </Link>
+                  </Button>
+
+                  <div className="text-center flex flex-col gap-2">
+                     <h1 className="text-3xl font-semibold font-serif">
+                        Esqueci Minha Senha
+                     </h1>
+                     <p className="text-muted-foreground text-sm">
+                        {methods.state.current.data.id === "enter-email"
+                           ? "Digite seu e-mail para receber o codigo de recuperacao"
+                           : methods.state.current.data.id === "enter-otp"
+                             ? "Digite o codigo enviado para seu e-mail"
+                             : "Digite sua nova senha"}
+                     </p>
                   </div>
-               </div>
-            </section>
-         )}
-      </Stepper.Provider>
+
+                  <div className="flex flex-col gap-4">
+                     <Stepper.Navigation className="w-full">
+                        {steps.map((step) => (
+                           <Stepper.Step key={step.id} of={step.id} />
+                        ))}
+                     </Stepper.Navigation>
+                     <form
+                        className="flex flex-col gap-4"
+                        onSubmit={handleSubmit}
+                     >
+                        {methods.flow.switch({
+                           "enter-email": () => <EmailStep />,
+                           "enter-otp": () => <OtpStep />,
+                           "enter-password": () => <PasswordStep />,
+                        })}
+                        <Stepper.Controls className="flex w-full justify-between">
+                           <Button
+                              disabled={methods.state.isFirst}
+                              onClick={() => methods.navigation.prev()}
+                              type="button"
+                              variant="outline"
+                           >
+                              Voltar
+                           </Button>
+                           {methods.state.isLast ? (
+                              <form.Subscribe
+                                 selector={(state) =>
+                                    [
+                                       state.canSubmit,
+                                       state.isSubmitting,
+                                    ] as const
+                                 }
+                              >
+                                 {([canSubmit, isSubmitting]) => (
+                                    <Button
+                                       className="flex gap-2 items-center justify-center"
+                                       disabled={!canSubmit || isSubmitting}
+                                       type="submit"
+                                       variant="default"
+                                    >
+                                       Redefinir senha
+                                    </Button>
+                                 )}
+                              </form.Subscribe>
+                           ) : methods.flow.is("enter-email") ? (
+                              <form.Subscribe
+                                 selector={(state) => ({
+                                    emailValid: state.fieldMeta.email?.isValid,
+                                    emailValue: state.values.email,
+                                 })}
+                              >
+                                 {({ emailValid, emailValue }) => (
+                                    <Button
+                                       disabled={!emailValid}
+                                       onClick={async () => {
+                                          await handleSendOtp(emailValue);
+                                          methods.navigation.next();
+                                       }}
+                                       type="button"
+                                    >
+                                       Proximo
+                                    </Button>
+                                 )}
+                              </form.Subscribe>
+                           ) : (
+                              <Button
+                                 onClick={() => methods.navigation.next()}
+                                 type="button"
+                              >
+                                 Proximo
+                              </Button>
+                           )}
+                        </Stepper.Controls>
+                     </form>
+                  </div>
+
+                  <div className="text-sm text-center">
+                     <div className="flex gap-1 justify-center items-center">
+                        <span>Lembrou sua senha?</span>
+                        <Link
+                           className="text-primary hover:underline"
+                           to="/auth/sign-in"
+                        >
+                           Entrar
+                        </Link>
+                     </div>
+                  </div>
+               </section>
+            )}
+         </Stepper.Provider>
+      </ForgotPasswordFormContext.Provider>
    );
 }

--- a/apps/web/src/routes/auth/forgot-password.tsx
+++ b/apps/web/src/routes/auth/forgot-password.tsx
@@ -385,6 +385,22 @@ function ForgotPasswordPage() {
                                     </Button>
                                  )}
                               </form.Subscribe>
+                           ) : methods.flow.is("enter-otp") ? (
+                              <form.Subscribe
+                                 selector={(state) =>
+                                    state.fieldMeta.otp?.isValid
+                                 }
+                              >
+                                 {(otpValid) => (
+                                    <Button
+                                       disabled={!otpValid}
+                                       onClick={() => methods.navigation.next()}
+                                       type="button"
+                                    >
+                                       Proximo
+                                    </Button>
+                                 )}
+                              </form.Subscribe>
                            ) : (
                               <Button
                                  onClick={() => methods.navigation.next()}

--- a/apps/web/src/routes/auth/forgot-password.tsx
+++ b/apps/web/src/routes/auth/forgot-password.tsx
@@ -221,23 +221,19 @@ function ForgotPasswordPage() {
    const router = useRouter();
 
    const handleSendOtp = useCallback(async (email: string) => {
+      let success = false;
       await authClient.emailOtp.sendVerificationOtp(
+         { email, type: "forget-password" },
          {
-            email,
-            type: "forget-password",
-         },
-         {
-            onError: ({ error }) => {
-               toast.error(error.message);
-            },
-            onRequest: () => {
-               toast.loading("Processando...");
-            },
+            onError: ({ error }) => toast.error(error.message),
+            onRequest: () => toast.loading("Processando..."),
             onSuccess: () => {
                toast.success("Codigo enviado!");
+               success = true;
             },
          },
       );
+      return success;
    }, []);
 
    const handleResetPassword = useCallback(
@@ -371,8 +367,9 @@ function ForgotPasswordPage() {
                                     <Button
                                        disabled={!emailValid}
                                        onClick={async () => {
-                                          await handleSendOtp(emailValue);
-                                          methods.navigation.next();
+                                          const sent =
+                                             await handleSendOtp(emailValue);
+                                          if (sent) methods.navigation.next();
                                        }}
                                        type="button"
                                     >

--- a/apps/web/src/routes/auth/magic-link.tsx
+++ b/apps/web/src/routes/auth/magic-link.tsx
@@ -177,14 +177,18 @@ function MagicLinkPage() {
                   }}
                />
             </FieldGroup>
-            <form.Subscribe selector={(state) => state}>
-               {(formState) => (
+            <form.Subscribe
+               selector={(state) =>
+                  [state.canSubmit, state.isSubmitting] as const
+               }
+            >
+               {([canSubmit, isSubmitting]) => (
                   <Button
                      className="w-full h-11"
-                     disabled={!formState.canSubmit || formState.isSubmitting}
+                     disabled={!canSubmit || isSubmitting}
                      type="submit"
                   >
-                     {formState.isSubmitting ? <Spinner /> : "Enviar link"}
+                     {isSubmitting ? <Spinner /> : "Enviar link"}
                   </Button>
                )}
             </form.Subscribe>

--- a/apps/web/src/routes/auth/sign-in/email.tsx
+++ b/apps/web/src/routes/auth/sign-in/email.tsx
@@ -169,11 +169,15 @@ function SignInEmailPage() {
                   }}
                />
             </FieldGroup>
-            <form.Subscribe selector={(state) => state}>
-               {(formState) => (
+            <form.Subscribe
+               selector={(state) =>
+                  [state.canSubmit, state.isSubmitting] as const
+               }
+            >
+               {([canSubmit, isSubmitting]) => (
                   <Button
                      className="w-full h-11"
-                     disabled={!formState.canSubmit || formState.isSubmitting}
+                     disabled={!canSubmit || isSubmitting}
                      type="submit"
                   >
                      Entrar

--- a/apps/web/src/routes/auth/sign-in/email.tsx
+++ b/apps/web/src/routes/auth/sign-in/email.tsx
@@ -79,7 +79,6 @@ function SignInEmailPage() {
 
    return (
       <section className="flex flex-col gap-4 w-full">
-         {/* Back Link */}
          <Button asChild className="gap-2 px-0" variant="link">
             <Link to="/auth/sign-in">
                <ArrowLeft className="size-4" />
@@ -87,7 +86,6 @@ function SignInEmailPage() {
             </Link>
          </Button>
 
-         {/* Header */}
          <div className="text-center flex flex-col gap-2">
             <h1 className="text-3xl font-semibold font-serif">
                Entrar com Email
@@ -97,7 +95,6 @@ function SignInEmailPage() {
             </p>
          </div>
 
-         {/* Form */}
          <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
             <FieldGroup>
                <form.Field
@@ -186,7 +183,6 @@ function SignInEmailPage() {
             </form.Subscribe>
          </form>
 
-         {/* Footer */}
          <div className="text-sm text-center">
             <div className="flex gap-1 justify-center items-center">
                <span>Primeira vez aqui? </span>

--- a/apps/web/src/routes/auth/sign-up.tsx
+++ b/apps/web/src/routes/auth/sign-up.tsx
@@ -47,14 +47,18 @@ const signUpSchema = z
       path: ["confirmPassword"],
    });
 
-type SignUpFormApi = ReturnType<
-   typeof useForm<{
-      confirmPassword: string;
-      email: string;
-      name: string;
-      password: string;
-   }>
->;
+function createSignUpForm() {
+   return useForm({
+      defaultValues: {
+         confirmPassword: "",
+         email: "",
+         name: "",
+         password: "",
+      },
+      validators: { onBlur: signUpSchema },
+   });
+}
+type SignUpFormApi = ReturnType<typeof createSignUpForm>;
 
 const SignUpFormContext = createContext<SignUpFormApi | null>(null);
 

--- a/apps/web/src/routes/auth/sign-up.tsx
+++ b/apps/web/src/routes/auth/sign-up.tsx
@@ -29,22 +29,21 @@ export const Route = createFileRoute("/auth/sign-up")({
    component: SignUpPage,
 });
 
+const signUpSchema = z
+   .object({
+      confirmPassword: z.string(),
+      email: z.email("Insira um endereco de email valido."),
+      name: z.string().min(2, "O campo deve ter no minimo 2 caracteres."),
+      password: z.string().min(8, "O campo deve ter no minimo 8 caracteres."),
+   })
+   .refine((data) => data.password === data.confirmPassword, {
+      message: "As senhas nao coincidem.",
+      path: ["confirmPassword"],
+   });
+
 function SignUpPage() {
    const router = useRouter();
    const [isPending, startTransition] = useTransition();
-   const schema = z
-      .object({
-         confirmPassword: z.string(),
-         email: z.email("Insira um endereco de email valido."),
-         name: z.string().min(2, "O campo deve ter no minimo 2 caracteres."),
-         password: z
-            .string()
-            .min(8, "O campo deve ter no minimo 8 caracteres."),
-      })
-      .refine((data) => data.password === data.confirmPassword, {
-         message: "As senhas nao coincidem.",
-         path: ["confirmPassword"],
-      });
 
    const handleSignUp = useCallback(
       async (email: string, name: string, password: string) => {
@@ -87,7 +86,7 @@ function SignUpPage() {
          formApi.reset();
       },
       validators: {
-         onBlur: schema,
+         onBlur: signUpSchema,
       },
    });
 

--- a/apps/web/src/routes/auth/sign-up.tsx
+++ b/apps/web/src/routes/auth/sign-up.tsx
@@ -280,14 +280,16 @@ function SignUpPage() {
                            Voltar
                         </Button>
                         {methods.state.isLast ? (
-                           <form.Subscribe selector={(state) => state}>
-                              {(formState) => (
+                           <form.Subscribe
+                              selector={(state) =>
+                                 [state.canSubmit, state.isSubmitting] as const
+                              }
+                           >
+                              {([canSubmit, isSubmitting]) => (
                                  <Button
                                     className="h-11"
                                     disabled={
-                                       !formState.canSubmit ||
-                                       formState.isSubmitting ||
-                                       isPending
+                                       !canSubmit || isSubmitting || isPending
                                     }
                                     type="submit"
                                     variant="default"

--- a/apps/web/src/routes/auth/sign-up.tsx
+++ b/apps/web/src/routes/auth/sign-up.tsx
@@ -11,7 +11,13 @@ import { defineStepper } from "@packages/ui/components/stepper";
 import { useForm } from "@tanstack/react-form";
 import { createFileRoute, Link, useRouter } from "@tanstack/react-router";
 import { Loader2 } from "lucide-react";
-import { type FormEvent, useCallback, useTransition } from "react";
+import {
+   createContext,
+   type FormEvent,
+   useCallback,
+   useContext,
+   useTransition,
+} from "react";
 import { toast } from "sonner";
 import z from "zod";
 import { authClient } from "@/integrations/better-auth/auth-client";
@@ -40,6 +46,157 @@ const signUpSchema = z
       message: "As senhas nao coincidem.",
       path: ["confirmPassword"],
    });
+
+type SignUpFormApi = ReturnType<
+   typeof useForm<{
+      confirmPassword: string;
+      email: string;
+      name: string;
+      password: string;
+   }>
+>;
+
+const SignUpFormContext = createContext<SignUpFormApi | null>(null);
+
+function useSignUpForm() {
+   const form = useContext(SignUpFormContext);
+   if (!form) throw new Error("useSignUpForm used outside provider");
+   return form;
+}
+
+function BasicInfoStep() {
+   const form = useSignUpForm();
+   return (
+      <>
+         <FieldGroup>
+            <form.Field
+               name="name"
+               children={(field) => {
+                  const isInvalid =
+                     field.state.meta.isTouched &&
+                     field.state.meta.errors.length > 0;
+                  return (
+                     <Field data-invalid={isInvalid}>
+                        <FieldLabel htmlFor={field.name}>Nome</FieldLabel>
+                        <Input
+                           aria-invalid={isInvalid}
+                           autoComplete="name"
+                           id={field.name}
+                           name={field.name}
+                           onBlur={field.handleBlur}
+                           onChange={(e) => field.handleChange(e.target.value)}
+                           placeholder="Seu nome completo"
+                           value={field.state.value}
+                        />
+                        {isInvalid && (
+                           <FieldError errors={field.state.meta.errors} />
+                        )}
+                     </Field>
+                  );
+               }}
+            />
+         </FieldGroup>
+         <FieldGroup>
+            <form.Field
+               name="email"
+               children={(field) => {
+                  const isInvalid =
+                     field.state.meta.isTouched &&
+                     field.state.meta.errors.length > 0;
+                  return (
+                     <Field data-invalid={isInvalid}>
+                        <FieldLabel htmlFor={field.name}>Email</FieldLabel>
+                        <Input
+                           aria-invalid={isInvalid}
+                           autoComplete="email"
+                           id={field.name}
+                           name={field.name}
+                           onBlur={field.handleBlur}
+                           onChange={(e) => field.handleChange(e.target.value)}
+                           placeholder="seu@email.com"
+                           type="email"
+                           value={field.state.value}
+                        />
+                        {isInvalid && (
+                           <FieldError errors={field.state.meta.errors} />
+                        )}
+                     </Field>
+                  );
+               }}
+            />
+         </FieldGroup>
+      </>
+   );
+}
+
+function PasswordStep() {
+   const form = useSignUpForm();
+   return (
+      <>
+         <FieldGroup>
+            <form.Field
+               name="password"
+               children={(field) => {
+                  const isInvalid =
+                     field.state.meta.isTouched &&
+                     field.state.meta.errors.length > 0;
+                  return (
+                     <Field data-invalid={isInvalid}>
+                        <FieldLabel htmlFor={field.name}>Senha</FieldLabel>
+                        <PasswordInput
+                           aria-invalid={isInvalid}
+                           autoComplete="new-password"
+                           id={field.name}
+                           name={field.name}
+                           onBlur={field.handleBlur}
+                           onChange={(e) => field.handleChange(e.target.value)}
+                           placeholder="Minimo 8 caracteres"
+                           value={field.state.value}
+                        />
+                        {isInvalid && (
+                           <FieldError errors={field.state.meta.errors} />
+                        )}
+                     </Field>
+                  );
+               }}
+            />
+         </FieldGroup>
+         <FieldGroup>
+            <form.Field
+               name="confirmPassword"
+               children={(field) => {
+                  const isInvalid =
+                     field.state.meta.isTouched &&
+                     field.state.meta.errors.length > 0;
+                  return (
+                     <Field data-invalid={isInvalid}>
+                        <FieldLabel htmlFor={field.name}>
+                           Confirmar Senha
+                        </FieldLabel>
+                        <PasswordInput
+                           aria-invalid={isInvalid}
+                           autoComplete="new-password"
+                           id={field.name}
+                           name={field.name}
+                           onBlur={field.handleBlur}
+                           onChange={(e) => field.handleChange(e.target.value)}
+                           placeholder="Repita a senha"
+                           value={field.state.value}
+                        />
+                        {isInvalid && (
+                           <FieldError errors={field.state.meta.errors} />
+                        )}
+                     </Field>
+                  );
+               }}
+            />
+         </FieldGroup>
+         <form.Subscribe selector={(state) => state.values.password}>
+            {(password) => <PasswordStrengthCard password={password} />}
+         </form.Subscribe>
+      </>
+   );
+}
 
 function SignUpPage() {
    const router = useRouter();
@@ -101,245 +258,111 @@ function SignUpPage() {
       [form, startTransition],
    );
 
-   function BasicInfoStep() {
-      return (
-         <>
-            <FieldGroup>
-               <form.Field
-                  name="name"
-                  children={(field) => {
-                     const isInvalid =
-                        field.state.meta.isTouched &&
-                        field.state.meta.errors.length > 0;
-                     return (
-                        <Field data-invalid={isInvalid}>
-                           <FieldLabel htmlFor={field.name}>Nome</FieldLabel>
-                           <Input
-                              aria-invalid={isInvalid}
-                              autoComplete="name"
-                              id={field.name}
-                              name={field.name}
-                              onBlur={field.handleBlur}
-                              onChange={(e) =>
-                                 field.handleChange(e.target.value)
-                              }
-                              placeholder="Seu nome completo"
-                              value={field.state.value}
-                           />
-                           {isInvalid && (
-                              <FieldError errors={field.state.meta.errors} />
-                           )}
-                        </Field>
-                     );
-                  }}
-               />
-            </FieldGroup>
-            <FieldGroup>
-               <form.Field
-                  name="email"
-                  children={(field) => {
-                     const isInvalid =
-                        field.state.meta.isTouched &&
-                        field.state.meta.errors.length > 0;
-                     return (
-                        <Field data-invalid={isInvalid}>
-                           <FieldLabel htmlFor={field.name}>Email</FieldLabel>
-                           <Input
-                              aria-invalid={isInvalid}
-                              autoComplete="email"
-                              id={field.name}
-                              name={field.name}
-                              onBlur={field.handleBlur}
-                              onChange={(e) =>
-                                 field.handleChange(e.target.value)
-                              }
-                              placeholder="seu@email.com"
-                              type="email"
-                              value={field.state.value}
-                           />
-                           {isInvalid && (
-                              <FieldError errors={field.state.meta.errors} />
-                           )}
-                        </Field>
-                     );
-                  }}
-               />
-            </FieldGroup>
-         </>
-      );
-   }
-
-   // Internal component for password step
-   function PasswordStep() {
-      return (
-         <>
-            <FieldGroup>
-               <form.Field
-                  name="password"
-                  children={(field) => {
-                     const isInvalid =
-                        field.state.meta.isTouched &&
-                        field.state.meta.errors.length > 0;
-                     return (
-                        <Field data-invalid={isInvalid}>
-                           <FieldLabel htmlFor={field.name}>Senha</FieldLabel>
-                           <PasswordInput
-                              aria-invalid={isInvalid}
-                              autoComplete="new-password"
-                              id={field.name}
-                              name={field.name}
-                              onBlur={field.handleBlur}
-                              onChange={(e) =>
-                                 field.handleChange(e.target.value)
-                              }
-                              placeholder="Minimo 8 caracteres"
-                              value={field.state.value}
-                           />
-                           {isInvalid && (
-                              <FieldError errors={field.state.meta.errors} />
-                           )}
-                        </Field>
-                     );
-                  }}
-               />
-            </FieldGroup>
-            <FieldGroup>
-               <form.Field
-                  name="confirmPassword"
-                  children={(field) => {
-                     const isInvalid =
-                        field.state.meta.isTouched &&
-                        field.state.meta.errors.length > 0;
-                     return (
-                        <Field data-invalid={isInvalid}>
-                           <FieldLabel htmlFor={field.name}>
-                              Confirmar Senha
-                           </FieldLabel>
-                           <PasswordInput
-                              aria-invalid={isInvalid}
-                              autoComplete="new-password"
-                              id={field.name}
-                              name={field.name}
-                              onBlur={field.handleBlur}
-                              onChange={(e) =>
-                                 field.handleChange(e.target.value)
-                              }
-                              placeholder="Repita a senha"
-                              value={field.state.value}
-                           />
-                           {isInvalid && (
-                              <FieldError errors={field.state.meta.errors} />
-                           )}
-                        </Field>
-                     );
-                  }}
-               />
-            </FieldGroup>
-            <form.Subscribe selector={(state) => state.values.password}>
-               {(password) => <PasswordStrengthCard password={password} />}
-            </form.Subscribe>
-         </>
-      );
-   }
-
    return (
-      <Stepper.Provider>
-         {({ methods }) => (
-            <section className="flex flex-col gap-4 w-full">
-               {/* Header */}
-               <div className="text-center flex flex-col gap-2">
-                  <h1 className="text-3xl font-semibold font-serif">
-                     Cadastrar
-                  </h1>
-                  <p className="text-muted-foreground text-sm">
-                     Crie sua conta e comece a gerenciar seu negocio com IA.
-                  </p>
-               </div>
-
-               {/* Form */}
-               <div className="flex flex-col gap-4">
-                  <Stepper.Navigation>
-                     {steps.map((step) => (
-                        <Stepper.Step key={step.id} of={step.id}></Stepper.Step>
-                     ))}
-                  </Stepper.Navigation>
-                  <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
-                     {methods.flow.switch({
-                        "basic-info": () => <BasicInfoStep />,
-                        password: () => <PasswordStep />,
-                     })}
-                     <Stepper.Controls className="flex w-full justify-between">
-                        <Button
-                           className="h-11"
-                           disabled={methods.state.isFirst}
-                           onClick={() => methods.navigation.prev()}
-                           type="button"
-                           variant="outline"
-                        >
-                           Voltar
-                        </Button>
-                        {methods.state.isLast ? (
-                           <form.Subscribe
-                              selector={(state) =>
-                                 [state.canSubmit, state.isSubmitting] as const
-                              }
-                           >
-                              {([canSubmit, isSubmitting]) => (
-                                 <Button
-                                    className="h-11"
-                                    disabled={
-                                       !canSubmit || isSubmitting || isPending
-                                    }
-                                    type="submit"
-                                    variant="default"
-                                 >
-                                    <span className="flex items-center gap-2">
-                                       {isPending && (
-                                          <Loader2 className="size-4 animate-spin" />
-                                       )}
-                                       Enviar
-                                    </span>
-                                 </Button>
-                              )}
-                           </form.Subscribe>
-                        ) : (
-                           <form.Subscribe
-                              selector={(state) => ({
-                                 emailValid: state.fieldMeta.email?.isValid,
-                                 nameValid: state.fieldMeta.name?.isValid,
-                              })}
-                           >
-                              {({ nameValid, emailValid }) => (
-                                 <Button
-                                    className="h-11"
-                                    disabled={!nameValid || !emailValid}
-                                    onClick={() => methods.navigation.next()}
-                                    type="button"
-                                 >
-                                    Proximo
-                                 </Button>
-                              )}
-                           </form.Subscribe>
-                        )}
-                     </Stepper.Controls>
-                  </form>
-               </div>
-
-               {/* Footer */}
-               <div className="text-sm text-center flex flex-col gap-4">
-                  <div className="flex gap-1 justify-center items-center">
-                     <span>Ja tem uma conta?</span>
-                     <Link
-                        className="text-primary font-medium hover:underline"
-                        to="/auth/sign-in"
-                     >
-                        Entre aqui
-                     </Link>
+      <SignUpFormContext.Provider value={form}>
+         <Stepper.Provider>
+            {({ methods }) => (
+               <section className="flex flex-col gap-4 w-full">
+                  <div className="text-center flex flex-col gap-2">
+                     <h1 className="text-3xl font-semibold font-serif">
+                        Cadastrar
+                     </h1>
+                     <p className="text-muted-foreground text-sm">
+                        Crie sua conta e comece a gerenciar seu negocio com IA.
+                     </p>
                   </div>
-                  <TermsAndPrivacyText />
-               </div>
-            </section>
-         )}
-      </Stepper.Provider>
+
+                  <div className="flex flex-col gap-4">
+                     <Stepper.Navigation>
+                        {steps.map((step) => (
+                           <Stepper.Step key={step.id} of={step.id} />
+                        ))}
+                     </Stepper.Navigation>
+                     <form
+                        className="flex flex-col gap-4"
+                        onSubmit={handleSubmit}
+                     >
+                        {methods.flow.switch({
+                           "basic-info": () => <BasicInfoStep />,
+                           password: () => <PasswordStep />,
+                        })}
+                        <Stepper.Controls className="flex w-full justify-between">
+                           <Button
+                              className="h-11"
+                              disabled={methods.state.isFirst}
+                              onClick={() => methods.navigation.prev()}
+                              type="button"
+                              variant="outline"
+                           >
+                              Voltar
+                           </Button>
+                           {methods.state.isLast ? (
+                              <form.Subscribe
+                                 selector={(state) =>
+                                    [
+                                       state.canSubmit,
+                                       state.isSubmitting,
+                                    ] as const
+                                 }
+                              >
+                                 {([canSubmit, isSubmitting]) => (
+                                    <Button
+                                       className="h-11"
+                                       disabled={
+                                          !canSubmit ||
+                                          isSubmitting ||
+                                          isPending
+                                       }
+                                       type="submit"
+                                       variant="default"
+                                    >
+                                       <span className="flex items-center gap-2">
+                                          {isPending && (
+                                             <Loader2 className="size-4 animate-spin" />
+                                          )}
+                                          Enviar
+                                       </span>
+                                    </Button>
+                                 )}
+                              </form.Subscribe>
+                           ) : (
+                              <form.Subscribe
+                                 selector={(state) => ({
+                                    emailValid: state.fieldMeta.email?.isValid,
+                                    nameValid: state.fieldMeta.name?.isValid,
+                                 })}
+                              >
+                                 {({ nameValid, emailValid }) => (
+                                    <Button
+                                       className="h-11"
+                                       disabled={!nameValid || !emailValid}
+                                       onClick={() => methods.navigation.next()}
+                                       type="button"
+                                    >
+                                       Proximo
+                                    </Button>
+                                 )}
+                              </form.Subscribe>
+                           )}
+                        </Stepper.Controls>
+                     </form>
+                  </div>
+
+                  <div className="text-sm text-center flex flex-col gap-4">
+                     <div className="flex gap-1 justify-center items-center">
+                        <span>Ja tem uma conta?</span>
+                        <Link
+                           className="text-primary font-medium hover:underline"
+                           to="/auth/sign-in"
+                        >
+                           Entre aqui
+                        </Link>
+                     </div>
+                     <TermsAndPrivacyText />
+                  </div>
+               </section>
+            )}
+         </Stepper.Provider>
+      </SignUpFormContext.Provider>
    );
 }

--- a/docs/plans/2026-04-09-tanstack-form-advanced-patterns.md
+++ b/docs/plans/2026-04-09-tanstack-form-advanced-patterns.md
@@ -1,0 +1,433 @@
+# TanStack Form — Advanced Patterns Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Unlock server-side inline field errors, selective subscriptions, navigation guard, and async field validation using TanStack Form v1 advanced APIs — without introducing a new helper component, leveraging the existing `FieldError` from `@packages/ui/components/field`.
+
+**Architecture:** Three changes propagate across all 28 form files: (1) `FieldError` updated to handle string errors from `onSubmitAsync`, (2) `onSubmitAsync` replaces `onError` toast in critical forms, (3) `form.Subscribe` receives typed selectors everywhere. `useBlocker` and async field validation are applied only where meaningful (edit forms and CNPJ/CPF fields).
+
+**Tech Stack:** `@tanstack/react-form@1.28.5`, `@packages/ui/components/field` (FieldError), `@tanstack/react-router` (useBlocker), TanStack Form `onSubmitAsync`, `field.state.meta.*`
+
+---
+
+## Context
+
+- **28 form files** — all in `apps/web/src/` under `features/*/ui/` and `routes/`
+- **FieldError component** — `packages/ui/src/components/field.tsx:187`. Accepts `errors?: Array<{ message?: string } | undefined>`. Currently **does not handle string errors** — TanStack Form's `onSubmitAsync` field errors are strings, so they silently fail to render.
+- **No `@tanstack/react-form-devtools` package** exists in the installed monorepo — skip the devtools phase from the issue.
+- **Zod validator** — errors from Zod are `ZodIssue[]` (have `.message` ✅). Manual validators and `onSubmitAsync` produce `string[]` ❌ — these won't display in current `FieldError`.
+- **Current server error pattern** — all forms use `useMutation` + `onError: (err) => toast.error(err.message)`. This needs to become `onSubmitAsync` for field-level errors.
+
+---
+
+## Task 1: Fix FieldError to handle string errors
+
+**Files:**
+- Modify: `packages/ui/src/components/field.tsx:187-249`
+
+**Why:** `onSubmitAsync` server field errors are `string`. Current FieldError only reads `.message` from objects, so strings silently render nothing.
+
+**Step 1: Update FieldError signature and logic**
+
+In `packages/ui/src/components/field.tsx`, change FieldError to accept `string | { message?: string }`:
+
+```tsx
+function FieldError({
+   className,
+   children,
+   errors,
+   ...props
+}: React.ComponentProps<"div"> & {
+   errors?: Array<{ message?: string } | string | undefined>;
+}) {
+   const content = useMemo(() => {
+      if (children) {
+         return children;
+      }
+
+      if (!errors?.length) {
+         return null;
+      }
+
+      const messages = errors
+         .map((error) => (typeof error === "string" ? error : error?.message))
+         .filter(Boolean);
+
+      const unique = [...new Set(messages)];
+
+      if (unique.length === 0) return null;
+      if (unique.length === 1) return unique[0];
+
+      return (
+         <ul className="ml-4 flex list-disc flex-col gap-1">
+            {unique.map((msg, index) => (
+               <li key={`step-${index + 1}`}>{msg}</li>
+            ))}
+         </ul>
+      );
+   }, [children, errors]);
+
+   if (!content) {
+      return null;
+   }
+
+   return (
+      <div
+         className={cn("text-destructive text-sm font-normal", className)}
+         data-slot="field-error"
+         role="alert"
+         {...props}
+      >
+         {content}
+      </div>
+   );
+}
+```
+
+**Step 2: Verify existing usages still compile**
+
+```bash
+cd /home/yorizel/Documents/montte-nx && bun run typecheck 2>&1 | grep "field.tsx\|FieldError" | head -20
+```
+
+Expected: no new errors.
+
+**Step 3: Commit**
+
+```bash
+git add packages/ui/src/components/field.tsx
+git commit -m "fix(ui): FieldError handles string errors from onSubmitAsync"
+```
+
+---
+
+## Task 2: Migrate bills-form to onSubmitAsync with inline server errors
+
+**Files:**
+- Modify: `apps/web/src/features/bills/ui/bills-form.tsx`
+
+**Why:** Bills is a critical financial form. Server errors like "Conta sem saldo" or conflicts should appear inline, not in a toast.
+
+**Step 1: Read the current bills-form**
+
+Read `apps/web/src/features/bills/ui/bills-form.tsx` fully before touching it.
+
+**Step 2: Replace the mutation + onSubmit pattern**
+
+Current pattern (all forms):
+```tsx
+const mutation = useMutation(orpc.bills.create.mutationOptions());
+
+const form = useForm({
+   defaultValues: { ... },
+   onSubmit: async ({ value }) => {
+      await mutation.mutateAsync({ input: value });
+      toast.success("Conta criada");
+   },
+});
+```
+
+New pattern with `onSubmitAsync`:
+```tsx
+const form = useForm({
+   defaultValues: { ... },
+   validators: {
+      onSubmitAsync: async ({ value }) => {
+         try {
+            await orpc.bills.create.call({ input: value });
+            toast.success("Conta criada");
+            onSuccess?.();
+            return null;
+         } catch (err) {
+            if (err instanceof WebAppError) {
+               if (err.code === "CONFLICT") {
+                  return { form: "Já existe uma conta com esses dados" };
+               }
+               if (err.code === "BAD_REQUEST") {
+                  // map to specific fields when you know the field
+                  return { form: err.message };
+               }
+            }
+            return { form: "Erro inesperado. Tente novamente." };
+         }
+      },
+   },
+});
+```
+
+**Step 3: Add form-level error display**
+
+Below the `<form>` element's fields, before the submit button:
+```tsx
+<form.Subscribe selector={(state) => state.errors}>
+   {(errors) =>
+      errors.length > 0 && (
+         <FieldError errors={errors} />
+      )
+   }
+</form.Subscribe>
+```
+
+**Step 4: Simplify the submit button**
+
+```tsx
+<form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting] as const}>
+   {([canSubmit, isSubmitting]) => (
+      <Button type="submit" disabled={!canSubmit}>
+         {isSubmitting ? <Spinner /> : "Salvar"}
+      </Button>
+   )}
+</form.Subscribe>
+```
+
+**Step 5: Import WebAppError on the client**
+
+```tsx
+import { WebAppError } from "@core/logging/errors";
+```
+
+Wait — CLAUDE.md says "Frontend only imports inferred types via Inputs/Outputs — never imports backend schemas or `@core/*` packages." Check if `WebAppError` is re-exported from somewhere in the web app, or use a type check instead:
+
+```tsx
+// Safe pattern without importing @core:
+const errorMessage = err instanceof Error ? err.message : "Erro inesperado";
+// Or check err.code if it's serialized by oRPC middleware
+```
+
+Actually, oRPC serializes `WebAppError` over the wire. Check how client-side currently accesses `err.code`. Read `apps/web/src/integrations/orpc/client.ts` to understand the client error type before implementing.
+
+**Step 6: Typecheck**
+
+```bash
+bun run typecheck 2>&1 | grep bills-form | head -20
+```
+
+**Step 7: Commit**
+
+```bash
+git add apps/web/src/features/bills/ui/bills-form.tsx
+git commit -m "feat(bills): inline server errors via onSubmitAsync"
+```
+
+---
+
+## Task 3: Migrate contacts-form to onSubmitAsync
+
+**Files:**
+- Modify: `apps/web/src/features/contacts/ui/contacts-form.tsx`
+
+**Why:** Contact creation/editing has potential CNPJ conflicts and validation errors that should show inline.
+
+Same pattern as Task 2. Key mappings to research:
+- `CONFLICT` → `fields.document: "CNPJ/CPF já cadastrado"`
+- `NOT_FOUND` → `form: "Contato não encontrado"`
+
+**Step 1:** Read the form fully.
+**Step 2:** Apply `onSubmitAsync` pattern from Task 2.
+**Step 3:** Remove the `useMutation` hook if no longer used.
+**Step 4:** Typecheck + commit.
+
+```bash
+git add apps/web/src/features/contacts/ui/contacts-form.tsx
+git commit -m "feat(contacts): inline server errors via onSubmitAsync"
+```
+
+---
+
+## Task 4: Migrate bank-accounts-form to onSubmitAsync
+
+**Files:**
+- Modify: `apps/web/src/features/bank-accounts/ui/bank-accounts-form.tsx`
+
+**Why:** Bank account creation has strict validation (agency/account format, balance conflicts).
+
+Same pattern. Commit separately:
+
+```bash
+git commit -m "feat(bank-accounts): inline server errors via onSubmitAsync"
+```
+
+---
+
+## Task 5: Add selective selectors to all form.Subscribe usages
+
+**Files:**
+- Audit all 28 form files for `form.Subscribe` without selector or with `selector={(state) => state}`
+
+**Step 1: Find non-selective Subscribe usages**
+
+```bash
+grep -rn "form.Subscribe" apps/web/src/features/ apps/web/src/routes/ --include="*.tsx" | grep -v "selector"
+```
+
+Any `form.Subscribe` without `selector` re-renders on every state change. Add the minimal selector.
+
+**Step 2: Common patterns to apply**
+
+Replace:
+```tsx
+// Anti-pattern — re-renders on every state change
+<form.Subscribe>
+   {(state) => <Button disabled={!state.canSubmit}>{state.isSubmitting ? <Spinner /> : "Salvar"}</Button>}
+</form.Subscribe>
+```
+
+With:
+```tsx
+// ✅ Only re-renders when canSubmit or isSubmitting changes
+<form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting] as const}>
+   {([canSubmit, isSubmitting]) => (
+      <Button type="submit" disabled={!canSubmit}>
+         {isSubmitting ? <Spinner /> : "Salvar"}
+      </Button>
+   )}
+</form.Subscribe>
+```
+
+**Step 3: Typecheck**
+
+```bash
+bun run typecheck 2>&1 | grep -E "Subscribe|selector" | head -20
+```
+
+**Step 4: Commit**
+
+```bash
+git add -p  # stage only Subscribe selector changes
+git commit -m "perf(forms): add selective selectors to all form.Subscribe usages"
+```
+
+---
+
+## Task 6: Add useBlocker to edit forms
+
+**Files:**
+- Modify: `apps/web/src/features/contacts/ui/contacts-form.tsx`
+- Modify: `apps/web/src/features/bills/ui/bills-form.tsx`
+- Modify: `apps/web/src/features/bank-accounts/ui/bank-accounts-form.tsx`
+- Modify: `apps/web/src/features/services/ui/services-form.tsx`
+
+**Why:** Edit forms (not create) should warn users before navigating away with unsaved changes.
+
+**Step 1: Import useBlocker**
+
+```tsx
+import { useBlocker } from "@tanstack/react-router";
+```
+
+**Step 2: Add inside the form component (after useForm)**
+
+```tsx
+useBlocker({
+   shouldBlockFn: () => form.state.isDirty && !form.state.isSubmitted,
+});
+```
+
+**Note:** `useBlocker` in TanStack Router shows a browser-native confirmation by default. If `useBlocker` API requires a `blocker` callback or `blockerFn`, read the current `@tanstack/react-router` types before implementing.
+
+**Step 3: Only apply to edit mode**
+
+```tsx
+// Only block navigation when editing an existing record (not creating)
+useBlocker({
+   shouldBlockFn: () => isEditing && form.state.isDirty && !form.state.isSubmitted,
+});
+```
+
+**Step 4: Typecheck + commit**
+
+```bash
+git add apps/web/src/features/{contacts,bills,bank-accounts,services}/ui/*.tsx
+git commit -m "feat(forms): block navigation on unsaved changes"
+```
+
+---
+
+## Task 7: Add async CNPJ validation on onboarding form
+
+**Files:**
+- Modify: `apps/web/src/routes/_authenticated/-onboarding/cnpj-step.tsx`
+
+**Why:** The CNPJ step already has a mask but no async validation. Server-side CNPJ verification during onboarding would give immediate feedback.
+
+**Step 1: Read cnpj-step.tsx fully.**
+
+**Step 2: Add async validator to the CNPJ field**
+
+```tsx
+<form.Field
+   name="cnpj"
+   validators={{
+      onBlurAsync: async ({ value }) => {
+         const digits = value.replace(/\D/g, "");
+         if (digits.length !== 14) return;
+         // Call the existing CNPJ lookup endpoint if available
+         // or use orpc.onboarding.validateCnpj.call({ input: { cnpj: digits } })
+         // Return string error or undefined
+      },
+      onBlurAsyncDebounceMs: 500,
+   }}
+>
+   {(field) => (
+      <>
+         <Input ... />
+         {field.state.meta.isValidating && <Spinner size="sm" />}
+         <FieldError errors={field.state.meta.errors} />
+      </>
+   )}
+</form.Field>
+```
+
+**Note:** Only implement if there's an existing CNPJ validation endpoint. Read the onboarding router to check.
+
+**Step 3: Commit**
+
+```bash
+git commit -m "feat(onboarding): async CNPJ validation on blur"
+```
+
+---
+
+## Task 8: Update CLAUDE.md — TanStack Form Pattern Section
+
+**Files:**
+- Modify: `CLAUDE.md` — "TanStack Form Pattern" section
+
+**Step 1: Add the following to the TanStack Form Pattern section**
+
+```markdown
+## TanStack Form Pattern
+
+- **Schema at module level** — never define `z.object({...})` inside a component.
+- **`isInvalid` check** — `field.state.meta.isTouched && field.state.meta.errors.length > 0`.
+- **Accessibility** — always set `id`, `name`, `aria-invalid` on inputs; `htmlFor` on `<FieldLabel>`.
+- **`children` prop** — always use `children={(field) => ...}` as explicit JSX prop.
+- **FieldError** — use `<FieldError errors={field.state.meta.errors} />` from `@packages/ui/components/field`. No custom error display. Handles both string[] and ZodIssue[].
+- **Server errors** — use `onSubmitAsync` (not `onError` toast) for field-level server validation. Return `{ fields: { fieldName: "message" } }` or `{ form: "message" }`.
+- **Form-level errors** — display with `<form.Subscribe selector={(state) => state.errors}>{(errors) => <FieldError errors={errors} />}</form.Subscribe>`.
+- **Selective Subscribe** — always pass a `selector` to `form.Subscribe` to avoid unnecessary re-renders. Use `as const` for tuple selectors.
+- **Navigation guard** — use `useBlocker({ shouldBlockFn: () => form.state.isDirty && !form.state.isSubmitted })` in all edit forms.
+- **Async field validation** — use `onBlurAsync` + `onBlurAsyncDebounceMs: 500`. Show `field.state.meta.isValidating` as a spinner next to the field.
+```
+
+**Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(claude): document TanStack Form advanced patterns"
+```
+
+---
+
+## Execution Order
+
+1. Task 1 (FieldError fix) — unblocks everything else
+2. Task 2-4 (onSubmitAsync) — high value, apply one at a time
+3. Task 5 (selective Subscribe) — batch across all forms
+4. Task 6 (useBlocker) — apply to edit forms
+5. Task 7 (async CNPJ) — conditional on endpoint existence
+6. Task 8 (CLAUDE.md) — last
+
+## Pre-flight Checks
+
+Before starting Task 2-4, read `apps/web/src/integrations/orpc/client.ts` to understand how `WebAppError` is exposed on the client side (it may be typed as a plain `Error` with a `code` property). Do not import `@core/logging/errors` in frontend code.

--- a/docs/plans/2026-04-09-tanstack-form-query-pacer-adoption.md
+++ b/docs/plans/2026-04-09-tanstack-form-query-pacer-adoption.md
@@ -1,0 +1,791 @@
+# TanStack Form + Query + Pacer — Advanced Adoption Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+> **Code Review:** After EVERY task commit, dispatch a `superpowers:code-reviewer` subagent. Fix Critical and Important issues before proceeding to the next task. See the Code Review Protocol section at the bottom.
+
+**Goal:** Unlock TanStack Form server-side inline field errors, TanStack Query v5 parallel queries / pagination / conditional query patterns, and migrate debounce from foxact to TanStack Pacer — across the 28+ form files and all route components.
+
+**Architecture:** Three independent tracks that share no dependencies: (A) Form track — fix `FieldError` string handling, adopt `onSubmitAsync`, selective `Subscribe`, `useBlocker`; (B) Query track — `useSuspenseQueries` for parallel queries, `skipToken` for conditional queries, `keepPreviousData` for pagination, migrate raw `createErrorFallback` usages to `QueryBoundary`; (C) Pacer track — migrate 3 `useDebouncedValue` usages to `useDebouncedCallback`, add `useRateLimiter` on export buttons.
+
+**Tech Stack:** `@tanstack/react-form@1.28.5`, `@tanstack/react-query@5`, `@tanstack/react-pacer` (already installed), `@tanstack/react-router` (`useBlocker`), `apps/web/src/components/query-boundary.tsx` (`QueryBoundary`, `createErrorFallback`), `packages/ui/src/components/field.tsx` (`FieldError`)
+
+---
+
+## Pre-flight Context
+
+### FieldError — type mismatch (blocks Form Track)
+`packages/ui/src/components/field.tsx:187` — `FieldError` accepts `errors?: Array<{ message?: string } | undefined>`. TanStack Form's `field.state.meta.errors` from Zod validators are `ZodIssue[]` (have `.message` ✅). Errors from `onSubmitAsync` field returns are **plain strings** ❌ — they silently render nothing because `"string".message === undefined`.
+
+### QueryBoundary already wraps QueryErrorResetBoundary
+`apps/web/src/components/query-boundary.tsx:60` — `QueryBoundary` already internally wraps `QueryErrorResetBoundary`. The issue is that many routes use `createErrorFallback` + bare `ErrorBoundary` + `Suspense` directly, bypassing the reset. Those need to migrate to `QueryBoundary`.
+
+### Pacer already installed and in CLAUDE.md
+`@tanstack/react-pacer` is in `catalog:tanstack`. CLAUDE.md already mandates `useDebouncedCallback` from Pacer for callbacks — 3 files still use `foxact/use-debounced-value` and need migration.
+
+### oRPC client error codes
+Before implementing `onSubmitAsync`, read `apps/web/src/integrations/orpc/client.ts` to understand how `WebAppError` surfaces on the client. Do **not** import `@core/logging/errors` in frontend code — `WebAppError` may be a plain `Error` with a serialized `code` field.
+
+---
+
+## Track A — TanStack Form
+
+### Task A1: Fix FieldError to handle string errors
+
+**Files:**
+- Modify: `packages/ui/src/components/field.tsx:187-236`
+
+**Step 1: Replace the FieldError implementation**
+
+```tsx
+function FieldError({
+   className,
+   children,
+   errors,
+   ...props
+}: React.ComponentProps<"div"> & {
+   errors?: Array<{ message?: string } | string | undefined>;
+}) {
+   const content = useMemo(() => {
+      if (children) return children;
+      if (!errors?.length) return null;
+
+      const messages = errors
+         .map((error) => (typeof error === "string" ? error : error?.message))
+         .filter(Boolean) as string[];
+
+      const unique = [...new Set(messages)];
+
+      if (unique.length === 0) return null;
+      if (unique.length === 1) return unique[0];
+
+      return (
+         <ul className="ml-4 flex list-disc flex-col gap-1">
+            {unique.map((msg, index) => (
+               <li key={`step-${index + 1}`}>{msg}</li>
+            ))}
+         </ul>
+      );
+   }, [children, errors]);
+
+   if (!content) return null;
+
+   return (
+      <div
+         className={cn("text-destructive text-sm font-normal", className)}
+         data-slot="field-error"
+         role="alert"
+         {...props}
+      >
+         {content}
+      </div>
+   );
+}
+```
+
+**Step 2: Typecheck**
+
+```bash
+cd /home/yorizel/Documents/montte-nx && bun run typecheck 2>&1 | grep "field.tsx" | head -10
+```
+
+Expected: no new errors from existing usages.
+
+**Step 3: Commit**
+
+```bash
+git add packages/ui/src/components/field.tsx
+git commit -m "fix(ui): FieldError handles plain string errors from onSubmitAsync"
+```
+
+**Step 4: Code review**
+
+```bash
+BASE_SHA=$(git rev-parse HEAD~1)
+HEAD_SHA=$(git rev-parse HEAD)
+```
+
+Dispatch `superpowers:code-reviewer`:
+- `WHAT_WAS_IMPLEMENTED`: FieldError updated to accept `string | { message?: string }` union
+- `PLAN_OR_REQUIREMENTS`: Task A1 — fix FieldError string handling
+- `BASE_SHA` / `HEAD_SHA`: from above
+- `DESCRIPTION`: Single component change in packages/ui — check for regressions in existing error displays
+
+---
+
+### Task A2: Read oRPC client to understand error type
+
+**Files:**
+- Read: `apps/web/src/integrations/orpc/client.ts`
+- Read: `apps/web/src/integrations/orpc/server.ts` (or wherever middleware is defined)
+
+**Goal:** Understand if `err.code` is available on the client without importing `@core/logging/errors`. Write down the safe pattern for the tasks below. Likely: `err instanceof Error && 'code' in err && err.code === 'CONFLICT'`.
+
+---
+
+### Task A3: Migrate bills-form to onSubmitAsync
+
+**Files:**
+- Read then modify: `apps/web/src/features/bills/ui/bills-form.tsx`
+
+**Step 1: Replace mutation + onSubmit with onSubmitAsync**
+
+Remove `useMutation` if the only usage is in `onSubmit`. Replace with:
+
+```tsx
+const form = useForm({
+   defaultValues: { ... },
+   validators: {
+      onSubmitAsync: async ({ value }) => {
+         try {
+            await orpc.bills.create.call({ input: value });
+            toast.success("Conta a pagar criada");
+            onSuccess?.();
+            return null;
+         } catch (err) {
+            // Use pattern determined in Task A2
+            if (err instanceof Error && (err as { code?: string }).code === "CONFLICT") {
+               return { form: "Já existe uma conta com esses dados" };
+            }
+            return { form: err instanceof Error ? err.message : "Erro inesperado" };
+         }
+      },
+   },
+});
+```
+
+**Step 2: Add form-level error display above the submit button**
+
+```tsx
+<form.Subscribe selector={(state) => state.errors}>
+   {(errors) => errors.length > 0 && <FieldError errors={errors} />}
+</form.Subscribe>
+```
+
+**Step 3: Migrate submit button to selective Subscribe**
+
+```tsx
+<form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting] as const}>
+   {([canSubmit, isSubmitting]) => (
+      <Button type="submit" disabled={!canSubmit}>
+         {isSubmitting ? <Spinner /> : "Salvar"}
+      </Button>
+   )}
+</form.Subscribe>
+```
+
+**Step 4: Typecheck + commit**
+
+```bash
+bun run typecheck 2>&1 | grep "bills-form" | head -10
+git add apps/web/src/features/bills/ui/bills-form.tsx
+git commit -m "feat(bills): inline server errors via onSubmitAsync"
+```
+
+**Step 5: Code review**
+
+```bash
+BASE_SHA=$(git rev-parse HEAD~1)
+HEAD_SHA=$(git rev-parse HEAD)
+```
+
+Dispatch `superpowers:code-reviewer`:
+- `WHAT_WAS_IMPLEMENTED`: bills-form migrated from useMutation+toast to onSubmitAsync with inline errors
+- `PLAN_OR_REQUIREMENTS`: Task A3 — onSubmitAsync pattern, form-level FieldError, selective Subscribe on submit button
+- `DESCRIPTION`: Check error mapping is complete, toast.success still fires on success, no dead useMutation code left
+
+---
+
+### Task A4: Migrate contacts-form to onSubmitAsync
+
+**Files:**
+- Read then modify: `apps/web/src/features/contacts/ui/contacts-form.tsx`
+
+Same pattern as A3. Map known conflict:
+
+```tsx
+if (code === "CONFLICT") {
+   return { fields: { document: "CNPJ/CPF já cadastrado" } };
+}
+```
+
+The field name `document` must match the exact key in `defaultValues` — verify before applying.
+
+**Commit:**
+```bash
+git commit -m "feat(contacts): inline server errors via onSubmitAsync"
+```
+
+**Code review** — Dispatch `superpowers:code-reviewer`:
+- `WHAT_WAS_IMPLEMENTED`: contacts-form migrated to onSubmitAsync, CONFLICT mapped to document field
+- `DESCRIPTION`: Verify field name matches defaultValues key, check CNPJ/CPF conflict error path, no orphaned imports
+
+---
+
+### Task A5: Migrate bank-accounts-form to onSubmitAsync
+
+**Files:**
+- Read then modify: `apps/web/src/features/bank-accounts/ui/bank-accounts-form.tsx`
+
+Same pattern. Commit separately:
+```bash
+git commit -m "feat(bank-accounts): inline server errors via onSubmitAsync"
+```
+
+**Code review** — Dispatch `superpowers:code-reviewer`:
+- `WHAT_WAS_IMPLEMENTED`: bank-accounts-form migrated to onSubmitAsync
+- `DESCRIPTION`: Verify agency/account validation errors map correctly, no dead mutation code
+
+---
+
+### Task A6: Audit and fix non-selective form.Subscribe
+
+**Step 1: Find all non-selective usages**
+
+```bash
+grep -rn "form\.Subscribe" apps/web/src/ --include="*.tsx" | grep -v "selector"
+```
+
+**Step 2: For each hit, add the minimal selector**
+
+Common pattern — replace:
+```tsx
+<form.Subscribe>
+   {(state) => <Button disabled={!state.canSubmit} />}
+</form.Subscribe>
+```
+
+With:
+```tsx
+<form.Subscribe selector={(state) => state.canSubmit}>
+   {(canSubmit) => <Button disabled={!canSubmit} />}
+</form.Subscribe>
+```
+
+For multiple values use `as const` tuple:
+```tsx
+selector={(state) => [state.canSubmit, state.isSubmitting] as const}
+```
+
+**Step 3: Typecheck + commit**
+
+```bash
+bun run typecheck 2>&1 | grep -E "Subscribe" | head -10
+git add -p
+git commit -m "perf(forms): add selective selectors to all form.Subscribe usages"
+```
+
+**Step 4: Code review** — Dispatch `superpowers:code-reviewer`:
+- `WHAT_WAS_IMPLEMENTED`: All form.Subscribe usages now use typed selectors
+- `DESCRIPTION`: Check for any remaining non-selective Subscribe, verify tuple selectors use `as const`, no type errors introduced
+
+---
+
+### Task A7: Add useBlocker to edit forms
+
+**Files:**
+- Modify: `apps/web/src/features/contacts/ui/contacts-form.tsx`
+- Modify: `apps/web/src/features/bills/ui/bills-form.tsx`
+- Modify: `apps/web/src/features/bank-accounts/ui/bank-accounts-form.tsx`
+
+**API shape (from types):**
+```typescript
+// useBlocker without withResolver → uses browser native confirm (void return)
+useBlocker({ shouldBlockFn: () => boolean });
+
+// useBlocker with withResolver: true → returns proceed()/reset() for custom UI
+const blocker = useBlocker({ shouldBlockFn: () => boolean, withResolver: true });
+// blocker.status === 'blocked' | 'idle'
+// blocker.proceed() — allow navigation
+// blocker.reset()   — cancel, stay on current page
+```
+
+**Step 1: Add import**
+
+```tsx
+import { useBlocker } from "@tanstack/react-router";
+```
+
+**Step 2: Use `withResolver: true` for a custom confirmation dialog**
+
+Add inside the form component, after `useForm`. The `isEditing` condition depends on whether a record prop is passed (truthy = edit mode):
+
+```tsx
+const blocker = useBlocker({
+   shouldBlockFn: () => form.state.isDirty && !form.state.isSubmitted,
+   disabled: !isEditing,
+   withResolver: true,
+});
+```
+
+**Step 3: Render a confirmation dialog when blocked**
+
+```tsx
+{blocker.status === "blocked" && (
+   <AlertDialog open>
+      <AlertDialogContent>
+         <AlertDialogHeader>
+            <AlertDialogTitle>Alterações não salvas</AlertDialogTitle>
+            <AlertDialogDescription>
+               Você tem alterações não salvas. Deseja sair sem salvar?
+            </AlertDialogDescription>
+         </AlertDialogHeader>
+         <AlertDialogFooter>
+            <AlertDialogCancel onClick={blocker.reset}>Continuar editando</AlertDialogCancel>
+            <AlertDialogAction onClick={blocker.proceed}>Sair sem salvar</AlertDialogAction>
+         </AlertDialogFooter>
+      </AlertDialogContent>
+   </AlertDialog>
+)}
+```
+
+Note: Use `useAlertDialog` hook (from the global store) if this confirmation pattern already exists in the project — check before adding inline JSX.
+
+**Step 4: Typecheck + commit**
+
+```bash
+bun run typecheck 2>&1 | grep "useBlocker\|contacts-form\|bills-form\|bank-accounts" | head -10
+git add apps/web/src/features/{contacts,bills,bank-accounts}/ui/*.tsx
+git commit -m "feat(forms): block navigation on unsaved changes in edit mode"
+```
+
+**Step 5: Code review** — Dispatch `superpowers:code-reviewer`:
+- `WHAT_WAS_IMPLEMENTED`: useBlocker with withResolver added to contacts, bills, bank-accounts edit forms
+- `DESCRIPTION`: Check `disabled` prop correctly gates blocking to edit mode only, verify `!isSubmitted` prevents false blocks after save, confirm AlertDialog uses Portuguese strings, check `proceed`/`reset` wired to correct buttons
+
+---
+
+## Track B — TanStack Query v5
+
+### Task B1: Fix useActiveTeam waterfall → useSuspenseQueries
+
+**Files:**
+- Modify: `apps/web/src/hooks/use-active-team.ts`
+
+Current (sequential suspense = waterfall):
+```tsx
+const { data: session } = useSuspenseQuery(orpc.session.getSession.queryOptions({}));
+const { data: teams } = useSuspenseQuery(orpc.organization.getOrganizationTeams.queryOptions({}));
+```
+
+Replace with:
+```tsx
+import { useSuspenseQueries } from "@tanstack/react-query";
+
+export function useActiveTeam() {
+   const [{ data: session }, { data: teams }] = useSuspenseQueries({
+      queries: [
+         orpc.session.getSession.queryOptions({}),
+         orpc.organization.getOrganizationTeams.queryOptions({}),
+      ],
+   });
+
+   const activeTeamId = session?.session.activeTeamId ?? null;
+   const activeTeam = teams.find((team) => team.id === activeTeamId) ?? null;
+
+   return { activeTeam, activeTeamId, teams };
+}
+```
+
+**Typecheck + commit:**
+```bash
+bun run typecheck 2>&1 | grep "use-active-team" | head -10
+git add apps/web/src/hooks/use-active-team.ts
+git commit -m "perf(query): parallel queries in useActiveTeam via useSuspenseQueries"
+```
+
+**Code review** — Dispatch `superpowers:code-reviewer`:
+- `WHAT_WAS_IMPLEMENTED`: useActiveTeam refactored from 2 sequential useSuspenseQuery to useSuspenseQueries
+- `DESCRIPTION`: Verify destructure order matches query order, check activeTeam lookup logic unchanged
+
+---
+
+### Task B2: Migrate useQuery + enabled to skipToken
+
+**Files:**
+- Modify: `apps/web/src/features/services/ui/subscription-form.tsx:87`
+- Modify: `apps/web/src/features/services/ui/services-form.tsx:68`
+- Modify: `apps/web/src/features/analytics/ui/dashboard-tile.tsx:201`
+
+**Pattern — subscription-form.tsx (selectedServiceId may be empty string):**
+
+```tsx
+import { skipToken, useSuspenseQuery } from "@tanstack/react-query";
+
+const { data: variants } = useSuspenseQuery(
+   selectedServiceId
+      ? orpc.services.getVariants.queryOptions({ input: { serviceId: selectedServiceId } })
+      : { queryKey: ["variants", "skip"], queryFn: skipToken },
+);
+// variants is [] when skipped — may need fallback: const safeVariants = variants ?? []
+```
+
+**Pattern — services-form.tsx (conditional on edit mode):**
+
+```tsx
+const { data: existingVariants } = useSuspenseQuery(
+   !isCreate && service?.id
+      ? orpc.services.getVariants.queryOptions({ input: { serviceId: service.id } })
+      : { queryKey: ["variants", "skip"], queryFn: skipToken },
+);
+```
+
+**Pattern — dashboard-tile.tsx (insightId + !insightName):**
+
+```tsx
+const { data: insight } = useSuspenseQuery(
+   insightId && !insightName
+      ? orpc.insights.getById.queryOptions({ input: { id: insightId } })
+      : { queryKey: ["insight", "skip"], queryFn: skipToken },
+);
+```
+
+**Important:** Each component using `useSuspenseQuery` with `skipToken` must already be inside a `<Suspense>` boundary. Verify this before applying. If not, add the boundary or keep `useQuery + enabled`.
+
+**Typecheck each file after change. Commit per file:**
+```bash
+git commit -m "feat(services): use skipToken for conditional variant query"
+git commit -m "feat(analytics): use skipToken for conditional insight query"
+```
+
+**Code review** (after all 3 files) — Dispatch `superpowers:code-reviewer`:
+- `WHAT_WAS_IMPLEMENTED`: 3 useQuery+enabled migrated to skipToken+useSuspenseQuery
+- `DESCRIPTION`: Verify each component is inside a Suspense boundary, check skipped query returns correct fallback type (undefined vs []), no TypeScript errors on skipped data usage
+
+---
+
+### Task B3: Add keepPreviousData to all paginated queries
+
+**Step 1: Find all paginated query usages**
+
+```bash
+grep -rn "page\|pageSize" apps/web/src/ --include="*.tsx" | grep "queryOptions\|useSuspense" | head -30
+```
+
+**Step 2: Apply keepPreviousData**
+
+For every `useSuspenseQuery` that takes `page` or `pageSize` as input:
+
+```tsx
+import { keepPreviousData } from "@tanstack/react-query";
+
+const { data, isPlaceholderData } = useSuspenseQuery({
+   ...orpc.transactions.getAll.queryOptions({
+      input: { page, pageSize, ...otherFilters },
+   }),
+   placeholderData: keepPreviousData,
+});
+```
+
+Use `isPlaceholderData` to show a subtle loading indicator (optional opacity change):
+```tsx
+<div className={isPlaceholderData ? "opacity-50" : ""}>
+   {/* table content */}
+</div>
+```
+
+**Known paginated queries to update:** transactions, contacts, bills, credit-cards, inventory, services, bank-accounts, budget-goals.
+
+**Commit per feature area:**
+```bash
+git commit -m "feat(transactions): keepPreviousData for smooth page transitions"
+# repeat for others
+```
+
+**Code review** (after all paginated queries updated) — Dispatch `superpowers:code-reviewer`:
+- `WHAT_WAS_IMPLEMENTED`: keepPreviousData added to all paginated queries
+- `DESCRIPTION`: Check isPlaceholderData is used consistently for visual feedback, verify no paginated query was missed, no conflicts with existing Suspense skeleton fallbacks
+
+---
+
+### Task B4: Migrate raw ErrorBoundary usages to QueryBoundary
+
+**Step 1: Find files using createErrorFallback directly with ErrorBoundary (not via QueryBoundary)**
+
+```bash
+grep -rn "createErrorFallback\|ErrorBoundary" apps/web/src/ --include="*.tsx" | grep -v "QueryBoundary\|query-boundary" | head -30
+```
+
+**Step 2: Replace the pattern**
+
+Before:
+```tsx
+<ErrorBoundary FallbackComponent={createErrorFallback({ errorTitle: "Erro ao carregar" })}>
+   <Suspense fallback={<MySkeleton />}>
+      <MyContent />
+   </Suspense>
+</ErrorBoundary>
+```
+
+After:
+```tsx
+import { QueryBoundary } from "@/components/query-boundary";
+
+<QueryBoundary errorTitle="Erro ao carregar" fallback={<MySkeleton />}>
+   <MyContent />
+</QueryBoundary>
+```
+
+`QueryBoundary` already wraps `QueryErrorResetBoundary` internally — no changes to the component needed.
+
+**Step 3: Typecheck + commit**
+
+```bash
+bun run typecheck 2>&1 | head -20
+git add -p
+git commit -m "feat(query): migrate ErrorBoundary usages to QueryBoundary for retry support"
+```
+
+**Step 4: Code review** — Dispatch `superpowers:code-reviewer`:
+- `WHAT_WAS_IMPLEMENTED`: All bare ErrorBoundary+Suspense replaced with QueryBoundary
+- `DESCRIPTION`: Verify errorTitle/fallback props preserved correctly in each migration, check no manual Suspense wrappers remain inside QueryBoundary children
+
+---
+
+## Track C — TanStack Pacer
+
+### Task C1: Migrate transaction-filter-bar debounce
+
+**Files:**
+- Read then modify: `apps/web/src/features/transactions/ui/transaction-filter-bar.tsx`
+
+**Current (line 14 + 144):**
+```tsx
+import { useDebouncedValue } from "foxact/use-debounced-value";
+const debouncedSearch = useDebouncedValue(searchInput, 350);
+// + useEffect watching debouncedSearch
+```
+
+**New:**
+```tsx
+import { useDebouncedCallback } from "@tanstack/react-pacer";
+
+const handleSearchChange = useDebouncedCallback(
+   (value: string) => {
+      navigate({ search: (prev) => ({ ...prev, search: value, page: 1 }), replace: true });
+   },
+   { wait: 350 },
+);
+```
+
+Remove the `useDebouncedValue` import, the `debouncedSearch` variable, and the `useEffect` that watched it. Wire `handleSearchChange` directly to the input's `onInput` or `onChange`.
+
+**Typecheck + commit:**
+```bash
+bun run typecheck 2>&1 | grep "transaction-filter" | head -10
+git add apps/web/src/features/transactions/ui/transaction-filter-bar.tsx
+git commit -m "perf(transactions): migrate debounce to useDebouncedCallback from Pacer"
+```
+
+**Code review** — Dispatch `superpowers:code-reviewer`:
+- `WHAT_WAS_IMPLEMENTED`: transaction-filter-bar debounce migrated from foxact to Pacer
+- `DESCRIPTION`: Verify isMounted guard removed (Pacer handles this), useEffect deleted, no foxact import remains, debounce timing preserved (350ms)
+
+---
+
+### Task C2: Migrate category-filter-bar debounce
+
+**Files:**
+- Read then modify: `apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-categories/category-filter-bar.tsx`
+
+Same migration pattern (300ms). Remove `foxact` import.
+
+**Commit:**
+```bash
+git commit -m "perf(categories): migrate debounce to useDebouncedCallback from Pacer"
+```
+
+**Code review** — Dispatch `superpowers:code-reviewer`:
+- `WHAT_WAS_IMPLEMENTED`: category-filter-bar debounce migrated to Pacer
+- `DESCRIPTION`: Same checks as C1 — no foxact import, no useEffect, 300ms preserved
+
+---
+
+### Task C3: Migrate use-insight-config debounce
+
+**Files:**
+- Read then modify: `apps/web/src/features/analytics/hooks/use-insight-config.ts`
+
+Current uses `useDebouncedValue(pendingUpdates, 500)` + `useEffect`. Replace with `useDebouncedCallback`:
+
+```tsx
+import { useDebouncedCallback } from "@tanstack/react-pacer";
+
+const flushPendingUpdates = useDebouncedCallback(
+   (updates: Partial<InsightConfig>) => {
+      applyConfig(updates); // whatever the current flush does
+   },
+   { wait: 500 },
+);
+
+// Call flushPendingUpdates(updates) directly instead of setPendingUpdates
+```
+
+**Commit:**
+```bash
+git commit -m "perf(analytics): migrate insight config debounce to Pacer"
+```
+
+**Code review** — Dispatch `superpowers:code-reviewer`:
+- `WHAT_WAS_IMPLEMENTED`: use-insight-config debounce migrated to useDebouncedCallback
+- `DESCRIPTION`: Verify updateConfigImmediate still works synchronously, debouncedUpdates state variable removed, 500ms preserved, useEffect deleted
+
+---
+
+### Task C4: Add useRateLimiter to export buttons (optional)
+
+**Files:** Find export buttons in transactions, contacts feature areas.
+
+```bash
+grep -rn "Exportar\|handleExport\|exportCSV" apps/web/src/ --include="*.tsx" | head -10
+```
+
+If export handlers exist, apply:
+```tsx
+import { useRateLimiter } from "@tanstack/react-pacer";
+
+const exportLimiter = useRateLimiter(handleExport, {
+   limit: 3,
+   window: 60_000,
+   windowType: "sliding",
+   onReject: () => toast.error("Aguarde antes de exportar novamente."),
+});
+
+<Button onClick={() => exportLimiter.maybeExecute("csv")}>Exportar CSV</Button>
+```
+
+**Only apply if export handlers exist and are prone to rapid-clicking.**
+
+---
+
+## Task D: Update CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md` — sections "TanStack Form Pattern" and "Client-Side Patterns (oRPC + TanStack Query)"
+
+**Add to TanStack Form Pattern section:**
+```markdown
+- **FieldError** — use `<FieldError errors={field.state.meta.errors} />`. Handles Zod `ZodIssue[]` and plain `string[]`.
+- **Server errors** — use `validators.onSubmitAsync` (not `onError` toast) for field-level server validation. Return `{ fields: { fieldName: "msg" } }` or `{ form: "msg" }`.
+- **Form-level errors** — `<form.Subscribe selector={(state) => state.errors}>{(errors) => <FieldError errors={errors} />}</form.Subscribe>`.
+- **Selective Subscribe** — always pass `selector` to `form.Subscribe`. Use `as const` for tuple selectors: `selector={(state) => [state.canSubmit, state.isSubmitting] as const}`.
+- **Navigation guard** — `useBlocker({ shouldBlockFn: () => form.state.isDirty && !form.state.isSubmitted, disabled: !isEditing, withResolver: true })` in all edit forms. Use `blocker.status === "blocked"` to render a custom pt-BR AlertDialog with `blocker.proceed()` / `blocker.reset()`.
+```
+
+**Add to Client-Side Patterns section:**
+```markdown
+**Hook selection:**
+
+| Need | Hook |
+|------|------|
+| Single query | `useSuspenseQuery` |
+| Multiple independent queries in same component | `useSuspenseQueries` — prevents waterfall |
+| Conditional query | `useSuspenseQuery` + `skipToken` |
+| Paginated query (no flicker on page change) | `useSuspenseQuery` + `placeholderData: keepPreviousData` |
+| Subscribe to partial data | `useSuspenseQuery` + `select` option |
+
+**Rules:**
+- `useSuspenseQueries` when multiple independent queries in same component — never sequential `useSuspenseQuery` calls.
+- `skipToken` as default for conditional queries — not `useQuery + enabled`.
+- `placeholderData: keepPreviousData` required for all queries with `page`/`pageSize` input.
+- Use `QueryBoundary` (not bare `ErrorBoundary + Suspense`) so retry resets the query cache.
+- `useQuery + enabled` only when intentionally outside a `<Suspense>` boundary.
+```
+
+**Add/update Foxact Hooks section:**
+```markdown
+- Debounce callbacks → `useDebouncedCallback` from `@tanstack/react-pacer` (not `foxact/use-debounced-value`)
+- Rate limit → `useRateLimiter` from `@tanstack/react-pacer`
+```
+
+**Commit:**
+```bash
+git add CLAUDE.md
+git commit -m "docs(claude): document TanStack Form, Query, and Pacer advanced patterns"
+```
+
+**Final code review** — Dispatch `superpowers:code-reviewer` with the full branch diff:
+```bash
+BASE_SHA=$(git rev-parse origin/master)
+HEAD_SHA=$(git rev-parse HEAD)
+```
+- `WHAT_WAS_IMPLEMENTED`: Full CLAUDE.md update documenting Form, Query, and Pacer patterns
+- `DESCRIPTION`: Verify all new rules are accurate, no contradictions with existing rules, examples compile, hook table is complete
+
+---
+
+## Execution Order
+
+| Priority | Task | Unblocks |
+|----------|------|----------|
+| 1 | A1 — FieldError string fix | A3, A4, A5 |
+| 2 | A2 — Read oRPC error types | A3, A4, A5 |
+| 3 | B1 — useActiveTeam parallel | standalone |
+| 3 | C1-C3 — Pacer migration | standalone |
+| 4 | A3-A5 — onSubmitAsync forms | A6, A7 |
+| 4 | B2 — skipToken migration | standalone |
+| 5 | B3 — keepPreviousData | standalone |
+| 5 | A6 — selective Subscribe | standalone |
+| 6 | B4 — QueryBoundary migration | standalone |
+| 6 | A7 — useBlocker | standalone |
+| 7 | C4 — useRateLimiter | standalone |
+| 8 | D — CLAUDE.md | last |
+
+Tracks B (Query) and C (Pacer) are fully independent of Track A (Form) and can run in parallel.
+
+---
+
+## Code Review Protocol
+
+After every task commit, dispatch `superpowers:code-reviewer`. This is mandatory, not optional.
+
+**How to get SHAs:**
+```bash
+BASE_SHA=$(git rev-parse HEAD~1)
+HEAD_SHA=$(git rev-parse HEAD)
+```
+
+**Severity handling:**
+- **Critical** — stop, fix immediately, recommit, re-review before proceeding
+- **Important** — fix before starting the next task
+- **Minor** — note for later, do not block progress
+
+**Template for each review:**
+```
+WHAT_WAS_IMPLEMENTED: <what the task built>
+PLAN_OR_REQUIREMENTS: Task <ID> from docs/plans/2026-04-09-tanstack-form-query-pacer-adoption.md
+BASE_SHA: <previous commit>
+HEAD_SHA: <current commit>
+DESCRIPTION: <1-2 sentences about what to focus on>
+```
+
+**Cross-cutting things the reviewer should always check:**
+- No `@core/*` imports in frontend files
+- No `as` type casts introduced
+- No `space-x-*` / `space-y-*` / margin utilities — only `gap-2` or `gap-4`
+- No barrel file imports — direct source imports only
+- No `useEffect` introduced where Pacer/form callbacks replace it
+- Brazilian Portuguese in all user-facing strings
+
+---
+
+## CLAUDE.md Update Checklist
+
+Before the final commit on Task D, verify every item below is covered in CLAUDE.md:
+
+**TanStack Form section:**
+- [ ] `FieldError` handles both `ZodIssue[]` and `string[]`
+- [ ] `onSubmitAsync` as the pattern for server-side field errors (with `{ fields, form }` return shape)
+- [ ] Form-level error display via `form.Subscribe selector={(state) => state.errors}`
+- [ ] `selector` mandatory on all `form.Subscribe` — `as const` for tuples
+- [ ] `useBlocker` with `withResolver: true` + `disabled: !isEditing` in all edit forms — custom AlertDialog for pt-BR confirmation, `proceed()`/`reset()` wired to actions
+
+**TanStack Query section:**
+- [ ] Hook selection table (single / parallel / conditional / paginated / partial)
+- [ ] `useSuspenseQueries` for multiple independent queries — no sequential `useSuspenseQuery`
+- [ ] `skipToken` over `useQuery + enabled`
+- [ ] `keepPreviousData` required for page/pageSize queries
+- [ ] `QueryBoundary` over bare `ErrorBoundary + Suspense`
+
+**Foxact Hooks section:**
+- [ ] `foxact/use-debounced-value` removed from table — replaced by `useDebouncedCallback` from Pacer
+- [ ] `useRateLimiter` documented for rate-limiting user actions

--- a/packages/ui/src/components/field.tsx
+++ b/packages/ui/src/components/field.tsx
@@ -190,38 +190,31 @@ function FieldError({
    errors,
    ...props
 }: React.ComponentProps<"div"> & {
-   errors?: Array<{ message?: string } | undefined>;
+   errors?: Array<{ message?: string } | string | undefined>;
 }) {
    const content = useMemo(() => {
-      if (children) {
-         return children;
-      }
+      if (children) return children;
+      if (!errors?.length) return null;
 
-      if (!errors?.length) {
-         return null;
-      }
+      const messages = errors
+         .map((error) => (typeof error === "string" ? error : error?.message))
+         .filter(Boolean) as string[];
 
-      const uniqueErrors = [
-         ...new Map(errors.map((error) => [error?.message, error])).values(),
-      ];
+      const unique = [...new Set(messages)];
 
-      if (uniqueErrors?.length === 1) {
-         return uniqueErrors[0]?.message;
-      }
+      if (unique.length === 0) return null;
+      if (unique.length === 1) return unique[0];
 
       return (
          <ul className="ml-4 flex list-disc flex-col gap-1">
-            {uniqueErrors.map(
-               (error, index) =>
-                  error?.message && <li key={index}>{error.message}</li>,
-            )}
+            {unique.map((msg, index) => (
+               <li key={`step-${index + 1}`}>{msg}</li>
+            ))}
          </ul>
       );
    }, [children, errors]);
 
-   if (!content) {
-      return null;
-   }
+   if (!content) return null;
 
    return (
       <div


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades TanStack Form usage across the app, migrating forms to `onSubmitAsync` + `fromPromise` for inline server-error injection, adding `useBlocker` navigation guards on edit forms via `useAlertDialog`, updating `FieldError` to accept plain strings from server responses, and resolving all three issues flagged in previous review threads (`use-alert-dialog` double-reset bug, `bills-form` bypassing MutationCache, and `forgot-password` advancing even on OTP send failure).

All remaining findings below are P2 style/cleanup suggestions — none block merge.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three previously flagged P1 bugs are resolved and no new blocking issues were introduced.

All remaining findings are P2 style suggestions (size utilities, redundant local state). The three issues from prior review rounds — alert dialog double-reset, bills MutationCache bypass, and OTP navigation advancing on failure — are all correctly addressed. The new patterns (onSubmitAsync + fromPromise, useBlocker + useAlertDialog, FieldError string support) are implemented consistently across forms.

No files require special attention before merging.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/ui/src/components/field.tsx | FieldError updated to handle both string and object-with-message errors; deduplication and list rendering logic is correct. |
| apps/web/src/hooks/use-alert-dialog.tsx | Addresses the double-reset bug: onCancel is now cleared synchronously (via store update) before state.onAction() is awaited, so handleOpenChange can no longer call blocker.reset() after blocker.proceed() has already run. |
| apps/web/src/features/bills/ui/bills-form.tsx | Migrated from direct orpc.bills.update.call() to useMutation + mutateAsync so the global MutationCache correctly invalidates after save; useBlocker guard added. |
| apps/web/src/features/contacts/ui/contacts-form.tsx | onSubmitAsync + fromPromise pattern correctly injects CONFLICT server error into the document field; useBlocker guard added for edit mode. |
| apps/web/src/features/bank-accounts/ui/bank-accounts-form.tsx | onSubmitAsync + fromPromise correctly maps CONFLICT → nickname field error; useBlocker guard with isCreate guard is correct. |
| apps/web/src/features/credit-cards/ui/credit-cards-form.tsx | onSubmitAsync + useBlocker added correctly; minor: color swatch uses w-4 h-4 instead of size-4. |
| apps/web/src/features/services/ui/services-form.tsx | onSubmitAsync handles create+variant creation and update paths; useBlocker guard added for edit mode. |
| apps/web/src/features/services/ui/subscription-form.tsx | VariantSelectField child-component pattern is correctly implemented; minor: negotiatedPrice local state duplicates the form field value. |
| apps/web/src/routes/auth/forgot-password.tsx | handleSendOtp now returns a boolean; navigation only advances when sent === true, fixing the previously flagged unconditional advance bug. |
| apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-form.tsx | TagForm logic is correct; minor: w-10 h-10 and w-5 h-5 should use size-* utilities per CLAUDE.md sizing conventions. |
| apps/web/src/hooks/use-active-team.ts | Migrated to useSuspenseQueries to eliminate sequential waterfall — correct pattern per CLAUDE.md. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Form Submit] --> B{onSubmitAsync}
    B --> C[fromPromise mutateAsync]
    C --> D{isErr?}
    D -->|yes, CONFLICT| E[Return field error\nobject to TanStack Form]
    D -->|yes, other| F[Return string error\nto TanStack Form]
    D -->|no| G[toast.success + onSuccess]
    E --> H[FieldError renders\nbelow conflicting field]
    F --> I[Generic error shown]
    G --> J[Close dialog]

    K[Navigation attempt] --> L{form.isDirty\n&& !isSubmitted?}
    L -->|yes| M[shouldBlockFn returns true]
    M --> N[openAlertDialog]
    N --> O{User choice}
    O -->|Descartar| P[blocker.proceed]
    O -->|Continuar editando| Q[blocker.reset]
    L -->|no| R[Navigation proceeds]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (6)</h3></summary>

1. `apps/web/src/features/contacts/ui/contacts-form.tsx`, line 304-340 ([link](https://github.com/montte-erp/montte-nx/blob/9498814550b06a0293be9e8a5e391cddfa41ee7d/apps/web/src/features/contacts/ui/contacts-form.tsx#L304-L340)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Server error on `document` field never rendered**

   `onSubmitAsync` can return `{ fields: { document: "CNPJ/CPF já cadastrado." } }` on a `CONFLICT`, but the `document` field renders no `<FieldError>`. The field turns red via `data-invalid`, but the error message is silently discarded — the user only sees the submit button become enabled again with no feedback.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/features/contacts/ui/contacts-form.tsx
   Line: 304-340

   Comment:
   **Server error on `document` field never rendered**

   `onSubmitAsync` can return `{ fields: { document: "CNPJ/CPF já cadastrado." } }` on a `CONFLICT`, but the `document` field renders no `<FieldError>`. The field turns red via `data-invalid`, but the error message is silently discarded — the user only sees the submit button become enabled again with no feedback.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `apps/web/src/routes/auth/sign-up.tsx`, line 35-47 ([link](https://github.com/montte-erp/montte-nx/blob/9498814550b06a0293be9e8a5e391cddfa41ee7d/apps/web/src/routes/auth/sign-up.tsx#L35-L47)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Zod schema defined inside component**

   The codebase guideline requires schemas to live at module level, never inside a component function. Defining it inside `SignUpPage` recreates the schema object on every render. The same pattern appears in `forgot-password.tsx` (line 39). Move both schemas to module scope, similar to how `signInSchema` is already at module level in `sign-in/email.tsx`.

   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=50793934-4fc6-4fd8-9b91-f358e100c905))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/routes/auth/sign-up.tsx
   Line: 35-47
   
   Comment:
   **Zod schema defined inside component**
   
   The codebase guideline requires schemas to live at module level, never inside a component function. Defining it inside `SignUpPage` recreates the schema object on every render. The same pattern appears in `forgot-password.tsx` (line 39). Move both schemas to module scope, similar to how `signInSchema` is already at module level in `sign-in/email.tsx`.
   
   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=50793934-4fc6-4fd8-9b91-f358e100c905))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `apps/web/src/features/credit-cards/ui/credit-cards-form.tsx`, line 169 ([link](https://github.com/montte-erp/montte-nx/blob/9498814550b06a0293be9e8a5e391cddfa41ee7d/apps/web/src/features/credit-cards/ui/credit-cards-form.tsx#L169)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`as any` type cast**

   The codebase prohibits `as` casts — fix the source types instead. The same cast appears on lines 281 and 321 in this file. The field-level `validators.onBlur` return type is already compatible with `FieldError`'s expected type; the casts can simply be removed.

   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=50793934-4fc6-4fd8-9b91-f358e100c905))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/features/credit-cards/ui/credit-cards-form.tsx
   Line: 169
   
   Comment:
   **`as any` type cast**
   
   The codebase prohibits `as` casts — fix the source types instead. The same cast appears on lines 281 and 321 in this file. The field-level `validators.onBlur` return type is already compatible with `FieldError`'s expected type; the casts can simply be removed.
   
   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=50793934-4fc6-4fd8-9b91-f358e100c905))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

4. `apps/web/src/features/services/ui/services-form.tsx`, line 322 ([link](https://github.com/montte-erp/montte-nx/blob/9498814550b06a0293be9e8a5e391cddfa41ee7d/apps/web/src/features/services/ui/services-form.tsx#L322)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Margin utilities (`mr-*`) used**

   The codebase bans all margin utilities — `mr-1` here and `mr-2` on the `<Spinner>` at line 481 of this file, and `mr-2` on the `<Spinner>` in `subscription-form.tsx` (line 363). Use `gap-*` on a flex container instead.

   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=50793934-4fc6-4fd8-9b91-f358e100c905))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/features/services/ui/services-form.tsx
   Line: 322
   
   Comment:
   **Margin utilities (`mr-*`) used**
   
   The codebase bans all margin utilities — `mr-1` here and `mr-2` on the `<Spinner>` at line 481 of this file, and `mr-2` on the `<Spinner>` in `subscription-form.tsx` (line 363). Use `gap-*` on a flex container instead.
   
   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=50793934-4fc6-4fd8-9b91-f358e100c905))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

5. `apps/web/src/features/services/ui/subscription-form.tsx`, line 209-228 ([link](https://github.com/montte-erp/montte-nx/blob/10ccd8a5044789b74755b933bdab34e9356e806f/apps/web/src/features/services/ui/subscription-form.tsx#L209-L228)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Missing Suspense boundary around conditional `VariantSelectField`**

   `VariantSelectField` calls `useSuspenseQuery` unconditionally. When a service is first selected and its variants aren't cached, the query suspends — but there is no local `<Suspense>` boundary here. The suspension propagates to the nearest ancestor boundary (the dialog's outer `QueryBoundary`), causing the entire `SubscriptionForm` to be replaced by the outer skeleton. CLAUDE.md's conditional query pattern requires a local `Suspense` wrapper:

   ```tsx
   {selectedServiceId && (
      <form.Field
         name="variantId"
         children={(field) => {
            const isInvalid =
               field.state.meta.isTouched &&
               field.state.meta.errors.length > 0;
            return (
               <Suspense fallback={<Skeleton className="h-10 w-full" />}>
                  <VariantSelectField
                     errors={field.state.meta.errors}
                     isInvalid={isInvalid}
                     onValueChange={(v) => field.handleChange(v)}
                     onVariantChange={setSelectedVariant}
                     serviceId={selectedServiceId}
                     value={field.state.value}
                  />
               </Suspense>
            );
         }}
      />
   )}
   ```

   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=50793934-4fc6-4fd8-9b91-f358e100c905))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/features/services/ui/subscription-form.tsx
   Line: 209-228
   
   Comment:
   **Missing Suspense boundary around conditional `VariantSelectField`**
   
   `VariantSelectField` calls `useSuspenseQuery` unconditionally. When a service is first selected and its variants aren't cached, the query suspends — but there is no local `<Suspense>` boundary here. The suspension propagates to the nearest ancestor boundary (the dialog's outer `QueryBoundary`), causing the entire `SubscriptionForm` to be replaced by the outer skeleton. CLAUDE.md's conditional query pattern requires a local `Suspense` wrapper:
   
   ```tsx
   {selectedServiceId && (
      <form.Field
         name="variantId"
         children={(field) => {
            const isInvalid =
               field.state.meta.isTouched &&
               field.state.meta.errors.length > 0;
            return (
               <Suspense fallback={<Skeleton className="h-10 w-full" />}>
                  <VariantSelectField
                     errors={field.state.meta.errors}
                     isInvalid={isInvalid}
                     onValueChange={(v) => field.handleChange(v)}
                     onVariantChange={setSelectedVariant}
                     serviceId={selectedServiceId}
                     value={field.state.value}
                  />
               </Suspense>
            );
         }}
      />
   )}
   ```
   
   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=50793934-4fc6-4fd8-9b91-f358e100c905))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

6. `apps/web/src/routes/auth/sign-up.tsx`, line 244-248 ([link](https://github.com/montte-erp/montte-nx/blob/40a509183c78355264bf9b6c3ae2483c49b5afe7/apps/web/src/routes/auth/sign-up.tsx#L244-L248)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`formApi.reset()` erases form data on failed sign-up**

   `handleSignUp` uses Better Auth's callback pattern (`onError`/`onSuccess`), so the returned promise always resolves — it never rejects on error. `formApi.reset()` is therefore called unconditionally, clearing all fields (name, email, password, confirmPassword across both stepper steps) even when the server returns a "email already exists" error. The user sees a toast but loses all their typed data.

   The same unconditional-reset pattern also exists in `sign-in/email.tsx` (line 64), where it clears the email field even when login fails.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/routes/auth/sign-up.tsx
   Line: 244-248

   Comment:
   **`formApi.reset()` erases form data on failed sign-up**

   `handleSignUp` uses Better Auth's callback pattern (`onError`/`onSuccess`), so the returned promise always resolves — it never rejects on error. `formApi.reset()` is therefore called unconditionally, clearing all fields (name, email, password, confirmPassword across both stepper steps) even when the server returns a "email already exists" error. The user sees a toast but loses all their typed data.

   The same unconditional-reset pattern also exists in `sign-in/email.tsx` (line 64), where it clears the email field even when login fails.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/web/src/features/credit-cards/ui/credit-cards-form.tsx
Line: 209

Comment:
**`w-4 h-4` should be `size-4`**

CLAUDE.md specifies using `size-*` utilities for square elements instead of separate `w-*` + `h-*` pairs.

```suggestion
                                 <div
                                    className="size-4 rounded border border-border shrink-0"
```

**Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=50793934-4fc6-4fd8-9b91-f358e100c905))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-form.tsx
Line: 160-165

Comment:
**`w-*`/`h-*` pairs should use `size-*`**

Both the button and the inner swatch div use separate width/height utilities. Per CLAUDE.md, square elements should use `size-*` instead.

```suggestion
                                    <Button
                                       className="size-10 p-0 shrink-0"
                                       type="button"
                                       variant="outline"
                                    >
                                       <div
                                          className="size-5 rounded-full border border-border"
```

**Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=50793934-4fc6-4fd8-9b91-f358e100c905))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/src/features/services/ui/subscription-form.tsx
Line: 139-147

Comment:
**`negotiatedPrice` local state duplicates the form field**

`negotiatedPrice` state mirrors `value.negotiatedPrice` in the form. CLAUDE.md recommends using `form.Subscribe` with a `select` to derive values from form state rather than maintaining a parallel copy. You can read the current negotiated price via `select` and pass it into a child component that computes the discount:

```tsx
// Replace useState<string>("0") with a Subscribe-derived value:
<form.Subscribe
  selector={(s) => [s.values.negotiatedPrice, s.values.variantId] as const}
>
  {([negotiatedPrice]) => {
    const neg = Number(negotiatedPrice);
    // ... discount calculation here
  }}
</form.Subscribe>
```

This eliminates `setNegotiatedPrice` calls from the `MoneyInput` handler and keeps a single source of truth.

**Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=50793934-4fc6-4fd8-9b91-f358e100c905))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (10): Last reviewed commit: ["feat(web): Add next button for OTP in fo..."](https://github.com/montte-erp/montte-nx/commit/f9657e9fb9202e9311d78ec33ffc6bb860b275dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27894194)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=50793934-4fc6-4fd8-9b91-f358e100c905))

<!-- /greptile_comment -->