### PR TITLE
Manoelnetocarvalho03/mon 246 featagents auto categorize transactions on creation via llm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,16 +132,22 @@ export const bulkRemove = protectedProcedure
 | ---- | ---- |
 | Single query (default) | `useSuspenseQuery` |
 | Multiple independent queries in same component | `useSuspenseQueries` — avoids waterfall |
-| Conditional query (depends on user input/state) | Child component pattern — see below |
+| Conditional query (depends on user input/state) | `useQuery` + `skipToken` as input, or child component pattern for `useSuspenseQuery` |
 | Subscribe to partial query data | `useSuspenseQuery` + `select` option |
 | Prefetch before render | `queryClient.prefetchQuery` in route loader |
 | Track mutation state cross-component | `useMutationState` + `orpc.procedure.mutationKey()` |
 | SSE / Event Iterator (live stream) | `useQuery` + `experimental_liveOptions` — see below |
 
 **Key rules:**
-- **Never `useQuery`** — always `useSuspenseQuery`. The only exception is `experimental_liveOptions` (SSE / Event Iterator) — live queries have no initial data so suspending is wrong.
-- **Never `useQuery + enabled`** — use the child component pattern instead (see below).
-- **Never `skipToken + useSuspenseQuery`** — `UseSuspenseQueryOptions` does not support `skipToken`. Use child component pattern.
+- **Never `useQuery`** — always `useSuspenseQuery`. Exceptions: `experimental_liveOptions` (SSE / Event Iterator) and conditional queries via `skipToken` (see below).
+- **Never `useQuery + enabled`** — use `skipToken` as input instead: `orpc.procedure.queryOptions({ input: condition ? { ...} : skipToken })`.
+- **`skipToken` with `useQuery` only** — `UseSuspenseQueryOptions` does not support `skipToken`. For conditional `useSuspenseQuery`, use the child component pattern instead.
+  ```tsx
+  // ✅ Conditional query with useQuery + skipToken
+  const { data } = useQuery(
+     orpc.items.getById.queryOptions({ input: selectedId ? { id: selectedId } : skipToken }),
+  );
+  ```
 - **`useSuspenseQueries`** for 2+ independent queries in the same component — prevents React from suspending sequentially (waterfall).
 - **`select` aggressively** — whenever a component needs only part of a query response, use `select` to derive the exact shape needed. This eliminates `useState` for derived values, prevents re-renders from unrelated field changes, and removes the need for intermediate variables or `useMemo`. Prefer `select` over storing values in separate state:
   ```tsx
@@ -282,7 +288,7 @@ function ItemDetails({ id }: { id: string }) {
    </Suspense>
 )}
 ```
-Never use `skipToken` with `useSuspenseQuery` — it is not supported in TanStack Query v5.
+`skipToken` works with `useQuery` only — pass it as `input` when condition is false. `useSuspenseQuery` does not support `skipToken`; use the child component pattern above instead.
 
 **Empty states** — always use `Empty`/`EmptyHeader`/`EmptyMedia`/`EmptyTitle`/`EmptyDescription`/`EmptyContent` from `@packages/ui/components/empty`. Never build custom empty states with raw divs.
 

--- a/apps/web/src/features/transactions/ui/transaction-import-dialog-stack.tsx
+++ b/apps/web/src/features/transactions/ui/transaction-import-dialog-stack.tsx
@@ -1142,7 +1142,6 @@ function ConfirmStep({
 }: ConfirmStepProps) {
    const [isPending, startTransition] = useTransition();
    const [ignoreOnServer, setIgnoreOnServer] = useState(true);
-   const [autoCategorize, setAutoCategorize] = useState(false);
 
    const { data: bankAccounts } = useSuspenseQuery(
       orpc.bankAccounts.getAll.queryOptions({}),
@@ -1234,7 +1233,7 @@ function ConfirmStep({
             };
          });
 
-         importMutation.mutate({ transactions: payload, autoCategorize });
+         importMutation.mutate({ transactions: payload });
       });
    }
 
@@ -1342,24 +1341,6 @@ function ConfirmStep({
                         <p className="text-xs text-muted-foreground">
                            Lançamentos exatamente iguais já existentes serão
                            ignoradas automaticamente.
-                        </p>
-                     </div>
-                  </label>
-
-                  {/* biome-ignore lint/a11y/noLabelWithoutControl: Checkbox is a Radix button */}
-                  <label className="flex cursor-pointer select-none items-start gap-2">
-                     <Checkbox
-                        checked={autoCategorize}
-                        className="mt-0.5"
-                        onCheckedChange={(c) => setAutoCategorize(c === true)}
-                     />
-                     <div>
-                        <p className="text-xs font-medium">
-                           Auto-categorizar com IA
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                           Lançamentos sem categoria serão categorizados
-                           automaticamente pela IA após a importação.
                         </p>
                      </div>
                   </label>

--- a/apps/web/src/features/transactions/ui/transaction-import-dialog-stack.tsx
+++ b/apps/web/src/features/transactions/ui/transaction-import-dialog-stack.tsx
@@ -1142,6 +1142,7 @@ function ConfirmStep({
 }: ConfirmStepProps) {
    const [isPending, startTransition] = useTransition();
    const [ignoreOnServer, setIgnoreOnServer] = useState(true);
+   const [autoCategorize, setAutoCategorize] = useState(false);
 
    const { data: bankAccounts } = useSuspenseQuery(
       orpc.bankAccounts.getAll.queryOptions({}),
@@ -1233,7 +1234,7 @@ function ConfirmStep({
             };
          });
 
-         importMutation.mutate({ transactions: payload });
+         importMutation.mutate({ transactions: payload, autoCategorize });
       });
    }
 
@@ -1341,6 +1342,24 @@ function ConfirmStep({
                         <p className="text-xs text-muted-foreground">
                            Lançamentos exatamente iguais já existentes serão
                            ignoradas automaticamente.
+                        </p>
+                     </div>
+                  </label>
+
+                  {/* biome-ignore lint/a11y/noLabelWithoutControl: Checkbox is a Radix button */}
+                  <label className="flex cursor-pointer select-none items-start gap-2">
+                     <Checkbox
+                        checked={autoCategorize}
+                        className="mt-0.5"
+                        onCheckedChange={(c) => setAutoCategorize(c === true)}
+                     />
+                     <div>
+                        <p className="text-xs font-medium">
+                           Auto-categorizar com IA
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                           Lançamentos sem categoria serão categorizados
+                           automaticamente pela IA após a importação.
                         </p>
                      </div>
                   </label>

--- a/apps/web/src/features/transactions/ui/transactions-columns.tsx
+++ b/apps/web/src/features/transactions/ui/transactions-columns.tsx
@@ -23,7 +23,13 @@ function formatDate(dateStr: string): string {
    return `${day}/${month}/${year}`;
 }
 
-function SuggestedCategoryCell({ id }: { id: string }) {
+function SuggestedCategoryCell({
+   id,
+   categoryName,
+}: {
+   id: string;
+   categoryName: string | null;
+}) {
    const accept = useMutation(
       orpc.transactions.acceptSuggestedCategory.mutationOptions(),
    );
@@ -39,6 +45,9 @@ function SuggestedCategoryCell({ id }: { id: string }) {
             </Badge>
          </PopoverTrigger>
          <PopoverContent className="w-56 p-3">
+            {categoryName && (
+               <p className="text-sm font-medium">{categoryName}</p>
+            )}
             <p className="text-sm text-muted-foreground">
                Categoria sugerida pela IA. Deseja aceitar?
             </p>
@@ -131,7 +140,12 @@ export function buildTransactionColumns(): ColumnDef<TransactionRow>[] {
             if (!name && !hasSuggestion)
                return <span className="text-xs text-muted-foreground">—</span>;
             if (hasSuggestion)
-               return <SuggestedCategoryCell id={row.original.id} />;
+               return (
+                  <SuggestedCategoryCell
+                     id={row.original.id}
+                     categoryName={row.original.suggestedCategoryName ?? null}
+                  />
+               );
             return <span className="text-sm">{name}</span>;
          },
       },

--- a/apps/web/src/features/transactions/ui/transactions-columns.tsx
+++ b/apps/web/src/features/transactions/ui/transactions-columns.tsx
@@ -39,7 +39,7 @@ function SuggestedCategoryCell({ id }: { id: string }) {
             </Badge>
          </PopoverTrigger>
          <PopoverContent className="w-56 p-3">
-            <p className="text-sm text-muted-foreground mb-2">
+            <p className="text-sm text-muted-foreground">
                Categoria sugerida pela IA. Deseja aceitar?
             </p>
             <div className="flex gap-2">

--- a/apps/web/src/features/transactions/ui/transactions-columns.tsx
+++ b/apps/web/src/features/transactions/ui/transactions-columns.tsx
@@ -1,5 +1,10 @@
 import { format, of } from "@f-o-t/money";
 import { Badge } from "@packages/ui/components/badge";
+import {
+   Tooltip,
+   TooltipContent,
+   TooltipTrigger,
+} from "@packages/ui/components/tooltip";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { Outputs } from "@/integrations/orpc/client";
 
@@ -76,8 +81,26 @@ export function buildTransactionColumns(): ColumnDef<TransactionRow>[] {
          header: "Categoria",
          cell: ({ row }) => {
             const name = row.original.categoryName;
-            if (!name)
+            const hasSuggestion = !name && row.original.suggestedCategoryId;
+            if (!name && !hasSuggestion)
                return <span className="text-xs text-muted-foreground">—</span>;
+            if (hasSuggestion) {
+               return (
+                  <Tooltip>
+                     <TooltipTrigger asChild>
+                        <Badge
+                           variant="outline"
+                           className="text-xs cursor-default"
+                        >
+                           sugestão IA
+                        </Badge>
+                     </TooltipTrigger>
+                     <TooltipContent>
+                        Categoria sugerida pela IA. Clique para revisar.
+                     </TooltipContent>
+                  </Tooltip>
+               );
+            }
             return <span className="text-sm">{name}</span>;
          },
       },

--- a/apps/web/src/features/transactions/ui/transactions-columns.tsx
+++ b/apps/web/src/features/transactions/ui/transactions-columns.tsx
@@ -1,12 +1,15 @@
 import { format, of } from "@f-o-t/money";
 import { Badge } from "@packages/ui/components/badge";
+import { Button } from "@packages/ui/components/button";
 import {
-   Tooltip,
-   TooltipContent,
-   TooltipTrigger,
-} from "@packages/ui/components/tooltip";
+   Popover,
+   PopoverContent,
+   PopoverTrigger,
+} from "@packages/ui/components/popover";
+import { useMutation } from "@tanstack/react-query";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { Outputs } from "@/integrations/orpc/client";
+import { orpc } from "@/integrations/orpc/client";
 
 export type TransactionRow = Outputs["transactions"]["getAll"]["data"][number];
 
@@ -18,6 +21,49 @@ function formatDate(dateStr: string): string {
    // date is stored as YYYY-MM-DD
    const [year, month, day] = dateStr.split("-");
    return `${day}/${month}/${year}`;
+}
+
+function SuggestedCategoryCell({ id }: { id: string }) {
+   const accept = useMutation(
+      orpc.transactions.acceptSuggestedCategory.mutationOptions(),
+   );
+   const dismiss = useMutation(
+      orpc.transactions.dismissSuggestedCategory.mutationOptions(),
+   );
+
+   return (
+      <Popover>
+         <PopoverTrigger asChild>
+            <Badge variant="outline" className="text-xs cursor-pointer">
+               sugestão IA
+            </Badge>
+         </PopoverTrigger>
+         <PopoverContent className="w-56 p-3">
+            <p className="text-sm text-muted-foreground mb-2">
+               Categoria sugerida pela IA. Deseja aceitar?
+            </p>
+            <div className="flex gap-2">
+               <Button
+                  size="sm"
+                  className="flex-1"
+                  disabled={accept.isPending || dismiss.isPending}
+                  onClick={() => accept.mutate({ id })}
+               >
+                  Aceitar
+               </Button>
+               <Button
+                  size="sm"
+                  variant="outline"
+                  className="flex-1"
+                  disabled={accept.isPending || dismiss.isPending}
+                  onClick={() => dismiss.mutate({ id })}
+               >
+                  Ignorar
+               </Button>
+            </div>
+         </PopoverContent>
+      </Popover>
+   );
 }
 
 export function buildTransactionColumns(): ColumnDef<TransactionRow>[] {
@@ -84,23 +130,8 @@ export function buildTransactionColumns(): ColumnDef<TransactionRow>[] {
             const hasSuggestion = !name && row.original.suggestedCategoryId;
             if (!name && !hasSuggestion)
                return <span className="text-xs text-muted-foreground">—</span>;
-            if (hasSuggestion) {
-               return (
-                  <Tooltip>
-                     <TooltipTrigger asChild>
-                        <Badge
-                           variant="outline"
-                           className="text-xs cursor-default"
-                        >
-                           sugestão IA
-                        </Badge>
-                     </TooltipTrigger>
-                     <TooltipContent>
-                        Categoria sugerida pela IA. Clique para revisar.
-                     </TooltipContent>
-                  </Tooltip>
-               );
-            }
+            if (hasSuggestion)
+               return <SuggestedCategoryCell id={row.original.id} />;
             return <span className="text-sm">{name}</span>;
          },
       },

--- a/apps/web/src/integrations/dbos/workflows/categorization.workflow.ts
+++ b/apps/web/src/integrations/dbos/workflows/categorization.workflow.ts
@@ -1,0 +1,117 @@
+import { DBOS } from "@dbos-inc/dbos-sdk";
+import { chat } from "@tanstack/ai";
+import { openRouterText } from "@tanstack/ai-openrouter";
+import { z } from "zod";
+import {
+   findCategoryByKeywords,
+   listCategories,
+} from "@core/database/repositories/categories-repository";
+import { updateTransactionCategory } from "@core/database/repositories/transactions-repository";
+import { db } from "@/integrations/singletons";
+
+export type CategorizationInput = {
+   transactionId: string;
+   teamId: string;
+   name: string;
+   type: "income" | "expense";
+   contactName?: string | null;
+};
+
+const MODEL = "google/gemini-3.1-flash-lite-preview";
+
+const outputSchema = z.object({
+   categoryName: z.string().nullable(),
+   confidence: z.enum(["high", "low"]),
+});
+
+export class CategorizationWorkflow {
+   @DBOS.workflow()
+   static async run(input: CategorizationInput) {
+      const keywordMatch =
+         await CategorizationWorkflow.matchKeywordsStep(input);
+
+      if (keywordMatch) {
+         await CategorizationWorkflow.applyStep(input.transactionId, {
+            categoryId: keywordMatch.id,
+         });
+         return;
+      }
+
+      const aiResult = await CategorizationWorkflow.inferWithAIStep(input);
+      if (!aiResult) return;
+
+      if (aiResult.confidence === "high") {
+         await CategorizationWorkflow.applyStep(input.transactionId, {
+            categoryId: aiResult.categoryId,
+         });
+      } else {
+         await CategorizationWorkflow.applyStep(input.transactionId, {
+            suggestedCategoryId: aiResult.categoryId,
+         });
+      }
+   }
+
+   @DBOS.step()
+   static async matchKeywordsStep(
+      input: Pick<CategorizationInput, "teamId" | "name" | "type">,
+   ): Promise<{ id: string } | null> {
+      return findCategoryByKeywords(db, input.teamId, {
+         name: input.name,
+         type: input.type,
+      });
+   }
+
+   @DBOS.step()
+   static async inferWithAIStep(
+      input: CategorizationInput,
+   ): Promise<{ categoryId: string; confidence: "high" | "low" } | null> {
+      const cats = await listCategories(db, input.teamId, {
+         type: input.type,
+         includeArchived: false,
+      });
+      if (cats.length === 0) return null;
+
+      const categoryList = cats
+         .map(
+            (c) =>
+               `- ${c.name}${c.keywords?.length ? ` (palavras: ${c.keywords.join(", ")})` : ""}`,
+         )
+         .join("\n");
+
+      const prompt = `Você é um assistente financeiro brasileiro. Classifique a transação abaixo na categoria mais adequada.
+
+Transação:
+- Nome: ${input.name}${input.contactName ? `\n- Contato: ${input.contactName}` : ""}
+- Tipo: ${input.type === "income" ? "Receita" : "Despesa"}
+
+Categorias disponíveis:
+${categoryList}
+
+Retorne o nome exato de uma categoria da lista acima, ou null se nenhuma for adequada.
+Se tiver certeza, retorne confidence "high". Se estiver em dúvida, retorne "low".`;
+
+      const result = await chat({
+         adapter: openRouterText(MODEL),
+         messages: [
+            { role: "user", content: [{ type: "text", content: prompt }] },
+         ],
+         outputSchema,
+         stream: false,
+      });
+
+      if (!result.categoryName) return null;
+
+      const match = cats.find((c) => c.name === result.categoryName);
+      if (!match) return null;
+
+      return { categoryId: match.id, confidence: result.confidence };
+   }
+
+   @DBOS.step()
+   static async applyStep(
+      transactionId: string,
+      data: { categoryId?: string; suggestedCategoryId?: string },
+   ) {
+      await updateTransactionCategory(db, transactionId, data);
+   }
+}

--- a/apps/web/src/integrations/dbos/workflows/index.ts
+++ b/apps/web/src/integrations/dbos/workflows/index.ts
@@ -1,3 +1,9 @@
 export { DeriveKeywordsWorkflow } from "./derive-keywords.workflow";
 export { BackfillKeywordsWorkflow } from "./backfill-keywords.workflow";
 export { CategorizationWorkflow } from "./categorization.workflow";
+
+import { DeriveKeywordsWorkflow } from "./derive-keywords.workflow";
+import { CategorizationWorkflow } from "./categorization.workflow";
+import { registerWorkflowClasses } from "./runner";
+
+registerWorkflowClasses({ DeriveKeywordsWorkflow, CategorizationWorkflow });

--- a/apps/web/src/integrations/dbos/workflows/index.ts
+++ b/apps/web/src/integrations/dbos/workflows/index.ts
@@ -1,2 +1,3 @@
 export { DeriveKeywordsWorkflow } from "./derive-keywords.workflow";
 export { BackfillKeywordsWorkflow } from "./backfill-keywords.workflow";
+export { CategorizationWorkflow } from "./categorization.workflow";

--- a/apps/web/src/integrations/dbos/workflows/index.ts
+++ b/apps/web/src/integrations/dbos/workflows/index.ts
@@ -7,3 +7,10 @@ import { CategorizationWorkflow } from "./categorization.workflow";
 import { registerWorkflowClasses } from "./runner";
 
 registerWorkflowClasses({ DeriveKeywordsWorkflow, CategorizationWorkflow });
+
+// DBOS decorators must register before DBOS.launch(). HMR partial re-evaluation
+// re-applies decorators on an already-launched instance → crash.
+// Declining HMR forces a full reload when workflow files change.
+if (import.meta.hot) {
+   import.meta.hot.decline();
+}

--- a/apps/web/src/integrations/dbos/workflows/index.ts
+++ b/apps/web/src/integrations/dbos/workflows/index.ts
@@ -7,10 +7,3 @@ import { CategorizationWorkflow } from "./categorization.workflow";
 import { registerWorkflowClasses } from "./runner";
 
 registerWorkflowClasses({ DeriveKeywordsWorkflow, CategorizationWorkflow });
-
-// DBOS decorators must register before DBOS.launch(). HMR partial re-evaluation
-// re-applies decorators on an already-launched instance → crash.
-// Declining HMR forces a full reload when workflow files change.
-if (import.meta.hot) {
-   import.meta.hot.decline();
-}

--- a/apps/web/src/integrations/dbos/workflows/runner.ts
+++ b/apps/web/src/integrations/dbos/workflows/runner.ts
@@ -1,0 +1,43 @@
+import { DBOS } from "@dbos-inc/dbos-sdk";
+import { getLogger } from "@core/logging/root";
+import type { CategorizationInput } from "./categorization.workflow";
+import type { DeriveKeywordsInput } from "./derive-keywords.workflow";
+
+const logger = getLogger().child({ module: "dbos.runner" });
+
+type WorkflowClasses = {
+   CategorizationWorkflow: typeof import("./categorization.workflow").CategorizationWorkflow;
+   DeriveKeywordsWorkflow: typeof import("./derive-keywords.workflow").DeriveKeywordsWorkflow;
+};
+
+const registry: Partial<WorkflowClasses> = {};
+
+export function registerWorkflowClasses(classes: WorkflowClasses) {
+   Object.assign(registry, classes);
+}
+
+export function startCategorizationWorkflow(input: CategorizationInput): void {
+   if (!registry.CategorizationWorkflow) return;
+   void DBOS.startWorkflow(registry.CategorizationWorkflow, {
+      workflowID: `categorize-${input.transactionId}`,
+   })
+      .run(input)
+      .catch((err) => {
+         logger.error(
+            { err, transactionId: input.transactionId },
+            "Failed to start categorization workflow",
+         );
+      });
+}
+
+export function startDeriveKeywordsWorkflow(input: DeriveKeywordsInput): void {
+   if (!registry.DeriveKeywordsWorkflow) return;
+   void DBOS.startWorkflow(registry.DeriveKeywordsWorkflow)
+      .run(input)
+      .catch((err) => {
+         logger.error(
+            { err, categoryId: input.categoryId },
+            "Failed to start derive-keywords workflow",
+         );
+      });
+}

--- a/apps/web/src/integrations/orpc/router/categories.ts
+++ b/apps/web/src/integrations/orpc/router/categories.ts
@@ -14,9 +14,8 @@ import {
 import { user as userTable } from "@core/database/schemas/auth";
 import { getLogger } from "@core/logging/root";
 import { eq } from "drizzle-orm";
-import { DBOS } from "@dbos-inc/dbos-sdk";
 import { z } from "zod";
-import { DeriveKeywordsWorkflow } from "@/integrations/dbos/workflows";
+import { startDeriveKeywordsWorkflow } from "@/integrations/dbos/workflows/runner";
 import { protectedProcedure } from "../server";
 
 const logger = getLogger().child({ module: "categories.router" });
@@ -30,14 +29,7 @@ function enqueueKeywordDerivation(input: {
    description?: string | null;
    stripeCustomerId?: string | null;
 }): void {
-   void DBOS.startWorkflow(DeriveKeywordsWorkflow)
-      .run(input)
-      .catch((err) => {
-         logger.error(
-            { err, categoryId: input.categoryId },
-            "Failed to start derive-keywords workflow",
-         );
-      });
+   startDeriveKeywordsWorkflow(input);
 }
 
 const idSchema = z.object({ id: z.string().uuid() });

--- a/apps/web/src/integrations/orpc/router/categories.ts
+++ b/apps/web/src/integrations/orpc/router/categories.ts
@@ -12,25 +12,10 @@ import {
    updateCategorySchema,
 } from "@core/database/schemas/categories";
 import { user as userTable } from "@core/database/schemas/auth";
-import { getLogger } from "@core/logging/root";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { startDeriveKeywordsWorkflow } from "@/integrations/dbos/workflows/runner";
 import { protectedProcedure } from "../server";
-
-const logger = getLogger().child({ module: "categories.router" });
-
-function enqueueKeywordDerivation(input: {
-   categoryId: string;
-   teamId: string;
-   organizationId: string;
-   userId: string;
-   name: string;
-   description?: string | null;
-   stripeCustomerId?: string | null;
-}): void {
-   startDeriveKeywordsWorkflow(input);
-}
 
 const idSchema = z.object({ id: z.string().uuid() });
 
@@ -44,7 +29,7 @@ export const create = protectedProcedure
             columns: { stripeCustomerId: true },
          }),
       ]);
-      enqueueKeywordDerivation({
+      startDeriveKeywordsWorkflow({
          categoryId: category.id,
          teamId: context.teamId,
          organizationId: context.organizationId,
@@ -83,7 +68,7 @@ export const update = protectedProcedure
             where: eq(userTable.id, context.userId),
             columns: { stripeCustomerId: true },
          });
-         enqueueKeywordDerivation({
+         startDeriveKeywordsWorkflow({
             categoryId: category.id,
             teamId: context.teamId,
             organizationId: context.organizationId,
@@ -123,7 +108,7 @@ export const importBatch = protectedProcedure
       for (const cat of input.categories) {
          const created = await createCategory(context.db, context.teamId, cat);
          results.push(created);
-         enqueueKeywordDerivation({
+         startDeriveKeywordsWorkflow({
             categoryId: created.id,
             teamId: context.teamId,
             organizationId: context.organizationId,

--- a/apps/web/src/integrations/orpc/router/transactions.ts
+++ b/apps/web/src/integrations/orpc/router/transactions.ts
@@ -271,7 +271,7 @@ export const importStatement = withCreditEnforcement(
             !tx.categoryId &&
             (tx.type === "income" || tx.type === "expense")
          ) {
-            enqueueCategorization({
+            startCategorizationWorkflow({
                transactionId: tx.id,
                teamId: context.teamId,
                name: tx.name ?? "",
@@ -439,7 +439,7 @@ export const importBulk = protectedProcedure
             !data.categoryId &&
             (data.type === "income" || data.type === "expense")
          ) {
-            enqueueCategorization({
+            startCategorizationWorkflow({
                transactionId: transaction.id,
                teamId: context.teamId,
                name: data.name ?? "",

--- a/apps/web/src/integrations/orpc/router/transactions.ts
+++ b/apps/web/src/integrations/orpc/router/transactions.ts
@@ -227,6 +227,7 @@ export const importStatement = withCreditEnforcement(
             )
             .min(1)
             .max(1000),
+         autoCategorize: z.boolean().default(false),
       }),
    )
    .handler(async ({ context, input }) => {
@@ -266,17 +267,19 @@ export const importStatement = withCreditEnforcement(
          rows,
       );
 
-      for (const tx of inserted) {
-         if (
-            !tx.categoryId &&
-            (tx.type === "income" || tx.type === "expense")
-         ) {
-            startCategorizationWorkflow({
-               transactionId: tx.id,
-               teamId: context.teamId,
-               name: tx.name ?? "",
-               type: tx.type,
-            });
+      if (input.autoCategorize) {
+         for (const tx of inserted) {
+            if (
+               !tx.categoryId &&
+               (tx.type === "income" || tx.type === "expense")
+            ) {
+               startCategorizationWorkflow({
+                  transactionId: tx.id,
+                  teamId: context.teamId,
+                  name: tx.name ?? "",
+                  type: tx.type,
+               });
+            }
          }
       }
 
@@ -318,6 +321,7 @@ export const checkDuplicates = protectedProcedure
             )
             .min(1)
             .max(1000),
+         autoCategorize: z.boolean().default(false),
       }),
    )
    .handler(async ({ context, input }) => {

--- a/apps/web/src/integrations/orpc/router/transactions.ts
+++ b/apps/web/src/integrations/orpc/router/transactions.ts
@@ -4,6 +4,7 @@ import {
    evaluateConditionGroup,
 } from "@f-o-t/condition-evaluator";
 import {
+   bulkCreateTransactions,
    createTransaction,
    createTransactionItems,
    deleteTransaction,
@@ -257,7 +258,6 @@ export const importStatement = withCreditEnforcement(
       }
 
       const rows = input.transactions.map((t) => ({
-         teamId: context.teamId,
          bankAccountId: input.bankAccountId,
          name: t.name ?? null,
          type: t.type,
@@ -268,7 +268,25 @@ export const importStatement = withCreditEnforcement(
          paymentMethod: t.paymentMethod ?? null,
       }));
 
-      await context.db.insert(transactions).values(rows);
+      const inserted = await bulkCreateTransactions(
+         context.db,
+         context.teamId,
+         rows,
+      );
+
+      for (const tx of inserted) {
+         if (
+            !tx.categoryId &&
+            (tx.type === "income" || tx.type === "expense")
+         ) {
+            enqueueCategorization({
+               transactionId: tx.id,
+               teamId: context.teamId,
+               name: tx.name ?? "",
+               type: tx.type,
+            });
+         }
+      }
 
       try {
          const emit = createEmitFn(context.db, context.posthog);

--- a/apps/web/src/integrations/orpc/router/transactions.ts
+++ b/apps/web/src/integrations/orpc/router/transactions.ts
@@ -27,8 +27,7 @@ import { emitFinanceStatementImported } from "@packages/events/finance";
 import { getLogger } from "@core/logging/root";
 import { WebAppError } from "@core/logging/errors";
 import { z } from "zod";
-import { DBOS } from "@dbos-inc/dbos-sdk";
-import { CategorizationWorkflow } from "@/integrations/dbos/workflows";
+import { startCategorizationWorkflow } from "@/integrations/dbos/workflows/runner";
 import { withCreditEnforcement } from "../middlewares/credit-enforcement";
 import { protectedProcedure } from "../server";
 
@@ -41,16 +40,7 @@ function enqueueCategorization(input: {
    type: "income" | "expense";
    contactName?: string | null;
 }): void {
-   void DBOS.startWorkflow(CategorizationWorkflow, {
-      workflowID: `categorize-${input.transactionId}`,
-   })
-      .run(input)
-      .catch((err) => {
-         logger.error(
-            { err, transactionId: input.transactionId },
-            "Failed to start categorization workflow",
-         );
-      });
+   startCategorizationWorkflow(input);
 }
 
 const idSchema = z.object({ id: z.string().uuid() });
@@ -413,6 +403,7 @@ export const importBulk = protectedProcedure
             .array(createTransactionSchema.merge(tagAndItemsSchema))
             .min(1)
             .max(500),
+         autoCategorize: z.boolean().default(false),
       }),
    )
    .handler(async ({ context, input }) => {
@@ -426,7 +417,25 @@ export const importBulk = protectedProcedure
             tagIds,
             date: data.date,
          });
-         await createTransaction(context.db, context.teamId, data, tagIds);
+         const transaction = await createTransaction(
+            context.db,
+            context.teamId,
+            data,
+            tagIds,
+         );
+         if (
+            input.autoCategorize &&
+            transaction &&
+            !data.categoryId &&
+            (data.type === "income" || data.type === "expense")
+         ) {
+            enqueueCategorization({
+               transactionId: transaction.id,
+               teamId: context.teamId,
+               name: data.name ?? "",
+               type: data.type,
+            });
+         }
          imported++;
       }
       return { imported, skipped: 0 };

--- a/apps/web/src/integrations/orpc/router/transactions.ts
+++ b/apps/web/src/integrations/orpc/router/transactions.ts
@@ -13,6 +13,7 @@ import {
    listTransactions,
    replaceTransactionItems,
    updateTransaction,
+   updateTransactionCategory,
    validateTransactionReferences,
 } from "@core/database/repositories/transactions-repository";
 import { ensureBankAccountOwnership } from "@core/database/repositories/bank-accounts-repository";
@@ -24,6 +25,7 @@ import {
 import { createEmitFn } from "@packages/events/emit";
 import { emitFinanceStatementImported } from "@packages/events/finance";
 import { getLogger } from "@core/logging/root";
+import { WebAppError } from "@core/logging/errors";
 import { z } from "zod";
 import { DBOS } from "@dbos-inc/dbos-sdk";
 import { CategorizationWorkflow } from "@/integrations/dbos/workflows";
@@ -428,4 +430,34 @@ export const importBulk = protectedProcedure
          imported++;
       }
       return { imported, skipped: 0 };
+   });
+
+export const acceptSuggestedCategory = protectedProcedure
+   .input(z.object({ id: z.string().uuid() }))
+   .handler(async ({ context, input }) => {
+      const tx = await ensureTransactionOwnership(
+         context.db,
+         input.id,
+         context.teamId,
+      );
+      if (!tx.suggestedCategoryId) {
+         throw WebAppError.badRequest(
+            "Nenhuma sugestão de categoria disponível.",
+         );
+      }
+      await updateTransactionCategory(context.db, input.id, {
+         categoryId: tx.suggestedCategoryId,
+         suggestedCategoryId: null,
+      });
+      return { ok: true };
+   });
+
+export const dismissSuggestedCategory = protectedProcedure
+   .input(z.object({ id: z.string().uuid() }))
+   .handler(async ({ context, input }) => {
+      await ensureTransactionOwnership(context.db, input.id, context.teamId);
+      await updateTransactionCategory(context.db, input.id, {
+         suggestedCategoryId: null,
+      });
+      return { ok: true };
    });

--- a/apps/web/src/integrations/orpc/router/transactions.ts
+++ b/apps/web/src/integrations/orpc/router/transactions.ts
@@ -25,24 +25,11 @@ import {
 } from "@core/database/schemas/transactions";
 import { createEmitFn } from "@packages/events/emit";
 import { emitFinanceStatementImported } from "@packages/events/finance";
-import { getLogger } from "@core/logging/root";
 import { WebAppError } from "@core/logging/errors";
 import { z } from "zod";
 import { startCategorizationWorkflow } from "@/integrations/dbos/workflows/runner";
 import { withCreditEnforcement } from "../middlewares/credit-enforcement";
 import { protectedProcedure } from "../server";
-
-const logger = getLogger().child({ module: "transactions.router" });
-
-function enqueueCategorization(input: {
-   transactionId: string;
-   teamId: string;
-   name: string;
-   type: "income" | "expense";
-   contactName?: string | null;
-}): void {
-   startCategorizationWorkflow(input);
-}
 
 const idSchema = z.object({ id: z.string().uuid() });
 
@@ -87,9 +74,13 @@ const filterSchema = z
    .optional();
 
 export const create = protectedProcedure
-   .input(createTransactionSchema.merge(tagAndItemsSchema))
+   .input(
+      createTransactionSchema
+         .merge(tagAndItemsSchema)
+         .merge(z.object({ autoCategorize: z.boolean().default(false) })),
+   )
    .handler(async ({ context, input }) => {
-      const { tagIds, items, ...data } = input;
+      const { tagIds, items, autoCategorize, ...data } = input;
       await validateTransactionReferences(context.db, context.teamId, {
          bankAccountId: data.bankAccountId,
          destinationBankAccountId: data.destinationBankAccountId,
@@ -121,11 +112,12 @@ export const create = protectedProcedure
       }
 
       if (
+         autoCategorize &&
          transaction &&
          !input.categoryId &&
          (input.type === "income" || input.type === "expense")
       ) {
-         enqueueCategorization({
+         startCategorizationWorkflow({
             transactionId: transaction.id,
             teamId: context.teamId,
             name: input.name ?? "",

--- a/apps/web/src/integrations/orpc/router/transactions.ts
+++ b/apps/web/src/integrations/orpc/router/transactions.ts
@@ -23,9 +23,33 @@ import {
 } from "@core/database/schemas/transactions";
 import { createEmitFn } from "@packages/events/emit";
 import { emitFinanceStatementImported } from "@packages/events/finance";
+import { getLogger } from "@core/logging/root";
 import { z } from "zod";
+import { DBOS } from "@dbos-inc/dbos-sdk";
+import { CategorizationWorkflow } from "@/integrations/dbos/workflows";
 import { withCreditEnforcement } from "../middlewares/credit-enforcement";
 import { protectedProcedure } from "../server";
+
+const logger = getLogger().child({ module: "transactions.router" });
+
+function enqueueCategorization(input: {
+   transactionId: string;
+   teamId: string;
+   name: string;
+   type: "income" | "expense";
+   contactName?: string | null;
+}): void {
+   void DBOS.startWorkflow(CategorizationWorkflow, {
+      workflowID: `categorize-${input.transactionId}`,
+   })
+      .run(input)
+      .catch((err) => {
+         logger.error(
+            { err, transactionId: input.transactionId },
+            "Failed to start categorization workflow",
+         );
+      });
+}
 
 const idSchema = z.object({ id: z.string().uuid() });
 
@@ -101,6 +125,19 @@ export const create = protectedProcedure
             context.teamId,
             items,
          );
+      }
+
+      if (
+         transaction &&
+         !input.categoryId &&
+         (input.type === "income" || input.type === "expense")
+      ) {
+         enqueueCategorization({
+            transactionId: transaction.id,
+            teamId: context.teamId,
+            name: input.name ?? "",
+            type: input.type,
+         });
       }
 
       return transaction;

--- a/apps/web/src/integrations/orpc/router/transactions.ts
+++ b/apps/web/src/integrations/orpc/router/transactions.ts
@@ -321,7 +321,6 @@ export const checkDuplicates = protectedProcedure
             )
             .min(1)
             .max(1000),
-         autoCategorize: z.boolean().default(false),
       }),
    )
    .handler(async ({ context, input }) => {

--- a/apps/web/src/layout/dashboard/ui/sidebar-nav.tsx
+++ b/apps/web/src/layout/dashboard/ui/sidebar-nav.tsx
@@ -138,8 +138,14 @@ function CollapsibleNavItem({
    isItemActive: (item: NavItemDef) => boolean;
    onMainItemClick: () => void;
 }) {
+   const { isVisible } = useSidebarVisibility();
    const Icon = item.icon;
-   const anyChildActive = (item.children ?? []).some(isItemActive);
+   const visibleChildren = (item.children ?? []).filter((child) =>
+      isVisible(child.id),
+   );
+   const anyChildActive = visibleChildren.some(isItemActive);
+
+   if (visibleChildren.length === 0) return null;
 
    return (
       <Collapsible asChild className="group/collapsible" defaultOpen>
@@ -157,7 +163,7 @@ function CollapsibleNavItem({
             </CollapsibleTrigger>
             <CollapsibleContent>
                <SidebarMenuSub>
-                  {(item.children ?? []).map((child) => (
+                  {visibleChildren.map((child) => (
                      <SidebarMenuSubItem key={child.id}>
                         <SidebarMenuSubButton
                            asChild

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-categories/categories-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-categories/categories-columns.tsx
@@ -30,6 +30,7 @@ import {
    Smartphone,
    ShieldCheck,
    Star,
+   Tags,
    Utensils,
    Wallet,
    Zap,
@@ -76,8 +77,21 @@ export function buildCategoryColumns(): ColumnDef<CategoryRow>[] {
          accessorKey: "name",
          header: "Nome",
          cell: ({ row }) => {
-            const { name, color, icon, isDefault } = row.original;
+            const { name, color, icon, isDefault, keywords } = row.original;
             const IconComponent = icon ? ICON_MAP[icon] : null;
+            const hasKeywords = keywords && keywords.length > 0;
+
+            const keywordsTooltip = hasKeywords ? (
+               <Tooltip>
+                  <TooltipTrigger asChild>
+                     <Tags className="size-4 text-muted-foreground shrink-0" />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-64">
+                     <p className="font-medium">Palavras-chave IA</p>
+                     <p className="text-xs">{keywords.join(", ")}</p>
+                  </TooltipContent>
+               </Tooltip>
+            ) : null;
 
             if (row.depth === 0 && (color || IconComponent)) {
                return (
@@ -100,6 +114,7 @@ export function buildCategoryColumns(): ColumnDef<CategoryRow>[] {
                               <TooltipContent>Padrão</TooltipContent>
                            </Tooltip>
                         )}
+                        {keywordsTooltip}
                      </AnnouncementTitle>
                   </Announcement>
                );
@@ -122,6 +137,7 @@ export function buildCategoryColumns(): ColumnDef<CategoryRow>[] {
                         <TooltipContent>Padrão</TooltipContent>
                      </Tooltip>
                   )}
+                  {keywordsTooltip}
                </div>
             );
          },

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/statement-import-credenza.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/statement-import-credenza.tsx
@@ -732,6 +732,7 @@ function PreviewStep({ methods }: { methods: StepperMethods }) {
    }
 
    function autoCategorize() {
+      let matched = 0;
       const updated = rows.map((r) => {
          if (r.categoryId || !r.isValid) return r;
          const text = (r.description || r.name || "").toLowerCase();
@@ -741,12 +742,20 @@ function PreviewStep({ methods }: { methods: StepperMethods }) {
                ...(cat.keywords ?? []).map((k: string) => k.toLowerCase()),
             ];
             if (terms.some((t) => text.includes(t))) {
+               matched++;
                return { ...r, categoryId: cat.id };
             }
          }
          return r;
       });
       onRowsChange(updated);
+      if (matched > 0) {
+         toast.success(
+            `${matched} lançamento(s) categorizados automaticamente.`,
+         );
+      } else {
+         toast.info("Nenhum lançamento pôde ser categorizado automaticamente.");
+      }
    }
 
    function commitDescEdit(originalIndex: number) {
@@ -766,8 +775,8 @@ function PreviewStep({ methods }: { methods: StepperMethods }) {
          <CredenzaHeader>
             <CredenzaTitle>Revise as transações</CredenzaTitle>
             <CredenzaDescription>
-               Desmarque o que não deseja importar — duplicatas já estão
-               desmarcadas
+               Todos os lançamentos válidos serão importados — duplicatas já
+               estão ignoradas automaticamente
             </CredenzaDescription>
          </CredenzaHeader>
 
@@ -858,9 +867,9 @@ function PreviewStep({ methods }: { methods: StepperMethods }) {
                         <TooltipProvider>
                            <Button
                               type="button"
-                              variant="ghost"
+                              variant="outline"
                               size="icon-xs"
-                              className="text-muted-foreground hover:text-primary"
+                              className="border-primary/40 text-primary hover:bg-primary/10"
                               tooltip="Categorização automática"
                               onClick={autoCategorize}
                            >
@@ -1320,10 +1329,10 @@ function PreviewStep({ methods }: { methods: StepperMethods }) {
                   </Button>
                   <Button
                      className="flex-1"
-                     disabled={selectedIndices.size === 0}
+                     disabled={selectableIndices.length === 0}
                      onClick={() => {
-                        const confirmedSet = new Set(selectedIndices);
-                        const duplicateCount = [...selectedIndices].filter(
+                        const confirmedSet = new Set(selectableIndices);
+                        const duplicateCount = selectableIndices.filter(
                            (i) => duplicateFlags[i],
                         ).length;
                         if (duplicateCount > 0) {
@@ -1426,7 +1435,7 @@ function ConfirmStep({
                      )}
                      <div className="flex items-center justify-between bg-primary/5 px-4 py-2.5">
                         <span className="text-sm font-medium">
-                           Total selecionadas
+                           Serão importadas
                         </span>
                         <span className="text-sm font-bold text-primary">
                            {selectedIndices.size}
@@ -1459,7 +1468,7 @@ function ConfirmStep({
                         {importMutation.isPending && (
                            <Loader2 className="size-4 animate-spin" />
                         )}
-                        Importar {selectedCount} transação(ões)
+                        Importar {selectedCount} lançamento(s)
                      </span>
                   </Button>
                </div>

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -1,16 +1,20 @@
 import "@/integrations/otel/init";
-import "@/integrations/dbos/workflows";
 
 import { DBOS } from "@dbos-inc/dbos-sdk";
 import handler, { createServerEntry } from "@tanstack/react-start/server-entry";
 import { launchDBOS } from "@/integrations/dbos/init";
+
+async function bootDbos() {
+   await import("@/integrations/dbos/workflows");
+   launchDBOS();
+}
 
 if (import.meta.hot) {
    const boot = async () => {
       if (import.meta.hot!.data.shutdown) {
          await import.meta.hot!.data.shutdown;
       }
-      launchDBOS();
+      await bootDbos();
    };
 
    import.meta.hot.dispose(async () => {
@@ -20,7 +24,7 @@ if (import.meta.hot) {
 
    void boot();
 } else {
-   launchDBOS();
+   void bootDbos();
 }
 
 export default createServerEntry({

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -16,6 +16,9 @@ const config = defineConfig({
       transform: {
          target: "es2022",
       },
+      decorators: {
+         legacy: true,
+      },
    },
    server: {
       watch: {

--- a/core/database/src/repositories/categories-repository.ts
+++ b/core/database/src/repositories/categories-repository.ts
@@ -1,5 +1,5 @@
 import { AppError, propagateError, validateInput } from "@core/logging/errors";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 import type { DatabaseInstance } from "@core/database/client";
 import {
@@ -487,5 +487,42 @@ export async function validateKeywordsUniqueness(
       throw AppError.conflict(
          "Palavras-chave já utilizadas em outra categoria ativa.",
       );
+   }
+}
+
+export async function findCategoryByKeywords(
+   db: DatabaseInstance,
+   teamId: string,
+   opts: {
+      name: string;
+      type: "income" | "expense";
+   },
+): Promise<{ id: string; name: string } | null> {
+   try {
+      const rows = await db
+         .select({
+            id: categories.id,
+            name: categories.name,
+            level: categories.level,
+         })
+         .from(categories)
+         .where(
+            and(
+               eq(categories.teamId, teamId),
+               eq(categories.type, opts.type),
+               eq(categories.isArchived, false),
+               sql`EXISTS (
+                  SELECT 1 FROM unnest(${categories.keywords}) k
+                  WHERE ${opts.name} ILIKE '%' || k || '%'
+               )`,
+            ),
+         )
+         .orderBy(desc(categories.level))
+         .limit(1);
+
+      return rows[0] ?? null;
+   } catch (err) {
+      propagateError(err);
+      throw AppError.database("Failed to find category by keywords");
    }
 }

--- a/core/database/src/repositories/transactions-repository.ts
+++ b/core/database/src/repositories/transactions-repository.ts
@@ -515,6 +515,36 @@ export async function updateTransaction(
    }
 }
 
+export async function bulkCreateTransactions(
+   db: DatabaseInstance,
+   teamId: string,
+   rows: {
+      bankAccountId: string;
+      name: string | null;
+      type: "income" | "expense";
+      amount: string;
+      date: string;
+      description: string | null;
+      categoryId: string | null;
+      paymentMethod: string | null;
+   }[],
+) {
+   try {
+      return await db
+         .insert(transactions)
+         .values(rows.map((r) => ({ ...r, teamId })))
+         .returning({
+            id: transactions.id,
+            name: transactions.name,
+            type: transactions.type,
+            categoryId: transactions.categoryId,
+         });
+   } catch (err) {
+      propagateError(err);
+      throw AppError.database("Failed to bulk create transactions");
+   }
+}
+
 export async function deleteTransaction(db: DatabaseInstance, id: string) {
    try {
       await db.delete(transactions).where(eq(transactions.id, id));

--- a/core/database/src/repositories/transactions-repository.ts
+++ b/core/database/src/repositories/transactions-repository.ts
@@ -510,7 +510,12 @@ export async function updateTransaction(
       const validated = validateInput(updateTransactionSchema, data);
       const [updated] = await db
          .update(transactions)
-         .set(validated)
+         .set({
+            ...validated,
+            ...(validated.categoryId !== undefined
+               ? { suggestedCategoryId: null }
+               : {}),
+         })
          .where(eq(transactions.id, id))
          .returning();
 

--- a/core/database/src/repositories/transactions-repository.ts
+++ b/core/database/src/repositories/transactions-repository.ts
@@ -2,6 +2,7 @@ import type { Condition, ConditionGroup } from "@f-o-t/condition-evaluator";
 import { evaluateConditionGroup } from "@f-o-t/condition-evaluator";
 import { AppError, propagateError, validateInput } from "@core/logging/errors";
 import { of, toDecimal } from "@f-o-t/money";
+import { alias } from "drizzle-orm/pg-core";
 import {
    and,
    count,
@@ -298,6 +299,10 @@ export async function listTransactions(
 
       if (isWeighted && filter.conditionGroup) {
          const condGroup = filter.conditionGroup;
+         const suggestedCategoriesWeighted = alias(
+            categories,
+            "suggested_categories",
+         );
          const allRows = await db
             .select({
                ...getTableColumns(transactions),
@@ -305,9 +310,17 @@ export async function listTransactions(
                creditCardName: creditCards.name,
                bankAccountName: bankAccounts.name,
                contactName: contacts.name,
+               suggestedCategoryName: suggestedCategoriesWeighted.name,
             })
             .from(transactions)
             .leftJoin(categories, eq(transactions.categoryId, categories.id))
+            .leftJoin(
+               suggestedCategoriesWeighted,
+               eq(
+                  transactions.suggestedCategoryId,
+                  suggestedCategoriesWeighted.id,
+               ),
+            )
             .leftJoin(
                creditCards,
                eq(transactions.creditCardId, creditCards.id),
@@ -350,6 +363,8 @@ export async function listTransactions(
          .leftJoin(contacts, eq(transactions.contactId, contacts.id))
          .where(whereClause);
 
+      const suggestedCategories = alias(categories, "suggested_categories");
+
       const data = await db
          .select({
             ...getTableColumns(transactions),
@@ -357,9 +372,14 @@ export async function listTransactions(
             creditCardName: creditCards.name,
             bankAccountName: bankAccounts.name,
             contactName: contacts.name,
+            suggestedCategoryName: suggestedCategories.name,
          })
          .from(transactions)
          .leftJoin(categories, eq(transactions.categoryId, categories.id))
+         .leftJoin(
+            suggestedCategories,
+            eq(transactions.suggestedCategoryId, suggestedCategories.id),
+         )
          .leftJoin(creditCards, eq(transactions.creditCardId, creditCards.id))
          .leftJoin(
             bankAccounts,

--- a/core/database/src/repositories/transactions-repository.ts
+++ b/core/database/src/repositories/transactions-repository.ts
@@ -591,3 +591,22 @@ export async function replaceTransactionItems(
       throw AppError.database("Failed to replace transaction items");
    }
 }
+
+export async function updateTransactionCategory(
+   db: DatabaseInstance,
+   id: string,
+   data: {
+      categoryId?: string | null;
+      suggestedCategoryId?: string | null;
+   },
+) {
+   try {
+      await db
+         .update(transactions)
+         .set({ ...data, updatedAt: new Date() })
+         .where(eq(transactions.id, id));
+   } catch (err) {
+      propagateError(err);
+      throw AppError.database("Failed to update transaction category");
+   }
+}

--- a/core/database/src/repositories/transactions-repository.ts
+++ b/core/database/src/repositories/transactions-repository.ts
@@ -26,6 +26,7 @@ import {
    type UpdateTransactionInput,
    createTransactionSchema,
    updateTransactionSchema,
+   paymentMethodEnum,
    transactionItems,
    transactions,
    transactionTags,
@@ -526,7 +527,7 @@ export async function bulkCreateTransactions(
       date: string;
       description: string | null;
       categoryId: string | null;
-      paymentMethod: string | null;
+      paymentMethod: (typeof paymentMethodEnum.enumValues)[number] | null;
    }[],
 ) {
    try {

--- a/core/database/src/schemas/transactions.ts
+++ b/core/database/src/schemas/transactions.ts
@@ -102,6 +102,9 @@ export const transactions = financeSchema.table(
       index("transactions_category_id_idx").on(table.categoryId),
       index("transactions_credit_card_id_idx").on(table.creditCardId),
       index("transactions_contact_id_idx").on(table.contactId),
+      index("transactions_suggested_category_id_idx").on(
+         table.suggestedCategoryId,
+      ),
       index("transactions_statement_period_idx").on(
          table.creditCardId,
          table.statementPeriod,

--- a/core/database/src/schemas/transactions.ts
+++ b/core/database/src/schemas/transactions.ts
@@ -73,6 +73,10 @@ export const transactions = financeSchema.table(
       categoryId: uuid("category_id").references(() => categories.id, {
          onDelete: "set null",
       }),
+      suggestedCategoryId: uuid("suggested_category_id").references(
+         () => categories.id,
+         { onDelete: "set null" },
+      ),
       attachments: jsonb("attachments").$type<Attachment[]>(),
       paymentMethod: paymentMethodEnum("payment_method"),
       isInstallment: boolean("is_installment").default(false).notNull(),

--- a/docs/plans/2026-04-13-transaction-auto-categorization.md
+++ b/docs/plans/2026-04-13-transaction-auto-categorization.md
@@ -1,0 +1,446 @@
+# Transaction Auto-Categorization Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Automatically assign categories to transactions on creation using keyword matching first, falling back to AI inference only when needed.
+
+**Architecture:** Keyword match runs as a DB query against `categories.keywords` (text array). If no match, a cheap LLM call infers the best existing category. Both run inside a DBOS workflow triggered fire-and-forget from the `transactions.create` oRPC procedure. Low-confidence AI results stored as `suggestedCategoryId` for user review; high-confidence and keyword matches set `categoryId` directly.
+
+**Tech Stack:** DBOS workflows, Drizzle ORM, `@tanstack/ai` + `@tanstack/ai-openrouter`, oRPC, PostgreSQL text array operators.
+
+---
+
+### Task 1: Add `suggestedCategoryId` column to transactions schema
+
+**Files:**
+- Modify: `core/database/src/schemas/transactions.ts`
+
+**Step 1: Add column to transactions table**
+
+In `core/database/src/schemas/transactions.ts`, add after the `categoryId` column:
+
+```typescript
+suggestedCategoryId: uuid("suggested_category_id").references(
+  () => categories.id,
+  { onDelete: "set null" },
+),
+```
+
+Make sure `categories` is already imported in that file (it is, via the `categoryId` FK).
+
+**Step 2: Push schema to DB**
+
+```bash
+bun run db:push
+```
+
+Expected: migration applied, no errors.
+
+**Step 3: Commit**
+
+```bash
+git add core/database/src/schemas/transactions.ts
+git commit -m "feat(schema): add suggestedCategoryId to transactions"
+```
+
+---
+
+### Task 2: Add `updateTransactionCategory` to transactions repository
+
+**Files:**
+- Modify: `core/database/src/repositories/transactions-repository.ts`
+
+**Step 1: Add the function**
+
+At the bottom of `core/database/src/repositories/transactions-repository.ts`:
+
+```typescript
+export async function updateTransactionCategory(
+  db: DatabaseInstance,
+  id: string,
+  data: {
+    categoryId?: string | null;
+    suggestedCategoryId?: string | null;
+  },
+) {
+  try {
+    await db
+      .update(transactions)
+      .set({ ...data, updatedAt: new Date() })
+      .where(eq(transactions.id, id));
+  } catch (err) {
+    propagateError(err);
+    throw AppError.database("Failed to update transaction category");
+  }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add core/database/src/repositories/transactions-repository.ts
+git commit -m "feat(repo): add updateTransactionCategory"
+```
+
+---
+
+### Task 3: Add `findCategoryByKeywords` to categories repository
+
+**Files:**
+- Modify: `core/database/src/repositories/categories-repository.ts`
+
+**Step 1: Add query function**
+
+This does one DB round-trip: checks if any keyword in the category's `keywords` array is a substring of the transaction name (case-insensitive). Filters by type, excludes archived, returns best match (deepest level first).
+
+```typescript
+export async function findCategoryByKeywords(
+  db: DatabaseInstance,
+  teamId: string,
+  opts: {
+    name: string;
+    type: "income" | "expense";
+  },
+): Promise<{ id: string; name: string } | null> {
+  try {
+    const rows = await db
+      .select({ id: categories.id, name: categories.name, level: categories.level })
+      .from(categories)
+      .where(
+        and(
+          eq(categories.teamId, teamId),
+          eq(categories.type, opts.type),
+          eq(categories.isArchived, false),
+          sql`EXISTS (
+            SELECT 1 FROM unnest(${categories.keywords}) k
+            WHERE ${opts.name} ILIKE '%' || k || '%'
+          )`,
+        ),
+      )
+      .orderBy(desc(categories.level))
+      .limit(1);
+
+    return rows[0] ?? null;
+  } catch (err) {
+    propagateError(err);
+    throw AppError.database("Failed to find category by keywords");
+  }
+}
+```
+
+Make sure `sql`, `desc`, `and`, `eq` are imported from `drizzle-orm` at the top of the file (they likely already are).
+
+**Step 2: Commit**
+
+```bash
+git add core/database/src/repositories/categories-repository.ts
+git commit -m "feat(repo): add findCategoryByKeywords"
+```
+
+---
+
+### Task 4: Create the categorization DBOS workflow
+
+**Files:**
+- Create: `apps/web/src/integrations/dbos/workflows/categorization.workflow.ts`
+- Modify: `apps/web/src/integrations/dbos/workflows/index.ts`
+
+**Step 1: Create workflow file**
+
+```typescript
+import { DBOS } from "@dbos-inc/dbos-sdk";
+import { chat } from "@tanstack/ai";
+import { openRouterText } from "@tanstack/ai-openrouter";
+import { z } from "zod";
+import { db } from "@core/database/client";
+import { findCategoryByKeywords } from "@core/database/repositories/categories-repository";
+import { listCategories } from "@core/database/repositories/categories-repository";
+import { updateTransactionCategory } from "@core/database/repositories/transactions-repository";
+import { env } from "@core/environment/server";
+
+export type CategorizationInput = {
+  transactionId: string;
+  teamId: string;
+  name: string;
+  type: "income" | "expense";
+  contactName?: string | null;
+};
+
+const MODEL = "google/gemini-3.1-flash-lite-preview";
+
+const outputSchema = z.object({
+  categoryName: z.string().nullable(),
+  confidence: z.enum(["high", "low"]),
+});
+
+export class CategorizationWorkflow {
+  @DBOS.workflow()
+  static async run(input: CategorizationInput) {
+    const keywordMatch = await CategorizationWorkflow.matchKeywordsStep(input);
+
+    if (keywordMatch) {
+      await CategorizationWorkflow.applyStep(input.transactionId, {
+        categoryId: keywordMatch.id,
+      });
+      return;
+    }
+
+    const aiResult = await CategorizationWorkflow.inferWithAIStep(input);
+    if (!aiResult) return;
+
+    if (aiResult.confidence === "high") {
+      await CategorizationWorkflow.applyStep(input.transactionId, {
+        categoryId: aiResult.categoryId,
+      });
+    } else {
+      await CategorizationWorkflow.applyStep(input.transactionId, {
+        suggestedCategoryId: aiResult.categoryId,
+      });
+    }
+  }
+
+  @DBOS.step()
+  static async matchKeywordsStep(
+    input: Pick<CategorizationInput, "teamId" | "name" | "type">,
+  ): Promise<{ id: string } | null> {
+    return findCategoryByKeywords(db, input.teamId, {
+      name: input.name,
+      type: input.type,
+    });
+  }
+
+  @DBOS.step()
+  static async inferWithAIStep(
+    input: CategorizationInput,
+  ): Promise<{ categoryId: string; confidence: "high" | "low" } | null> {
+    const categories = await listCategories(db, input.teamId, {
+      type: input.type,
+      includeArchived: false,
+    });
+    if (categories.length === 0) return null;
+
+    const categoryList = categories
+      .map((c) => `- ${c.name}${c.keywords?.length ? ` (palavras: ${c.keywords.join(", ")})` : ""}`)
+      .join("\n");
+
+    const prompt = `Você é um assistente financeiro brasileiro. Classifique a transação abaixo na categoria mais adequada.
+
+Transação:
+- Nome: ${input.name}${input.contactName ? `\n- Contato: ${input.contactName}` : ""}
+- Tipo: ${input.type === "income" ? "Receita" : "Despesa"}
+
+Categorias disponíveis:
+${categoryList}
+
+Retorne o nome exato de uma categoria da lista acima, ou null se nenhuma for adequada.
+Se tiver certeza, retorne confidence "high". Se estiver em dúvida, retorne "low".`;
+
+    const result = await chat({
+      adapter: openRouterText(MODEL, { apiKey: env.OPENROUTER_API_KEY }),
+      messages: [{ role: "user", content: [{ type: "text", content: prompt }] }],
+      outputSchema,
+      stream: false,
+    });
+
+    if (!result.categoryName) return null;
+
+    const match = categories.find((c) => c.name === result.categoryName);
+    if (!match) return null;
+
+    return { categoryId: match.id, confidence: result.confidence };
+  }
+
+  @DBOS.step()
+  static async applyStep(
+    transactionId: string,
+    data: { categoryId?: string; suggestedCategoryId?: string },
+  ) {
+    await updateTransactionCategory(db, transactionId, data);
+  }
+}
+```
+
+**Step 2: Export from index**
+
+In `apps/web/src/integrations/dbos/workflows/index.ts`, add:
+
+```typescript
+export { CategorizationWorkflow } from "./categorization.workflow";
+```
+
+**Step 3: Commit**
+
+```bash
+git add apps/web/src/integrations/dbos/workflows/categorization.workflow.ts \
+        apps/web/src/integrations/dbos/workflows/index.ts
+git commit -m "feat(workflow): add CategorizationWorkflow"
+```
+
+---
+
+### Task 5: Wire workflow into transactions.create router
+
+**Files:**
+- Modify: `apps/web/src/integrations/orpc/router/transactions.ts`
+
+**Step 1: Add trigger helper**
+
+At the top of the file, after existing imports, add:
+
+```typescript
+import { DBOS } from "@dbos-inc/dbos-sdk";
+import { CategorizationWorkflow } from "../../../integrations/dbos/workflows/categorization.workflow";
+import { logger } from "@core/logging";
+
+function enqueueCategorization(input: {
+  transactionId: string;
+  teamId: string;
+  name: string;
+  type: "income" | "expense";
+  contactName?: string | null;
+}): void {
+  void DBOS.startWorkflow(CategorizationWorkflow)
+    .run(input)
+    .catch((err) => {
+      logger.error(
+        { err, transactionId: input.transactionId },
+        "Failed to start categorization workflow",
+      );
+    });
+}
+```
+
+**Step 2: Call after transaction creation**
+
+Inside the `create` procedure handler, after the transaction is created and **only if `categoryId` is not already set** (user manually chose one), call:
+
+```typescript
+if (!input.categoryId) {
+  enqueueCategorization({
+    transactionId: transaction.id,
+    teamId: context.teamId,
+    name: input.name,
+    type: input.type as "income" | "expense",
+    contactName: input.contactName ?? null,
+  });
+}
+```
+
+Check what `input.contactName` looks like in the existing schema — it may be `contactId` not `contactName`. If so, skip `contactName` for now (workflow still works, just without contact context).
+
+**Step 3: Typecheck**
+
+```bash
+bun run typecheck
+```
+
+Fix any errors before committing.
+
+**Step 4: Commit**
+
+```bash
+git add apps/web/src/integrations/orpc/router/transactions.ts
+git commit -m "feat(router): trigger categorization workflow on transaction create"
+```
+
+---
+
+### Task 6: Add "sugestão IA" badge to transaction UI
+
+**Files:**
+- Find the transaction list/row component — likely in `apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/transactions.tsx` or colocated `-transactions/` folder
+- Modify the component that renders each transaction row
+
+**Step 1: Locate the row component**
+
+Search for where `categoryId` is rendered in the transactions UI. The badge should appear on the category cell or transaction name when `suggestedCategoryId` is set and `categoryId` is null.
+
+**Step 2: Query includes suggestedCategoryId**
+
+Ensure `getAll` or `getById` oRPC procedure returns `suggestedCategoryId`. Check `apps/web/src/integrations/orpc/router/transactions.ts` — the list query likely returns raw DB rows. If `suggestedCategoryId` is on the DB row, it's already returned.
+
+**Step 3: Add badge**
+
+In the transaction row component, where category is displayed:
+
+```tsx
+{transaction.suggestedCategoryId && !transaction.categoryId && (
+  <Tooltip>
+    <TooltipTrigger>
+      <Badge variant="outline" className="text-xs">sugestão IA</Badge>
+    </TooltipTrigger>
+    <TooltipContent>
+      Categoria sugerida pela IA. Clique para revisar.
+    </TooltipContent>
+  </Tooltip>
+)}
+```
+
+Import `Badge` from `@packages/ui/components/badge`, `Tooltip`/`TooltipTrigger`/`TooltipContent` from `@packages/ui/components/tooltip`.
+
+**Step 4: Commit**
+
+```bash
+git add <modified UI files>
+git commit -m "feat(ui): add sugestão IA badge to transactions"
+```
+
+---
+
+### Task 7: Manual review action for suggested category
+
+**Goal:** When user clicks the "sugestão IA" badge, show them the suggested category name and let them accept or dismiss it.
+
+**Files:**
+- Modify: transaction row or a colocated action component
+- Modify: `apps/web/src/integrations/orpc/router/transactions.ts` — add `acceptSuggestedCategory` procedure
+
+**Step 1: Add `acceptSuggestedCategory` procedure**
+
+```typescript
+export const acceptSuggestedCategory = protectedProcedure
+  .input(z.object({ id: z.string().uuid() }))
+  .handler(async ({ context, input }) => {
+    const tx = await getTransactionById(context.db, input.id);
+    if (!tx) throw WebAppError.notFound("Transaction not found");
+    if (tx.teamId !== context.teamId) throw WebAppError.forbidden();
+    if (!tx.suggestedCategoryId) throw WebAppError.badRequest("No suggestion");
+
+    await updateTransactionCategory(context.db, input.id, {
+      categoryId: tx.suggestedCategoryId,
+      suggestedCategoryId: null,
+    });
+
+    return { ok: true };
+  });
+```
+
+Add `dismissSuggestedCategory` the same way but sets `suggestedCategoryId: null` without setting `categoryId`.
+
+**Step 2: Wire into router export**
+
+Make sure both procedures are exported in the transactions router object.
+
+**Step 3: Add UI actions**
+
+In the tooltip or a popover triggered by the badge, add two buttons:
+- "Aceitar" → calls `acceptSuggestedCategory` mutation
+- "Ignorar" → calls `dismissSuggestedCategory` mutation
+
+Both invalidate the transactions query on success (handled by global `MutationCache` automatically).
+
+**Step 4: Commit**
+
+```bash
+git add <all changed files>
+git commit -m "feat: accept/dismiss suggested category for transactions"
+```
+
+---
+
+## Notes
+
+- `agentSettings.dataSourceTransactions` toggle: if this setting exists on the team, check it in the `enqueueCategorization` helper before calling `DBOS.startWorkflow`. Skip if disabled.
+- Keyword match is free (no AI cost). AI only fires when no keyword matches.
+- The workflow is idempotent-safe — DBOS deduplicates on `workflowID`. Add `{ workflowID: \`categorize-${transactionId}\` }` to `DBOS.startWorkflow` options to prevent double-runs on retries.
+- `importBulk` and `importStatement` procedures also create transactions — wire `enqueueCategorization` there too after Task 5 is verified working.

--- a/packages/ui/src/components/data-table.tsx
+++ b/packages/ui/src/components/data-table.tsx
@@ -47,6 +47,8 @@ import {
    ChevronDown,
    ChevronRight,
    GripVertical,
+   Pin,
+   PinOff,
    Settings2,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -86,6 +88,12 @@ import {
    TableHeader,
    TableRow,
 } from "./table";
+import {
+   Tooltip,
+   TooltipContent,
+   TooltipProvider,
+   TooltipTrigger,
+} from "./tooltip";
 
 declare module "@tanstack/react-table" {
    // oxlint-ignore @typescript-eslint/no-unused-vars
@@ -176,13 +184,14 @@ function getPageNumbers(currentPage: number, totalPages: number): number[] {
 // DnD — Sortable header cell
 // =============================================================================
 
-function SortableHeaderCell({
+function SortableHeaderCell<TData>({
    headerId,
    colSpan,
    children,
    pinningStyle,
    isPinned,
    align,
+   column,
 }: {
    headerId: string;
    colSpan: number;
@@ -190,6 +199,7 @@ function SortableHeaderCell({
    pinningStyle?: React.CSSProperties;
    isPinned?: false | "left" | "right";
    align?: "left" | "center" | "right";
+   column: Column<TData>;
 }) {
    const {
       attributes,
@@ -207,7 +217,7 @@ function SortableHeaderCell({
          className={cn(
             "text-xs font-medium",
             isDragging && "opacity-50",
-            isPinned ? "sticky bg-background" : "relative",
+            isPinned ? "sticky bg-inherit" : "relative",
             isDragging ? (isPinned ? "z-[2]" : "z-[1]") : isPinned && "z-[1]",
             align === "right" && "text-right",
             align === "center" && "text-center",
@@ -228,6 +238,31 @@ function SortableHeaderCell({
                <GripVertical className="size-3.5" />
             </button>
             {children}
+            <TooltipProvider>
+               <Tooltip>
+                  <TooltipTrigger asChild>
+                     <button
+                        type="button"
+                        className={cn(
+                           "ml-1 flex size-5 items-center justify-center rounded transition-opacity",
+                           isPinned
+                              ? "opacity-100 text-muted-foreground"
+                              : "opacity-0 group-hover:opacity-100 text-muted-foreground/50 hover:text-muted-foreground",
+                        )}
+                        onClick={() => column.pin(isPinned ? false : "left")}
+                     >
+                        {isPinned ? (
+                           <PinOff className="size-3" />
+                        ) : (
+                           <Pin className="size-3" />
+                        )}
+                     </button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                     {isPinned ? "Desafixar coluna" : "Fixar coluna"}
+                  </TooltipContent>
+               </Tooltip>
+            </TooltipProvider>
          </div>
       </TableHead>
    );
@@ -351,6 +386,7 @@ function DataTableHeaderRow<TData>({
                pinningStyle={getPinningOffsets(header.column)}
                isPinned={header.column.getIsPinned()}
                align={header.column.columnDef.meta?.align}
+               column={header.column}
             >
                {content}
             </SortableHeaderCell>
@@ -363,7 +399,7 @@ function DataTableHeaderRow<TData>({
             colSpan={header.colSpan}
             className={cn(
                "text-xs font-medium",
-               header.column.getIsPinned() && "sticky z-[1] bg-background",
+               header.column.getIsPinned() && "sticky z-[1] bg-inherit",
                header.column.columnDef.meta?.align === "right" && "text-right",
                header.column.columnDef.meta?.align === "center" &&
                   "text-center",
@@ -458,7 +494,7 @@ function DataTableBodyRow<TData>({
             <TableCell
                className={cn(
                   "truncate",
-                  cell.column.getIsPinned() && "sticky z-[1] bg-background",
+                  cell.column.getIsPinned() && "sticky z-[1] bg-inherit",
                   cell.column.columnDef.meta?.align === "right" && "text-right",
                   cell.column.columnDef.meta?.align === "center" &&
                      "text-center",
@@ -861,7 +897,10 @@ export function DataTable<TData, TValue>({
          rowSelection,
          sorting: effectiveSorting,
          columnOrder,
-         columnPinning: tableState?.columnPinning ?? {},
+         columnPinning: {
+            ...tableState?.columnPinning,
+            right: [...(tableState?.columnPinning?.right ?? []), "__actions"],
+         },
       },
    });
 

--- a/scripts/dev-init.ts
+++ b/scripts/dev-init.ts
@@ -41,7 +41,14 @@ if (!fs.existsSync(envLocalPath)) {
    );
 }
 
-// ── 2. Start containers ───────────────────────────────────────────────────────
+// ── 2. Install dependencies if needed ────────────────────────────────────────
+if (!fs.existsSync("node_modules")) {
+   step("node_modules not found — installing dependencies...");
+   run("bun install");
+   ok("Dependencies installed.");
+}
+
+// ── 3. Start containers ───────────────────────────────────────────────────────
 step("Starting containers...");
 try {
    run("bun run --cwd apps/web container-start");
@@ -49,7 +56,7 @@ try {
    console.log(colors.yellow("⚠ Could not start containers — continuing."));
 }
 
-// ── 3. Push DB schema ─────────────────────────────────────────────────────────
+// ── 4. Push DB schema ─────────────────────────────────────────────────────────
 step("Pushing database schema...");
 try {
    run("bun run db:push");
@@ -59,7 +66,7 @@ try {
    );
 }
 
-// ── 4. Seed event catalog ─────────────────────────────────────────────────────
+// ── 5. Seed event catalog ─────────────────────────────────────────────────────
 step("Seeding event catalog...");
 try {
    run("bun run scripts/seed-event-catalog.ts run --env local");


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Este PR implementa auto-categorização de transações via LLM: ao criar uma transação com `autoCategorize: true` e sem categoria, um workflow DBOS é disparado de forma assíncrona (*fire-and-forget*). O workflow tenta primeiro um match por palavras-chave no banco, e só chama a IA quando necessário. Resultados de alta confiança definem `categoryId` diretamente; baixa confiança grava em `suggestedCategoryId` para o usuário revisar via badge "sugestão IA" na tabela de transações.

O `runner.ts` centraliza o despacho dos workflows DBOS (refatoração que também beneficia o fluxo de `categories`), e a migração adiciona a coluna `suggested_category_id` com FK e índice corretos.

<h3>Confidence Score: 5/5</h3>

PR está seguro para merge — os dois apontamentos são P2 (especulativos/UX) e não bloqueiam a funcionalidade.

A implementação é sólida: schema com FK + índice correto, workflow DBOS com deduplicação por workflowID, opt-in explícito via autoCategorize, ownership check nos novos procedures. Os dois apontamentos restantes são P2: a race condition requer uma janela de milissegundos improvável na prática, e a falta de feedback de erro é UX menor coberta trivialmente com onError. Nenhum item bloqueia merge.

apps/web/src/integrations/dbos/workflows/categorization.workflow.ts (applyStep blind update) e apps/web/src/features/transactions/ui/transactions-columns.tsx (sem onError nas mutações).

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/integrations/dbos/workflows/categorization.workflow.ts | Novo workflow DBOS de auto-categorização: keyword match no DB primeiro, fallback para IA (OpenRouter) — applyStep faz UPDATE cego em categoryId sem checar se foi preenchido manualmente entretempos. |
| apps/web/src/integrations/dbos/workflows/runner.ts | Novo módulo centralizador de despacho DBOS — encapsula DBOS.startWorkflow com logging de erros e registro tardio de classes para evitar imports circulares. |
| apps/web/src/integrations/orpc/router/transactions.ts | Adiciona autoCategorize opt-in em create, importStatement e importBulk, além dos procedures acceptSuggestedCategory e dismissSuggestedCategory com ownership check. |
| core/database/src/schemas/transactions.ts | Adiciona coluna suggested_category_id com FK para categories (onDelete: set null) e índice explícito — schema correto. |
| core/database/src/repositories/transactions-repository.ts | Adiciona bulkCreateTransactions e updateTransactionCategory; join para suggestedCategoryName em listTransactions; updateTransaction limpa suggestedCategoryId ao setar categoryId manualmente. |
| core/database/src/repositories/categories-repository.ts | Adiciona findCategoryByKeywords com query PostgreSQL parametrizada (ILIKE via unnest), ordenada por level desc para preferir categorias mais específicas. |
| apps/web/src/features/transactions/ui/transactions-columns.tsx | Adiciona SuggestedCategoryCell com Popover accept/dismiss — mutações sem handler de erro; o MutationCache global não cobre onError. |
| apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/statement-import-credenza.tsx | UX de importação refatorada para importar todos os lançamentos válidos automaticamente; feedback de auto-categorização por keyword com contagem de matches. |
| apps/web/src/server.ts | Boot de DBOS agora aguarda import dinâmico dos workflows antes de launchDBOS(), garantindo que as classes estejam registradas antes da inicialização. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as Frontend
    participant Router as transactions.create (oRPC)
    participant DBOS as CategorizationWorkflow
    participant DB as PostgreSQL

    UI->>Router: create({ autoCategorize: true, type: expense, ... })
    Router->>DB: INSERT INTO transactions
    DB-->>Router: { id, name, type, categoryId }
    Router->>DBOS: startCategorizationWorkflow (fire & forget)
    Router-->>UI: transaction

    DBOS->>DB: matchKeywordsStep (ILIKE against keywords[])
    alt keyword match found
        DB-->>DBOS: { id: categoryId }
        DBOS->>DB: updateTransactionCategory({ categoryId })
    else no keyword match
        DB-->>DBOS: null
        DBOS->>DB: listCategories
        DB-->>DBOS: categories[]
        DBOS->>DBOS: inferWithAIStep (OpenRouter)
        alt confidence = high
            DBOS->>DB: updateTransactionCategory({ categoryId })
        else confidence = low
            DBOS->>DB: updateTransactionCategory({ suggestedCategoryId })
            Note over UI,DB: Badge sugestao IA aparece na tabela
            UI->>Router: acceptSuggestedCategory / dismissSuggestedCategory
            Router->>DB: updateTransactionCategory(...)
        end
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/web/src/features/transactions/ui/transactions-columns.tsx`, line 88 ([link](https://github.com/montte-erp/montte-nx/blob/d0f483f9751f06c1904d81a2f97676d6a878616a/apps/web/src/features/transactions/ui/transactions-columns.tsx#L88)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Uso de `mb-2` proibido pelo guia de estilo**

   O projeto proíbe utilities de margem (`m-`, `mt-`, `mb-`, etc.) — use `gap-*` com flex/grid no elemento pai. Basta remover o `mb-2` do `<p>`, pois o `<div className="flex gap-2">` abaixo já garante o espaçamento correto.

   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=50793934-4fc6-4fd8-9b91-f358e100c905))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/features/transactions/ui/transactions-columns.tsx
   Line: 88
   
   Comment:
   **Uso de `mb-2` proibido pelo guia de estilo**
   
   O projeto proíbe utilities de margem (`m-`, `mt-`, `mb-`, etc.) — use `gap-*` com flex/grid no elemento pai. Basta remover o `mb-2` do `<p>`, pois o `<div className="flex gap-2">` abaixo já garante o espaçamento correto.
   
   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=50793934-4fc6-4fd8-9b91-f358e100c905))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
   
   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Ffeatures%2Ftransactions%2Fui%2Ftransactions-columns.tsx%0ALine%3A%2088%0A%0AComment%3A%0A**Uso%20de%20%60mb-2%60%20proibido%20pelo%20guia%20de%20estilo**%0A%0AO%20projeto%20pro%C3%ADbe%20utilities%20de%20margem%20%28%60m-%60%2C%20%60mt-%60%2C%20%60mb-%60%2C%20etc.%29%20%E2%80%94%20use%20%60gap-*%60%20com%20flex%2Fgrid%20no%20elemento%20pai.%20Basta%20remover%20o%20%60mb-2%60%20do%20%60%3Cp%3E%60%2C%20pois%20o%20%60%3Cdiv%20className%3D%22flex%20gap-2%22%3E%60%20abaixo%20j%C3%A1%20garante%20o%20espa%C3%A7amento%20correto.%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D50793934-4fc6-4fd8-9b91-f358e100c905%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=montte-erp%2Fmontte-nx"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Ffeatures%2Ftransactions%2Fui%2Ftransactions-columns.tsx%0ALine%3A%2088%0A%0AComment%3A%0A**Uso%20de%20%60mb-2%60%20proibido%20pelo%20guia%20de%20estilo**%0A%0AO%20projeto%20pro%C3%ADbe%20utilities%20de%20margem%20%28%60m-%60%2C%20%60mt-%60%2C%20%60mb-%60%2C%20etc.%29%20%E2%80%94%20use%20%60gap-*%60%20com%20flex%2Fgrid%20no%20elemento%20pai.%20Basta%20remover%20o%20%60mb-2%60%20do%20%60%3Cp%3E%60%2C%20pois%20o%20%60%3Cdiv%20className%3D%22flex%20gap-2%22%3E%60%20abaixo%20j%C3%A1%20garante%20o%20espa%C3%A7amento%20correto.%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D50793934-4fc6-4fd8-9b91-f358e100c905%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22montte-erp%2Fmontte-nx%22%20on%20the%20existing%20branch%20%22manoelnetocarvalho03%2Fmon-246-featagents-auto-categorize-transactions-on-creation-via-llm%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22manoelnetocarvalho03%2Fmon-246-featagents-auto-categorize-transactions-on-creation-via-llm%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Ffeatures%2Ftransactions%2Fui%2Ftransactions-columns.tsx%0ALine%3A%2088%0A%0AComment%3A%0A**Uso%20de%20%60mb-2%60%20proibido%20pelo%20guia%20de%20estilo**%0A%0AO%20projeto%20pro%C3%ADbe%20utilities%20de%20margem%20%28%60m-%60%2C%20%60mt-%60%2C%20%60mb-%60%2C%20etc.%29%20%E2%80%94%20use%20%60gap-*%60%20com%20flex%2Fgrid%20no%20elemento%20pai.%20Basta%20remover%20o%20%60mb-2%60%20do%20%60%3Cp%3E%60%2C%20pois%20o%20%60%3Cdiv%20className%3D%22flex%20gap-2%22%3E%60%20abaixo%20j%C3%A1%20garante%20o%20espa%C3%A7amento%20correto.%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D50793934-4fc6-4fd8-9b91-f358e100c905%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Ftransactions%2Fui%2Ftransactions-columns.tsx%3A71-76%0A**Muta%C3%A7%C3%B5es%20sem%20feedback%20de%20erro%20ao%20usu%C3%A1rio**%0A%0AO%20%60accept.mutate%28%29%60%20e%20o%20%60dismiss.mutate%28%29%60%20n%C3%A3o%20t%C3%AAm%20%60onError%60.%20O%20%60MutationCache%60%20global%20%28%60root-provider.tsx%60%29%20tem%20apenas%20%60onSuccess%60%20%E2%80%94%20logo%2C%20se%20o%20servidor%20retornar%20erro%20%28ex.%3A%20sugest%C3%A3o%20j%C3%A1%20aceita%20em%20outra%20aba%2C%20timeout%29%2C%20o%20popover%20simplesmente%20fica%20est%C3%A1tico%20sem%20nenhum%20aviso%20ao%20usu%C3%A1rio.%0A%0AConsidere%20passar%20um%20callback%20de%20erro%3A%0A%0A%60%60%60tsx%0Aconst%20accept%20%3D%20useMutation%28%7B%0A%20%20%20...orpc.transactions.acceptSuggestedCategory.mutationOptions%28%29%2C%0A%20%20%20onError%3A%20%28%29%20%3D%3E%20toast.error%28%22Falha%20ao%20aceitar%20sugest%C3%A3o.%22%29%2C%0A%7D%29%3B%0Aconst%20dismiss%20%3D%20useMutation%28%7B%0A%20%20%20...orpc.transactions.dismissSuggestedCategory.mutationOptions%28%29%2C%0A%20%20%20onError%3A%20%28%29%20%3D%3E%20toast.error%28%22Falha%20ao%20ignorar%20sugest%C3%A3o.%22%29%2C%0A%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Fintegrations%2Fdbos%2Fworkflows%2Fcategorization.workflow.ts%3A110-116%0A**%60applyStep%60%20sobrescreve%20categoria%20definida%20manualmente**%0A%0APara%20resultados%20de%20alta%20confian%C3%A7a%2C%20o%20%60applyStep%60%20executa%20um%20%60UPDATE%60%20cego%20em%20%60category_id%60%20sem%20verificar%20se%20o%20campo%20j%C3%A1%20foi%20preenchido%20pelo%20usu%C3%A1rio.%20Se%20o%20usu%C3%A1rio%20editar%20a%20transa%C3%A7%C3%A3o%20e%20definir%20uma%20categoria%20manualmente%20enquanto%20o%20workflow%20ainda%20est%C3%A1%20em%20execu%C3%A7%C3%A3o%20%28ex.%3A%20o%20step%20de%20IA%20demorou%20alguns%20segundos%29%2C%20a%20escolha%20manual%20%C3%A9%20silenciosamente%20descartada.%0A%0APara%20evitar%20isso%2C%20adicione%20%60WHERE%20category_id%20IS%20NULL%60%20%C3%A0%20query%20de%20atualiza%C3%A7%C3%A3o%20quando%20%60data.categoryId%60%20est%C3%A1%20presente%20%E2%80%94%20deixando%20a%20atualiza%C3%A7%C3%A3o%20de%20%60suggestedCategoryId%60%20sem%20essa%20restri%C3%A7%C3%A3o%3A%0A%0A%60%60%60typescript%0A%2F%2F%20No%20updateTransactionCategory%2C%20use%20condi%C3%A7%C3%A3o%20diferente%20por%20campo%3A%0Aconst%20whereClause%20%3D%20data.categoryId%20!%3D%3D%20undefined%0A%20%20%20%3F%20and%28eq%28transactions.id%2C%20id%29%2C%20isNull%28transactions.categoryId%29%29%0A%20%20%20%3A%20eq%28transactions.id%2C%20id%29%3B%0A%0Aawait%20db.update%28transactions%29.set%28%7B%20...data%2C%20updatedAt%3A%20new%20Date%28%29%20%7D%29.where%28whereClause%29%3B%0A%60%60%60%0A%0A&repo=montte-erp%2Fmontte-nx"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Ftransactions%2Fui%2Ftransactions-columns.tsx%3A71-76%0A**Muta%C3%A7%C3%B5es%20sem%20feedback%20de%20erro%20ao%20usu%C3%A1rio**%0A%0AO%20%60accept.mutate%28%29%60%20e%20o%20%60dismiss.mutate%28%29%60%20n%C3%A3o%20t%C3%AAm%20%60onError%60.%20O%20%60MutationCache%60%20global%20%28%60root-provider.tsx%60%29%20tem%20apenas%20%60onSuccess%60%20%E2%80%94%20logo%2C%20se%20o%20servidor%20retornar%20erro%20%28ex.%3A%20sugest%C3%A3o%20j%C3%A1%20aceita%20em%20outra%20aba%2C%20timeout%29%2C%20o%20popover%20simplesmente%20fica%20est%C3%A1tico%20sem%20nenhum%20aviso%20ao%20usu%C3%A1rio.%0A%0AConsidere%20passar%20um%20callback%20de%20erro%3A%0A%0A%60%60%60tsx%0Aconst%20accept%20%3D%20useMutation%28%7B%0A%20%20%20...orpc.transactions.acceptSuggestedCategory.mutationOptions%28%29%2C%0A%20%20%20onError%3A%20%28%29%20%3D%3E%20toast.error%28%22Falha%20ao%20aceitar%20sugest%C3%A3o.%22%29%2C%0A%7D%29%3B%0Aconst%20dismiss%20%3D%20useMutation%28%7B%0A%20%20%20...orpc.transactions.dismissSuggestedCategory.mutationOptions%28%29%2C%0A%20%20%20onError%3A%20%28%29%20%3D%3E%20toast.error%28%22Falha%20ao%20ignorar%20sugest%C3%A3o.%22%29%2C%0A%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Fintegrations%2Fdbos%2Fworkflows%2Fcategorization.workflow.ts%3A110-116%0A**%60applyStep%60%20sobrescreve%20categoria%20definida%20manualmente**%0A%0APara%20resultados%20de%20alta%20confian%C3%A7a%2C%20o%20%60applyStep%60%20executa%20um%20%60UPDATE%60%20cego%20em%20%60category_id%60%20sem%20verificar%20se%20o%20campo%20j%C3%A1%20foi%20preenchido%20pelo%20usu%C3%A1rio.%20Se%20o%20usu%C3%A1rio%20editar%20a%20transa%C3%A7%C3%A3o%20e%20definir%20uma%20categoria%20manualmente%20enquanto%20o%20workflow%20ainda%20est%C3%A1%20em%20execu%C3%A7%C3%A3o%20%28ex.%3A%20o%20step%20de%20IA%20demorou%20alguns%20segundos%29%2C%20a%20escolha%20manual%20%C3%A9%20silenciosamente%20descartada.%0A%0APara%20evitar%20isso%2C%20adicione%20%60WHERE%20category_id%20IS%20NULL%60%20%C3%A0%20query%20de%20atualiza%C3%A7%C3%A3o%20quando%20%60data.categoryId%60%20est%C3%A1%20presente%20%E2%80%94%20deixando%20a%20atualiza%C3%A7%C3%A3o%20de%20%60suggestedCategoryId%60%20sem%20essa%20restri%C3%A7%C3%A3o%3A%0A%0A%60%60%60typescript%0A%2F%2F%20No%20updateTransactionCategory%2C%20use%20condi%C3%A7%C3%A3o%20diferente%20por%20campo%3A%0Aconst%20whereClause%20%3D%20data.categoryId%20!%3D%3D%20undefined%0A%20%20%20%3F%20and%28eq%28transactions.id%2C%20id%29%2C%20isNull%28transactions.categoryId%29%29%0A%20%20%20%3A%20eq%28transactions.id%2C%20id%29%3B%0A%0Aawait%20db.update%28transactions%29.set%28%7B%20...data%2C%20updatedAt%3A%20new%20Date%28%29%20%7D%29.where%28whereClause%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22montte-erp%2Fmontte-nx%22%20on%20the%20existing%20branch%20%22manoelnetocarvalho03%2Fmon-246-featagents-auto-categorize-transactions-on-creation-via-llm%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22manoelnetocarvalho03%2Fmon-246-featagents-auto-categorize-transactions-on-creation-via-llm%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Ftransactions%2Fui%2Ftransactions-columns.tsx%3A71-76%0A**Muta%C3%A7%C3%B5es%20sem%20feedback%20de%20erro%20ao%20usu%C3%A1rio**%0A%0AO%20%60accept.mutate%28%29%60%20e%20o%20%60dismiss.mutate%28%29%60%20n%C3%A3o%20t%C3%AAm%20%60onError%60.%20O%20%60MutationCache%60%20global%20%28%60root-provider.tsx%60%29%20tem%20apenas%20%60onSuccess%60%20%E2%80%94%20logo%2C%20se%20o%20servidor%20retornar%20erro%20%28ex.%3A%20sugest%C3%A3o%20j%C3%A1%20aceita%20em%20outra%20aba%2C%20timeout%29%2C%20o%20popover%20simplesmente%20fica%20est%C3%A1tico%20sem%20nenhum%20aviso%20ao%20usu%C3%A1rio.%0A%0AConsidere%20passar%20um%20callback%20de%20erro%3A%0A%0A%60%60%60tsx%0Aconst%20accept%20%3D%20useMutation%28%7B%0A%20%20%20...orpc.transactions.acceptSuggestedCategory.mutationOptions%28%29%2C%0A%20%20%20onError%3A%20%28%29%20%3D%3E%20toast.error%28%22Falha%20ao%20aceitar%20sugest%C3%A3o.%22%29%2C%0A%7D%29%3B%0Aconst%20dismiss%20%3D%20useMutation%28%7B%0A%20%20%20...orpc.transactions.dismissSuggestedCategory.mutationOptions%28%29%2C%0A%20%20%20onError%3A%20%28%29%20%3D%3E%20toast.error%28%22Falha%20ao%20ignorar%20sugest%C3%A3o.%22%29%2C%0A%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Fintegrations%2Fdbos%2Fworkflows%2Fcategorization.workflow.ts%3A110-116%0A**%60applyStep%60%20sobrescreve%20categoria%20definida%20manualmente**%0A%0APara%20resultados%20de%20alta%20confian%C3%A7a%2C%20o%20%60applyStep%60%20executa%20um%20%60UPDATE%60%20cego%20em%20%60category_id%60%20sem%20verificar%20se%20o%20campo%20j%C3%A1%20foi%20preenchido%20pelo%20usu%C3%A1rio.%20Se%20o%20usu%C3%A1rio%20editar%20a%20transa%C3%A7%C3%A3o%20e%20definir%20uma%20categoria%20manualmente%20enquanto%20o%20workflow%20ainda%20est%C3%A1%20em%20execu%C3%A7%C3%A3o%20%28ex.%3A%20o%20step%20de%20IA%20demorou%20alguns%20segundos%29%2C%20a%20escolha%20manual%20%C3%A9%20silenciosamente%20descartada.%0A%0APara%20evitar%20isso%2C%20adicione%20%60WHERE%20category_id%20IS%20NULL%60%20%C3%A0%20query%20de%20atualiza%C3%A7%C3%A3o%20quando%20%60data.categoryId%60%20est%C3%A1%20presente%20%E2%80%94%20deixando%20a%20atualiza%C3%A7%C3%A3o%20de%20%60suggestedCategoryId%60%20sem%20essa%20restri%C3%A7%C3%A3o%3A%0A%0A%60%60%60typescript%0A%2F%2F%20No%20updateTransactionCategory%2C%20use%20condi%C3%A7%C3%A3o%20diferente%20por%20campo%3A%0Aconst%20whereClause%20%3D%20data.categoryId%20!%3D%3D%20undefined%0A%20%20%20%3F%20and%28eq%28transactions.id%2C%20id%29%2C%20isNull%28transactions.categoryId%29%29%0A%20%20%20%3A%20eq%28transactions.id%2C%20id%29%3B%0A%0Aawait%20db.update%28transactions%29.set%28%7B%20...data%2C%20updatedAt%3A%20new%20Date%28%29%20%7D%29.where%28whereClause%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/web/src/features/transactions/ui/transactions-columns.tsx
Line: 71-76

Comment:
**Mutações sem feedback de erro ao usuário**

O `accept.mutate()` e o `dismiss.mutate()` não têm `onError`. O `MutationCache` global (`root-provider.tsx`) tem apenas `onSuccess` — logo, se o servidor retornar erro (ex.: sugestão já aceita em outra aba, timeout), o popover simplesmente fica estático sem nenhum aviso ao usuário.

Considere passar um callback de erro:

```tsx
const accept = useMutation({
   ...orpc.transactions.acceptSuggestedCategory.mutationOptions(),
   onError: () => toast.error("Falha ao aceitar sugestão."),
});
const dismiss = useMutation({
   ...orpc.transactions.dismissSuggestedCategory.mutationOptions(),
   onError: () => toast.error("Falha ao ignorar sugestão."),
});
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/src/integrations/dbos/workflows/categorization.workflow.ts
Line: 110-116

Comment:
**`applyStep` sobrescreve categoria definida manualmente**

Para resultados de alta confiança, o `applyStep` executa um `UPDATE` cego em `category_id` sem verificar se o campo já foi preenchido pelo usuário. Se o usuário editar a transação e definir uma categoria manualmente enquanto o workflow ainda está em execução (ex.: o step de IA demorou alguns segundos), a escolha manual é silenciosamente descartada.

Para evitar isso, adicione `WHERE category_id IS NULL` à query de atualização quando `data.categoryId` está presente — deixando a atualização de `suggestedCategoryId` sem essa restrição:

```typescript
// No updateTransactionCategory, use condição diferente por campo:
const whereClause = data.categoryId !== undefined
   ? and(eq(transactions.id, id), isNull(transactions.categoryId))
   : eq(transactions.id, id);

await db.update(transactions).set({ ...data, updatedAt: new Date() }).where(whereClause);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["refactor(transactions): Remove autoCateg..."](https://github.com/montte-erp/montte-nx/commit/7c4aa1aacf8a7b0ba5dc54c5698a1e047b01b071) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28201571)</sub>

<!-- /greptile_comment -->