### PR TITLE
fix(hyprpay): use databaseHooks for customer sync, fix Better Auth crash

### DIFF
--- a/libraries/hyprpay/CHANGELOG.md
+++ b/libraries/hyprpay/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.1]
+
+### Fixed
+
+- Better Auth plugin: replace request `after` hooks with `databaseHooks.user.create.after` — fires on every user creation regardless of sign-up method (email, magic link, OAuth, OTP); eliminates the `TypeError: Cannot read properties of undefined (reading 'headers')` crash caused by raw async after-hook handlers returning `undefined` instead of a proper response object
+- Better Auth plugin: replace try/catch on `onCustomerCreate` with `fromPromise` (neverthrow)
+
 ## [0.1.0]
 
 ### Added

--- a/libraries/hyprpay/package.json
+++ b/libraries/hyprpay/package.json
@@ -1,6 +1,6 @@
 {
    "name": "@montte/hyprpay",
-   "version": "0.1.0",
+   "version": "0.1.1",
    "private": false,
    "description": "HyprPay SDK — sincronize o ciclo de vida de clientes com o Montte",
    "keywords": [

--- a/libraries/hyprpay/src/better-auth/index.test.ts
+++ b/libraries/hyprpay/src/better-auth/index.test.ts
@@ -15,13 +15,26 @@ async function importPlugin() {
    return mod;
 }
 
-const mockUser = { id: "u1", name: "Alice", email: "alice@example.com" };
+const mockUser = {
+   id: "u1",
+   name: "Alice",
+   email: "alice@example.com",
+   createdAt: new Date(),
+   updatedAt: new Date(),
+   emailVerified: false,
+   image: null,
+};
 
-function buildContext(body: unknown = {}) {
-   return {
-      path: "/sign-up/email",
-      body,
-   };
+function getAfterHook(
+   options: Parameters<(typeof import("./index"))["hyprpay"]>[0],
+) {
+   return importPlugin().then(({ hyprpay }) => {
+      const plugin = hyprpay(options);
+      const after = plugin.init?.({} as never)?.options?.databaseHooks?.user
+         ?.create?.after;
+      if (!after) throw new Error("after hook not found");
+      return after;
+   });
 }
 
 describe("hyprpay better-auth plugin", () => {
@@ -41,48 +54,23 @@ describe("hyprpay better-auth plugin", () => {
       expect(plugin.id).toBe("hyprpay");
    });
 
-   describe("sign-up hook", () => {
-      async function runHook(
-         options: Parameters<(typeof import("./index"))["hyprpay"]>[0],
-         context: { path: string; body: unknown },
-      ) {
-         const { hyprpay } = await importPlugin();
-         const plugin = hyprpay(options);
-         const handler = plugin.hooks?.after?.[0]?.handler;
-         if (!handler) throw new Error("handler not found");
-         await handler(context as never);
-      }
-
+   describe("databaseHooks.user.create.after", () => {
       it("does nothing when createCustomerOnSignUp is false", async () => {
-         await runHook(
-            { apiKey: "key", createCustomerOnSignUp: false },
-            buildContext({ user: mockUser }),
-         );
-         expect(mockCreate).not.toHaveBeenCalled();
-      });
-
-      it("does nothing when user is missing from body", async () => {
-         await runHook(
-            { apiKey: "key", createCustomerOnSignUp: true },
-            buildContext({}),
-         );
-         expect(mockCreate).not.toHaveBeenCalled();
-      });
-
-      it("does nothing when user.id is missing", async () => {
-         await runHook(
-            { apiKey: "key", createCustomerOnSignUp: true },
-            buildContext({ user: { name: "Alice", email: "a@b.com" } }),
-         );
+         const after = await getAfterHook({
+            apiKey: "key",
+            createCustomerOnSignUp: false,
+         });
+         await after(mockUser, null);
          expect(mockCreate).not.toHaveBeenCalled();
       });
 
       it("calls sdkClient.customers.create with default mapper", async () => {
          mockCreate.mockResolvedValueOnce(ok({ id: "c1" }));
-         await runHook(
-            { apiKey: "key", createCustomerOnSignUp: true },
-            buildContext({ user: mockUser }),
-         );
+         const after = await getAfterHook({
+            apiKey: "key",
+            createCustomerOnSignUp: true,
+         });
+         await after(mockUser, null);
          expect(mockCreate).toHaveBeenCalledWith({
             name: "Alice",
             email: "alice@example.com",
@@ -92,17 +80,15 @@ describe("hyprpay better-auth plugin", () => {
 
       it("uses custom customerData mapper when provided", async () => {
          mockCreate.mockResolvedValueOnce(ok({ id: "c1" }));
-         await runHook(
-            {
-               apiKey: "key",
-               createCustomerOnSignUp: true,
-               customerData: (u) => ({
-                  name: `CUSTOM-${u.name}`,
-                  externalId: u.id,
-               }),
-            },
-            buildContext({ user: mockUser }),
-         );
+         const after = await getAfterHook({
+            apiKey: "key",
+            createCustomerOnSignUp: true,
+            customerData: (u) => ({
+               name: `CUSTOM-${u.name}`,
+               externalId: u.id,
+            }),
+         });
+         await after(mockUser, null);
          expect(mockCreate).toHaveBeenCalledWith({
             name: "CUSTOM-Alice",
             externalId: "u1",
@@ -113,10 +99,12 @@ describe("hyprpay better-auth plugin", () => {
          const customer = { id: "c1", name: "Alice" };
          mockCreate.mockResolvedValueOnce(ok(customer));
          const onCustomerCreate = vi.fn().mockResolvedValue(undefined);
-         await runHook(
-            { apiKey: "key", createCustomerOnSignUp: true, onCustomerCreate },
-            buildContext({ user: mockUser }),
-         );
+         const after = await getAfterHook({
+            apiKey: "key",
+            createCustomerOnSignUp: true,
+            onCustomerCreate,
+         });
+         await after(mockUser, null);
          expect(onCustomerCreate).toHaveBeenCalledWith(customer, mockUser);
       });
 
@@ -125,12 +113,11 @@ describe("hyprpay better-auth plugin", () => {
             .spyOn(console, "error")
             .mockImplementation(() => {});
          mockCreate.mockResolvedValueOnce(err(HyprPayError.internal("fail")));
-         await expect(
-            runHook(
-               { apiKey: "key", createCustomerOnSignUp: true },
-               buildContext({ user: mockUser }),
-            ),
-         ).resolves.toBeUndefined();
+         const after = await getAfterHook({
+            apiKey: "key",
+            createCustomerOnSignUp: true,
+         });
+         await expect(after(mockUser, null)).resolves.toBeUndefined();
          expect(consoleError).toHaveBeenCalledWith(
             "[hyprpay] customer creation failed",
             expect.any(HyprPayError),
@@ -147,44 +134,23 @@ describe("hyprpay better-auth plugin", () => {
          const onCustomerCreate = vi
             .fn()
             .mockRejectedValue(new Error("callback boom"));
-         await expect(
-            runHook(
-               {
-                  apiKey: "key",
-                  createCustomerOnSignUp: true,
-                  onCustomerCreate,
-               },
-               buildContext({ user: mockUser }),
-            ),
-         ).resolves.toBeUndefined();
+         const after = await getAfterHook({
+            apiKey: "key",
+            createCustomerOnSignUp: true,
+            onCustomerCreate,
+         });
+         await expect(after(mockUser, null)).resolves.toBeUndefined();
          expect(consoleError).toHaveBeenCalledWith(
             "[hyprpay] onCustomerCreate threw",
             expect.any(Error),
          );
          consoleError.mockRestore();
       });
-
-      it.each(["/sign-up/email", "/sign-up/email-otp", "/sign-in/magic-link"])(
-         "matcher returns true for %s",
-         async (path) => {
-            const { hyprpay } = await importPlugin();
-            const plugin = hyprpay({ apiKey: "key" });
-            const matcher = plugin.hooks?.after?.[0]?.matcher;
-            expect(matcher?.({ path } as never)).toBe(true);
-         },
-      );
-
-      it("matcher returns false for other paths", async () => {
-         const { hyprpay } = await importPlugin();
-         const plugin = hyprpay({ apiKey: "key" });
-         const matcher = plugin.hooks?.after?.[0]?.matcher;
-         expect(matcher?.({ path: "/sign-in/email" } as never)).toBe(false);
-      });
    });
 
    describe("hyprpayClient", () => {
       it("returns client plugin with id 'hyprpay'", async () => {
-         const { hyprpayClient, hyprpay } = await importPlugin();
+         const { hyprpayClient } = await importPlugin();
          const client = hyprpayClient();
          expect(client.id).toBe("hyprpay");
          expect(client.$InferServerPlugin).toBeDefined();

--- a/libraries/hyprpay/src/better-auth/index.ts
+++ b/libraries/hyprpay/src/better-auth/index.ts
@@ -1,5 +1,6 @@
 import type { BetterAuthPlugin } from "better-auth";
 import type { BetterAuthClientPlugin } from "better-auth/client";
+import { fromPromise } from "neverthrow";
 import { createHyprPayClient } from "../client";
 import type { HyprPayCustomerFromContract as HyprPayCustomer } from "../contract";
 
@@ -40,39 +41,40 @@ export function hyprpay(options: HyprPayPluginOptions): BetterAuthPlugin {
 
    return {
       id: "hyprpay",
-      hooks: {
-         after: [
-            {
-               matcher: (context) =>
-                  context.path === "/sign-up/email" ||
-                  context.path === "/sign-up/email-otp" ||
-                  context.path === "/sign-in/magic-link",
-               handler: async (context) => {
-                  if (!options.createCustomerOnSignUp) return;
+      options: {
+         databaseHooks: {
+            user: {
+               create: {
+                  after: async (user) => {
+                     if (!options.createCustomerOnSignUp) return;
 
-                  const body = context.body as
-                     | { user?: { id: string; name: string; email: string } }
-                     | undefined;
-                  const user = body?.user;
-                  if (!user?.id) return;
+                     const input = mapper(user);
+                     const result = await sdkClient.customers.create(input);
 
-                  const input = mapper(user);
-                  const result = await sdkClient.customers.create(input);
-                  if (result.isErr()) {
-                     console.error(
-                        "[hyprpay] customer creation failed",
-                        result.error,
+                     if (result.isErr()) {
+                        console.error(
+                           "[hyprpay] customer creation failed",
+                           result.error,
+                        );
+                        return;
+                     }
+
+                     if (!options.onCustomerCreate) return;
+
+                     const onCreateResult = await fromPromise(
+                        options.onCustomerCreate(result.value, user),
+                        (e) => e,
                      );
-                     return;
-                  }
-                  try {
-                     await options.onCustomerCreate?.(result.value, user);
-                  } catch (err) {
-                     console.error("[hyprpay] onCustomerCreate threw", err);
-                  }
+                     if (onCreateResult.isErr()) {
+                        console.error(
+                           "[hyprpay] onCustomerCreate threw",
+                           onCreateResult.error,
+                        );
+                     }
+                  },
                },
             },
-         ],
+         },
       },
    };
 }

--- a/libraries/hyprpay/src/better-auth/index.ts
+++ b/libraries/hyprpay/src/better-auth/index.ts
@@ -41,40 +41,45 @@ export function hyprpay(options: HyprPayPluginOptions): BetterAuthPlugin {
 
    return {
       id: "hyprpay",
-      options: {
-         databaseHooks: {
-            user: {
-               create: {
-                  after: async (user) => {
-                     if (!options.createCustomerOnSignUp) return;
+      init() {
+         return {
+            options: {
+               databaseHooks: {
+                  user: {
+                     create: {
+                        after: async (user) => {
+                           if (!options.createCustomerOnSignUp) return;
 
-                     const input = mapper(user);
-                     const result = await sdkClient.customers.create(input);
+                           const input = mapper(user);
+                           const result =
+                              await sdkClient.customers.create(input);
 
-                     if (result.isErr()) {
-                        console.error(
-                           "[hyprpay] customer creation failed",
-                           result.error,
-                        );
-                        return;
-                     }
+                           if (result.isErr()) {
+                              console.error(
+                                 "[hyprpay] customer creation failed",
+                                 result.error,
+                              );
+                              return;
+                           }
 
-                     if (!options.onCustomerCreate) return;
+                           if (!options.onCustomerCreate) return;
 
-                     const onCreateResult = await fromPromise(
-                        options.onCustomerCreate(result.value, user),
-                        (e) => e,
-                     );
-                     if (onCreateResult.isErr()) {
-                        console.error(
-                           "[hyprpay] onCustomerCreate threw",
-                           onCreateResult.error,
-                        );
-                     }
+                           const onCreateResult = await fromPromise(
+                              options.onCustomerCreate(result.value, user),
+                              (e) => e,
+                           );
+                           if (onCreateResult.isErr()) {
+                              console.error(
+                                 "[hyprpay] onCustomerCreate threw",
+                                 onCreateResult.error,
+                              );
+                           }
+                        },
+                     },
                   },
                },
             },
-         },
+         };
       },
    };
 }

--- a/libraries/hyprpay/tsconfig.json
+++ b/libraries/hyprpay/tsconfig.json
@@ -8,5 +8,6 @@
       "skipLibCheck": true,
       "noEmit": true
    },
-   "include": ["src/**/*", "vite.config.ts"]
+   "include": ["src/**/*", "vite.config.ts"],
+   "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

- Replace request `after` hooks with `databaseHooks.user.create.after` — fires on every user creation regardless of sign-up method (email, magic link, OAuth, OTP)
- Fix `TypeError: Cannot read properties of undefined (reading 'headers')` — raw async after-hook handlers return `undefined`, but Better Auth's `runAfterHooks` reads `result.headers` unconditionally; `databaseHooks` sidesteps this entirely
- Replace `try/catch` on `onCustomerCreate` with `fromPromise` (neverthrow)
- Bump `@montte/hyprpay` to `0.1.1`

## Test plan

- [ ] Sign up via email — HyprPay customer created
- [ ] Sign up via magic link — HyprPay customer created
- [ ] Sign in via magic link (existing user) — no duplicate customer attempt (idempotent by `externalId`)
- [ ] `createCustomerOnSignUp: false` — no customer created on any sign-up method

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Esta PR corrige um crash real do Better Auth (`TypeError: Cannot read properties of undefined (reading 'headers')`) substituindo os hooks de request (`hooks.after` com matcher de path) por `databaseHooks.user.create.after`, garantindo que a criação do cliente HyprPay dispare em todos os métodos de sign-up (e-mail, magic link, OAuth, OTP). Também substitui o `try/catch` por `fromPromise` do neverthrow para consistência com os padrões do projeto.

<h3>Confidence Score: 5/5</h3>

PR segura para merge — corrige um crash real sem introduzir regressões ou novos riscos.

Todos os achados são P2 ou inferiores. A substituição para databaseHooks é a abordagem correta no Better Auth para hooks que devem disparar em todo método de sign-up. O uso de fromPromise está alinhado com os padrões neverthrow do projeto. Os testes cobrem os cenários relevantes. Versão e CHANGELOG devidamente bumpeados.

Nenhum arquivo requer atenção especial.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libraries/hyprpay/src/better-auth/index.ts | Substituição de hooks de request por databaseHooks.user.create.after via init(); uso de fromPromise para onCustomerCreate. Implementação correta e coerente com o sistema de plugins do Better Auth. |
| libraries/hyprpay/src/better-auth/index.test.ts | Testes refatorados para acessar o hook via plugin.init().options.databaseHooks; remoção correta dos testes de path-matcher que não se aplicam mais. |
| libraries/hyprpay/tsconfig.json | Adição de exclude para node_modules, dist e arquivos .test.ts — evita que imports de teste (vitest) contaminem a compilação da biblioteca. |
| libraries/hyprpay/CHANGELOG.md | Entrada 0.1.1 adicionada corretamente, descrevendo ambas as correções da PR. |
| libraries/hyprpay/package.json | Bump de versão de 0.1.0 para 0.1.1, alinhado com o CHANGELOG — atende ao requisito do script de release. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant BetterAuth
    participant DB
    participant HyprPayHook as databaseHooks.user.create.after
    participant HyprPayAPI as HyprPay API

    Client->>BetterAuth: sign-up (email / magic-link / OAuth / OTP)
    BetterAuth->>DB: INSERT INTO user
    DB-->>BetterAuth: user row created
    BetterAuth->>HyprPayHook: after(user)
    alt createCustomerOnSignUp = false
        HyprPayHook-->>BetterAuth: return (no-op)
    else createCustomerOnSignUp = true
        HyprPayHook->>HyprPayAPI: customers.create(input)
        alt success
            HyprPayAPI-->>HyprPayHook: Ok(customer)
            HyprPayHook->>HyprPayHook: fromPromise(onCustomerCreate?)
        else failure
            HyprPayAPI-->>HyprPayHook: Err(HyprPayError)
            HyprPayHook->>HyprPayHook: console.error (swallow)
        end
        HyprPayHook-->>BetterAuth: return
    end
    BetterAuth-->>Client: user created response
```

<sub>Reviews (3): Last reviewed commit: ["fix(hyprpay): exclude test files from ts..."](https://github.com/montte-erp/montte-nx/commit/ae12058de45b7edaedb115f18a8fa794ee2a8da1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28484756)</sub>

<!-- /greptile_comment -->