### PR TITLE
fix(hyprpay): correct base URL, RPC path, exclude test files from build

### DIFF
--- a/libraries/hyprpay/CHANGELOG.md
+++ b/libraries/hyprpay/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.1.3]
+
+### Fixed
+
+- Exclude test files from subpaths build script (glob was picking up `*.test.ts`, bundling 617KB test files into the package)
+
+## [0.1.2]
+
+### Fixed
+
+- Set correct default base URL to `https://app.montte.co` and fix RPC path from `/sdk/orpc` to `/api/sdk/hyprpay` — previous path never reached the server router
+
+## [0.1.1]
+
+### Fixed
+
+- Better Auth plugin: replace request `after` hooks with `databaseHooks.user.create.after` — fires on every user creation regardless of sign-up method (email, magic link, OAuth, OTP); eliminates `TypeError: Cannot read properties of undefined (reading 'headers')` crash
+- Better Auth plugin: replace try/catch on `onCustomerCreate` with `fromPromise` (neverthrow)
+- Exclude test files from tsconfig and subpaths build script
+
 ## [0.1.0]
 
 ### Added

--- a/libraries/hyprpay/package.json
+++ b/libraries/hyprpay/package.json
@@ -1,6 +1,6 @@
 {
    "name": "@montte/hyprpay",
-   "version": "0.1.0",
+   "version": "0.1.3",
    "private": false,
    "description": "HyprPay SDK — sincronize o ciclo de vida de clientes com o Montte",
    "keywords": [

--- a/libraries/hyprpay/scripts/build-subpaths.ts
+++ b/libraries/hyprpay/scripts/build-subpaths.ts
@@ -1,9 +1,11 @@
 import { build } from "esbuild";
 import { glob } from "node:fs/promises";
 
-const betterAuthFiles = await Array.fromAsync(
-   glob("src/better-auth/**/*.ts", { cwd: process.cwd() }),
-);
+const betterAuthFiles = (
+   await Array.fromAsync(
+      glob("src/better-auth/**/*.ts", { cwd: process.cwd() }),
+   )
+).filter((f) => !f.endsWith(".test.ts"));
 
 const contractFiles = await Array.fromAsync(
    glob("src/contract.ts", { cwd: process.cwd() }),

--- a/libraries/hyprpay/src/client.ts
+++ b/libraries/hyprpay/src/client.ts
@@ -12,7 +12,7 @@ import type {
    UpdateCustomerInput,
 } from "./types";
 
-const DEFAULT_BASE_URL = "https://api.montte.com.br";
+const DEFAULT_BASE_URL = "https://app.montte.co";
 
 export interface HyprPayClientConfig {
    apiKey: string;
@@ -38,7 +38,7 @@ export function createHyprPayClient(config: HyprPayClientConfig) {
    const { apiKey, baseUrl = DEFAULT_BASE_URL } = config;
 
    const link = new RPCLink({
-      url: `${baseUrl}/sdk/orpc`,
+      url: `${baseUrl}/api/sdk/hyprpay`,
       headers: { "sdk-api-key": apiKey },
    });
 


### PR DESCRIPTION
## Summary

- Fix `DEFAULT_BASE_URL` from `api.montte.com.br` → `https://app.montte.co`
- Fix RPC path from `/sdk/orpc` → `/api/sdk/hyprpay` — `/sdk/orpc` never matched the server router (`/api/sdk/$` with `hyprpay` namespace), causing all SDK calls to fail
- Exclude `*.test.ts` from `build-subpaths.ts` glob — test files were being bundled (617KB) into the published package
- Also carries all fixes from #767 (Better Auth plugin, tsconfig excludes) since that PR hasn't been merged yet

## Published

`@montte/hyprpay@0.1.3` — live on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Este PR corrige três bugs críticos que impediam o SDK `@montte/hyprpay` de funcionar: a URL base estava errada (`api.montte.com.br` vs `app.montte.co`), o caminho RPC `/sdk/orpc` nunca correspondia ao roteador do servidor (que espera `/api/sdk/hyprpay`), e arquivos de teste estavam sendo empacotados no build publicado (617 KB extras). O plugin de Better Auth também foi refatorado para usar `databaseHooks.user.create.after` em vez de `hooks.after`, garantindo que o hook dispare em todos os métodos de cadastro.

<h3>Confidence Score: 5/5</h3>

PR seguro para merge — todas as correções são verificadas e os testes foram atualizados corretamente.

Os três bugs corrigidos são críticos e as soluções estão corretas: o caminho /api/sdk/hyprpay corresponde exatamente ao handler do servidor (prefix /api/sdk + namespace hyprpay), a URL base atualizada é a correta, e o filtro de .test.ts no glob resolve o problema do bundle inflado. O único achado restante é P2 (versões fantasmas no CHANGELOG), que é puramente documental e não afeta o comportamento do pacote publicado.

CHANGELOG.md — contém entradas para versões 0.1.1 e 0.1.2 que nunca foram publicadas no npm.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libraries/hyprpay/src/client.ts | Corrige DEFAULT_BASE_URL (api.montte.com.br → app.montte.co) e o caminho RPC (/sdk/orpc → /api/sdk/hyprpay), que agora corresponde ao handler do servidor com prefix "/api/sdk" e namespace "hyprpay". |
| libraries/hyprpay/scripts/build-subpaths.ts | Adiciona .filter para excluir *.test.ts do glob de betterAuthFiles, evitando que arquivos de teste sejam empacotados no build publicado. |
| libraries/hyprpay/CHANGELOG.md | Documenta três versões (0.1.1, 0.1.2, 0.1.3), mas o package.json pula de 0.1.0 direto para 0.1.3 — as versões intermediárias nunca foram publicadas no npm. |
| libraries/hyprpay/package.json | Versão bumpeada de 0.1.0 para 0.1.3; estrutura e dependências sem problemas. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SDK as @montte/hyprpay SDK
    participant RPCLink as RPCLink (oRPC client)
    participant Server as TanStack Start /api/sdk/$
    participant Handler as RPCHandler (prefix: /api/sdk)
    participant Router as sdkRouter.hyprpay

    Note over SDK,RPCLink: ANTES (quebrado)
    SDK->>RPCLink: url = https://api.montte.com.br/sdk/orpc
    RPCLink->>Server: POST /sdk/orpc/create (rota nao existe)
    Server-->>RPCLink: 404 Not Found

    Note over SDK,Router: DEPOIS (correto)
    SDK->>RPCLink: url = https://app.montte.co/api/sdk/hyprpay
    RPCLink->>Server: POST /api/sdk/hyprpay/create
    Server->>Handler: handle(request, prefix: /api/sdk)
    Handler->>Router: resolve hyprpay.create
    Router-->>SDK: { id, name, email, ... }
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibraries%2Fhyprpay%2FCHANGELOG.md%3A3-21%0A**Vers%C3%B5es%20fantasmas%20no%20CHANGELOG**%0A%0AO%20%60package.json%60%20pula%20de%20%600.1.0%60%20diretamente%20para%20%600.1.3%60%2C%20mas%20o%20CHANGELOG%20documenta%20%600.1.1%60%20e%20%600.1.2%60%20como%20entradas%20separadas%20%E2%80%94%20essas%20vers%C3%B5es%20nunca%20existiram%20no%20npm.%20Consumidores%20da%20biblioteca%20que%20tentarem%20%60npm%20install%20%40montte%2Fhyprpay%400.1.1%60%20receber%C3%A3o%20um%20erro%20404.%20Considere%20consolidar%20todas%20as%20mudan%C3%A7as%20sob%20uma%20%C3%BAnica%20entrada%20%600.1.3%60%2C%20j%C3%A1%20que%20somente%20essa%20vers%C3%A3o%20foi%20de%20fato%20publicada%3A%0A%0A%60%60%60md%0A%23%23%20%5B0.1.3%5D%0A%0A%23%23%23%20Fixed%0A%0A-%20Correct%20%60DEFAULT_BASE_URL%60%20to%20%60https%3A%2F%2Fapp.montte.co%60%20and%20fix%20RPC%20path%20from%20%60%2Fsdk%2Forpc%60%20to%20%60%2Fapi%2Fsdk%2Fhyprpay%60%0A-%20Better%20Auth%20plugin%3A%20use%20%60databaseHooks.user.create.after%60%20instead%20of%20%60hooks.after%60%3B%20replace%20try%2Fcatch%20with%20%60fromPromise%60%0A-%20Exclude%20%60*.test.ts%60%20from%20subpaths%20build%20script%20and%20tsconfig%0A%60%60%60%0A%0A&repo=montte-erp%2Fmontte-nx"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibraries%2Fhyprpay%2FCHANGELOG.md%3A3-21%0A**Vers%C3%B5es%20fantasmas%20no%20CHANGELOG**%0A%0AO%20%60package.json%60%20pula%20de%20%600.1.0%60%20diretamente%20para%20%600.1.3%60%2C%20mas%20o%20CHANGELOG%20documenta%20%600.1.1%60%20e%20%600.1.2%60%20como%20entradas%20separadas%20%E2%80%94%20essas%20vers%C3%B5es%20nunca%20existiram%20no%20npm.%20Consumidores%20da%20biblioteca%20que%20tentarem%20%60npm%20install%20%40montte%2Fhyprpay%400.1.1%60%20receber%C3%A3o%20um%20erro%20404.%20Considere%20consolidar%20todas%20as%20mudan%C3%A7as%20sob%20uma%20%C3%BAnica%20entrada%20%600.1.3%60%2C%20j%C3%A1%20que%20somente%20essa%20vers%C3%A3o%20foi%20de%20fato%20publicada%3A%0A%0A%60%60%60md%0A%23%23%20%5B0.1.3%5D%0A%0A%23%23%23%20Fixed%0A%0A-%20Correct%20%60DEFAULT_BASE_URL%60%20to%20%60https%3A%2F%2Fapp.montte.co%60%20and%20fix%20RPC%20path%20from%20%60%2Fsdk%2Forpc%60%20to%20%60%2Fapi%2Fsdk%2Fhyprpay%60%0A-%20Better%20Auth%20plugin%3A%20use%20%60databaseHooks.user.create.after%60%20instead%20of%20%60hooks.after%60%3B%20replace%20try%2Fcatch%20with%20%60fromPromise%60%0A-%20Exclude%20%60*.test.ts%60%20from%20subpaths%20build%20script%20and%20tsconfig%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22montte-erp%2Fmontte-nx%22%20on%20the%20existing%20branch%20%22worktree-fix-hyprpay-base-url%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22worktree-fix-hyprpay-base-url%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibraries%2Fhyprpay%2FCHANGELOG.md%3A3-21%0A**Vers%C3%B5es%20fantasmas%20no%20CHANGELOG**%0A%0AO%20%60package.json%60%20pula%20de%20%600.1.0%60%20diretamente%20para%20%600.1.3%60%2C%20mas%20o%20CHANGELOG%20documenta%20%600.1.1%60%20e%20%600.1.2%60%20como%20entradas%20separadas%20%E2%80%94%20essas%20vers%C3%B5es%20nunca%20existiram%20no%20npm.%20Consumidores%20da%20biblioteca%20que%20tentarem%20%60npm%20install%20%40montte%2Fhyprpay%400.1.1%60%20receber%C3%A3o%20um%20erro%20404.%20Considere%20consolidar%20todas%20as%20mudan%C3%A7as%20sob%20uma%20%C3%BAnica%20entrada%20%600.1.3%60%2C%20j%C3%A1%20que%20somente%20essa%20vers%C3%A3o%20foi%20de%20fato%20publicada%3A%0A%0A%60%60%60md%0A%23%23%20%5B0.1.3%5D%0A%0A%23%23%23%20Fixed%0A%0A-%20Correct%20%60DEFAULT_BASE_URL%60%20to%20%60https%3A%2F%2Fapp.montte.co%60%20and%20fix%20RPC%20path%20from%20%60%2Fsdk%2Forpc%60%20to%20%60%2Fapi%2Fsdk%2Fhyprpay%60%0A-%20Better%20Auth%20plugin%3A%20use%20%60databaseHooks.user.create.after%60%20instead%20of%20%60hooks.after%60%3B%20replace%20try%2Fcatch%20with%20%60fromPromise%60%0A-%20Exclude%20%60*.test.ts%60%20from%20subpaths%20build%20script%20and%20tsconfig%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: libraries/hyprpay/CHANGELOG.md
Line: 3-21

Comment:
**Versões fantasmas no CHANGELOG**

O `package.json` pula de `0.1.0` diretamente para `0.1.3`, mas o CHANGELOG documenta `0.1.1` e `0.1.2` como entradas separadas — essas versões nunca existiram no npm. Consumidores da biblioteca que tentarem `npm install @montte/hyprpay@0.1.1` receberão um erro 404. Considere consolidar todas as mudanças sob uma única entrada `0.1.3`, já que somente essa versão foi de fato publicada:

```md
## [0.1.3]

### Fixed

- Correct `DEFAULT_BASE_URL` to `https://app.montte.co` and fix RPC path from `/sdk/orpc` to `/api/sdk/hyprpay`
- Better Auth plugin: use `databaseHooks.user.create.after` instead of `hooks.after`; replace try/catch with `fromPromise`
- Exclude `*.test.ts` from subpaths build script and tsconfig
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: merge master, resolve hyprpay ver..."](https://github.com/montte-erp/montte-nx/commit/ca236b9b8d11a96d5c179a80c084d56d55271f85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28487831)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->