### PR TITLE
refactor: Use dayjs for date formatting and manipulation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,7 @@ function ItemDetails({ id }: { id: string }) {
 - **Spacing & sizing scale** — only `2` and `4` suffixes for `p-*`, `px-*`, `py-*`, `size-*`.
 - **Early returns over if/else** — always guard and return early; never use `else` after a `return`.
 - **Minimize `useEffect`** — derive state, use event handlers. Only for external system sync.
-- **Dates** — always `dayjs`. Never raw `Date` math or manual string formatting.
+- **Dates** — always `dayjs`. Never `new Date()`, `date-fns`, or raw `Date` math. Exceptions: Drizzle schema `.$onUpdate(() => new Date())` defaults and test fixture inserts that require a `Date` object (use `new Date()` only there). For Drizzle `.set()` / `.values()`, use `dayjs().toDate()`. For ISO strings, use `dayjs().toISOString()`. For YYYY-MM-DD strings, use `dayjs().format("YYYY-MM-DD")`.
 - **URL search params over local state** — filters, sort, pagination, active tabs, selected IDs live in `validateSearch` on the route. See oRPC + TanStack Query section for the full pattern.
 - **Files:** kebab-case. **Components:** PascalCase `[Feature][Action][Type]`. **Hooks:** `use[Feature][Action]`.
 - **oxlint suppression:** `// oxlint-ignore <rule-name>` above the triggering line.

--- a/apps/web/src/features/analytics/ui/dashboard-tile.tsx
+++ b/apps/web/src/features/analytics/ui/dashboard-tile.tsx
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import type { Condition } from "@f-o-t/condition-evaluator";
@@ -298,7 +299,7 @@ function formatDateRange(value: string): string {
 }
 
 function formatLastComputed(date: Date): string {
-   const now = new Date();
+   const now = dayjs().toDate();
    const diffMs = now.getTime() - date.getTime();
    const diffMinutes = Math.floor(diffMs / 60000);
 

--- a/apps/web/src/features/analytics/ui/insight-status-line.tsx
+++ b/apps/web/src/features/analytics/ui/insight-status-line.tsx
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { Button } from "@packages/ui/components/button";
 
 interface InsightStatusLineProps {
@@ -16,7 +17,7 @@ export function InsightStatusLine({
          return "nunca";
       }
 
-      const now = new Date();
+      const now = dayjs().toDate();
       const diffMs = now.getTime() - lastComputedAt.getTime();
       const diffMins = Math.floor(diffMs / (1000 * 60));
       const diffHours = Math.floor(diffMs / (1000 * 60 * 60));

--- a/apps/web/src/features/bank-accounts/ui/bank-accounts-form.tsx
+++ b/apps/web/src/features/bank-accounts/ui/bank-accounts-form.tsx
@@ -716,7 +716,7 @@ export function BankAccountForm({
                                              ),
                                           }}
                                           fromDate={minDate}
-                                          toDate={new Date()}
+                                          toDate={dayjs().toDate()}
                                           hideNavigation
                                           mode="single"
                                           selected={selectedDate}

--- a/apps/web/src/features/billing/ui/billing-overview.tsx
+++ b/apps/web/src/features/billing/ui/billing-overview.tsx
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { format, fromMinorUnits, of } from "@f-o-t/money";
 import { Badge } from "@packages/ui/components/badge";
 import { Button } from "@packages/ui/components/button";
@@ -120,7 +121,7 @@ function computeMonthlyCost(item: EventWithUsage): number {
 }
 
 function computeProjectedCost(monthToDateCost: number): number {
-   const now = new Date();
+   const now = dayjs().toDate();
    const dayOfMonth = now.getDate();
    const daysInMonth = new Date(
       now.getFullYear(),
@@ -176,7 +177,7 @@ function formatCurrency(value: number): string {
 }
 
 function getBillingPeriodDates(): { start: Date; end: Date } {
-   const now = new Date();
+   const now = dayjs().toDate();
    const start = new Date(now.getFullYear(), now.getMonth(), 1);
    const end = new Date(now.getFullYear(), now.getMonth() + 1, 0);
    return { start, end };
@@ -191,7 +192,7 @@ function formatPeriodDate(d: Date): string {
 }
 
 function getDaysRemaining(): number {
-   const now = new Date();
+   const now = dayjs().toDate();
    const end = new Date(now.getFullYear(), now.getMonth() + 1, 0);
    return Math.max(
       0,

--- a/apps/web/src/features/billing/ui/billing-overview.tsx
+++ b/apps/web/src/features/billing/ui/billing-overview.tsx
@@ -177,10 +177,11 @@ function formatCurrency(value: number): string {
 }
 
 function getBillingPeriodDates(): { start: Date; end: Date } {
-   const now = dayjs().toDate();
-   const start = new Date(now.getFullYear(), now.getMonth(), 1);
-   const end = new Date(now.getFullYear(), now.getMonth() + 1, 0);
-   return { start, end };
+   const now = dayjs();
+   return {
+      start: now.startOf("month").toDate(),
+      end: now.endOf("month").toDate(),
+   };
 }
 
 function formatPeriodDate(d: Date): string {
@@ -192,12 +193,8 @@ function formatPeriodDate(d: Date): string {
 }
 
 function getDaysRemaining(): number {
-   const now = dayjs().toDate();
-   const end = new Date(now.getFullYear(), now.getMonth() + 1, 0);
-   return Math.max(
-      0,
-      Math.ceil((end.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)),
-   );
+   const now = dayjs();
+   return Math.max(0, now.endOf("month").diff(now, "day") + 1);
 }
 
 function CurrentBillHeader({ monthToDate }: { monthToDate: number }) {

--- a/apps/web/src/features/billing/ui/usage-chart.tsx
+++ b/apps/web/src/features/billing/ui/usage-chart.tsx
@@ -46,14 +46,10 @@ const CHART_COLORS: Record<string, string> = {
 // ============================================
 
 function generateEmptyDateRange(days: number): string[] {
-   const dates: string[] = [];
-   const now = dayjs().toDate();
-   for (let i = days - 1; i >= 0; i--) {
-      const d = new Date(now);
-      d.setDate(d.getDate() - i);
-      dates.push(d.toISOString().split("T")[0]);
-   }
-   return dates;
+   const now = dayjs();
+   return Array.from({ length: days }, (_, i) =>
+      now.subtract(days - 1 - i, "day").format("YYYY-MM-DD"),
+   );
 }
 
 function buildChartConfig(): ChartConfig {

--- a/apps/web/src/features/billing/ui/usage-chart.tsx
+++ b/apps/web/src/features/billing/ui/usage-chart.tsx
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import {
    type ChartConfig,
    ChartContainer,
@@ -46,7 +47,7 @@ const CHART_COLORS: Record<string, string> = {
 
 function generateEmptyDateRange(days: number): string[] {
    const dates: string[] = [];
-   const now = new Date();
+   const now = dayjs().toDate();
    for (let i = days - 1; i >= 0; i--) {
       const d = new Date(now);
       d.setDate(d.getDate() - i);

--- a/apps/web/src/features/bills/ui/bills-columns.tsx
+++ b/apps/web/src/features/bills/ui/bills-columns.tsx
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { format, of } from "@f-o-t/money";
 import { Badge } from "@packages/ui/components/badge";
 import type { ColumnDef } from "@tanstack/react-table";
@@ -23,7 +24,7 @@ function computeDisplayStatus(
 ): "pending" | "paid" | "overdue" | "cancelled" {
    if (row.status === "paid") return "paid";
    if (row.status === "cancelled") return "cancelled";
-   const today = new Date().toISOString().substring(0, 10);
+   const today = dayjs().format("YYYY-MM-DD");
    if (row.dueDate < today) return "overdue";
    return "pending";
 }

--- a/apps/web/src/features/transactions/ui/transaction-credenza.tsx
+++ b/apps/web/src/features/transactions/ui/transaction-credenza.tsx
@@ -1921,7 +1921,7 @@ function TransactionCredenzaContent({
                      })}
                   >
                      {({ date, type }) => {
-                        const isFuture = date && date > new Date();
+                        const isFuture = date && dayjs(date).isAfter(dayjs());
                         return (
                            <>
                               {isFuture && (

--- a/apps/web/src/features/transactions/ui/transaction-filter-bar.tsx
+++ b/apps/web/src/features/transactions/ui/transaction-filter-bar.tsx
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import type { ConditionGroup } from "@f-o-t/condition-evaluator";
 import { Button } from "@packages/ui/components/button";
 import { DateRangePicker } from "@packages/ui/components/date-range-picker";
@@ -50,7 +51,7 @@ export interface TransactionFilters {
 }
 
 function getThisMonthRange() {
-   const today = new Date();
+   const today = dayjs().toDate();
    const fmt = (d: Date) => d.toISOString().split("T")[0];
    return {
       dateFrom: fmt(new Date(today.getFullYear(), today.getMonth(), 1)),
@@ -90,7 +91,7 @@ export function presetToDateRange(preset: string): {
    dateFrom: string;
    dateTo: string;
 } {
-   const today = new Date();
+   const today = dayjs().toDate();
    const fmt = (d: Date) => d.toISOString().split("T")[0];
    switch (preset) {
       case "today":

--- a/apps/web/src/integrations/dbos/workflows/backfill-keywords.workflow.ts
+++ b/apps/web/src/integrations/dbos/workflows/backfill-keywords.workflow.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { DBOS } from "@dbos-inc/dbos-sdk";
 import {
    listTeamsWithPendingKeywords,
@@ -58,7 +59,7 @@ export class BackfillKeywordsWorkflow {
          }
 
          await DBOS.startWorkflow(DeriveKeywordsWorkflow, {
-            workflowID: `derive-${category.id}-${new Date().toISOString().slice(0, 10)}`,
+            workflowID: `derive-${category.id}-${dayjs().format("YYYY-MM-DD")}`,
          }).run({
             categoryId: category.id,
             teamId: category.teamId,
@@ -78,7 +79,7 @@ export class BackfillKeywordsWorkflow {
             message: `Palavras-chave configuradas para ${processed} categorias.`,
             payload: { count: processed },
             teamId: teamEntry.teamId,
-            timestamp: new Date().toISOString(),
+            timestamp: dayjs().toISOString(),
          };
          await jobPublisher.publish("job.notification", notification);
       }

--- a/apps/web/src/integrations/dbos/workflows/categorization.workflow.ts
+++ b/apps/web/src/integrations/dbos/workflows/categorization.workflow.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { DBOS } from "@dbos-inc/dbos-sdk";
 import { chat } from "@tanstack/ai";
 import { openRouterText } from "@tanstack/ai-openrouter";
@@ -181,7 +182,7 @@ Se tiver certeza, retorne confidence "high". Se estiver em dúvida, retorne "low
       },
    ) {
       const jobId = notification.jobId ?? crypto.randomUUID();
-      const timestamp = notification.timestamp ?? new Date().toISOString();
+      const timestamp = notification.timestamp ?? dayjs().toISOString();
       DBOS.logger.debug(
          `[categorization] publishStep status=${notification.status} team=${notification.teamId}`,
       );

--- a/apps/web/src/integrations/dbos/workflows/derive-keywords.workflow.ts
+++ b/apps/web/src/integrations/dbos/workflows/derive-keywords.workflow.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { DBOS } from "@dbos-inc/dbos-sdk";
 import { chat } from "@tanstack/ai";
 import { openRouterText } from "@tanstack/ai-openrouter";
@@ -44,7 +45,7 @@ export class DeriveKeywordsWorkflow {
          status: "failed",
          message: error,
          teamId: input.teamId,
-         timestamp: new Date().toISOString(),
+         timestamp: dayjs().toISOString(),
       });
 
       DBOS.logger.info(`${ctx} started name="${input.name}"`);
@@ -55,7 +56,7 @@ export class DeriveKeywordsWorkflow {
          status: "started",
          message: `Gerando palavras-chave para ${input.name}...`,
          teamId: input.teamId,
-         timestamp: new Date().toISOString(),
+         timestamp: dayjs().toISOString(),
       });
 
       try {
@@ -105,7 +106,7 @@ export class DeriveKeywordsWorkflow {
             count: keywords.length,
          },
          teamId: input.teamId,
-         timestamp: new Date().toISOString(),
+         timestamp: dayjs().toISOString(),
       });
 
       DBOS.logger.info(`${ctx} completed`);

--- a/apps/web/src/integrations/orpc/router/billing.ts
+++ b/apps/web/src/integrations/orpc/router/billing.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { eventCatalog } from "@core/database/schemas/event-catalog";
 import { WebAppError } from "@core/logging/errors";
 import {
@@ -142,11 +143,7 @@ export const getMeterUsage = protectedProcedure.handler(async ({ context }) => {
    try {
       const now = Math.floor(Date.now() / 1000);
       const startOfMonth = Math.floor(
-         new Date(
-            new Date().getFullYear(),
-            new Date().getMonth(),
-            1,
-         ).getTime() / 1000,
+         dayjs().startOf("month").valueOf() / 1000,
       );
 
       const meters = await stripeClient.billing.meters.list({ limit: 100 });

--- a/apps/web/src/integrations/orpc/router/bills.ts
+++ b/apps/web/src/integrations/orpc/router/bills.ts
@@ -50,25 +50,21 @@ function computeDueDate(
    frequency: string,
    offset: number,
 ): string {
-   const d = new Date(startDate);
+   const d = dayjs(startDate);
    switch (frequency) {
       case "weekly":
-         d.setDate(d.getDate() + 7 * offset);
-         break;
+         return d.add(7 * offset, "day").format("YYYY-MM-DD");
       case "biweekly":
-         d.setDate(d.getDate() + 14 * offset);
-         break;
+         return d.add(14 * offset, "day").format("YYYY-MM-DD");
       case "monthly":
-         d.setMonth(d.getMonth() + offset);
-         break;
+         return d.add(offset, "month").format("YYYY-MM-DD");
       case "quarterly":
-         d.setMonth(d.getMonth() + 3 * offset);
-         break;
+         return d.add(3 * offset, "month").format("YYYY-MM-DD");
       case "yearly":
-         d.setFullYear(d.getFullYear() + offset);
-         break;
+         return d.add(offset, "year").format("YYYY-MM-DD");
+      default:
+         return d.format("YYYY-MM-DD");
    }
-   return d.toISOString().substring(0, 10);
 }
 
 function buildBatch(
@@ -117,9 +113,7 @@ async function buildRecurrenceBatch(
       endsAt: endsAt ?? null,
    });
 
-   const windowEnd = dayjs().toDate();
-   windowEnd.setMonth(windowEnd.getMonth() + windowMonths);
-   const windowEndStr = windowEnd.toISOString().substring(0, 10);
+   const windowEndStr = dayjs().add(windowMonths, "month").format("YYYY-MM-DD");
 
    const batchData = [];
    let i = 0;

--- a/apps/web/src/integrations/orpc/router/bills.ts
+++ b/apps/web/src/integrations/orpc/router/bills.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import type { DatabaseInstance } from "@core/database/client";
 import {
    createBill,
@@ -116,7 +117,7 @@ async function buildRecurrenceBatch(
       endsAt: endsAt ?? null,
    });
 
-   const windowEnd = new Date();
+   const windowEnd = dayjs().toDate();
    windowEnd.setMonth(windowEnd.getMonth() + windowMonths);
    const windowEndStr = windowEnd.toISOString().substring(0, 10);
 
@@ -297,7 +298,7 @@ export const pay = protectedProcedure
 
       return updateBill(db, id, {
          status: "paid",
-         paidAt: new Date(),
+         paidAt: dayjs().toDate(),
          transactionId: transaction.id,
       });
    });

--- a/apps/web/src/integrations/orpc/router/insights.ts
+++ b/apps/web/src/integrations/orpc/router/insights.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { computeInsightData } from "@packages/analytics/compute-insight";
 import { ensureDashboardOwnership } from "@core/database/repositories/dashboard-repository";
 import {
@@ -162,7 +163,7 @@ export const refreshDashboard = protectedProcedure
                .update(insights)
                .set({
                   cachedResults: freshData,
-                  lastComputedAt: new Date(),
+                  lastComputedAt: dayjs().toDate(),
                })
                .where(eq(insights.id, insightId));
          } catch (error) {

--- a/apps/web/src/integrations/orpc/router/team.ts
+++ b/apps/web/src/integrations/orpc/router/team.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { cnpjDataSchema } from "@core/authentication/server";
 import type { DatabaseInstance } from "@core/database/client";
 import { WebAppError } from "@core/logging/errors";
@@ -155,7 +156,7 @@ export const addMember = protectedProcedure
          .values({
             teamId: input.teamId,
             userId: input.userId,
-            createdAt: new Date(),
+            createdAt: dayjs().toDate(),
          })
          .returning();
 

--- a/apps/web/src/integrations/orpc/sdk/router/budgets.ts
+++ b/apps/web/src/integrations/orpc/sdk/router/budgets.ts
@@ -49,12 +49,12 @@ export const get = sdkProcedure
    .handler(async ({ context, input }) => {
       if (!context.teamId) throw WebAppError.unauthorized("Team ID required");
       await ensureBudgetGoalOwnership(context.db, input.id, context.teamId);
-      const now = dayjs().toDate();
+      const now = dayjs();
       const goals = await listBudgetGoals(
          context.db,
          context.teamId,
-         now.getMonth() + 1,
-         now.getFullYear(),
+         now.month() + 1,
+         now.year(),
       );
       const goal = goals.find((g) => g.id === input.id);
       if (goal) return mapBudgetGoal(goal);

--- a/apps/web/src/integrations/orpc/sdk/router/budgets.ts
+++ b/apps/web/src/integrations/orpc/sdk/router/budgets.ts
@@ -49,7 +49,7 @@ export const get = sdkProcedure
    .handler(async ({ context, input }) => {
       if (!context.teamId) throw WebAppError.unauthorized("Team ID required");
       await ensureBudgetGoalOwnership(context.db, input.id, context.teamId);
-      const now = new Date();
+      const now = dayjs().toDate();
       const goals = await listBudgetGoals(
          context.db,
          context.teamId,

--- a/apps/web/src/integrations/orpc/server.ts
+++ b/apps/web/src/integrations/orpc/server.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { logs } from "@opentelemetry/api-logs";
 import { ORPCError, os } from "@orpc/server";
 import type { AuthInstance } from "@core/authentication/server";
@@ -134,7 +135,7 @@ const otelLogger = logs.getLogger("montte-web-orpc");
 
 const withTelemetry = withErrorHandling.use(
    async ({ context, path, next }, input) => {
-      const startDate = new Date();
+      const startDate = dayjs().toDate();
       const userId = context.session?.user?.id;
       const userEmail = context.session?.user?.email;
       const userName = context.session?.user?.name;
@@ -219,7 +220,7 @@ const withTelemetry = withErrorHandling.use(
                   event: "orpc_request",
                   properties: {
                      durationMs,
-                     endAt: new Date().toISOString(),
+                     endAt: dayjs().toISOString(),
                      input: sanitizeData(input),
                      path: path.join("."),
                      rootPath,

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/bills.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/bills.tsx
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { Button } from "@packages/ui/components/button";
 import { DataTable } from "@packages/ui/components/data-table";
 import type { DataTableStoredState } from "@packages/ui/components/data-table";
@@ -101,7 +102,7 @@ interface BillsSummaryProps {
 }
 
 function BillsSummary({ items }: BillsSummaryProps) {
-   const today = new Date().toISOString().substring(0, 10);
+   const today = dayjs().format("YYYY-MM-DD");
 
    const pending = items
       .filter((b) => b.status === "pending" && b.dueDate >= today)

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/goals.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/goals.tsx
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import type { BudgetGoalWithProgress } from "@core/database/repositories/budget-goals-repository";
 import { Button } from "@packages/ui/components/button";
 import { DataTable } from "@packages/ui/components/data-table";
@@ -51,7 +52,7 @@ const [useGoalsTableState] =
       null,
    );
 
-const now = new Date();
+const now = dayjs().toDate();
 
 export const Route = createFileRoute(
    "/_authenticated/$slug/$teamSlug/_dashboard/goals",

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/security.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/security.tsx
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { Badge } from "@packages/ui/components/badge";
 import { Button } from "@packages/ui/components/button";
 import { Card, CardContent } from "@packages/ui/components/card";
@@ -71,7 +72,7 @@ function getDeviceIcon(userAgent: string | null | undefined) {
 function formatLastActive(date: Date | string | null): string {
    if (!date) return "Agora";
    const d = new Date(date);
-   const now = new Date();
+   const now = dayjs().toDate();
    const diff = now.getTime() - d.getTime();
    const minutes = Math.floor(diff / 60000);
    const hours = Math.floor(diff / 3600000);

--- a/apps/web/src/routes/api/ping.ts
+++ b/apps/web/src/routes/api/ping.ts
@@ -1,8 +1,9 @@
+import dayjs from "dayjs";
 import { createFileRoute } from "@tanstack/react-router";
 
 export async function handleGet() {
    return new Response(
-      JSON.stringify({ pong: true, time: new Date().toISOString() }),
+      JSON.stringify({ pong: true, time: dayjs().toISOString() }),
       { status: 200, headers: { "Content-Type": "application/json" } },
    );
 }

--- a/apps/web/src/routes/auth.tsx
+++ b/apps/web/src/routes/auth.tsx
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import {
    createFileRoute,
    Outlet,
@@ -412,8 +413,7 @@ function AuthLayout() {
 
             {/* Footer */}
             <div className="relative z-10 text-white/50 text-xs">
-               &copy; {new Date().getFullYear()} Montte. Todos os direitos
-               reservados
+               &copy; {dayjs().year()} Montte. Todos os direitos reservados
             </div>
          </aside>
       </div>

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import "@/integrations/otel/init";
 
 import { DBOS } from "@dbos-inc/dbos-sdk";
@@ -42,7 +43,7 @@ export default createServerEntry({
          if (request.method === "GET") {
             return Response.json({
                pong: true,
-               time: new Date().toISOString(),
+               time: dayjs().toISOString(),
             });
          }
       }

--- a/core/database/package.json
+++ b/core/database/package.json
@@ -59,6 +59,7 @@
       "@core/utils": "workspace:*",
       "@f-o-t/condition-evaluator": "catalog:fot",
       "@f-o-t/money": "catalog:fot",
+      "dayjs": "catalog:ui",
       "drizzle-orm": "catalog:database",
       "pg": "catalog:database",
       "zod": "catalog:validation"

--- a/core/database/src/repositories/agent-settings-repository.ts
+++ b/core/database/src/repositories/agent-settings-repository.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { AppError, propagateError } from "@core/logging/errors";
 import { eq } from "drizzle-orm";
 import type { DatabaseInstance } from "@core/database/client";
@@ -32,7 +33,7 @@ export async function upsertAgentSettings(
          .values({ teamId, ...data })
          .onConflictDoUpdate({
             target: agentSettings.teamId,
-            set: { ...data, updatedAt: new Date() },
+            set: { ...data, updatedAt: dayjs().toDate() },
          })
          .returning();
       if (!settings) throw AppError.database("Failed to upsert agent settings");

--- a/core/database/src/repositories/auth-repository.ts
+++ b/core/database/src/repositories/auth-repository.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { getLogger } from "@core/logging/root";
 import { AppError, propagateError } from "@core/logging/errors";
 
@@ -136,7 +137,7 @@ export async function createDefaultOrganization(
       const safeSuffix = String(suffix).trim();
       const orgName = `${safeUserName}${safeSuffix}`;
       const orgSlug = createSlug(orgName);
-      const now = new Date();
+      const now = dayjs().toDate();
 
       const [createdOrganization] = await dbClient
          .insert(organization)
@@ -263,7 +264,7 @@ export async function ensureDefaultProject(
 
       if (existingTeam) return existingTeam;
 
-      const now = new Date();
+      const now = dayjs().toDate();
       const [created] = await dbClient
          .insert(team)
          .values({

--- a/core/database/src/repositories/bank-accounts-repository.ts
+++ b/core/database/src/repositories/bank-accounts-repository.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { AppError, propagateError, validateInput } from "@core/logging/errors";
 import { add, of, subtract, toDecimal } from "@f-o-t/money";
 import { and, eq, or, sql } from "drizzle-orm";
@@ -107,7 +108,7 @@ export async function updateBankAccount(
    try {
       const [updated] = await db
          .update(bankAccounts)
-         .set({ ...validated, updatedAt: new Date() })
+         .set({ ...validated, updatedAt: dayjs().toDate() })
          .where(eq(bankAccounts.id, id))
          .returning();
       if (!updated) throw AppError.notFound("Conta bancária não encontrada.");
@@ -122,7 +123,7 @@ export async function archiveBankAccount(db: DatabaseInstance, id: string) {
    try {
       const [updated] = await db
          .update(bankAccounts)
-         .set({ status: "archived", updatedAt: new Date() })
+         .set({ status: "archived", updatedAt: dayjs().toDate() })
          .where(eq(bankAccounts.id, id))
          .returning();
       if (!updated) throw AppError.notFound("Conta bancária não encontrada.");
@@ -137,7 +138,7 @@ export async function reactivateBankAccount(db: DatabaseInstance, id: string) {
    try {
       const [updated] = await db
          .update(bankAccounts)
-         .set({ status: "active", updatedAt: new Date() })
+         .set({ status: "active", updatedAt: dayjs().toDate() })
          .where(eq(bankAccounts.id, id))
          .returning();
       if (!updated) throw AppError.notFound("Conta bancária não encontrada.");

--- a/core/database/src/repositories/bills-repository.ts
+++ b/core/database/src/repositories/bills-repository.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { AppError, propagateError, validateInput } from "@core/logging/errors";
 import { and, count, eq, gte, isNull, lte, or, sql } from "drizzle-orm";
 import type { DatabaseInstance } from "@core/database/client";
@@ -143,7 +144,7 @@ export async function listBills(
          pageSize = 20,
       } = options;
 
-      const today = new Date().toISOString().substring(0, 10);
+      const today = dayjs().format("YYYY-MM-DD");
       const conditions = [eq(bills.teamId, teamId)];
 
       if (type) conditions.push(eq(bills.type, type));
@@ -227,7 +228,7 @@ export async function updateBill(
       const validated = validateInput(updateBillSchema, data);
       const [updated] = await db
          .update(bills)
-         .set({ ...validated, updatedAt: new Date() })
+         .set({ ...validated, updatedAt: dayjs().toDate() })
          .where(eq(bills.id, id))
          .returning();
       if (!updated) throw AppError.database("Bill not found");
@@ -254,7 +255,7 @@ export async function getActiveRecurrenceSettings(
    db: DatabaseInstance,
 ): Promise<RecurrenceSetting[]> {
    try {
-      const today = new Date().toISOString().substring(0, 10);
+      const today = dayjs().format("YYYY-MM-DD");
       return await db
          .select()
          .from(recurrenceSettings)

--- a/core/database/src/repositories/bills-repository.ts
+++ b/core/database/src/repositories/bills-repository.ts
@@ -163,7 +163,7 @@ export async function listBills(
 
       if (month && year) {
          const start = `${year}-${String(month).padStart(2, "0")}-01`;
-         const end = new Date(year, month, 0).toISOString().substring(0, 10);
+         const end = dayjs(start).endOf("month").format("YYYY-MM-DD");
          conditions.push(gte(bills.dueDate, start));
          conditions.push(lte(bills.dueDate, end));
       }
@@ -298,24 +298,24 @@ export async function generateBillsForSubscription(
    if (billingCycle === "hourly") return;
 
    const amount = subscription.negotiatedPrice;
-   const start = new Date(subscription.startDate);
-   const end = subscription.endDate ? new Date(subscription.endDate) : null;
+   const start = dayjs(subscription.startDate);
+   const end = subscription.endDate ? dayjs(subscription.endDate) : null;
 
-   const formatMonthYear = (d: Date) => {
-      const month = d
-         .toLocaleDateString("pt-BR", { month: "short" })
+   const formatMonthYear = (d: typeof start) => {
+      const month = new Intl.DateTimeFormat("pt-BR", { month: "short" })
+         .format(d.toDate())
          .replace(".", "")
          .replace(/^\w/, (c) => c.toUpperCase());
-      return `${month}/${d.getFullYear()}`;
+      return `${month}/${d.year()}`;
    };
 
-   const makeBill = (dueDate: Date, label: string) => ({
+   const makeBill = (dueDate: typeof start, label: string) => ({
       teamId: subscription.teamId,
       name: `${serviceName} – ${variant.name}`,
       description: `${serviceName} – ${variant.name} (${label})`,
       type: "receivable" as const,
       amount,
-      dueDate: dueDate.toISOString().slice(0, 10),
+      dueDate: dueDate.format("YYYY-MM-DD"),
       contactId: subscription.contactId,
       subscriptionId: subscription.id,
       status: "pending" as const,
@@ -328,19 +328,13 @@ export async function generateBillsForSubscription(
    } else if (billingCycle === "annual") {
       billsToCreate.push(makeBill(start, formatMonthYear(start)));
    } else if (billingCycle === "monthly") {
-      const cursor = new Date(start);
-      const twoYearLimit = (() => {
-         const d = new Date(start);
-         d.setFullYear(d.getFullYear() + 2);
-         return d;
-      })();
+      const twoYearLimit = start.add(2, "year");
       const limit = end ?? twoYearLimit;
       const inclusive = end !== null;
-      while (inclusive ? cursor <= limit : cursor < limit) {
-         billsToCreate.push(
-            makeBill(new Date(cursor), formatMonthYear(cursor)),
-         );
-         cursor.setMonth(cursor.getMonth() + 1);
+      let cursor = start;
+      while (inclusive ? !cursor.isAfter(limit) : cursor.isBefore(limit)) {
+         billsToCreate.push(makeBill(cursor, formatMonthYear(cursor)));
+         cursor = cursor.add(1, "month");
       }
    }
 

--- a/core/database/src/repositories/budget-goals-repository.ts
+++ b/core/database/src/repositories/budget-goals-repository.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { AppError, propagateError, validateInput } from "@core/logging/errors";
 import { of, toDecimal } from "@f-o-t/money";
 import { and, eq, isNotNull, isNull, sql } from "drizzle-orm";
@@ -123,7 +124,7 @@ export async function markAlertSent(
    try {
       const [updated] = await db
          .update(budgetGoals)
-         .set({ alertSentAt: new Date() })
+         .set({ alertSentAt: dayjs().toDate() })
          .where(and(eq(budgetGoals.id, id), eq(budgetGoals.teamId, teamId)))
          .returning();
       if (!updated)

--- a/core/database/src/repositories/categories-repository.ts
+++ b/core/database/src/repositories/categories-repository.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { AppError, propagateError, validateInput } from "@core/logging/errors";
 import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
@@ -253,7 +254,7 @@ export async function updateCategory(
 
       const [updated] = await db
          .update(categories)
-         .set({ ...validated, updatedAt: new Date() })
+         .set({ ...validated, updatedAt: dayjs().toDate() })
          .where(eq(categories.id, id))
          .returning();
       if (!updated) throw AppError.notFound("Categoria não encontrada.");
@@ -279,7 +280,7 @@ export async function archiveCategory(db: DatabaseInstance, id: string) {
 
       await db
          .update(categories)
-         .set({ isArchived: true, updatedAt: new Date() })
+         .set({ isArchived: true, updatedAt: dayjs().toDate() })
          .where(inArray(categories.id, allIds));
 
       return await db.query.categories.findFirst({
@@ -295,7 +296,7 @@ export async function reactivateCategory(db: DatabaseInstance, id: string) {
    try {
       const [updated] = await db
          .update(categories)
-         .set({ isArchived: false, updatedAt: new Date() })
+         .set({ isArchived: false, updatedAt: dayjs().toDate() })
          .where(eq(categories.id, id))
          .returning();
       if (!updated) throw AppError.notFound("Categoria não encontrada.");

--- a/core/database/src/repositories/contact-settings-repository.ts
+++ b/core/database/src/repositories/contact-settings-repository.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { AppError, propagateError } from "@core/logging/errors";
 import { eq } from "drizzle-orm";
 import type { DatabaseInstance } from "@core/database/client";
@@ -32,7 +33,7 @@ export async function upsertContactSettings(
          .values({ teamId, ...data })
          .onConflictDoUpdate({
             target: contactSettings.teamId,
-            set: { ...data, updatedAt: new Date() },
+            set: { ...data, updatedAt: dayjs().toDate() },
          })
          .returning();
       if (!settings)

--- a/core/database/src/repositories/contacts-repository.ts
+++ b/core/database/src/repositories/contacts-repository.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { AppError, propagateError, validateInput } from "@core/logging/errors";
 import { and, asc, count, eq } from "drizzle-orm";
 import type { DatabaseInstance } from "@core/database/client";
@@ -74,7 +75,7 @@ export async function updateContact(
    try {
       const [updated] = await db
          .update(contacts)
-         .set({ ...validated, updatedAt: new Date() })
+         .set({ ...validated, updatedAt: dayjs().toDate() })
          .where(eq(contacts.id, id))
          .returning();
       if (!updated) throw AppError.notFound("Contato não encontrado.");
@@ -89,7 +90,7 @@ export async function archiveContact(db: DatabaseInstance, id: string) {
    try {
       const [updated] = await db
          .update(contacts)
-         .set({ isArchived: true, updatedAt: new Date() })
+         .set({ isArchived: true, updatedAt: dayjs().toDate() })
          .where(eq(contacts.id, id))
          .returning();
       if (!updated) throw AppError.notFound("Contato não encontrado.");
@@ -104,7 +105,7 @@ export async function reactivateContact(db: DatabaseInstance, id: string) {
    try {
       const [updated] = await db
          .update(contacts)
-         .set({ isArchived: false, updatedAt: new Date() })
+         .set({ isArchived: false, updatedAt: dayjs().toDate() })
          .where(eq(contacts.id, id))
          .returning();
       if (!updated) throw AppError.notFound("Contato não encontrado.");

--- a/core/database/src/repositories/credit-card-statements-repository.ts
+++ b/core/database/src/repositories/credit-card-statements-repository.ts
@@ -245,7 +245,7 @@ export async function payStatement(
                .update(bills)
                .set({
                   status: "paid",
-                  paidAt: new Date(),
+                  paidAt: dayjs().toDate(),
                   amount,
                   transactionId: paymentTx.id,
                })
@@ -258,7 +258,7 @@ export async function payStatement(
             .set({
                status: "paid",
                paymentTransactionId: paymentTx.id,
-               updatedAt: new Date(),
+               updatedAt: dayjs().toDate(),
             })
             .where(eq(creditCardStatements.id, statementId))
             .returning();

--- a/core/database/src/repositories/credit-cards-repository.ts
+++ b/core/database/src/repositories/credit-cards-repository.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { AppError, propagateError, validateInput } from "@core/logging/errors";
 import { and, asc, eq, ilike, inArray, sql } from "drizzle-orm";
 import type { DatabaseInstance } from "@core/database/client";
@@ -182,7 +183,7 @@ export async function updateCreditCard(
    try {
       const [updated] = await db
          .update(creditCards)
-         .set({ ...validated, updatedAt: new Date() })
+         .set({ ...validated, updatedAt: dayjs().toDate() })
          .where(eq(creditCards.id, id))
          .returning();
       if (!updated)

--- a/core/database/src/repositories/financial-settings-repository.ts
+++ b/core/database/src/repositories/financial-settings-repository.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { AppError, propagateError } from "@core/logging/errors";
 import { eq } from "drizzle-orm";
 import type { DatabaseInstance } from "@core/database/client";
@@ -35,7 +36,7 @@ export async function upsertFinancialSettings(
          .values({ teamId, ...data })
          .onConflictDoUpdate({
             target: financialSettings.teamId,
-            set: { ...data, updatedAt: new Date() },
+            set: { ...data, updatedAt: dayjs().toDate() },
          })
          .returning();
       if (!settings)

--- a/core/database/src/repositories/inventory-repository.ts
+++ b/core/database/src/repositories/inventory-repository.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { AppError, propagateError, validateInput } from "@core/logging/errors";
 import { and, desc, eq, isNull, sql } from "drizzle-orm";
 import type { DatabaseInstance } from "@core/database/client";
@@ -112,7 +113,7 @@ export async function archiveInventoryProduct(
    try {
       const [product] = await db
          .update(inventoryProducts)
-         .set({ archivedAt: new Date() })
+         .set({ archivedAt: dayjs().toDate() })
          .where(eq(inventoryProducts.id, id))
          .returning();
       if (!product)
@@ -274,7 +275,7 @@ export async function upsertInventorySettings(
          .values({ teamId, ...data })
          .onConflictDoUpdate({
             target: inventorySettings.teamId,
-            set: { ...data, updatedAt: new Date() },
+            set: { ...data, updatedAt: dayjs().toDate() },
          })
          .returning();
       if (!settings)

--- a/core/database/src/repositories/onboarding-repository.ts
+++ b/core/database/src/repositories/onboarding-repository.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { AppError, propagateError } from "@core/logging/errors";
 import { eq, sql } from "drizzle-orm";
 import type { DatabaseInstance } from "@core/database/client";
@@ -16,7 +17,7 @@ export async function insertTeamMember(
       await db.insert(teamMember).values({
          teamId,
          userId,
-         createdAt: new Date(),
+         createdAt: dayjs().toDate(),
       });
    } catch (err) {
       propagateError(err);
@@ -214,7 +215,7 @@ export async function updateInsightCache(
    try {
       await db
          .update(insights)
-         .set({ cachedResults, lastComputedAt: new Date() })
+         .set({ cachedResults, lastComputedAt: dayjs().toDate() })
          .where(eq(insights.id, insightId));
    } catch (err) {
       propagateError(err);

--- a/core/database/src/repositories/subscriptions-repository.ts
+++ b/core/database/src/repositories/subscriptions-repository.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { AppError, propagateError, validateInput } from "@core/logging/errors";
 import { and, count, eq, gte, lte } from "drizzle-orm";
 import type { DatabaseInstance } from "@core/database/client";
@@ -51,7 +52,7 @@ export async function updateSubscription(
    try {
       const [updated] = await db
          .update(contactSubscriptions)
-         .set({ ...validated, updatedAt: new Date() })
+         .set({ ...validated, updatedAt: dayjs().toDate() })
          .where(eq(contactSubscriptions.id, id))
          .returning();
       if (!updated) throw AppError.notFound("Assinatura não encontrada.");
@@ -118,7 +119,7 @@ export async function upsertSubscriptionByExternalId(
                endDate: validated.endDate,
                currentPeriodStart: validated.currentPeriodStart,
                currentPeriodEnd: validated.currentPeriodEnd,
-               updatedAt: new Date(),
+               updatedAt: dayjs().toDate(),
             })
             .where(eq(contactSubscriptions.id, existing.id))
             .returning();
@@ -182,10 +183,8 @@ export async function listExpiringSoon(
    withinDays = 30,
 ) {
    try {
-      const now = new Date().toISOString().split("T")[0]!;
-      const futureDate = new Date(Date.now() + withinDays * 24 * 60 * 60 * 1000)
-         .toISOString()
-         .split("T")[0]!;
+      const now = dayjs().format("YYYY-MM-DD");
+      const futureDate = dayjs().add(withinDays, "day").format("YYYY-MM-DD");
 
       return await db
          .select()

--- a/core/database/src/repositories/tags-repository.ts
+++ b/core/database/src/repositories/tags-repository.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { AppError, propagateError, validateInput } from "@core/logging/errors";
 import { eq, inArray, sql } from "drizzle-orm";
 import type { DatabaseInstance } from "@core/database/client";
@@ -76,7 +77,7 @@ export async function updateTag(
    try {
       const [updated] = await db
          .update(tags)
-         .set({ ...validated, updatedAt: new Date() })
+         .set({ ...validated, updatedAt: dayjs().toDate() })
          .where(eq(tags.id, id))
          .returning();
       if (!updated) throw AppError.notFound("Tag não encontrada.");
@@ -91,7 +92,7 @@ export async function archiveTag(db: DatabaseInstance, id: string) {
    try {
       const [updated] = await db
          .update(tags)
-         .set({ isArchived: true, updatedAt: new Date() })
+         .set({ isArchived: true, updatedAt: dayjs().toDate() })
          .where(eq(tags.id, id))
          .returning();
       if (!updated) throw AppError.notFound("Tag não encontrada.");
@@ -106,7 +107,7 @@ export async function reactivateTag(db: DatabaseInstance, id: string) {
    try {
       const [updated] = await db
          .update(tags)
-         .set({ isArchived: false, updatedAt: new Date() })
+         .set({ isArchived: false, updatedAt: dayjs().toDate() })
          .where(eq(tags.id, id))
          .returning();
       if (!updated) throw AppError.notFound("Tag não encontrada.");

--- a/core/database/src/repositories/transactions-repository.ts
+++ b/core/database/src/repositories/transactions-repository.ts
@@ -139,11 +139,11 @@ export async function validateTransactionReferences(
          throw AppError.validation("Conta bancária inválida.");
       }
       if (account.initialBalanceDate && refs.date) {
-         const txDate = new Date(refs.date);
-         const balanceDate = new Date(account.initialBalanceDate);
-         if (txDate < balanceDate) {
+         const txDate = dayjs(refs.date);
+         const balanceDate = dayjs(account.initialBalanceDate);
+         if (txDate.isBefore(balanceDate)) {
             throw AppError.validation(
-               `Não é possível registrar lançamentos antes da data do saldo inicial (${balanceDate.toLocaleDateString("pt-BR")}).`,
+               `Não é possível registrar lançamentos antes da data do saldo inicial (${balanceDate.format("DD/MM/YYYY")}).`,
             );
          }
       }
@@ -155,11 +155,11 @@ export async function validateTransactionReferences(
          throw AppError.validation("Conta de destino inválida.");
       }
       if (dest.initialBalanceDate && refs.date) {
-         const txDate = new Date(refs.date);
-         const balanceDate = new Date(dest.initialBalanceDate);
-         if (txDate < balanceDate) {
+         const txDate = dayjs(refs.date);
+         const balanceDate = dayjs(dest.initialBalanceDate);
+         if (txDate.isBefore(balanceDate)) {
             throw AppError.validation(
-               `Não é possível registrar lançamentos antes da data do saldo inicial da conta de destino (${balanceDate.toLocaleDateString("pt-BR")}).`,
+               `Não é possível registrar lançamentos antes da data do saldo inicial da conta de destino (${balanceDate.format("DD/MM/YYYY")}).`,
             );
          }
       }

--- a/core/database/src/repositories/transactions-repository.ts
+++ b/core/database/src/repositories/transactions-repository.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import type { Condition, ConditionGroup } from "@f-o-t/condition-evaluator";
 import { evaluateConditionGroup } from "@f-o-t/condition-evaluator";
 import { AppError, propagateError, validateInput } from "@core/logging/errors";
@@ -659,7 +660,7 @@ export async function updateTransactionCategory(
    try {
       await db
          .update(transactions)
-         .set({ ...data, updatedAt: new Date() })
+         .set({ ...data, updatedAt: dayjs().toDate() })
          .where(eq(transactions.id, id));
    } catch (err) {
       propagateError(err);

--- a/core/database/src/repositories/webhook-repository.ts
+++ b/core/database/src/repositories/webhook-repository.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { AppError, propagateError } from "@core/logging/errors";
 import { and, desc, eq, sql } from "drizzle-orm";
 import type { DatabaseInstance } from "@core/database/client";
@@ -130,7 +131,7 @@ export async function updateWebhookLastSuccess(
       await db
          .update(webhookEndpoints)
          .set({
-            lastSuccessAt: new Date(),
+            lastSuccessAt: dayjs().toDate(),
             failureCount: 0,
          })
          .where(eq(webhookEndpoints.id, webhookId));
@@ -149,7 +150,7 @@ export async function incrementWebhookFailureCount(
          .update(webhookEndpoints)
          .set({
             failureCount: sql`${webhookEndpoints.failureCount} + 1`,
-            lastFailureAt: new Date(),
+            lastFailureAt: dayjs().toDate(),
          })
          .where(eq(webhookEndpoints.id, webhookId));
    } catch (err) {

--- a/core/transactional/package.json
+++ b/core/transactional/package.json
@@ -34,6 +34,7 @@
       "@core/logging": "workspace:*",
       "@core/utils": "workspace:*",
       "@react-email/components": "catalog:transactional",
+      "dayjs": "catalog:ui",
       "react": "catalog:react",
       "react-dom": "catalog:react",
       "resend": "catalog:transactional"

--- a/core/transactional/src/emails/default-footer.tsx
+++ b/core/transactional/src/emails/default-footer.tsx
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { Hr, Link, Section, Text } from "@react-email/components";
 
 export const DefaultFooter = () => {
@@ -42,7 +43,7 @@ export const DefaultFooter = () => {
                margin: 0,
             }}
          >
-            {new Date().getFullYear()} Montte. Todos os direitos reservados.
+            {dayjs().year()} Montte. Todos os direitos reservados.
          </Text>
       </Section>
    );

--- a/core/utils/package.json
+++ b/core/utils/package.json
@@ -54,7 +54,8 @@
       "typecheck": "tsgo"
    },
    "dependencies": {
-      "@core/logging": "workspace:*"
+      "@core/logging": "workspace:*",
+      "dayjs": "catalog:ui"
    },
    "devDependencies": {
       "@tooling/typescript": "workspace:*",

--- a/core/utils/src/date.ts
+++ b/core/utils/src/date.ts
@@ -1,111 +1,18 @@
-export function getCurrentDate(timezone?: string): { date: string } {
-   const now = new Date();
+import dayjs from "dayjs";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
 
-   if (timezone) {
-      return {
-         date: now
-            .toLocaleDateString("en-CA", {
-               day: "2-digit",
-               month: "2-digit",
-               timeZone: timezone,
-               year: "numeric",
-            })
-            .replace(/\//g, "-"),
-      };
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+export function getCurrentDate(tz?: string): { date: string } {
+   if (tz) {
+      return { date: dayjs().tz(tz).format("YYYY-MM-DD") };
    }
-
-   const year = now.getFullYear();
-   const month = String(now.getMonth() + 1).padStart(2, "0");
-   const day = String(now.getDate()).padStart(2, "0");
-
-   return { date: `${year}-${month}-${day}` };
+   return { date: dayjs().format("YYYY-MM-DD") };
 }
 
 export type DateLocale = "pt-BR" | "en-US";
-
-interface DateParts {
-   day: string;
-   hours: string;
-   minutes: string;
-   month: string;
-   monthLong: string;
-   monthShort: string;
-   seconds: string;
-   year: string;
-}
-
-function getDateParts(
-   date: Date,
-   locale: DateLocale,
-   timezone?: string,
-   useUTC = true,
-): DateParts {
-   if (useUTC) {
-      const day = String(date.getUTCDate()).padStart(2, "0");
-      const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-      const year = String(date.getUTCFullYear());
-      const hours = String(date.getUTCHours()).padStart(2, "0");
-      const minutes = String(date.getUTCMinutes()).padStart(2, "0");
-      const seconds = String(date.getUTCSeconds()).padStart(2, "0");
-
-      const monthLongFormatter = new Intl.DateTimeFormat(locale, {
-         month: "long",
-         timeZone: "UTC",
-      });
-      const monthShortFormatter = new Intl.DateTimeFormat(locale, {
-         month: "short",
-         timeZone: "UTC",
-      });
-
-      return {
-         day,
-         hours,
-         minutes,
-         month,
-         monthLong: monthLongFormatter.format(date),
-         monthShort: monthShortFormatter.format(date),
-         seconds,
-         year,
-      };
-   }
-
-   const options: Intl.DateTimeFormatOptions = {
-      day: "2-digit",
-      hour: "2-digit",
-      hour12: false,
-      minute: "2-digit",
-      month: "2-digit",
-      second: "2-digit",
-      timeZone: timezone,
-      year: "numeric",
-   };
-
-   const formatter = new Intl.DateTimeFormat(locale, options);
-   const parts = formatter.formatToParts(date);
-
-   const getPart = (type: Intl.DateTimeFormatPartTypes): string =>
-      parts.find((p) => p.type === type)?.value ?? "";
-
-   const monthLongFormatter = new Intl.DateTimeFormat(locale, {
-      month: "long",
-      timeZone: timezone,
-   });
-   const monthShortFormatter = new Intl.DateTimeFormat(locale, {
-      month: "short",
-      timeZone: timezone,
-   });
-
-   return {
-      day: getPart("day"),
-      hours: getPart("hour"),
-      minutes: getPart("minute"),
-      month: getPart("month"),
-      monthLong: monthLongFormatter.format(date),
-      monthShort: monthShortFormatter.format(date),
-      seconds: getPart("second"),
-      year: getPart("year"),
-   };
-}
 
 export function formatDate(
    date: Date,
@@ -116,35 +23,46 @@ export function formatDate(
       throw new Error("Invalid date provided");
    }
 
-   const locale = options?.locale ?? "pt-BR";
-   const timezone = options?.timezone;
    const useUTC = options?.useUTC ?? true;
+   const tz = options?.timezone;
 
-   const parts = getDateParts(date, locale, timezone, useUTC);
+   let d = dayjs(date);
+   if (useUTC) {
+      d = d.utc();
+   } else if (tz) {
+      d = d.tz(tz);
+   }
+
+   const locale = options?.locale ?? "pt-BR";
+   const monthLong = new Intl.DateTimeFormat(locale, {
+      month: "long",
+      timeZone: useUTC ? "UTC" : tz,
+   }).format(date);
+   const monthShort = new Intl.DateTimeFormat(locale, {
+      month: "short",
+      timeZone: useUTC ? "UTC" : tz,
+   }).format(date);
 
    return format
-      .replace(/YYYY/g, parts.year)
-      .replace(/yyyy/g, parts.year)
-      .replace(/MMMM/g, parts.monthLong)
-      .replace(/MMM/g, parts.monthShort)
-      .replace(/MM/g, parts.month)
-      .replace(/DD/g, parts.day)
-      .replace(/dd/g, parts.day)
-      .replace(/HH/g, parts.hours)
-      .replace(/mm/g, parts.minutes)
-      .replace(/ss/g, parts.seconds);
+      .replace(/YYYY/g, d.format("YYYY"))
+      .replace(/yyyy/g, d.format("YYYY"))
+      .replace(/MMMM/g, monthLong)
+      .replace(/MMM/g, monthShort)
+      .replace(/MM/g, d.format("MM"))
+      .replace(/DD/g, d.format("DD"))
+      .replace(/dd/g, d.format("DD"))
+      .replace(/HH/g, d.format("HH"))
+      .replace(/mm/g, d.format("mm"))
+      .replace(/ss/g, d.format("ss"));
 }
 
-/**
- * Format a date as relative time (e.g., "just now", "5 minutes ago", "2 hours ago")
- */
 export function formatRelativeTime(date: Date): string {
-   const now = new Date();
-   const diffInMs = now.getTime() - date.getTime();
-   const diffInSeconds = Math.floor(diffInMs / 1000);
-   const diffInMinutes = Math.floor(diffInSeconds / 60);
-   const diffInHours = Math.floor(diffInMinutes / 60);
-   const diffInDays = Math.floor(diffInHours / 24);
+   const now = dayjs();
+   const d = dayjs(date);
+   const diffInSeconds = now.diff(d, "second");
+   const diffInMinutes = now.diff(d, "minute");
+   const diffInHours = now.diff(d, "hour");
+   const diffInDays = now.diff(d, "day");
 
    if (diffInSeconds < 60) {
       return "agora mesmo";

--- a/core/utils/src/date.ts
+++ b/core/utils/src/date.ts
@@ -16,7 +16,7 @@ export type DateLocale = "pt-BR" | "en-US";
 
 export function formatDate(
    date: Date,
-   format: string = "MM/DD/YYYY",
+   format: string = "DD/MM/YYYY",
    options?: { locale?: DateLocale; timezone?: string; useUTC?: boolean },
 ): string {
    if (!(date instanceof Date) || Number.isNaN(date.getTime())) {

--- a/package.json
+++ b/package.json
@@ -159,7 +159,6 @@
             "clsx": "^2.1.1",
             "cmdk": "^1.1.1",
             "color": "^5.0.3",
-            "date-fns": "^4.1.0",
             "dayjs": "^1.11.13",
             "embla-carousel-autoplay": "^8.6.0",
             "embla-carousel-react": "^8.6.0",

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -52,6 +52,7 @@
       "@core/database": "workspace:*",
       "@core/logging": "workspace:*",
       "@core/utils": "workspace:*",
+      "dayjs": "catalog:ui",
       "drizzle-orm": "catalog:database",
       "zod": "catalog:validation"
    },

--- a/packages/analytics/src/date-ranges.ts
+++ b/packages/analytics/src/date-ranges.ts
@@ -1,4 +1,8 @@
+import dayjs from "dayjs";
+import quarterOfYear from "dayjs/plugin/quarterOfYear";
 import type { DateRange } from "./types";
+
+dayjs.extend(quarterOfYear);
 
 export interface ResolvedDateRange {
    start: Date;
@@ -17,35 +21,41 @@ export function resolveDateRange(dateRange: DateRange): ResolvedDateRange {
       };
    }
 
-   const now = new Date();
-   const end = startOfDay(addDays(now, 1));
+   const now = dayjs();
+   const end = now.add(1, "day").startOf("day").toDate();
 
    switch (dateRange.value) {
       case "7d":
-         return { start: startOfDay(subDays(now, 7)), end };
+         return { start: now.subtract(7, "day").startOf("day").toDate(), end };
       case "14d":
-         return { start: startOfDay(subDays(now, 14)), end };
+         return { start: now.subtract(14, "day").startOf("day").toDate(), end };
       case "30d":
-         return { start: startOfDay(subDays(now, 30)), end };
+         return { start: now.subtract(30, "day").startOf("day").toDate(), end };
       case "90d":
-         return { start: startOfDay(subDays(now, 90)), end };
+         return { start: now.subtract(90, "day").startOf("day").toDate(), end };
       case "180d":
-         return { start: startOfDay(subDays(now, 180)), end };
-      case "12m":
-         return { start: startOfDay(subMonths(now, 12)), end };
-      case "this_month":
-         return { start: startOfMonth(now), end };
-      case "last_month": {
-         const lastMonth = subMonths(now, 1);
          return {
-            start: startOfMonth(lastMonth),
-            end: startOfMonth(now),
+            start: now.subtract(180, "day").startOf("day").toDate(),
+            end,
+         };
+      case "12m":
+         return {
+            start: now.subtract(12, "month").startOf("day").toDate(),
+            end,
+         };
+      case "this_month":
+         return { start: now.startOf("month").toDate(), end };
+      case "last_month": {
+         const lastMonth = now.subtract(1, "month");
+         return {
+            start: lastMonth.startOf("month").toDate(),
+            end: now.startOf("month").toDate(),
          };
       }
       case "this_quarter":
-         return { start: startOfQuarter(now), end };
+         return { start: now.startOf("quarter").toDate(), end };
       case "this_year":
-         return { start: startOfYear(now), end };
+         return { start: now.startOf("year").toDate(), end };
    }
 }
 
@@ -64,49 +74,4 @@ export function resolveDateRangeWithComparison(
       ...resolved,
       previous,
    };
-}
-
-function startOfDay(date: Date): Date {
-   const d = new Date(date);
-   d.setHours(0, 0, 0, 0);
-   return d;
-}
-
-function addDays(date: Date, days: number): Date {
-   const d = new Date(date);
-   d.setDate(d.getDate() + days);
-   return d;
-}
-
-function subDays(date: Date, days: number): Date {
-   return addDays(date, -days);
-}
-
-function subMonths(date: Date, months: number): Date {
-   const d = new Date(date);
-   d.setMonth(d.getMonth() - months);
-   return d;
-}
-
-function startOfMonth(date: Date): Date {
-   const d = new Date(date);
-   d.setDate(1);
-   d.setHours(0, 0, 0, 0);
-   return d;
-}
-
-function startOfQuarter(date: Date): Date {
-   const d = new Date(date);
-   const month = d.getMonth();
-   const quarterStartMonth = month - (month % 3);
-   d.setMonth(quarterStartMonth, 1);
-   d.setHours(0, 0, 0, 0);
-   return d;
-}
-
-function startOfYear(date: Date): Date {
-   const d = new Date(date);
-   d.setMonth(0, 1);
-   d.setHours(0, 0, 0, 0);
-   return d;
 }

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -97,6 +97,7 @@
       "@core/stripe": "workspace:*",
       "@f-o-t/money": "catalog:fot",
       "@orpc/server": "catalog:orpc",
+      "dayjs": "catalog:ui",
       "drizzle-orm": "catalog:database",
       "zod": "catalog:validation"
    },

--- a/packages/events/src/credits.ts
+++ b/packages/events/src/credits.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import type { Redis } from "@core/redis/connection";
 import { FREE_TIER_LIMITS } from "@core/stripe/constants";
 
@@ -6,9 +7,9 @@ function usageHashKey(organizationId: string): string {
 }
 
 function msUntilEndOfMonth(): number {
-   const now = new Date();
-   const next = new Date(now.getFullYear(), now.getMonth() + 1, 1);
-   return new Date(next.getTime() + 86_400_000).getTime() - now.getTime();
+   const now = dayjs();
+   const next = now.add(1, "month").startOf("month").add(1, "day");
+   return next.valueOf() - now.valueOf();
 }
 
 export async function isWithinFreeTier(

--- a/packages/events/src/credits.ts
+++ b/packages/events/src/credits.ts
@@ -8,7 +8,7 @@ function usageHashKey(organizationId: string): string {
 
 function msUntilEndOfMonth(): number {
    const now = dayjs();
-   const next = now.add(1, "month").startOf("month").add(1, "day");
+   const next = now.add(1, "month").startOf("month");
    return next.valueOf() - now.valueOf();
 }
 

--- a/packages/events/src/emit.ts
+++ b/packages/events/src/emit.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import type { Money } from "@f-o-t/money";
 import { toMajorUnitsString } from "@f-o-t/money";
 import type { DatabaseInstance } from "@core/database/client";
@@ -80,7 +81,7 @@ function buildWebhookPayload(
       id: eventId,
       event: eventName,
       data: properties,
-      created_at: new Date().toISOString(),
+      created_at: dayjs().toISOString(),
       organization_id: organizationId,
    };
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -56,7 +56,7 @@
       "clsx": "catalog:ui",
       "cmdk": "^1.1.1",
       "color": "catalog:ui",
-      "date-fns": "^4.1.0",
+      "dayjs": "catalog:ui",
       "dedent": "1.0.0",
       "embla-carousel-autoplay": "catalog:ui",
       "embla-carousel-react": "catalog:ui",

--- a/packages/ui/src/components/date-picker.tsx
+++ b/packages/ui/src/components/date-picker.tsx
@@ -16,7 +16,7 @@ import {
 } from "@packages/ui/components/select";
 
 import { cn } from "@packages/ui/lib/utils";
-import { format } from "date-fns";
+import dayjs from "dayjs";
 import { CalendarIcon } from "lucide-react";
 import type { ChangeEvent, ChangeEventHandler } from "react";
 import { useState } from "react";
@@ -42,10 +42,10 @@ export const DatePicker = ({
 }: DatePickerProps = {}) => {
    const isControlled = dateProp !== undefined || onSelect !== undefined;
    const [internalDate, setInternalDate] = useState<Date | undefined>(
-      new Date(),
+      dayjs().toDate(),
    );
    const date = isControlled ? dateProp : internalDate;
-   const [month, setMonth] = useState<Date>(dateProp ?? new Date());
+   const [month, setMonth] = useState<Date>(dateProp ?? dayjs().toDate());
 
    const handleCalendarChange = (
       value: string | number,
@@ -81,7 +81,7 @@ export const DatePicker = ({
             >
                <CalendarIcon className="mr-2 h-4 w-4" />
                {date ? (
-                  format(date, "dd/MM/yyyy")
+                  dayjs(date).format("DD/MM/YYYY")
                ) : (
                   <span>{placeholder ?? "Pick a date"}</span>
                )}

--- a/packages/ui/src/components/date-range-picker.tsx
+++ b/packages/ui/src/components/date-range-picker.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import dayjs from "dayjs";
 import { Button } from "@packages/ui/components/button";
 import { Calendar } from "@packages/ui/components/calendar";
 import {
@@ -227,7 +228,7 @@ export function DateRangePicker({
                      numberOfMonths={2}
                      onSelect={handleCalendarSelect}
                      selected={calendarSelected}
-                     toYear={new Date().getFullYear() + 5}
+                     toYear={dayjs().year() + 5}
                   />
                </div>
             </div>

--- a/packages/ui/src/components/time-period-chips.tsx
+++ b/packages/ui/src/components/time-period-chips.tsx
@@ -1,18 +1,10 @@
 "use client";
 
 import { cn } from "@packages/ui/lib/utils";
-import {
-   endOfDay,
-   endOfMonth,
-   endOfWeek,
-   endOfYear,
-   startOfDay,
-   startOfMonth,
-   startOfWeek,
-   startOfYear,
-   subDays,
-   subMonths,
-} from "date-fns";
+import dayjs from "dayjs";
+import isoWeek from "dayjs/plugin/isoWeek";
+
+dayjs.extend(isoWeek);
 import {
    Calendar,
    CalendarDays,
@@ -92,65 +84,65 @@ const PERIODS: {
 ];
 
 export function getDateRangeForPeriod(period: TimePeriod): TimePeriodDateRange {
-   const today = new Date();
+   const today = dayjs();
 
    switch (period) {
       case "all-time":
          return {
             endDate: null,
-            selectedMonth: today,
+            selectedMonth: today.toDate(),
             startDate: null,
          };
       case "today":
          return {
-            endDate: endOfDay(today),
-            selectedMonth: today,
-            startDate: startOfDay(today),
+            endDate: today.endOf("day").toDate(),
+            selectedMonth: today.toDate(),
+            startDate: today.startOf("day").toDate(),
          };
       case "yesterday": {
-         const yesterday = subDays(today, 1);
+         const yesterday = today.subtract(1, "day");
          return {
-            endDate: endOfDay(yesterday),
-            selectedMonth: yesterday,
-            startDate: startOfDay(yesterday),
+            endDate: yesterday.endOf("day").toDate(),
+            selectedMonth: yesterday.toDate(),
+            startDate: yesterday.startOf("day").toDate(),
          };
       }
       case "this-week":
          return {
-            endDate: endOfWeek(today, { weekStartsOn: 1 }),
-            selectedMonth: today,
-            startDate: startOfWeek(today, { weekStartsOn: 1 }),
+            endDate: today.endOf("isoWeek").toDate(),
+            selectedMonth: today.toDate(),
+            startDate: today.startOf("isoWeek").toDate(),
          };
       case "this-month":
          return {
-            endDate: endOfMonth(today),
-            selectedMonth: today,
-            startDate: startOfMonth(today),
+            endDate: today.endOf("month").toDate(),
+            selectedMonth: today.toDate(),
+            startDate: today.startOf("month").toDate(),
          };
       case "last-month": {
-         const lastMonth = subMonths(today, 1);
+         const lastMonth = today.subtract(1, "month");
          return {
-            endDate: endOfMonth(lastMonth),
-            selectedMonth: lastMonth,
-            startDate: startOfMonth(lastMonth),
+            endDate: lastMonth.endOf("month").toDate(),
+            selectedMonth: lastMonth.toDate(),
+            startDate: lastMonth.startOf("month").toDate(),
          };
       }
       case "this-year":
          return {
-            endDate: endOfYear(today),
-            selectedMonth: today,
-            startDate: startOfYear(today),
+            endDate: today.endOf("year").toDate(),
+            selectedMonth: today.toDate(),
+            startDate: today.startOf("year").toDate(),
          };
       case "custom":
          return {
             endDate: null,
-            selectedMonth: today,
+            selectedMonth: today.toDate(),
             startDate: null,
          };
       default:
          return {
             endDate: null,
-            selectedMonth: today,
+            selectedMonth: today.toDate(),
             startDate: null,
          };
    }
@@ -168,7 +160,7 @@ export function TimePeriodChips({
       if (!newValue) {
          onValueChange(null, {
             endDate: null,
-            selectedMonth: new Date(),
+            selectedMonth: dayjs().toDate(),
             startDate: null,
          });
          return;

--- a/scripts/seed-addons.ts
+++ b/scripts/seed-addons.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { createDb } from "@core/database/client";
@@ -143,7 +144,7 @@ async function runSeed(
       return;
    }
 
-   const now = new Date();
+   const now = dayjs().toDate();
    const periodEnd = new Date(now.getFullYear(), now.getMonth() + 1, 1);
 
    for (const addon of toSeed) {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Este PR elimina `date-fns`, `new Date()` puro e helpers manuais de data em favor de `dayjs` em 57 arquivos, alinhando-se ao CLAUDE.md. Dois bugs pré-existentes importantes são corrigidos como efeito colateral: o TTL do Redis em `credits.ts` (que expirava 1 dia depois do fim do mês) e o cálculo de `windowEnd` em `bills.ts` (que usava `setMonth` nativo, suscetível a overflow de dia-31).

- **P1 em `core/utils/src/date.ts` linha 53:** `d.format(\"dd\")` em dayjs retorna abreviação do dia da semana (ex.: `\"Mo\"`) em vez do dia do mês — regressão silenciosa no contrato da função `formatDate`. Nenhum chamador atual usa esse token, mas a correção é trivial: trocar por `d.format(\"DD\")`.
- **P2 espalhado:** `new Date()` ainda aparece em 3 arquivos explicitamente refatorados neste PR (`billing-overview.tsx`, `usage-chart.tsx` e `scripts/seed-addons.ts`), violando a convenção do projeto.

<h3>Confidence Score: 4/5</h3>

Seguro para merge após corrigir o token `dd` em formatDate — regressão silenciosa mas de correção trivial (1 linha).

Dois bugs pré-existentes importantes foram corrigidos (TTL do Redis e overflow de mês em bills), e a migração mecânica para dayjs está correta em ~55 dos 57 arquivos. O único bloqueador real é o token `dd` em core/utils/src/date.ts que mudou silenciosamente de dia-do-mês para abreviação de dia-da-semana — embora nenhum chamador atual acione o bug, é uma regressão de contrato em função pública. Os demais `new Date()` residuais são P2 de estilo.

core/utils/src/date.ts (linha 53 — token dd), apps/web/src/features/billing/ui/billing-overview.tsx e usage-chart.tsx (new Date residual), scripts/seed-addons.ts (new Date residual)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| core/utils/src/date.ts | Reformulação substancial usando dayjs — introduz regressão no token `dd` (retorna nome do dia da semana em vez do dia do mês) e muda o formato padrão de MM/DD/YYYY para DD/MM/YYYY |
| packages/events/src/credits.ts | Corrige o TTL do Redis: remove o extra de 1 dia que fazia o hash de uso expirar na madrugada do dia 2 do próximo mês em vez da meia-noite do dia 1 |
| packages/analytics/src/date-ranges.ts | Remove helpers locais de data e migra para dayjs + plugin quarterOfYear — lógica equivalente, plugin corretamente importado e estendido |
| apps/web/src/integrations/orpc/router/bills.ts | Migra computeDueDate e windowEndStr para dayjs — elimina o overflow de mês, lógica correta |
| core/database/src/repositories/bills-repository.ts | Substituição mecânica de new Date() por dayjs — lógica equivalente, generateBillsForSubscription corretamente refatorado com cursor imutável |
| apps/web/src/features/billing/ui/billing-overview.tsx | getBillingPeriodDates e getDaysRemaining migrados corretamente; computeProjectedCost ainda usa new Date() internamente |
| apps/web/src/features/billing/ui/usage-chart.tsx | generateEmptyDateRange migrado para dayjs, mas linha 99 ainda usa new Date(d.date).toLocaleDateString() |
| scripts/seed-addons.ts | now migrado para dayjs().toDate() mas periodEnd ainda usa new Date() com aritmética nativa |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (6)</h3></summary>

1. `apps/web/src/integrations/orpc/router/bills.ts`, line 48-72 ([link](https://github.com/montte-erp/montte-nx/blob/972579327df5c0dc49d7073fb3ebc01dfd05f3ac/apps/web/src/integrations/orpc/router/bills.ts#L48-L72)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Overflow de data ao usar `setMonth()` com dias 29-31**

   `new Date(startDate)` + `d.setMonth(d.getMonth() + offset)` não foi migrado para dayjs e produz datas erradas quando o dia é 29-31. Por exemplo, `computeDueDate("2024-01-31", "monthly", 1)` retorna `"2024-03-02"` em vez de `"2024-02-29"`, pois `setMonth` não clampeia o dia. O mesmo vale para `quarterly`. Além disso, `d.toISOString().substring(0, 10)` muda o dia em ambientes não-UTC.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/integrations/orpc/router/bills.ts
   Line: 48-72

   Comment:
   **Overflow de data ao usar `setMonth()` com dias 29-31**

   `new Date(startDate)` + `d.setMonth(d.getMonth() + offset)` não foi migrado para dayjs e produz datas erradas quando o dia é 29-31. Por exemplo, `computeDueDate("2024-01-31", "monthly", 1)` retorna `"2024-03-02"` em vez de `"2024-02-29"`, pois `setMonth` não clampeia o dia. O mesmo vale para `quarterly`. Além disso, `d.toISOString().substring(0, 10)` muda o dia em ambientes não-UTC.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fintegrations%2Forpc%2Frouter%2Fbills.ts%0ALine%3A%2048-72%0A%0AComment%3A%0A**Overflow%20de%20data%20ao%20usar%20%60setMonth%28%29%60%20com%20dias%2029-31**%0A%0A%60new%20Date%28startDate%29%60%20%2B%20%60d.setMonth%28d.getMonth%28%29%20%2B%20offset%29%60%20n%C3%A3o%20foi%20migrado%20para%20dayjs%20e%20produz%20datas%20erradas%20quando%20o%20dia%20%C3%A9%2029-31.%20Por%20exemplo%2C%20%60computeDueDate%28%222024-01-31%22%2C%20%22monthly%22%2C%201%29%60%20retorna%20%60%222024-03-02%22%60%20em%20vez%20de%20%60%222024-02-29%22%60%2C%20pois%20%60setMonth%60%20n%C3%A3o%20clampeia%20o%20dia.%20O%20mesmo%20vale%20para%20%60quarterly%60.%20Al%C3%A9m%20disso%2C%20%60d.toISOString%28%29.substring%280%2C%2010%29%60%20muda%20o%20dia%20em%20ambientes%20n%C3%A3o-UTC.%0A%0A%60%60%60suggestion%0Afunction%20computeDueDate%28%0A%20%20%20startDate%3A%20string%2C%0A%20%20%20frequency%3A%20string%2C%0A%20%20%20offset%3A%20number%2C%0A%29%3A%20string%20%7B%0A%20%20%20const%20d%20%3D%20dayjs%28startDate%29%3B%0A%20%20%20switch%20%28frequency%29%20%7B%0A%20%20%20%20%20%20case%20%22weekly%22%3A%0A%20%20%20%20%20%20%20%20%20return%20d.add%287%20*%20offset%2C%20%22day%22%29.format%28%22YYYY-MM-DD%22%29%3B%0A%20%20%20%20%20%20case%20%22biweekly%22%3A%0A%20%20%20%20%20%20%20%20%20return%20d.add%2814%20*%20offset%2C%20%22day%22%29.format%28%22YYYY-MM-DD%22%29%3B%0A%20%20%20%20%20%20case%20%22monthly%22%3A%0A%20%20%20%20%20%20%20%20%20return%20d.add%28offset%2C%20%22month%22%29.format%28%22YYYY-MM-DD%22%29%3B%0A%20%20%20%20%20%20case%20%22quarterly%22%3A%0A%20%20%20%20%20%20%20%20%20return%20d.add%283%20*%20offset%2C%20%22month%22%29.format%28%22YYYY-MM-DD%22%29%3B%0A%20%20%20%20%20%20case%20%22yearly%22%3A%0A%20%20%20%20%20%20%20%20%20return%20d.add%28offset%2C%20%22year%22%29.format%28%22YYYY-MM-DD%22%29%3B%0A%20%20%20%20%20%20default%3A%0A%20%20%20%20%20%20%20%20%20return%20d.format%28%22YYYY-MM-DD%22%29%3B%0A%20%20%20%7D%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=montte-erp%2Fmontte-nx"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fintegrations%2Forpc%2Frouter%2Fbills.ts%0ALine%3A%2048-72%0A%0AComment%3A%0A**Overflow%20de%20data%20ao%20usar%20%60setMonth%28%29%60%20com%20dias%2029-31**%0A%0A%60new%20Date%28startDate%29%60%20%2B%20%60d.setMonth%28d.getMonth%28%29%20%2B%20offset%29%60%20n%C3%A3o%20foi%20migrado%20para%20dayjs%20e%20produz%20datas%20erradas%20quando%20o%20dia%20%C3%A9%2029-31.%20Por%20exemplo%2C%20%60computeDueDate%28%222024-01-31%22%2C%20%22monthly%22%2C%201%29%60%20retorna%20%60%222024-03-02%22%60%20em%20vez%20de%20%60%222024-02-29%22%60%2C%20pois%20%60setMonth%60%20n%C3%A3o%20clampeia%20o%20dia.%20O%20mesmo%20vale%20para%20%60quarterly%60.%20Al%C3%A9m%20disso%2C%20%60d.toISOString%28%29.substring%280%2C%2010%29%60%20muda%20o%20dia%20em%20ambientes%20n%C3%A3o-UTC.%0A%0A%60%60%60suggestion%0Afunction%20computeDueDate%28%0A%20%20%20startDate%3A%20string%2C%0A%20%20%20frequency%3A%20string%2C%0A%20%20%20offset%3A%20number%2C%0A%29%3A%20string%20%7B%0A%20%20%20const%20d%20%3D%20dayjs%28startDate%29%3B%0A%20%20%20switch%20%28frequency%29%20%7B%0A%20%20%20%20%20%20case%20%22weekly%22%3A%0A%20%20%20%20%20%20%20%20%20return%20d.add%287%20*%20offset%2C%20%22day%22%29.format%28%22YYYY-MM-DD%22%29%3B%0A%20%20%20%20%20%20case%20%22biweekly%22%3A%0A%20%20%20%20%20%20%20%20%20return%20d.add%2814%20*%20offset%2C%20%22day%22%29.format%28%22YYYY-MM-DD%22%29%3B%0A%20%20%20%20%20%20case%20%22monthly%22%3A%0A%20%20%20%20%20%20%20%20%20return%20d.add%28offset%2C%20%22month%22%29.format%28%22YYYY-MM-DD%22%29%3B%0A%20%20%20%20%20%20case%20%22quarterly%22%3A%0A%20%20%20%20%20%20%20%20%20return%20d.add%283%20*%20offset%2C%20%22month%22%29.format%28%22YYYY-MM-DD%22%29%3B%0A%20%20%20%20%20%20case%20%22yearly%22%3A%0A%20%20%20%20%20%20%20%20%20return%20d.add%28offset%2C%20%22year%22%29.format%28%22YYYY-MM-DD%22%29%3B%0A%20%20%20%20%20%20default%3A%0A%20%20%20%20%20%20%20%20%20return%20d.format%28%22YYYY-MM-DD%22%29%3B%0A%20%20%20%7D%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22montte-erp%2Fmontte-nx%22%20on%20the%20existing%20branch%20%22manoelnetocarvalho03%2Fmon-215-refactor-replace-new-date-and-date-fns-with-dayjs-across-the%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22manoelnetocarvalho03%2Fmon-215-refactor-replace-new-date-and-date-fns-with-dayjs-across-the%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fintegrations%2Forpc%2Frouter%2Fbills.ts%0ALine%3A%2048-72%0A%0AComment%3A%0A**Overflow%20de%20data%20ao%20usar%20%60setMonth%28%29%60%20com%20dias%2029-31**%0A%0A%60new%20Date%28startDate%29%60%20%2B%20%60d.setMonth%28d.getMonth%28%29%20%2B%20offset%29%60%20n%C3%A3o%20foi%20migrado%20para%20dayjs%20e%20produz%20datas%20erradas%20quando%20o%20dia%20%C3%A9%2029-31.%20Por%20exemplo%2C%20%60computeDueDate%28%222024-01-31%22%2C%20%22monthly%22%2C%201%29%60%20retorna%20%60%222024-03-02%22%60%20em%20vez%20de%20%60%222024-02-29%22%60%2C%20pois%20%60setMonth%60%20n%C3%A3o%20clampeia%20o%20dia.%20O%20mesmo%20vale%20para%20%60quarterly%60.%20Al%C3%A9m%20disso%2C%20%60d.toISOString%28%29.substring%280%2C%2010%29%60%20muda%20o%20dia%20em%20ambientes%20n%C3%A3o-UTC.%0A%0A%60%60%60suggestion%0Afunction%20computeDueDate%28%0A%20%20%20startDate%3A%20string%2C%0A%20%20%20frequency%3A%20string%2C%0A%20%20%20offset%3A%20number%2C%0A%29%3A%20string%20%7B%0A%20%20%20const%20d%20%3D%20dayjs%28startDate%29%3B%0A%20%20%20switch%20%28frequency%29%20%7B%0A%20%20%20%20%20%20case%20%22weekly%22%3A%0A%20%20%20%20%20%20%20%20%20return%20d.add%287%20*%20offset%2C%20%22day%22%29.format%28%22YYYY-MM-DD%22%29%3B%0A%20%20%20%20%20%20case%20%22biweekly%22%3A%0A%20%20%20%20%20%20%20%20%20return%20d.add%2814%20*%20offset%2C%20%22day%22%29.format%28%22YYYY-MM-DD%22%29%3B%0A%20%20%20%20%20%20case%20%22monthly%22%3A%0A%20%20%20%20%20%20%20%20%20return%20d.add%28offset%2C%20%22month%22%29.format%28%22YYYY-MM-DD%22%29%3B%0A%20%20%20%20%20%20case%20%22quarterly%22%3A%0A%20%20%20%20%20%20%20%20%20return%20d.add%283%20*%20offset%2C%20%22month%22%29.format%28%22YYYY-MM-DD%22%29%3B%0A%20%20%20%20%20%20case%20%22yearly%22%3A%0A%20%20%20%20%20%20%20%20%20return%20d.add%28offset%2C%20%22year%22%29.format%28%22YYYY-MM-DD%22%29%3B%0A%20%20%20%20%20%20default%3A%0A%20%20%20%20%20%20%20%20%20return%20d.format%28%22YYYY-MM-DD%22%29%3B%0A%20%20%20%7D%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

2. `core/database/src/repositories/bills-repository.ts`, line 164-166 ([link](https://github.com/montte-erp/montte-nx/blob/972579327df5c0dc49d7073fb3ebc01dfd05f3ac/core/database/src/repositories/bills-repository.ts#L164-L166)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`new Date(year, month, 0)` usa horário local, `.toISOString()` usa UTC**

   `new Date(year, month, 0)` é construído em horário local mas `.toISOString()` converte para UTC — em servidores com fuso diferente de UTC (ou no cliente), o dia devolvido pode ser um dia antes do esperado. Além disso, viola a regra do projeto de sempre usar `dayjs`.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: core/database/src/repositories/bills-repository.ts
   Line: 164-166

   Comment:
   **`new Date(year, month, 0)` usa horário local, `.toISOString()` usa UTC**

   `new Date(year, month, 0)` é construído em horário local mas `.toISOString()` converte para UTC — em servidores com fuso diferente de UTC (ou no cliente), o dia devolvido pode ser um dia antes do esperado. Além disso, viola a regra do projeto de sempre usar `dayjs`.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20core%2Fdatabase%2Fsrc%2Frepositories%2Fbills-repository.ts%0ALine%3A%20164-166%0A%0AComment%3A%0A**%60new%20Date%28year%2C%20month%2C%200%29%60%20usa%20hor%C3%A1rio%20local%2C%20%60.toISOString%28%29%60%20usa%20UTC**%0A%0A%60new%20Date%28year%2C%20month%2C%200%29%60%20%C3%A9%20constru%C3%ADdo%20em%20hor%C3%A1rio%20local%20mas%20%60.toISOString%28%29%60%20converte%20para%20UTC%20%E2%80%94%20em%20servidores%20com%20fuso%20diferente%20de%20UTC%20%28ou%20no%20cliente%29%2C%20o%20dia%20devolvido%20pode%20ser%20um%20dia%20antes%20do%20esperado.%20Al%C3%A9m%20disso%2C%20viola%20a%20regra%20do%20projeto%20de%20sempre%20usar%20%60dayjs%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20const%20end%20%3D%20dayjs%28start%29.endOf%28%22month%22%29.format%28%22YYYY-MM-DD%22%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=montte-erp%2Fmontte-nx"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20core%2Fdatabase%2Fsrc%2Frepositories%2Fbills-repository.ts%0ALine%3A%20164-166%0A%0AComment%3A%0A**%60new%20Date%28year%2C%20month%2C%200%29%60%20usa%20hor%C3%A1rio%20local%2C%20%60.toISOString%28%29%60%20usa%20UTC**%0A%0A%60new%20Date%28year%2C%20month%2C%200%29%60%20%C3%A9%20constru%C3%ADdo%20em%20hor%C3%A1rio%20local%20mas%20%60.toISOString%28%29%60%20converte%20para%20UTC%20%E2%80%94%20em%20servidores%20com%20fuso%20diferente%20de%20UTC%20%28ou%20no%20cliente%29%2C%20o%20dia%20devolvido%20pode%20ser%20um%20dia%20antes%20do%20esperado.%20Al%C3%A9m%20disso%2C%20viola%20a%20regra%20do%20projeto%20de%20sempre%20usar%20%60dayjs%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20const%20end%20%3D%20dayjs%28start%29.endOf%28%22month%22%29.format%28%22YYYY-MM-DD%22%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22montte-erp%2Fmontte-nx%22%20on%20the%20existing%20branch%20%22manoelnetocarvalho03%2Fmon-215-refactor-replace-new-date-and-date-fns-with-dayjs-across-the%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22manoelnetocarvalho03%2Fmon-215-refactor-replace-new-date-and-date-fns-with-dayjs-across-the%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20core%2Fdatabase%2Fsrc%2Frepositories%2Fbills-repository.ts%0ALine%3A%20164-166%0A%0AComment%3A%0A**%60new%20Date%28year%2C%20month%2C%200%29%60%20usa%20hor%C3%A1rio%20local%2C%20%60.toISOString%28%29%60%20usa%20UTC**%0A%0A%60new%20Date%28year%2C%20month%2C%200%29%60%20%C3%A9%20constru%C3%ADdo%20em%20hor%C3%A1rio%20local%20mas%20%60.toISOString%28%29%60%20converte%20para%20UTC%20%E2%80%94%20em%20servidores%20com%20fuso%20diferente%20de%20UTC%20%28ou%20no%20cliente%29%2C%20o%20dia%20devolvido%20pode%20ser%20um%20dia%20antes%20do%20esperado.%20Al%C3%A9m%20disso%2C%20viola%20a%20regra%20do%20projeto%20de%20sempre%20usar%20%60dayjs%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20const%20end%20%3D%20dayjs%28start%29.endOf%28%22month%22%29.format%28%22YYYY-MM-DD%22%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

3. `core/database/src/repositories/bills-repository.ts`, line 300-345 ([link](https://github.com/montte-erp/montte-nx/blob/972579327df5c0dc49d7073fb3ebc01dfd05f3ac/core/database/src/repositories/bills-repository.ts#L300-L345)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`generateBillsForSubscription` ainda usa `new Date()` e mutações nativas**

   A função usa `new Date(subscription.startDate)`, `new Date(start)`, `d.setFullYear(d.getFullYear() + 2)`, `cursor.setMonth(cursor.getMonth() + 1)`, e `toLocaleDateString("pt-BR")` — todos violam a regra do projeto de usar sempre `dayjs`. As mutações com `setMonth` também têm o risco de overflow de dia. Esta função não foi migrada neste PR.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: core/database/src/repositories/bills-repository.ts
   Line: 300-345

   Comment:
   **`generateBillsForSubscription` ainda usa `new Date()` e mutações nativas**

   A função usa `new Date(subscription.startDate)`, `new Date(start)`, `d.setFullYear(d.getFullYear() + 2)`, `cursor.setMonth(cursor.getMonth() + 1)`, e `toLocaleDateString("pt-BR")` — todos violam a regra do projeto de usar sempre `dayjs`. As mutações com `setMonth` também têm o risco de overflow de dia. Esta função não foi migrada neste PR.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20core%2Fdatabase%2Fsrc%2Frepositories%2Fbills-repository.ts%0ALine%3A%20300-345%0A%0AComment%3A%0A**%60generateBillsForSubscription%60%20ainda%20usa%20%60new%20Date%28%29%60%20e%20muta%C3%A7%C3%B5es%20nativas**%0A%0AA%20fun%C3%A7%C3%A3o%20usa%20%60new%20Date%28subscription.startDate%29%60%2C%20%60new%20Date%28start%29%60%2C%20%60d.setFullYear%28d.getFullYear%28%29%20%2B%202%29%60%2C%20%60cursor.setMonth%28cursor.getMonth%28%29%20%2B%201%29%60%2C%20e%20%60toLocaleDateString%28%22pt-BR%22%29%60%20%E2%80%94%20todos%20violam%20a%20regra%20do%20projeto%20de%20usar%20sempre%20%60dayjs%60.%20As%20muta%C3%A7%C3%B5es%20com%20%60setMonth%60%20tamb%C3%A9m%20t%C3%AAm%20o%20risco%20de%20overflow%20de%20dia.%20Esta%20fun%C3%A7%C3%A3o%20n%C3%A3o%20foi%20migrada%20neste%20PR.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=montte-erp%2Fmontte-nx"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20core%2Fdatabase%2Fsrc%2Frepositories%2Fbills-repository.ts%0ALine%3A%20300-345%0A%0AComment%3A%0A**%60generateBillsForSubscription%60%20ainda%20usa%20%60new%20Date%28%29%60%20e%20muta%C3%A7%C3%B5es%20nativas**%0A%0AA%20fun%C3%A7%C3%A3o%20usa%20%60new%20Date%28subscription.startDate%29%60%2C%20%60new%20Date%28start%29%60%2C%20%60d.setFullYear%28d.getFullYear%28%29%20%2B%202%29%60%2C%20%60cursor.setMonth%28cursor.getMonth%28%29%20%2B%201%29%60%2C%20e%20%60toLocaleDateString%28%22pt-BR%22%29%60%20%E2%80%94%20todos%20violam%20a%20regra%20do%20projeto%20de%20usar%20sempre%20%60dayjs%60.%20As%20muta%C3%A7%C3%B5es%20com%20%60setMonth%60%20tamb%C3%A9m%20t%C3%AAm%20o%20risco%20de%20overflow%20de%20dia.%20Esta%20fun%C3%A7%C3%A3o%20n%C3%A3o%20foi%20migrada%20neste%20PR.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22montte-erp%2Fmontte-nx%22%20on%20the%20existing%20branch%20%22manoelnetocarvalho03%2Fmon-215-refactor-replace-new-date-and-date-fns-with-dayjs-across-the%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22manoelnetocarvalho03%2Fmon-215-refactor-replace-new-date-and-date-fns-with-dayjs-across-the%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20core%2Fdatabase%2Fsrc%2Frepositories%2Fbills-repository.ts%0ALine%3A%20300-345%0A%0AComment%3A%0A**%60generateBillsForSubscription%60%20ainda%20usa%20%60new%20Date%28%29%60%20e%20muta%C3%A7%C3%B5es%20nativas**%0A%0AA%20fun%C3%A7%C3%A3o%20usa%20%60new%20Date%28subscription.startDate%29%60%2C%20%60new%20Date%28start%29%60%2C%20%60d.setFullYear%28d.getFullYear%28%29%20%2B%202%29%60%2C%20%60cursor.setMonth%28cursor.getMonth%28%29%20%2B%201%29%60%2C%20e%20%60toLocaleDateString%28%22pt-BR%22%29%60%20%E2%80%94%20todos%20violam%20a%20regra%20do%20projeto%20de%20usar%20sempre%20%60dayjs%60.%20As%20muta%C3%A7%C3%B5es%20com%20%60setMonth%60%20tamb%C3%A9m%20t%C3%AAm%20o%20risco%20de%20overflow%20de%20dia.%20Esta%20fun%C3%A7%C3%A3o%20n%C3%A3o%20foi%20migrada%20neste%20PR.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

4. `core/database/src/repositories/transactions-repository.ts`, line 140-165 ([link](https://github.com/montte-erp/montte-nx/blob/972579327df5c0dc49d7073fb3ebc01dfd05f3ac/core/database/src/repositories/transactions-repository.ts#L140-L165)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`validateTransactionReferences` ainda usa `new Date()` e `toLocaleDateString`**

   `new Date(refs.date)`, `new Date(account.initialBalanceDate)`, e `balanceDate.toLocaleDateString("pt-BR")` violam a regra de sempre usar `dayjs`. O arquivo está na lista de arquivos alterados neste PR.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: core/database/src/repositories/transactions-repository.ts
   Line: 140-165

   Comment:
   **`validateTransactionReferences` ainda usa `new Date()` e `toLocaleDateString`**

   `new Date(refs.date)`, `new Date(account.initialBalanceDate)`, e `balanceDate.toLocaleDateString("pt-BR")` violam a regra de sempre usar `dayjs`. O arquivo está na lista de arquivos alterados neste PR.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20core%2Fdatabase%2Fsrc%2Frepositories%2Ftransactions-repository.ts%0ALine%3A%20140-165%0A%0AComment%3A%0A**%60validateTransactionReferences%60%20ainda%20usa%20%60new%20Date%28%29%60%20e%20%60toLocaleDateString%60**%0A%0A%60new%20Date%28refs.date%29%60%2C%20%60new%20Date%28account.initialBalanceDate%29%60%2C%20e%20%60balanceDate.toLocaleDateString%28%22pt-BR%22%29%60%20violam%20a%20regra%20de%20sempre%20usar%20%60dayjs%60.%20O%20arquivo%20est%C3%A1%20na%20lista%20de%20arquivos%20alterados%20neste%20PR.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20%28account.initialBalanceDate%20%26%26%20refs.date%29%20%7B%0A%20%20%20%20%20%20%20%20%20const%20txDate%20%3D%20dayjs%28refs.date%29%3B%0A%20%20%20%20%20%20%20%20%20const%20balanceDate%20%3D%20dayjs%28account.initialBalanceDate%29%3B%0A%20%20%20%20%20%20%20%20%20if%20%28txDate.isBefore%28balanceDate%29%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20throw%20AppError.validation%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%60N%C3%A3o%20%C3%A9%20poss%C3%ADvel%20registrar%20lan%C3%A7amentos%20antes%20da%20data%20do%20saldo%20inicial%20%28%24%7BbalanceDate.format%28%22DD%2FMM%2FYYYY%22%29%7D%29.%60%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=montte-erp%2Fmontte-nx"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20core%2Fdatabase%2Fsrc%2Frepositories%2Ftransactions-repository.ts%0ALine%3A%20140-165%0A%0AComment%3A%0A**%60validateTransactionReferences%60%20ainda%20usa%20%60new%20Date%28%29%60%20e%20%60toLocaleDateString%60**%0A%0A%60new%20Date%28refs.date%29%60%2C%20%60new%20Date%28account.initialBalanceDate%29%60%2C%20e%20%60balanceDate.toLocaleDateString%28%22pt-BR%22%29%60%20violam%20a%20regra%20de%20sempre%20usar%20%60dayjs%60.%20O%20arquivo%20est%C3%A1%20na%20lista%20de%20arquivos%20alterados%20neste%20PR.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20%28account.initialBalanceDate%20%26%26%20refs.date%29%20%7B%0A%20%20%20%20%20%20%20%20%20const%20txDate%20%3D%20dayjs%28refs.date%29%3B%0A%20%20%20%20%20%20%20%20%20const%20balanceDate%20%3D%20dayjs%28account.initialBalanceDate%29%3B%0A%20%20%20%20%20%20%20%20%20if%20%28txDate.isBefore%28balanceDate%29%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20throw%20AppError.validation%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%60N%C3%A3o%20%C3%A9%20poss%C3%ADvel%20registrar%20lan%C3%A7amentos%20antes%20da%20data%20do%20saldo%20inicial%20%28%24%7BbalanceDate.format%28%22DD%2FMM%2FYYYY%22%29%7D%29.%60%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22montte-erp%2Fmontte-nx%22%20on%20the%20existing%20branch%20%22manoelnetocarvalho03%2Fmon-215-refactor-replace-new-date-and-date-fns-with-dayjs-across-the%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22manoelnetocarvalho03%2Fmon-215-refactor-replace-new-date-and-date-fns-with-dayjs-across-the%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20core%2Fdatabase%2Fsrc%2Frepositories%2Ftransactions-repository.ts%0ALine%3A%20140-165%0A%0AComment%3A%0A**%60validateTransactionReferences%60%20ainda%20usa%20%60new%20Date%28%29%60%20e%20%60toLocaleDateString%60**%0A%0A%60new%20Date%28refs.date%29%60%2C%20%60new%20Date%28account.initialBalanceDate%29%60%2C%20e%20%60balanceDate.toLocaleDateString%28%22pt-BR%22%29%60%20violam%20a%20regra%20de%20sempre%20usar%20%60dayjs%60.%20O%20arquivo%20est%C3%A1%20na%20lista%20de%20arquivos%20alterados%20neste%20PR.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20%28account.initialBalanceDate%20%26%26%20refs.date%29%20%7B%0A%20%20%20%20%20%20%20%20%20const%20txDate%20%3D%20dayjs%28refs.date%29%3B%0A%20%20%20%20%20%20%20%20%20const%20balanceDate%20%3D%20dayjs%28account.initialBalanceDate%29%3B%0A%20%20%20%20%20%20%20%20%20if%20%28txDate.isBefore%28balanceDate%29%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20throw%20AppError.validation%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%60N%C3%A3o%20%C3%A9%20poss%C3%ADvel%20registrar%20lan%C3%A7amentos%20antes%20da%20data%20do%20saldo%20inicial%20%28%24%7BbalanceDate.format%28%22DD%2FMM%2FYYYY%22%29%7D%29.%60%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

5. `apps/web/src/integrations/orpc/sdk/router/budgets.ts`, line 52-58 ([link](https://github.com/montte-erp/montte-nx/blob/972579327df5c0dc49d7073fb3ebc01dfd05f3ac/apps/web/src/integrations/orpc/sdk/router/budgets.ts#L52-L58)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Mistura `dayjs().toDate()` + métodos nativos desnecessariamente**

   `dayjs().toDate()` cria um `Date` só para chamar `.getMonth()` e `.getFullYear()`. Use `dayjs()` diretamente para manter o padrão do projeto.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/web/src/integrations/orpc/sdk/router/budgets.ts
   Line: 52-58

   Comment:
   **Mistura `dayjs().toDate()` + métodos nativos desnecessariamente**

   `dayjs().toDate()` cria um `Date` só para chamar `.getMonth()` e `.getFullYear()`. Use `dayjs()` diretamente para manter o padrão do projeto.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fintegrations%2Forpc%2Fsdk%2Frouter%2Fbudgets.ts%0ALine%3A%2052-58%0A%0AComment%3A%0A**Mistura%20%60dayjs%28%29.toDate%28%29%60%20%2B%20m%C3%A9todos%20nativos%20desnecessariamente**%0A%0A%60dayjs%28%29.toDate%28%29%60%20cria%20um%20%60Date%60%20s%C3%B3%20para%20chamar%20%60.getMonth%28%29%60%20e%20%60.getFullYear%28%29%60.%20Use%20%60dayjs%28%29%60%20diretamente%20para%20manter%20o%20padr%C3%A3o%20do%20projeto.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20const%20now%20%3D%20dayjs%28%29%3B%0A%20%20%20%20%20%20const%20goals%20%3D%20await%20listBudgetGoals%28%0A%20%20%20%20%20%20%20%20%20context.db%2C%0A%20%20%20%20%20%20%20%20%20context.teamId%2C%0A%20%20%20%20%20%20%20%20%20now.month%28%29%20%2B%201%2C%0A%20%20%20%20%20%20%20%20%20now.year%28%29%2C%0A%20%20%20%20%20%20%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=montte-erp%2Fmontte-nx"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fintegrations%2Forpc%2Fsdk%2Frouter%2Fbudgets.ts%0ALine%3A%2052-58%0A%0AComment%3A%0A**Mistura%20%60dayjs%28%29.toDate%28%29%60%20%2B%20m%C3%A9todos%20nativos%20desnecessariamente**%0A%0A%60dayjs%28%29.toDate%28%29%60%20cria%20um%20%60Date%60%20s%C3%B3%20para%20chamar%20%60.getMonth%28%29%60%20e%20%60.getFullYear%28%29%60.%20Use%20%60dayjs%28%29%60%20diretamente%20para%20manter%20o%20padr%C3%A3o%20do%20projeto.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20const%20now%20%3D%20dayjs%28%29%3B%0A%20%20%20%20%20%20const%20goals%20%3D%20await%20listBudgetGoals%28%0A%20%20%20%20%20%20%20%20%20context.db%2C%0A%20%20%20%20%20%20%20%20%20context.teamId%2C%0A%20%20%20%20%20%20%20%20%20now.month%28%29%20%2B%201%2C%0A%20%20%20%20%20%20%20%20%20now.year%28%29%2C%0A%20%20%20%20%20%20%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22montte-erp%2Fmontte-nx%22%20on%20the%20existing%20branch%20%22manoelnetocarvalho03%2Fmon-215-refactor-replace-new-date-and-date-fns-with-dayjs-across-the%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22manoelnetocarvalho03%2Fmon-215-refactor-replace-new-date-and-date-fns-with-dayjs-across-the%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fweb%2Fsrc%2Fintegrations%2Forpc%2Fsdk%2Frouter%2Fbudgets.ts%0ALine%3A%2052-58%0A%0AComment%3A%0A**Mistura%20%60dayjs%28%29.toDate%28%29%60%20%2B%20m%C3%A9todos%20nativos%20desnecessariamente**%0A%0A%60dayjs%28%29.toDate%28%29%60%20cria%20um%20%60Date%60%20s%C3%B3%20para%20chamar%20%60.getMonth%28%29%60%20e%20%60.getFullYear%28%29%60.%20Use%20%60dayjs%28%29%60%20diretamente%20para%20manter%20o%20padr%C3%A3o%20do%20projeto.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20const%20now%20%3D%20dayjs%28%29%3B%0A%20%20%20%20%20%20const%20goals%20%3D%20await%20listBudgetGoals%28%0A%20%20%20%20%20%20%20%20%20context.db%2C%0A%20%20%20%20%20%20%20%20%20context.teamId%2C%0A%20%20%20%20%20%20%20%20%20now.month%28%29%20%2B%201%2C%0A%20%20%20%20%20%20%20%20%20now.year%28%29%2C%0A%20%20%20%20%20%20%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

6. `core/utils/src/date.ts`, line 17-21 ([link](https://github.com/montte-erp/montte-nx/blob/972579327df5c0dc49d7073fb3ebc01dfd05f3ac/core/utils/src/date.ts#L17-L21)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Formato padrão `"MM/DD/YYYY"` é americano, não brasileiro**

   O projeto é totalmente em pt-BR, mas o valor padrão do parâmetro `format` é `"MM/DD/YYYY"` (formato americano). Qualquer chamada sem `format` explícito produzirá datas no formato errado para o usuário final.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: core/utils/src/date.ts
   Line: 17-21

   Comment:
   **Formato padrão `"MM/DD/YYYY"` é americano, não brasileiro**

   O projeto é totalmente em pt-BR, mas o valor padrão do parâmetro `format` é `"MM/DD/YYYY"` (formato americano). Qualquer chamada sem `format` explícito produzirá datas no formato errado para o usuário final.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20core%2Futils%2Fsrc%2Fdate.ts%0ALine%3A%2017-21%0A%0AComment%3A%0A**Formato%20padr%C3%A3o%20%60%22MM%2FDD%2FYYYY%22%60%20%C3%A9%20americano%2C%20n%C3%A3o%20brasileiro**%0A%0AO%20projeto%20%C3%A9%20totalmente%20em%20pt-BR%2C%20mas%20o%20valor%20padr%C3%A3o%20do%20par%C3%A2metro%20%60format%60%20%C3%A9%20%60%22MM%2FDD%2FYYYY%22%60%20%28formato%20americano%29.%20Qualquer%20chamada%20sem%20%60format%60%20expl%C3%ADcito%20produzir%C3%A1%20datas%20no%20formato%20errado%20para%20o%20usu%C3%A1rio%20final.%0A%0A%60%60%60suggestion%0Aexport%20function%20formatDate%28%0A%20%20%20date%3A%20Date%2C%0A%20%20%20format%3A%20string%20%3D%20%22DD%2FMM%2FYYYY%22%2C%0A%20%20%20options%3F%3A%20%7B%20locale%3F%3A%20DateLocale%3B%20timezone%3F%3A%20string%3B%20useUTC%3F%3A%20boolean%20%7D%2C%0A%29%3A%20string%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=montte-erp%2Fmontte-nx"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20core%2Futils%2Fsrc%2Fdate.ts%0ALine%3A%2017-21%0A%0AComment%3A%0A**Formato%20padr%C3%A3o%20%60%22MM%2FDD%2FYYYY%22%60%20%C3%A9%20americano%2C%20n%C3%A3o%20brasileiro**%0A%0AO%20projeto%20%C3%A9%20totalmente%20em%20pt-BR%2C%20mas%20o%20valor%20padr%C3%A3o%20do%20par%C3%A2metro%20%60format%60%20%C3%A9%20%60%22MM%2FDD%2FYYYY%22%60%20%28formato%20americano%29.%20Qualquer%20chamada%20sem%20%60format%60%20expl%C3%ADcito%20produzir%C3%A1%20datas%20no%20formato%20errado%20para%20o%20usu%C3%A1rio%20final.%0A%0A%60%60%60suggestion%0Aexport%20function%20formatDate%28%0A%20%20%20date%3A%20Date%2C%0A%20%20%20format%3A%20string%20%3D%20%22DD%2FMM%2FYYYY%22%2C%0A%20%20%20options%3F%3A%20%7B%20locale%3F%3A%20DateLocale%3B%20timezone%3F%3A%20string%3B%20useUTC%3F%3A%20boolean%20%7D%2C%0A%29%3A%20string%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22montte-erp%2Fmontte-nx%22%20on%20the%20existing%20branch%20%22manoelnetocarvalho03%2Fmon-215-refactor-replace-new-date-and-date-fns-with-dayjs-across-the%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22manoelnetocarvalho03%2Fmon-215-refactor-replace-new-date-and-date-fns-with-dayjs-across-the%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20core%2Futils%2Fsrc%2Fdate.ts%0ALine%3A%2017-21%0A%0AComment%3A%0A**Formato%20padr%C3%A3o%20%60%22MM%2FDD%2FYYYY%22%60%20%C3%A9%20americano%2C%20n%C3%A3o%20brasileiro**%0A%0AO%20projeto%20%C3%A9%20totalmente%20em%20pt-BR%2C%20mas%20o%20valor%20padr%C3%A3o%20do%20par%C3%A2metro%20%60format%60%20%C3%A9%20%60%22MM%2FDD%2FYYYY%22%60%20%28formato%20americano%29.%20Qualquer%20chamada%20sem%20%60format%60%20expl%C3%ADcito%20produzir%C3%A1%20datas%20no%20formato%20errado%20para%20o%20usu%C3%A1rio%20final.%0A%0A%60%60%60suggestion%0Aexport%20function%20formatDate%28%0A%20%20%20date%3A%20Date%2C%0A%20%20%20format%3A%20string%20%3D%20%22DD%2FMM%2FYYYY%22%2C%0A%20%20%20options%3F%3A%20%7B%20locale%3F%3A%20DateLocale%3B%20timezone%3F%3A%20string%3B%20useUTC%3F%3A%20boolean%20%7D%2C%0A%29%3A%20string%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acore%2Futils%2Fsrc%2Fdate.ts%3A53%0A**Token%20%60dd%60%20agora%20retorna%20abrevia%C3%A7%C3%A3o%20do%20dia%20da%20semana%2C%20n%C3%A3o%20o%20dia%20do%20m%C3%AAs**%0A%0AEm%20dayjs%2C%20%60format%28%22dd%22%29%60%20retorna%20a%20abrevia%C3%A7%C3%A3o%20m%C3%ADnima%20do%20dia%20da%20semana%20%28ex.%3A%20%60%22Mo%22%60%2C%20%60%22Tu%22%60%29%20e%20**n%C3%A3o**%20o%20dia%20do%20m%C3%AAs%20com%202%20d%C3%ADgitos.%20O%20comportamento%20original%20era%20id%C3%AAntico%20ao%20de%20%60DD%60%20%E2%80%94%20substituir%20%60dd%60%20pelo%20dia%20do%20m%C3%AAs%20zero-padded%20%28%60%2205%22%60%2C%20%60%2215%22%60%20etc.%29.%20Qualquer%20chamada%20que%20passe%20um%20formato%20com%20%60dd%60%20para%20representar%20dia%20do%20m%C3%AAs%20%28conven%C3%A7%C3%A3o%20comum%29%20agora%20recebe%20silenciosamente%20o%20nome%20do%20dia%20da%20semana.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20.replace%28%2Fdd%2Fg%2C%20d.format%28%22DD%22%29%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Fbilling%2Fui%2Fbilling-overview.tsx%3A122-128%0A**%60new%20Date%28%29%60%20residual%20em%20%60computeProjectedCost%60**%0A%0AO%20arquivo%20foi%20explicitamente%20inclu%C3%ADdo%20nesta%20refatora%C3%A7%C3%A3o%2C%20mas%20%60computeProjectedCost%60%20ainda%20usa%20%60new%20Date%28...%29%60%20para%20calcular%20os%20dias%20do%20m%C3%AAs%20%E2%80%94%20violando%20a%20regra%20do%20projeto.%20O%20mesmo%20padr%C3%A3o%20ocorre%20em%20%60usage-chart.tsx%60%20linha%2099%20%28%60new%20Date%28d.date%29.toLocaleDateString%28...%29%60%29%20e%20%60scripts%2Fseed-addons.ts%60%20linha%20145%20%28%60new%20Date%28now.getFullYear%28%29%2C%20...%29%60%29.%0A%0ASugest%C3%A3o%20para%20este%20trecho%3A%0A%60%60%60ts%0Aconst%20now%20%3D%20dayjs%28%29%3B%0Aconst%20dayOfMonth%20%3D%20now.date%28%29%3B%0Aconst%20daysInMonth%20%3D%20now.endOf%28%22month%22%29.date%28%29%3B%0A%60%60%60%0A%0A&repo=montte-erp%2Fmontte-nx"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acore%2Futils%2Fsrc%2Fdate.ts%3A53%0A**Token%20%60dd%60%20agora%20retorna%20abrevia%C3%A7%C3%A3o%20do%20dia%20da%20semana%2C%20n%C3%A3o%20o%20dia%20do%20m%C3%AAs**%0A%0AEm%20dayjs%2C%20%60format%28%22dd%22%29%60%20retorna%20a%20abrevia%C3%A7%C3%A3o%20m%C3%ADnima%20do%20dia%20da%20semana%20%28ex.%3A%20%60%22Mo%22%60%2C%20%60%22Tu%22%60%29%20e%20**n%C3%A3o**%20o%20dia%20do%20m%C3%AAs%20com%202%20d%C3%ADgitos.%20O%20comportamento%20original%20era%20id%C3%AAntico%20ao%20de%20%60DD%60%20%E2%80%94%20substituir%20%60dd%60%20pelo%20dia%20do%20m%C3%AAs%20zero-padded%20%28%60%2205%22%60%2C%20%60%2215%22%60%20etc.%29.%20Qualquer%20chamada%20que%20passe%20um%20formato%20com%20%60dd%60%20para%20representar%20dia%20do%20m%C3%AAs%20%28conven%C3%A7%C3%A3o%20comum%29%20agora%20recebe%20silenciosamente%20o%20nome%20do%20dia%20da%20semana.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20.replace%28%2Fdd%2Fg%2C%20d.format%28%22DD%22%29%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Fbilling%2Fui%2Fbilling-overview.tsx%3A122-128%0A**%60new%20Date%28%29%60%20residual%20em%20%60computeProjectedCost%60**%0A%0AO%20arquivo%20foi%20explicitamente%20inclu%C3%ADdo%20nesta%20refatora%C3%A7%C3%A3o%2C%20mas%20%60computeProjectedCost%60%20ainda%20usa%20%60new%20Date%28...%29%60%20para%20calcular%20os%20dias%20do%20m%C3%AAs%20%E2%80%94%20violando%20a%20regra%20do%20projeto.%20O%20mesmo%20padr%C3%A3o%20ocorre%20em%20%60usage-chart.tsx%60%20linha%2099%20%28%60new%20Date%28d.date%29.toLocaleDateString%28...%29%60%29%20e%20%60scripts%2Fseed-addons.ts%60%20linha%20145%20%28%60new%20Date%28now.getFullYear%28%29%2C%20...%29%60%29.%0A%0ASugest%C3%A3o%20para%20este%20trecho%3A%0A%60%60%60ts%0Aconst%20now%20%3D%20dayjs%28%29%3B%0Aconst%20dayOfMonth%20%3D%20now.date%28%29%3B%0Aconst%20daysInMonth%20%3D%20now.endOf%28%22month%22%29.date%28%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22montte-erp%2Fmontte-nx%22%20on%20the%20existing%20branch%20%22manoelnetocarvalho03%2Fmon-215-refactor-replace-new-date-and-date-fns-with-dayjs-across-the%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22manoelnetocarvalho03%2Fmon-215-refactor-replace-new-date-and-date-fns-with-dayjs-across-the%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acore%2Futils%2Fsrc%2Fdate.ts%3A53%0A**Token%20%60dd%60%20agora%20retorna%20abrevia%C3%A7%C3%A3o%20do%20dia%20da%20semana%2C%20n%C3%A3o%20o%20dia%20do%20m%C3%AAs**%0A%0AEm%20dayjs%2C%20%60format%28%22dd%22%29%60%20retorna%20a%20abrevia%C3%A7%C3%A3o%20m%C3%ADnima%20do%20dia%20da%20semana%20%28ex.%3A%20%60%22Mo%22%60%2C%20%60%22Tu%22%60%29%20e%20**n%C3%A3o**%20o%20dia%20do%20m%C3%AAs%20com%202%20d%C3%ADgitos.%20O%20comportamento%20original%20era%20id%C3%AAntico%20ao%20de%20%60DD%60%20%E2%80%94%20substituir%20%60dd%60%20pelo%20dia%20do%20m%C3%AAs%20zero-padded%20%28%60%2205%22%60%2C%20%60%2215%22%60%20etc.%29.%20Qualquer%20chamada%20que%20passe%20um%20formato%20com%20%60dd%60%20para%20representar%20dia%20do%20m%C3%AAs%20%28conven%C3%A7%C3%A3o%20comum%29%20agora%20recebe%20silenciosamente%20o%20nome%20do%20dia%20da%20semana.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20.replace%28%2Fdd%2Fg%2C%20d.format%28%22DD%22%29%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Fbilling%2Fui%2Fbilling-overview.tsx%3A122-128%0A**%60new%20Date%28%29%60%20residual%20em%20%60computeProjectedCost%60**%0A%0AO%20arquivo%20foi%20explicitamente%20inclu%C3%ADdo%20nesta%20refatora%C3%A7%C3%A3o%2C%20mas%20%60computeProjectedCost%60%20ainda%20usa%20%60new%20Date%28...%29%60%20para%20calcular%20os%20dias%20do%20m%C3%AAs%20%E2%80%94%20violando%20a%20regra%20do%20projeto.%20O%20mesmo%20padr%C3%A3o%20ocorre%20em%20%60usage-chart.tsx%60%20linha%2099%20%28%60new%20Date%28d.date%29.toLocaleDateString%28...%29%60%29%20e%20%60scripts%2Fseed-addons.ts%60%20linha%20145%20%28%60new%20Date%28now.getFullYear%28%29%2C%20...%29%60%29.%0A%0ASugest%C3%A3o%20para%20este%20trecho%3A%0A%60%60%60ts%0Aconst%20now%20%3D%20dayjs%28%29%3B%0Aconst%20dayOfMonth%20%3D%20now.date%28%29%3B%0Aconst%20daysInMonth%20%3D%20now.endOf%28%22month%22%29.date%28%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: core/utils/src/date.ts
Line: 53

Comment:
**Token `dd` agora retorna abreviação do dia da semana, não o dia do mês**

Em dayjs, `format("dd")` retorna a abreviação mínima do dia da semana (ex.: `"Mo"`, `"Tu"`) e **não** o dia do mês com 2 dígitos. O comportamento original era idêntico ao de `DD` — substituir `dd` pelo dia do mês zero-padded (`"05"`, `"15"` etc.). Qualquer chamada que passe um formato com `dd` para representar dia do mês (convenção comum) agora recebe silenciosamente o nome do dia da semana.

```suggestion
      .replace(/dd/g, d.format("DD"))
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/src/features/billing/ui/billing-overview.tsx
Line: 122-128

Comment:
**`new Date()` residual em `computeProjectedCost`**

O arquivo foi explicitamente incluído nesta refatoração, mas `computeProjectedCost` ainda usa `new Date(...)` para calcular os dias do mês — violando a regra do projeto. O mesmo padrão ocorre em `usage-chart.tsx` linha 99 (`new Date(d.date).toLocaleDateString(...)`) e `scripts/seed-addons.ts` linha 145 (`new Date(now.getFullYear(), ...)`).

Sugestão para este trecho:
```ts
const now = dayjs();
const dayOfMonth = now.date();
const daysInMonth = now.endOf("month").date();
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["refactor(billing): Improve date calculat..."](https://github.com/montte-erp/montte-nx/commit/ecffb933c3d654205834982de235435c21be0a62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28536635)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=50793934-4fc6-4fd8-9b91-f358e100c905))

<!-- /greptile_comment -->