### PR TITLE
docs: Add rationale for using Credenza components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -599,6 +599,8 @@ startTransition(async () => { await authClient.method(...); });
 
 **ALWAYS use these — never import Sheet/Dialog/Drawer/AlertDialog/Credenza components directly.**
 
+> **Why:** Ensures single overlay stack, consistent focus trapping, and uniform close behavior across all modals. Direct imports break keyboard navigation and screen reader focus flow.
+
 | Hook             | Use For                                         |
 | ---------------- | ----------------------------------------------- |
 | `useCredenza`    | All modals and overlays — creating/editing records, selecting agents, export formats, any overlay UI |


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Atualiza a documentação para explicar por que devemos sempre usar `useCredenza`/`useAlertDialog` em vez de importar componentes de modal diretamente. Reforça requisitos de acessibilidade: pilha única de overlays, focus trap consistente e fechamento uniforme, evitando problemas de navegação por teclado e fluxo de foco em leitores de tela (atende ao MON-350).

<sup>Written for commit 761583a216e44a7a86a940482a30e5d268baf47c. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/773">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Esta PR adiciona um blockquote `> **Why:** ...` à seção "Global UI Hooks (TanStack Store)" do `CLAUDE.md`, documentando o motivo pelo qual desenvolvedores devem usar `useCredenza` e `useAlertDialog` em vez de importar diretamente os componentes Radix (`Dialog`, `Sheet`, `AlertDialog`, etc.). A mudança é puramente de documentação e não altera nenhum código de produção.

<h3>Confidence Score: 5/5</h3>

PR seguro para merge — mudança exclusivamente em documentação, sem impacto em código de produção.

Único arquivo alterado é CLAUDE.md com adição de uma linha de documentação. O único achado é P2 (sugestão de clareza na redação da justificativa), sem qualquer risco de regressão ou quebra de funcionalidade.

Nenhum arquivo requer atenção especial.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CLAUDE.md | Adicionado blockquote de justificativa (`> **Why:** ...`) à seção "Global UI Hooks", explicando o motivo para usar `useCredenza`/`useAlertDialog` em vez de importar componentes diretamente. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Componente precisa de modal] --> B{Usar hook global?}
    B -- Sim: useCredenza / useAlertDialog --> C[Stack único de overlays]
    C --> D[Focus trapping coordenado]
    C --> E[Comportamento de fechar uniforme]
    C --> F[Navegação por teclado consistente]
    B -- Não: import direto de Dialog/Sheet/etc. --> G[Múltiplos overlays independentes]
    G --> H[Conflito de focus trapping]
    G --> I[Quebra de navegação por teclado]
    G --> J[Comportamento inconsistente de fechar]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACLAUDE.md%3A602%0A**Justificativa%20imprecisa%20para%20o%20problema%20de%20keyboard%20navigation**%0A%0AA%20afirma%C3%A7%C3%A3o%20%22Direct%20imports%20break%20keyboard%20navigation%20and%20screen%20reader%20focus%20flow%22%20%C3%A9%20forte%20demais.%20Componentes%20Radix%20UI%20%28%60Dialog%60%2C%20%60Sheet%60%2C%20%60AlertDialog%60%2C%20etc.%29%20_individualmente_%20s%C3%A3o%20acess%C3%ADveis%20por%20design%20%E2%80%94%20eles%20implementam%20focus%20trapping%20e%20navega%C3%A7%C3%A3o%20por%20teclado%20corretamente.%20O%20problema%20real%20ocorre%20quando%20m%C3%BAltiplos%20overlays%20s%C3%A3o%20abertos%20simultaneamente%20sem%20coordena%C3%A7%C3%A3o%2C%20pois%20cada%20um%20tenta%20capturar%20o%20foco%20de%20forma%20independente%2C%20gerando%20conflito.%20Uma%20reda%C3%A7%C3%A3o%20mais%20precisa%20seria%3A%0A%0A%60%60%60suggestion%0A%3E%20**Why%3A**%20Ensures%20a%20single%20overlay%20stack%2C%20preventing%20multiple%20simultaneous%20modals%20from%20competing%20for%20focus.%20Direct%20imports%20allow%20parallel%20overlays%20that%20conflict%20on%20focus%20trapping%20and%20produce%20inconsistent%20close%20behavior%20across%20the%20app.%0A%60%60%60%0A%0A&repo=montte-erp%2Fmontte-nx"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACLAUDE.md%3A602%0A**Justificativa%20imprecisa%20para%20o%20problema%20de%20keyboard%20navigation**%0A%0AA%20afirma%C3%A7%C3%A3o%20%22Direct%20imports%20break%20keyboard%20navigation%20and%20screen%20reader%20focus%20flow%22%20%C3%A9%20forte%20demais.%20Componentes%20Radix%20UI%20%28%60Dialog%60%2C%20%60Sheet%60%2C%20%60AlertDialog%60%2C%20etc.%29%20_individualmente_%20s%C3%A3o%20acess%C3%ADveis%20por%20design%20%E2%80%94%20eles%20implementam%20focus%20trapping%20e%20navega%C3%A7%C3%A3o%20por%20teclado%20corretamente.%20O%20problema%20real%20ocorre%20quando%20m%C3%BAltiplos%20overlays%20s%C3%A3o%20abertos%20simultaneamente%20sem%20coordena%C3%A7%C3%A3o%2C%20pois%20cada%20um%20tenta%20capturar%20o%20foco%20de%20forma%20independente%2C%20gerando%20conflito.%20Uma%20reda%C3%A7%C3%A3o%20mais%20precisa%20seria%3A%0A%0A%60%60%60suggestion%0A%3E%20**Why%3A**%20Ensures%20a%20single%20overlay%20stack%2C%20preventing%20multiple%20simultaneous%20modals%20from%20competing%20for%20focus.%20Direct%20imports%20allow%20parallel%20overlays%20that%20conflict%20on%20focus%20trapping%20and%20produce%20inconsistent%20close%20behavior%20across%20the%20app.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22montte-erp%2Fmontte-nx%22%20on%20the%20existing%20branch%20%22manoelnetocarvalho03%2Fmon-350-add-accessibility-rationale-to-usecredenzausealertdialog%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22manoelnetocarvalho03%2Fmon-350-add-accessibility-rationale-to-usecredenzausealertdialog%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACLAUDE.md%3A602%0A**Justificativa%20imprecisa%20para%20o%20problema%20de%20keyboard%20navigation**%0A%0AA%20afirma%C3%A7%C3%A3o%20%22Direct%20imports%20break%20keyboard%20navigation%20and%20screen%20reader%20focus%20flow%22%20%C3%A9%20forte%20demais.%20Componentes%20Radix%20UI%20%28%60Dialog%60%2C%20%60Sheet%60%2C%20%60AlertDialog%60%2C%20etc.%29%20_individualmente_%20s%C3%A3o%20acess%C3%ADveis%20por%20design%20%E2%80%94%20eles%20implementam%20focus%20trapping%20e%20navega%C3%A7%C3%A3o%20por%20teclado%20corretamente.%20O%20problema%20real%20ocorre%20quando%20m%C3%BAltiplos%20overlays%20s%C3%A3o%20abertos%20simultaneamente%20sem%20coordena%C3%A7%C3%A3o%2C%20pois%20cada%20um%20tenta%20capturar%20o%20foco%20de%20forma%20independente%2C%20gerando%20conflito.%20Uma%20reda%C3%A7%C3%A3o%20mais%20precisa%20seria%3A%0A%0A%60%60%60suggestion%0A%3E%20**Why%3A**%20Ensures%20a%20single%20overlay%20stack%2C%20preventing%20multiple%20simultaneous%20modals%20from%20competing%20for%20focus.%20Direct%20imports%20allow%20parallel%20overlays%20that%20conflict%20on%20focus%20trapping%20and%20produce%20inconsistent%20close%20behavior%20across%20the%20app.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: CLAUDE.md
Line: 602

Comment:
**Justificativa imprecisa para o problema de keyboard navigation**

A afirmação "Direct imports break keyboard navigation and screen reader focus flow" é forte demais. Componentes Radix UI (`Dialog`, `Sheet`, `AlertDialog`, etc.) _individualmente_ são acessíveis por design — eles implementam focus trapping e navegação por teclado corretamente. O problema real ocorre quando múltiplos overlays são abertos simultaneamente sem coordenação, pois cada um tenta capturar o foco de forma independente, gerando conflito. Uma redação mais precisa seria:

```suggestion
> **Why:** Ensures a single overlay stack, preventing multiple simultaneous modals from competing for focus. Direct imports allow parallel overlays that conflict on focus trapping and produce inconsistent close behavior across the app.
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: Add rationale for using Credenza c..."](https://github.com/montte-erp/montte-nx/commit/761583a216e44a7a86a940482a30e5d268baf47c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28565012)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->