### PR TITLE
perf(store): narrow useStore selectors to prevent unnecessary re-renders

### DIFF
--- a/apps/web/src/features/context-panel/context-panel.tsx
+++ b/apps/web/src/features/context-panel/context-panel.tsx
@@ -81,7 +81,11 @@ function ViewSwitchPanelAction({ config }: { config: PageViewSwitchConfig }) {
 function InfoContent() {
    const { infoContent, pageActions, pageViewSwitch } = useStore(
       contextPanelStore,
-      (s) => s,
+      (s) => ({
+         infoContent: s.infoContent,
+         pageActions: s.pageActions,
+         pageViewSwitch: s.pageViewSwitch,
+      }),
    );
 
    const emptyState = (
@@ -130,7 +134,10 @@ const INFO_TAB: ContextPanelTab = {
 };
 
 function ContextPanelInner() {
-   const { activeTabId, dynamicTabs } = useStore(contextPanelStore, (s) => s);
+   const { activeTabId, dynamicTabs } = useStore(contextPanelStore, (s) => ({
+      activeTabId: s.activeTabId,
+      dynamicTabs: s.dynamicTabs,
+   }));
 
    const allTabs: ContextPanelTab[] = [
       INFO_TAB,
@@ -188,7 +195,7 @@ function ContextPanelInner() {
 }
 
 export function GlobalContextPanel() {
-   const { isOpen } = useStore(contextPanelStore, (s) => s);
+   const isOpen = useStore(contextPanelStore, (s) => s.isOpen);
 
    return (
       <SidebarManager

--- a/apps/web/src/hooks/use-credenza.tsx
+++ b/apps/web/src/hooks/use-credenza.tsx
@@ -24,7 +24,7 @@ export const useCredenza = () => ({
 });
 
 export function GlobalCredenza() {
-   const { stack } = useStore(credenzaStore, (s) => s);
+   const stack = useStore(credenzaStore, (s) => s.stack);
 
    return (
       <>


### PR DESCRIPTION
## Summary

- Narrow `(s) => s` full-store subscriptions to specific field selectors in `contextPanelStore` and `credenzaStore`
- `InfoContent`: selects `infoContent`, `pageActions`, `pageViewSwitch` only
- `ContextPanelInner`: selects `activeTabId`, `dynamicTabs` only
- `GlobalContextPanel`: selects `isOpen` only
- `GlobalCredenza`: selects `stack` only

## Test plan

- [ ] Open/close context panel — no unrelated re-renders
- [ ] Switch context panel tabs — only `ContextPanelInner` re-renders
- [ ] Open/close credenza — only `GlobalCredenza` re-renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduzimos re-renderizações desnecessárias ao trocar assinaturas `(s) => s` por seletores específicos em `useStore`, melhorando a performance do painel de contexto e da credenza.

- **Refactors**
  - `InfoContent`: agora assina apenas `infoContent`, `pageActions`, `pageViewSwitch` de `contextPanelStore`.
  - `ContextPanelInner`: agora assina apenas `activeTabId`, `dynamicTabs` de `contextPanelStore`.
  - `GlobalContextPanel`: agora assina apenas `isOpen` de `contextPanelStore`.
  - `GlobalCredenza`: agora assina apenas `stack` de `credenzaStore`.

<sup>Written for commit 502d40da8c7c2ae3cfae6c739a6ebb5136a00dca. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/775">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

O PR tem o objetivo correto — estreitar os seletores do `useStore` para evitar re-renders desnecessários — mas a implementação em `InfoContent` e `ContextPanelInner` é incorreta. `useStore` do `@tanstack/react-store` usa igualdade referencial (`Object.is`); seletores que retornam objetos literais criam uma nova referência a cada chamada, fazendo o componente re-renderizar em **todo** update da store, equivalente ou pior que o `(s) => s` original.

- Os seletores de primitivo em `GlobalContextPanel` (`s.isOpen`) e `GlobalCredenza` (`s.stack`) estão corretos.
- `InfoContent` e `ContextPanelInner` precisam ser reescritos com chamadas individuais de `useStore` por campo.

<h3>Confidence Score: 3/5</h3>

O PR não deve ser mergeado: a otimização central falha em 2 dos 4 componentes.

Dois P1 ativos — seletores com objeto literal sempre produzem nova referência com Object.is, anulando o objetivo do PR em InfoContent e ContextPanelInner.

apps/web/src/features/context-panel/context-panel.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/features/context-panel/context-panel.tsx | Os seletores de `InfoContent` e `ContextPanelInner` retornam objetos literais a cada chamada, invalidando a otimização pretendida; os seletores de primitivo em `GlobalContextPanel` estão corretos. |
| apps/web/src/hooks/use-credenza.tsx | Seletor correto: retorna diretamente a referência do array `s.stack`, que só muda quando a store é mutada. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Store["contextPanelStore / credenzaStore"]
        S[Estado atualizado via setState]
    end
    subgraph Correto["Seletores corretos"]
        GCP["GlobalContextPanel\nuseStore(s => s.isOpen)"]
        GC["GlobalCredenza\nuseStore(s => s.stack)"]
    end
    subgraph Incorreto["Objeto literal - sempre nova referencia"]
        IC["InfoContent\n(s) => ({ infoContent, pageActions, pageViewSwitch })"]
        CPI["ContextPanelInner\n(s) => ({ activeTabId, dynamicTabs })"]
    end
    S -->|"Object.is OK"| GCP
    S -->|"Object.is OK"| GC
    S -->|"SEMPRE re-render"| IC
    S -->|"SEMPRE re-render"| CPI
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Fcontext-panel%2Fcontext-panel.tsx%3A81-89%0A**Seletor%20de%20objeto%20cria%20nova%20refer%C3%AAncia%20em%20todo%20update**%0A%0A%60useStore%60%20do%20%60%40tanstack%2Freact-store%60%20usa%20igualdade%20referencial%20%28%60Object.is%60%29%20para%20comparar%20o%20retorno%20do%20seletor.%20Um%20seletor%20que%20retorna%20um%20**objeto%20literal**%20%28%60%7B%20a%3A%20s.a%2C%20b%3A%20s.b%20%7D%60%29%20sempre%20produz%20uma%20nova%20refer%C3%AAncia%2C%20mesmo%20quando%20os%20valores%20n%C3%A3o%20mudaram%20%E2%80%94%20e%20o%20componente%20re-renderiza%20a%20cada%20qualquer%20update%20da%20store%2C%20pior%20do%20que%20o%20%60%28s%29%20%3D%3E%20s%60%20original.%0A%0APara%20o%20seletor%20funcionar%20como%20pretendido%2C%20separe%20em%20chamadas%20individuais%20%28um%20%60useStore%60%20por%20campo%29%3A%0A%0A%60%60%60suggestion%0A%20%20%20const%20infoContent%20%3D%20useStore%28contextPanelStore%2C%20%28s%29%20%3D%3E%20s.infoContent%29%3B%0A%20%20%20const%20pageActions%20%3D%20useStore%28contextPanelStore%2C%20%28s%29%20%3D%3E%20s.pageActions%29%3B%0A%20%20%20const%20pageViewSwitch%20%3D%20useStore%28contextPanelStore%2C%20%28s%29%20%3D%3E%20s.pageViewSwitch%29%3B%0A%60%60%60%0A%0AO%20mesmo%20problema%20ocorre%20em%20%60ContextPanelInner%60%20nas%20linhas%20137%E2%80%93140.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Fcontext-panel%2Fcontext-panel.tsx%3A137-140%0A**Mesmo%20problema%20de%20refer%C3%AAncia%20de%20objeto**%0A%0AAssim%20como%20em%20%60InfoContent%60%2C%20este%20seletor%20retorna%20um%20novo%20objeto%20literal%20a%20cada%20chamada%2C%20fazendo%20%60ContextPanelInner%60%20re-renderizar%20em%20toda%20atualiza%C3%A7%C3%A3o%20da%20store%20%E2%80%94%20o%20oposto%20do%20objetivo%20declarado%20no%20PR.%20Use%20chamadas%20separadas%3A%0A%0A%60%60%60suggestion%0A%20%20%20const%20activeTabId%20%3D%20useStore%28contextPanelStore%2C%20%28s%29%20%3D%3E%20s.activeTabId%29%3B%0A%20%20%20const%20dynamicTabs%20%3D%20useStore%28contextPanelStore%2C%20%28s%29%20%3D%3E%20s.dynamicTabs%29%3B%0A%60%60%60%0A%0A&repo=montte-erp%2Fmontte-nx"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Fcontext-panel%2Fcontext-panel.tsx%3A81-89%0A**Seletor%20de%20objeto%20cria%20nova%20refer%C3%AAncia%20em%20todo%20update**%0A%0A%60useStore%60%20do%20%60%40tanstack%2Freact-store%60%20usa%20igualdade%20referencial%20%28%60Object.is%60%29%20para%20comparar%20o%20retorno%20do%20seletor.%20Um%20seletor%20que%20retorna%20um%20**objeto%20literal**%20%28%60%7B%20a%3A%20s.a%2C%20b%3A%20s.b%20%7D%60%29%20sempre%20produz%20uma%20nova%20refer%C3%AAncia%2C%20mesmo%20quando%20os%20valores%20n%C3%A3o%20mudaram%20%E2%80%94%20e%20o%20componente%20re-renderiza%20a%20cada%20qualquer%20update%20da%20store%2C%20pior%20do%20que%20o%20%60%28s%29%20%3D%3E%20s%60%20original.%0A%0APara%20o%20seletor%20funcionar%20como%20pretendido%2C%20separe%20em%20chamadas%20individuais%20%28um%20%60useStore%60%20por%20campo%29%3A%0A%0A%60%60%60suggestion%0A%20%20%20const%20infoContent%20%3D%20useStore%28contextPanelStore%2C%20%28s%29%20%3D%3E%20s.infoContent%29%3B%0A%20%20%20const%20pageActions%20%3D%20useStore%28contextPanelStore%2C%20%28s%29%20%3D%3E%20s.pageActions%29%3B%0A%20%20%20const%20pageViewSwitch%20%3D%20useStore%28contextPanelStore%2C%20%28s%29%20%3D%3E%20s.pageViewSwitch%29%3B%0A%60%60%60%0A%0AO%20mesmo%20problema%20ocorre%20em%20%60ContextPanelInner%60%20nas%20linhas%20137%E2%80%93140.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Fcontext-panel%2Fcontext-panel.tsx%3A137-140%0A**Mesmo%20problema%20de%20refer%C3%AAncia%20de%20objeto**%0A%0AAssim%20como%20em%20%60InfoContent%60%2C%20este%20seletor%20retorna%20um%20novo%20objeto%20literal%20a%20cada%20chamada%2C%20fazendo%20%60ContextPanelInner%60%20re-renderizar%20em%20toda%20atualiza%C3%A7%C3%A3o%20da%20store%20%E2%80%94%20o%20oposto%20do%20objetivo%20declarado%20no%20PR.%20Use%20chamadas%20separadas%3A%0A%0A%60%60%60suggestion%0A%20%20%20const%20activeTabId%20%3D%20useStore%28contextPanelStore%2C%20%28s%29%20%3D%3E%20s.activeTabId%29%3B%0A%20%20%20const%20dynamicTabs%20%3D%20useStore%28contextPanelStore%2C%20%28s%29%20%3D%3E%20s.dynamicTabs%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22montte-erp%2Fmontte-nx%22%20on%20the%20existing%20branch%20%22manoelnetocarvalho03%2Fmon-350-add-accessibility-rationale-to-usecredenzausealertdialog%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22manoelnetocarvalho03%2Fmon-350-add-accessibility-rationale-to-usecredenzausealertdialog%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Fcontext-panel%2Fcontext-panel.tsx%3A81-89%0A**Seletor%20de%20objeto%20cria%20nova%20refer%C3%AAncia%20em%20todo%20update**%0A%0A%60useStore%60%20do%20%60%40tanstack%2Freact-store%60%20usa%20igualdade%20referencial%20%28%60Object.is%60%29%20para%20comparar%20o%20retorno%20do%20seletor.%20Um%20seletor%20que%20retorna%20um%20**objeto%20literal**%20%28%60%7B%20a%3A%20s.a%2C%20b%3A%20s.b%20%7D%60%29%20sempre%20produz%20uma%20nova%20refer%C3%AAncia%2C%20mesmo%20quando%20os%20valores%20n%C3%A3o%20mudaram%20%E2%80%94%20e%20o%20componente%20re-renderiza%20a%20cada%20qualquer%20update%20da%20store%2C%20pior%20do%20que%20o%20%60%28s%29%20%3D%3E%20s%60%20original.%0A%0APara%20o%20seletor%20funcionar%20como%20pretendido%2C%20separe%20em%20chamadas%20individuais%20%28um%20%60useStore%60%20por%20campo%29%3A%0A%0A%60%60%60suggestion%0A%20%20%20const%20infoContent%20%3D%20useStore%28contextPanelStore%2C%20%28s%29%20%3D%3E%20s.infoContent%29%3B%0A%20%20%20const%20pageActions%20%3D%20useStore%28contextPanelStore%2C%20%28s%29%20%3D%3E%20s.pageActions%29%3B%0A%20%20%20const%20pageViewSwitch%20%3D%20useStore%28contextPanelStore%2C%20%28s%29%20%3D%3E%20s.pageViewSwitch%29%3B%0A%60%60%60%0A%0AO%20mesmo%20problema%20ocorre%20em%20%60ContextPanelInner%60%20nas%20linhas%20137%E2%80%93140.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Fcontext-panel%2Fcontext-panel.tsx%3A137-140%0A**Mesmo%20problema%20de%20refer%C3%AAncia%20de%20objeto**%0A%0AAssim%20como%20em%20%60InfoContent%60%2C%20este%20seletor%20retorna%20um%20novo%20objeto%20literal%20a%20cada%20chamada%2C%20fazendo%20%60ContextPanelInner%60%20re-renderizar%20em%20toda%20atualiza%C3%A7%C3%A3o%20da%20store%20%E2%80%94%20o%20oposto%20do%20objetivo%20declarado%20no%20PR.%20Use%20chamadas%20separadas%3A%0A%0A%60%60%60suggestion%0A%20%20%20const%20activeTabId%20%3D%20useStore%28contextPanelStore%2C%20%28s%29%20%3D%3E%20s.activeTabId%29%3B%0A%20%20%20const%20dynamicTabs%20%3D%20useStore%28contextPanelStore%2C%20%28s%29%20%3D%3E%20s.dynamicTabs%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/web/src/features/context-panel/context-panel.tsx
Line: 81-89

Comment:
**Seletor de objeto cria nova referência em todo update**

`useStore` do `@tanstack/react-store` usa igualdade referencial (`Object.is`) para comparar o retorno do seletor. Um seletor que retorna um **objeto literal** (`{ a: s.a, b: s.b }`) sempre produz uma nova referência, mesmo quando os valores não mudaram — e o componente re-renderiza a cada qualquer update da store, pior do que o `(s) => s` original.

Para o seletor funcionar como pretendido, separe em chamadas individuais (um `useStore` por campo):

```suggestion
   const infoContent = useStore(contextPanelStore, (s) => s.infoContent);
   const pageActions = useStore(contextPanelStore, (s) => s.pageActions);
   const pageViewSwitch = useStore(contextPanelStore, (s) => s.pageViewSwitch);
```

O mesmo problema ocorre em `ContextPanelInner` nas linhas 137–140.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/src/features/context-panel/context-panel.tsx
Line: 137-140

Comment:
**Mesmo problema de referência de objeto**

Assim como em `InfoContent`, este seletor retorna um novo objeto literal a cada chamada, fazendo `ContextPanelInner` re-renderizar em toda atualização da store — o oposto do objetivo declarado no PR. Use chamadas separadas:

```suggestion
   const activeTabId = useStore(contextPanelStore, (s) => s.activeTabId);
   const dynamicTabs = useStore(contextPanelStore, (s) => s.dynamicTabs);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(store): narrow useStore selectors t..."](https://github.com/montte-erp/montte-nx/commit/502d40da8c7c2ae3cfae6c739a6ebb5136a00dca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28567223)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->