### PR TITLE
refactor(store): add createPersistedStore utility and migrate sidebarNavStore

### DIFF
--- a/apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts
+++ b/apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts
@@ -10,14 +10,12 @@ interface SidebarNavState {
    pinnedItems: string[];
 }
 
-const sidebarNavStore = createPersistedStore<SidebarNavState>(
-   "montte:sidebar-nav",
-   {
+const { store: sidebarNavStore, useStorePersistence } =
+   createPersistedStore<SidebarNavState>("montte:sidebar-nav", {
       activeSection: null,
       searchQuery: "",
       pinnedItems: [],
-   },
-);
+   });
 
 export function setActiveSection(section: SubSidebarSection | null) {
    sidebarNavStore.setState((state) => ({
@@ -44,6 +42,7 @@ export function togglePinnedItem(itemId: string) {
 }
 
 export function useSidebarNav() {
+   useStorePersistence();
    const state = useStore(sidebarNavStore, (s) => s);
 
    return {

--- a/apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts
+++ b/apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts
@@ -1,24 +1,8 @@
-import { Store, useStore } from "@tanstack/react-store";
+import { useStore } from "@tanstack/react-store";
 import { useEffect } from "react";
+import { createPersistedStore } from "@/lib/persisted-store";
 
 export type SubSidebarSection = "dashboards" | "insights" | "data-management";
-
-const PINNED_STORAGE_KEY = "montte:sidebar-pinned";
-
-function loadPinnedItems(): string[] {
-   try {
-      const stored = localStorage.getItem(PINNED_STORAGE_KEY);
-      return stored ? JSON.parse(stored) : [];
-   } catch {
-      return [];
-   }
-}
-
-function savePinnedItems(items: string[]) {
-   try {
-      localStorage.setItem(PINNED_STORAGE_KEY, JSON.stringify(items));
-   } catch {}
-}
 
 interface SidebarNavState {
    activeSection: SubSidebarSection | null;
@@ -26,13 +10,14 @@ interface SidebarNavState {
    pinnedItems: string[];
 }
 
-const initialState: SidebarNavState = {
-   activeSection: null,
-   searchQuery: "",
-   pinnedItems: loadPinnedItems(),
-};
-
-const sidebarNavStore = new Store<SidebarNavState>(initialState);
+const sidebarNavStore = createPersistedStore<SidebarNavState>(
+   "montte:sidebar-nav",
+   {
+      activeSection: null,
+      searchQuery: "",
+      pinnedItems: [],
+   },
+);
 
 export function setActiveSection(section: SubSidebarSection | null) {
    sidebarNavStore.setState((state) => ({
@@ -50,13 +35,12 @@ export function setSearchQuery(query: string) {
 }
 
 export function togglePinnedItem(itemId: string) {
-   sidebarNavStore.setState((state) => {
-      const pinned = state.pinnedItems.includes(itemId)
+   sidebarNavStore.setState((state) => ({
+      ...state,
+      pinnedItems: state.pinnedItems.includes(itemId)
          ? state.pinnedItems.filter((id) => id !== itemId)
-         : [...state.pinnedItems, itemId];
-      savePinnedItems(pinned);
-      return { ...state, pinnedItems: pinned };
-   });
+         : [...state.pinnedItems, itemId],
+   }));
 }
 
 export function useSidebarNav() {

--- a/apps/web/src/lib/persisted-store.ts
+++ b/apps/web/src/lib/persisted-store.ts
@@ -1,20 +1,32 @@
+import { createLocalStorageState } from "foxact/create-local-storage-state";
+import { useIsomorphicLayoutEffect } from "foxact/use-isomorphic-layout-effect";
 import { Store } from "@tanstack/react-store";
+import { useEffect } from "react";
 
 export function createPersistedStore<T>(
    key: string,
-   initialState: T,
-): Store<T> {
-   let hydrated: T = initialState;
-   try {
-      const raw = localStorage.getItem(key);
-      if (raw) hydrated = { ...initialState, ...JSON.parse(raw) };
-   } catch {}
+   initialState: NonNullable<T>,
+) {
+   const [useStoredState] = createLocalStorageState<NonNullable<T>>(
+      key,
+      initialState,
+   );
+   const store = new Store<NonNullable<T>>(initialState);
 
-   const store = new Store<T>(hydrated);
-   store.subscribe(() => {
-      try {
-         localStorage.setItem(key, JSON.stringify(store.state));
-      } catch {}
-   });
-   return store;
+   function useStorePersistence() {
+      const [storedValue, setStoredValue] = useStoredState();
+
+      useIsomorphicLayoutEffect(() => {
+         if (storedValue != null) store.setState(() => storedValue);
+      }, []);
+
+      useEffect(() => {
+         const subscription = store.subscribe(() =>
+            setStoredValue(store.state),
+         );
+         return () => subscription.unsubscribe();
+      }, [setStoredValue]);
+   }
+
+   return { store, useStorePersistence };
 }

--- a/apps/web/src/lib/persisted-store.ts
+++ b/apps/web/src/lib/persisted-store.ts
@@ -1,0 +1,20 @@
+import { Store } from "@tanstack/react-store";
+
+export function createPersistedStore<T>(
+   key: string,
+   initialState: T,
+): Store<T> {
+   let hydrated: T = initialState;
+   try {
+      const raw = localStorage.getItem(key);
+      if (raw) hydrated = { ...initialState, ...JSON.parse(raw) };
+   } catch {}
+
+   const store = new Store<T>(hydrated);
+   store.subscribe(() => {
+      try {
+         localStorage.setItem(key, JSON.stringify(store.state));
+      } catch {}
+   });
+   return store;
+}


### PR DESCRIPTION
## Summary

- Adds `createPersistedStore<T>(key, initialState)` in `apps/web/src/lib/persisted-store.ts` — wraps `@tanstack/react-store`'s `Store` with automatic localStorage hydration on init and auto-save via `store.subscribe()`
- Migrates `sidebarNavStore` to use the new utility, dropping manual `loadPinnedItems` / `savePinnedItems` helpers
- Storage key changed from `montte:sidebar-pinned` → `montte:sidebar-nav`
- Dependency for MON-260 (sidebar state unification)

## Test plan

- [ ] Pin/unpin sidebar items — verify persisted after page reload
- [ ] Active section and search query restore on reload
- [ ] No console errors from localStorage access

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adiciona `createPersistedStore` com persistência SSR-safe via `foxact` e migra o `sidebarNavStore` para usá-lo. Simplifica a lógica, sincroniza entre abas, evita esquecer de salvar e atende ao MON-260 (unificação do estado da sidebar).

- **New Features**
  - `createPersistedStore<T>(key, initialState)`: retorna `{ store, useStorePersistence }`; encapsula `@tanstack/react-store` e usa `foxact/create-local-storage-state` para hidratar e persistir (SSR-safe, sync entre abas).
  - `sidebarNavStore` migrado para o utilitário; remove `loadPinnedItems`/`savePinnedItems`.

- **Migration**
  - Chave de storage alterada: `montte:sidebar-pinned` → `montte:sidebar-nav`.
  - Itens já fixados não migram automaticamente; se necessário, copiar o valor antigo para a nova chave.

<sup>Written for commit cf8548c143b8a65d8c771e659a096c9175e7129d. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/777">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Este PR introduz `createPersistedStore<T>` — utilitário que combina `@tanstack/react-store` com `foxact/create-local-storage-state` para persistência automática no localStorage — e migra o `sidebarNavStore` para utilizá-lo, eliminando os helpers manuais `loadPinnedItems`/`savePinnedItems`. A abordagem com foxact resolve corretamente o problema de SSR (diferente da versão anterior que acessava `localStorage` diretamente na inicialização do módulo).

- **P1**: `useStorePersistence()` é chamado dentro de `useSidebarNav()`, que é usado em 3+ componentes além de renderizar uma instância por item de sidebar via `MoreMenu` — isso cria N subscrições duplicadas no store, causando N escritas no localStorage e N notificações por mudança de estado.

<h3>Confidence Score: 3/5</h3>

Não recomendado para merge: múltiplas subscrições por instância de componente causam writes redundantes e re-renders desnecessários em cascata

O P1 é um defeito presente e real: cada item de sidebar monta sua própria cópia de `useStorePersistence`, criando N subscrições ao store singleton. Com ~10 itens típicos + componentes de panel, toda interação com a sidebar dispara ~12 chamadas a `setStoredValue` e 12 notificações de store. O fix é direto (mover o `useStorePersistence` para o layout raiz), mas precisa ser feito antes de mergear.

apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts — `useStorePersistence()` precisa ser movido para fora de `useSidebarNav`

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/lib/persisted-store.ts | Novo utilitário SSR-safe usando foxact para persistência no localStorage — design correto, mas `useStorePersistence` assume uso único e não se protege contra múltiplas montagens simultâneas |
| apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts | Migração para `createPersistedStore` simplifica o código, mas chamar `useStorePersistence()` dentro de `useSidebarNav()` cria N subscrições duplicadas pois o hook é usado em múltiplos componentes (incluindo um por item de sidebar) |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[createPersistedStore] -->|cria| B[Store TanStack]
    A -->|cria hook| C[useStorePersistence]
    A -->|usa| D[createLocalStorageState foxact]

    C -->|useIsomorphicLayoutEffect mount| E{storedValue != null?}
    E -->|sim| F[store.setState storedValue]
    E -->|não| G[mantém initialState]

    C -->|store.subscribe| H[setStoredValue store.state]
    H --> D

    D <-->|SSR-safe sync| I[(localStorage)]

    B -->|useStore| J[useSidebarNav]
    J --> K[SidebarSubPanel x1]
    J --> L[SubPanelSidebar x1]
    J --> M[useNavHandlers x1]
    J --> N[MoreMenu xN items]

    K & L & M & N -->|cada um monta useStorePersistence| C

    style N fill:#f96,stroke:#d00
    style C fill:#f96,stroke:#d00
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Flayout%2Fdashboard%2Fhooks%2Fuse-sidebar-nav.ts%3A45%0A**M%C3%BAltiplas%20subscri%C3%A7%C3%B5es%20por%20%60useStorePersistence%60%20chamado%20em%20v%C3%A1rios%20componentes**%0A%0A%60useSidebarNav%28%29%60%20%C3%A9%20chamado%20em%20pelo%20menos%204%20locais%20simult%C3%A2neos%3A%20%60SidebarSubPanel%60%2C%20%60SubPanelSidebar%60%20%28ambos%20em%20%60sidebar-sub-panel.tsx%60%29%2C%20%60useNavHandlers%60%20em%20%60sidebar-nav.tsx%60%2C%20e%20%60MoreMenu%60%20em%20%60sidebar-item-actions.tsx%60%20%E2%80%94%20sendo%20que%20%60MoreMenu%60%20renderiza%20**uma%20inst%C3%A2ncia%20por%20item%20de%20nav**.%0A%0ACada%20montagem%20chama%20%60useStorePersistence%28%29%60%2C%20que%3A%0A1.%20Executa%20%60store.setState%28%28%29%20%3D%3E%20storedValue%29%60%20via%20%60useIsomorphicLayoutEffect%60%20%E2%86%92%20N%20chamadas%20de%20setState%20disparando%20N%20notifica%C3%A7%C3%B5es%20no%20store%20para%20todos%20os%20%60useStore%60%20subscribers%0A2.%20Cria%20um%20%60store.subscribe%28%29%60%20independente%20%E2%86%92%20N%20handlers%20chamando%20%60setStoredValue%60%20a%20cada%20mudan%C3%A7a%20de%20estado%0A%0ACom%2010%20itens%20de%20sidebar%2C%20h%C3%A1%20~12%20subscri%C3%A7%C3%B5es%20ativas.%20Toda%20mudan%C3%A7a%20em%20%60pinnedItems%60%2C%20%60searchQuery%60%20ou%20%60activeSection%60%20dispara%2012%20escritas%20no%20localStorage%20e%2012%20notifica%C3%A7%C3%B5es%20de%20re-render.%0A%0AA%20corre%C3%A7%C3%A3o%20%C3%A9%20mover%20a%20chamada%20de%20%60useStorePersistence%60%20para%20fora%20de%20%60useSidebarNav%60%20e%20invoc%C3%A1-la%20uma%20%C3%BAnica%20vez%20no%20componente%20raiz%20do%20layout%20do%20dashboard%3A%0A%0A%60%60%60typescript%0A%2F%2F%20apps%2Fweb%2Fsrc%2Flayout%2Fdashboard%2Fui%2Fdashboard-layout.tsx%20%28ou%20similar%29%0Aexport%20function%20DashboardLayout%28%29%20%7B%0A%20%20%20useStorePersistence%28%29%3B%20%2F%2F%20chamado%20apenas%20aqui%2C%20uma%20vez%0A%20%20%20%2F%2F%20...%0A%7D%0A%60%60%60%0A%0AE%20em%20%60useSidebarNav%60%2C%20remover%20o%20%60useStorePersistence%28%29%60%3A%0A%0A%60%60%60suggestion%0Aexport%20function%20useSidebarNav%28%29%20%7B%0A%20%20%20const%20state%20%3D%20useStore%28sidebarNavStore%2C%20%28s%29%20%3D%3E%20s%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Flib%2Fpersisted-store.ts%3A19-21%0A**%60storedValue%60%20ausente%20nas%20deps%20do%20%60useIsomorphicLayoutEffect%60**%0A%0A%60storedValue%60%20%C3%A9%20usado%20dentro%20do%20effect%20mas%20n%C3%A3o%20est%C3%A1%20no%20array%20de%20depend%C3%AAncias.%20Embora%20seja%20intencional%20%28hidrata%C3%A7%C3%A3o%20%C3%BAnica%20no%20mount%29%2C%20o%20oxlint%20vai%20reportar%20uma%20viola%C3%A7%C3%A3o%20de%20%60react-hooks%2Fexhaustive-deps%60.%20Adicione%20um%20coment%C3%A1rio%20de%20supress%C3%A3o%20para%20tornar%20a%20inten%C3%A7%C3%A3o%20expl%C3%ADcita%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%2F%2F%20oxlint-ignore%20react-hooks%2Fexhaustive-deps%0A%20%20%20%20%20%20useIsomorphicLayoutEffect%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20if%20%28storedValue%20!%3D%20null%29%20store.setState%28%28%29%20%3D%3E%20storedValue%29%3B%0A%20%20%20%20%20%20%7D%2C%20%5B%5D%29%3B%0A%60%60%60%0A%0A&repo=montte-erp%2Fmontte-nx"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Flayout%2Fdashboard%2Fhooks%2Fuse-sidebar-nav.ts%3A45%0A**M%C3%BAltiplas%20subscri%C3%A7%C3%B5es%20por%20%60useStorePersistence%60%20chamado%20em%20v%C3%A1rios%20componentes**%0A%0A%60useSidebarNav%28%29%60%20%C3%A9%20chamado%20em%20pelo%20menos%204%20locais%20simult%C3%A2neos%3A%20%60SidebarSubPanel%60%2C%20%60SubPanelSidebar%60%20%28ambos%20em%20%60sidebar-sub-panel.tsx%60%29%2C%20%60useNavHandlers%60%20em%20%60sidebar-nav.tsx%60%2C%20e%20%60MoreMenu%60%20em%20%60sidebar-item-actions.tsx%60%20%E2%80%94%20sendo%20que%20%60MoreMenu%60%20renderiza%20**uma%20inst%C3%A2ncia%20por%20item%20de%20nav**.%0A%0ACada%20montagem%20chama%20%60useStorePersistence%28%29%60%2C%20que%3A%0A1.%20Executa%20%60store.setState%28%28%29%20%3D%3E%20storedValue%29%60%20via%20%60useIsomorphicLayoutEffect%60%20%E2%86%92%20N%20chamadas%20de%20setState%20disparando%20N%20notifica%C3%A7%C3%B5es%20no%20store%20para%20todos%20os%20%60useStore%60%20subscribers%0A2.%20Cria%20um%20%60store.subscribe%28%29%60%20independente%20%E2%86%92%20N%20handlers%20chamando%20%60setStoredValue%60%20a%20cada%20mudan%C3%A7a%20de%20estado%0A%0ACom%2010%20itens%20de%20sidebar%2C%20h%C3%A1%20~12%20subscri%C3%A7%C3%B5es%20ativas.%20Toda%20mudan%C3%A7a%20em%20%60pinnedItems%60%2C%20%60searchQuery%60%20ou%20%60activeSection%60%20dispara%2012%20escritas%20no%20localStorage%20e%2012%20notifica%C3%A7%C3%B5es%20de%20re-render.%0A%0AA%20corre%C3%A7%C3%A3o%20%C3%A9%20mover%20a%20chamada%20de%20%60useStorePersistence%60%20para%20fora%20de%20%60useSidebarNav%60%20e%20invoc%C3%A1-la%20uma%20%C3%BAnica%20vez%20no%20componente%20raiz%20do%20layout%20do%20dashboard%3A%0A%0A%60%60%60typescript%0A%2F%2F%20apps%2Fweb%2Fsrc%2Flayout%2Fdashboard%2Fui%2Fdashboard-layout.tsx%20%28ou%20similar%29%0Aexport%20function%20DashboardLayout%28%29%20%7B%0A%20%20%20useStorePersistence%28%29%3B%20%2F%2F%20chamado%20apenas%20aqui%2C%20uma%20vez%0A%20%20%20%2F%2F%20...%0A%7D%0A%60%60%60%0A%0AE%20em%20%60useSidebarNav%60%2C%20remover%20o%20%60useStorePersistence%28%29%60%3A%0A%0A%60%60%60suggestion%0Aexport%20function%20useSidebarNav%28%29%20%7B%0A%20%20%20const%20state%20%3D%20useStore%28sidebarNavStore%2C%20%28s%29%20%3D%3E%20s%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Flib%2Fpersisted-store.ts%3A19-21%0A**%60storedValue%60%20ausente%20nas%20deps%20do%20%60useIsomorphicLayoutEffect%60**%0A%0A%60storedValue%60%20%C3%A9%20usado%20dentro%20do%20effect%20mas%20n%C3%A3o%20est%C3%A1%20no%20array%20de%20depend%C3%AAncias.%20Embora%20seja%20intencional%20%28hidrata%C3%A7%C3%A3o%20%C3%BAnica%20no%20mount%29%2C%20o%20oxlint%20vai%20reportar%20uma%20viola%C3%A7%C3%A3o%20de%20%60react-hooks%2Fexhaustive-deps%60.%20Adicione%20um%20coment%C3%A1rio%20de%20supress%C3%A3o%20para%20tornar%20a%20inten%C3%A7%C3%A3o%20expl%C3%ADcita%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%2F%2F%20oxlint-ignore%20react-hooks%2Fexhaustive-deps%0A%20%20%20%20%20%20useIsomorphicLayoutEffect%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20if%20%28storedValue%20!%3D%20null%29%20store.setState%28%28%29%20%3D%3E%20storedValue%29%3B%0A%20%20%20%20%20%20%7D%2C%20%5B%5D%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22montte-erp%2Fmontte-nx%22%20on%20the%20existing%20branch%20%22manoelnetocarvalho03%2Fmon-260-persisted-store-clean%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22manoelnetocarvalho03%2Fmon-260-persisted-store-clean%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Flayout%2Fdashboard%2Fhooks%2Fuse-sidebar-nav.ts%3A45%0A**M%C3%BAltiplas%20subscri%C3%A7%C3%B5es%20por%20%60useStorePersistence%60%20chamado%20em%20v%C3%A1rios%20componentes**%0A%0A%60useSidebarNav%28%29%60%20%C3%A9%20chamado%20em%20pelo%20menos%204%20locais%20simult%C3%A2neos%3A%20%60SidebarSubPanel%60%2C%20%60SubPanelSidebar%60%20%28ambos%20em%20%60sidebar-sub-panel.tsx%60%29%2C%20%60useNavHandlers%60%20em%20%60sidebar-nav.tsx%60%2C%20e%20%60MoreMenu%60%20em%20%60sidebar-item-actions.tsx%60%20%E2%80%94%20sendo%20que%20%60MoreMenu%60%20renderiza%20**uma%20inst%C3%A2ncia%20por%20item%20de%20nav**.%0A%0ACada%20montagem%20chama%20%60useStorePersistence%28%29%60%2C%20que%3A%0A1.%20Executa%20%60store.setState%28%28%29%20%3D%3E%20storedValue%29%60%20via%20%60useIsomorphicLayoutEffect%60%20%E2%86%92%20N%20chamadas%20de%20setState%20disparando%20N%20notifica%C3%A7%C3%B5es%20no%20store%20para%20todos%20os%20%60useStore%60%20subscribers%0A2.%20Cria%20um%20%60store.subscribe%28%29%60%20independente%20%E2%86%92%20N%20handlers%20chamando%20%60setStoredValue%60%20a%20cada%20mudan%C3%A7a%20de%20estado%0A%0ACom%2010%20itens%20de%20sidebar%2C%20h%C3%A1%20~12%20subscri%C3%A7%C3%B5es%20ativas.%20Toda%20mudan%C3%A7a%20em%20%60pinnedItems%60%2C%20%60searchQuery%60%20ou%20%60activeSection%60%20dispara%2012%20escritas%20no%20localStorage%20e%2012%20notifica%C3%A7%C3%B5es%20de%20re-render.%0A%0AA%20corre%C3%A7%C3%A3o%20%C3%A9%20mover%20a%20chamada%20de%20%60useStorePersistence%60%20para%20fora%20de%20%60useSidebarNav%60%20e%20invoc%C3%A1-la%20uma%20%C3%BAnica%20vez%20no%20componente%20raiz%20do%20layout%20do%20dashboard%3A%0A%0A%60%60%60typescript%0A%2F%2F%20apps%2Fweb%2Fsrc%2Flayout%2Fdashboard%2Fui%2Fdashboard-layout.tsx%20%28ou%20similar%29%0Aexport%20function%20DashboardLayout%28%29%20%7B%0A%20%20%20useStorePersistence%28%29%3B%20%2F%2F%20chamado%20apenas%20aqui%2C%20uma%20vez%0A%20%20%20%2F%2F%20...%0A%7D%0A%60%60%60%0A%0AE%20em%20%60useSidebarNav%60%2C%20remover%20o%20%60useStorePersistence%28%29%60%3A%0A%0A%60%60%60suggestion%0Aexport%20function%20useSidebarNav%28%29%20%7B%0A%20%20%20const%20state%20%3D%20useStore%28sidebarNavStore%2C%20%28s%29%20%3D%3E%20s%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Fsrc%2Flib%2Fpersisted-store.ts%3A19-21%0A**%60storedValue%60%20ausente%20nas%20deps%20do%20%60useIsomorphicLayoutEffect%60**%0A%0A%60storedValue%60%20%C3%A9%20usado%20dentro%20do%20effect%20mas%20n%C3%A3o%20est%C3%A1%20no%20array%20de%20depend%C3%AAncias.%20Embora%20seja%20intencional%20%28hidrata%C3%A7%C3%A3o%20%C3%BAnica%20no%20mount%29%2C%20o%20oxlint%20vai%20reportar%20uma%20viola%C3%A7%C3%A3o%20de%20%60react-hooks%2Fexhaustive-deps%60.%20Adicione%20um%20coment%C3%A1rio%20de%20supress%C3%A3o%20para%20tornar%20a%20inten%C3%A7%C3%A3o%20expl%C3%ADcita%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%2F%2F%20oxlint-ignore%20react-hooks%2Fexhaustive-deps%0A%20%20%20%20%20%20useIsomorphicLayoutEffect%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20if%20%28storedValue%20!%3D%20null%29%20store.setState%28%28%29%20%3D%3E%20storedValue%29%3B%0A%20%20%20%20%20%20%7D%2C%20%5B%5D%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts
Line: 45

Comment:
**Múltiplas subscrições por `useStorePersistence` chamado em vários componentes**

`useSidebarNav()` é chamado em pelo menos 4 locais simultâneos: `SidebarSubPanel`, `SubPanelSidebar` (ambos em `sidebar-sub-panel.tsx`), `useNavHandlers` em `sidebar-nav.tsx`, e `MoreMenu` em `sidebar-item-actions.tsx` — sendo que `MoreMenu` renderiza **uma instância por item de nav**.

Cada montagem chama `useStorePersistence()`, que:
1. Executa `store.setState(() => storedValue)` via `useIsomorphicLayoutEffect` → N chamadas de setState disparando N notificações no store para todos os `useStore` subscribers
2. Cria um `store.subscribe()` independente → N handlers chamando `setStoredValue` a cada mudança de estado

Com 10 itens de sidebar, há ~12 subscrições ativas. Toda mudança em `pinnedItems`, `searchQuery` ou `activeSection` dispara 12 escritas no localStorage e 12 notificações de re-render.

A correção é mover a chamada de `useStorePersistence` para fora de `useSidebarNav` e invocá-la uma única vez no componente raiz do layout do dashboard:

```typescript
// apps/web/src/layout/dashboard/ui/dashboard-layout.tsx (ou similar)
export function DashboardLayout() {
   useStorePersistence(); // chamado apenas aqui, uma vez
   // ...
}
```

E em `useSidebarNav`, remover o `useStorePersistence()`:

```suggestion
export function useSidebarNav() {
   const state = useStore(sidebarNavStore, (s) => s);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/web/src/lib/persisted-store.ts
Line: 19-21

Comment:
**`storedValue` ausente nas deps do `useIsomorphicLayoutEffect`**

`storedValue` é usado dentro do effect mas não está no array de dependências. Embora seja intencional (hidratação única no mount), o oxlint vai reportar uma violação de `react-hooks/exhaustive-deps`. Adicione um comentário de supressão para tornar a intenção explícita:

```suggestion
      // oxlint-ignore react-hooks/exhaustive-deps
      useIsomorphicLayoutEffect(() => {
         if (storedValue != null) store.setState(() => storedValue);
      }, []);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(store): integrate foxact create..."](https://github.com/montte-erp/montte-nx/commit/cf8548c143b8a65d8c771e659a096c9175e7129d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28567610)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->