### PR TITLE
feat(store): createStoreEffect utility + sidebar cross-store coordination (MON-259)

### DIFF
--- a/apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts
+++ b/apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts
@@ -35,8 +35,12 @@ const initialState: SidebarNavState = {
 
 const sidebarNavStore = new Store<SidebarNavState>(initialState);
 
-createStoreEffect(sidebarNavStore, (next, prev) => {
-   if (prev.activeSection !== null && next.activeSection === null) {
+void createStoreEffect(sidebarNavStore, (next, prev) => {
+   if (
+      prev.activeSection !== null &&
+      next.activeSection === null &&
+      next.searchQuery !== ""
+   ) {
       sidebarNavStore.setState((s) => ({ ...s, searchQuery: "" }));
    }
 });

--- a/apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts
+++ b/apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts
@@ -1,5 +1,6 @@
 import { Store, useStore } from "@tanstack/react-store";
 import { useEffect } from "react";
+import { createStoreEffect } from "@/lib/store-effects";
 
 export type SubSidebarSection = "dashboards" | "insights" | "data-management";
 
@@ -33,6 +34,12 @@ const initialState: SidebarNavState = {
 };
 
 const sidebarNavStore = new Store<SidebarNavState>(initialState);
+
+createStoreEffect(sidebarNavStore, (next, prev) => {
+   if (prev.activeSection !== null && next.activeSection === null) {
+      sidebarNavStore.setState((s) => ({ ...s, searchQuery: "" }));
+   }
+});
 
 export function setActiveSection(section: SubSidebarSection | null) {
    sidebarNavStore.setState((state) => ({
@@ -74,13 +81,9 @@ export function useSidebarSection(section: SubSidebarSection) {
    useEffect(() => {
       setActiveSection(section);
       return () => {
-         sidebarNavStore.setState((state) => ({
-            ...state,
-            activeSection:
-               state.activeSection === section ? null : state.activeSection,
-            searchQuery:
-               state.activeSection === section ? "" : state.searchQuery,
-         }));
+         if (sidebarNavStore.state.activeSection === section) {
+            setActiveSection(null);
+         }
       };
    }, [section]);
 }

--- a/apps/web/src/lib/store-effects.ts
+++ b/apps/web/src/lib/store-effects.ts
@@ -1,0 +1,18 @@
+import type { Store } from "@tanstack/react-store";
+
+type Cleanup = () => void;
+
+export function createStoreEffect<T>(
+   store: Store<T>,
+   effect: (state: T, prevState: T) => void,
+): Cleanup {
+   let prevState = store.state;
+
+   const { unsubscribe } = store.subscribe(() => {
+      const nextState = store.state;
+      effect(nextState, prevState);
+      prevState = nextState;
+   });
+
+   return unsubscribe;
+}

--- a/apps/web/src/lib/store-effects.ts
+++ b/apps/web/src/lib/store-effects.ts
@@ -4,7 +4,7 @@ type Cleanup = () => void;
 
 export function createStoreEffect<T>(
    store: Store<T>,
-   effect: (state: T, prevState: T) => void,
+   effect: (nextState: T, prevState: T) => void,
 ): Cleanup {
    let prevState = store.state;
 


### PR DESCRIPTION
## Summary

- Adds `createStoreEffect<T>` in `apps/web/src/lib/store-effects.ts` — a thin wrapper around `store.subscribe` that tracks `prevState` and runs deterministic effects on state transitions, outside React
- Refactors `use-sidebar-nav.ts` to wire a module-level effect: whenever `activeSection → null`, `searchQuery` auto-clears regardless of what code path triggered the change
- Updates `useSidebarSection` cleanup to call `setActiveSection(null)` directly instead of raw `setState`, keeping the normal and cleanup paths in sync

## Test plan

- [ ] Open the dashboard, navigate to a sub-sidebar section (dashboards/insights/data-management) — search query input should be visible
- [ ] Type something in the search box, then navigate away — verify `searchQuery` resets to `""` on unmount
- [ ] Call `setActiveSection(null)` programmatically (or navigate to a route without a sub-sidebar) — verify search clears
- [ ] Verify no infinite re-render loops (React DevTools profiler or console)
- [ ] `bun run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adiciona `createStoreEffect` para efeitos determinísticos fora do React e coordena o sidebar: quando `activeSection` vira `null`, `searchQuery` é limpa automaticamente. Atende MON-259 ao mover a regra para a store e tornar o comportamento consistente.

- **New Features**
  - `createStoreEffect<T>(store, effect)`: wrapper de `store.subscribe` do `@tanstack/react-store` que entrega `prevState` e executa efeitos em transições.
  - Efeito global no sidebar: limpa `searchQuery` sempre que `activeSection` → `null`, independente da origem da mudança.

- **Refactors**
  - `useSidebarSection` agora chama `setActiveSection(null)` no cleanup em vez de mutar o estado diretamente, mantendo caminhos normal e de desmontagem alinhados.

<sup>Written for commit e7c05e9baad536625dcd5146fea68a3946d519b8. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/779">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Este PR adiciona a utilidade `createStoreEffect` (wrapper sobre `store.subscribe` com rastreamento de `prevState`) e a usa em `use-sidebar-nav.ts` para limpar automaticamente `searchQuery` sempre que `activeSection` transitar para `null`, independentemente do caminho de código. O cleanup de `useSidebarSection` foi simplificado para chamar `setActiveSection(null)` diretamente, mantendo consistência com a API pública.

<h3>Confidence Score: 4/5</h3>

PR seguro para merge; a única ressalva é uma fragilidade de design na utilidade `createStoreEffect` que não gera bugs observáveis no uso atual.

O único achado é P2: a atribuição `prevState = nextState` após `effect()` pode ficar desatualizada se o efeito disparar um `setState` aninhado. No uso atual isso não causa comportamento incorreto (a condição de reativação falha naturalmente), mas é uma armadilha para futuros consumidores da utilidade. Todos os demais aspectos — API correta do `@tanstack/store` v0.9.x, lógica de cleanup, ausência de loops infinitos — estão corretos.

apps/web/src/lib/store-effects.ts — ordem de atualização do `prevState` em relação à chamada do `effect`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/lib/store-effects.ts | Nova utilidade `createStoreEffect` com API correta do `@tanstack/store` v0.9.x, mas a atribuição `prevState = nextState` após `effect()` pode ficar desatualizada quando o efeito dispara um `setState` aninhado sincronamente. |
| apps/web/src/layout/dashboard/hooks/use-sidebar-nav.ts | Refatoração do cleanup de `useSidebarSection` para usar `setActiveSection(null)` em vez de `setState` direto, adicionando `createStoreEffect` como guarda defensivo. O comportamento está correto — `setActiveSection` já limpa `searchQuery` atomicamente, então o efeito é um safety net para chamadas diretas de `setState`. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[useSidebarSection monta] -->|useEffect| B["setActiveSection(section)"]
    B --> C["sidebarNavStore.setState\nactiveSection=section, searchQuery=''"]

    D[useSidebarSection desmonta] -->|cleanup| E{"activeSection === section?"}
    E -- Sim --> F["setActiveSection(null)"]
    E -- Nao --> G[nenhuma acao]
    F --> H["sidebarNavStore.setState\nactiveSection=null, searchQuery=''"]

    H --> I[createStoreEffect subscriber dispara]
    I --> J{"prev.activeSection != null\nAND next.activeSection == null\nAND next.searchQuery != ''"}
    J -- Verdadeiro --> K["setState: searchQuery=''\n(safety net para setState direto)"]
    J -- Falso\nnoop no caso normal --> L[sem acao]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Flib%2Fstore-effects.ts%3A11-14%0A**%60prevState%60%20fica%20desatualizado%20em%20chamadas%20%60setState%60%20aninhadas**%0A%0ASe%20o%20callback%20%60effect%60%20chamar%20%60store.setState%28...%29%60%20internamente%20%28como%20acontece%20no%20%60use-sidebar-nav.ts%60%29%2C%20o%20subscriber%20%C3%A9%20disparado%20recursivamente%20*antes*%20de%20%60prevState%20%3D%20nextState%60%20executar%20no%20frame%20externo.%20Quando%20a%20chamada%20interna%20termina%20e%20atualiza%20%60prevState%60%20corretamente%2C%20o%20frame%20externo%20sobrescreve%20esse%20valor%20com%20o%20%60nextState%60%20antigo%3A%0A%0A%60%60%60%0Aframe%20externo%3A%20%20nextState%20%3D%20B%2C%20prevState%20%3D%20A%20%E2%86%92%20effect%20chama%20setState%20%E2%86%92%20frame%20interno%20atualiza%20prevState%20%3D%20C%20%E2%86%92%20frame%20externo%20faz%20prevState%20%3D%20B%20%28sobrescreve%20C%29%0A%60%60%60%0A%0AAp%C3%B3s%20isso%2C%20%60prevState%60%20aponta%20para%20%60B%60%20%28estado%20intermedi%C3%A1rio%29%2C%20embora%20o%20estado%20real%20seja%20%60C%60.%20No%20uso%20atual%20isso%20n%C3%A3o%20causa%20bugs%20observ%C3%A1veis%20%28porque%20%60B.activeSection%20%3D%3D%3D%20null%60%20bloqueia%20o%20gatilho%29%2C%20mas%20como%20utilidade%20reutiliz%C3%A1vel%20o%20comportamento%20%C3%A9%20inesperado.%0A%0AUma%20solu%C3%A7%C3%A3o%20seria%20capturar%20%60prevState%60%20localmente%20antes%20de%20chamar%20o%20efeito%3A%0A%60%60%60typescript%0Aconst%20%7B%20unsubscribe%20%7D%20%3D%20store.subscribe%28%28%29%20%3D%3E%20%7B%0A%20%20%20const%20nextState%20%3D%20store.state%3B%0A%20%20%20const%20snapshot%20%3D%20prevState%3B%0A%20%20%20prevState%20%3D%20nextState%3B%20%20%20%20%20%20%20%20%20%20%2F%2F%20atualiza%20ANTES%20de%20chamar%20o%20efeito%0A%20%20%20effect%28nextState%2C%20snapshot%29%3B%0A%7D%29%3B%0A%60%60%60%0A%0A&repo=montte-erp%2Fmontte-nx"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Flib%2Fstore-effects.ts%3A11-14%0A**%60prevState%60%20fica%20desatualizado%20em%20chamadas%20%60setState%60%20aninhadas**%0A%0ASe%20o%20callback%20%60effect%60%20chamar%20%60store.setState%28...%29%60%20internamente%20%28como%20acontece%20no%20%60use-sidebar-nav.ts%60%29%2C%20o%20subscriber%20%C3%A9%20disparado%20recursivamente%20*antes*%20de%20%60prevState%20%3D%20nextState%60%20executar%20no%20frame%20externo.%20Quando%20a%20chamada%20interna%20termina%20e%20atualiza%20%60prevState%60%20corretamente%2C%20o%20frame%20externo%20sobrescreve%20esse%20valor%20com%20o%20%60nextState%60%20antigo%3A%0A%0A%60%60%60%0Aframe%20externo%3A%20%20nextState%20%3D%20B%2C%20prevState%20%3D%20A%20%E2%86%92%20effect%20chama%20setState%20%E2%86%92%20frame%20interno%20atualiza%20prevState%20%3D%20C%20%E2%86%92%20frame%20externo%20faz%20prevState%20%3D%20B%20%28sobrescreve%20C%29%0A%60%60%60%0A%0AAp%C3%B3s%20isso%2C%20%60prevState%60%20aponta%20para%20%60B%60%20%28estado%20intermedi%C3%A1rio%29%2C%20embora%20o%20estado%20real%20seja%20%60C%60.%20No%20uso%20atual%20isso%20n%C3%A3o%20causa%20bugs%20observ%C3%A1veis%20%28porque%20%60B.activeSection%20%3D%3D%3D%20null%60%20bloqueia%20o%20gatilho%29%2C%20mas%20como%20utilidade%20reutiliz%C3%A1vel%20o%20comportamento%20%C3%A9%20inesperado.%0A%0AUma%20solu%C3%A7%C3%A3o%20seria%20capturar%20%60prevState%60%20localmente%20antes%20de%20chamar%20o%20efeito%3A%0A%60%60%60typescript%0Aconst%20%7B%20unsubscribe%20%7D%20%3D%20store.subscribe%28%28%29%20%3D%3E%20%7B%0A%20%20%20const%20nextState%20%3D%20store.state%3B%0A%20%20%20const%20snapshot%20%3D%20prevState%3B%0A%20%20%20prevState%20%3D%20nextState%3B%20%20%20%20%20%20%20%20%20%20%2F%2F%20atualiza%20ANTES%20de%20chamar%20o%20efeito%0A%20%20%20effect%28nextState%2C%20snapshot%29%3B%0A%7D%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22montte-erp%2Fmontte-nx%22%20on%20the%20existing%20branch%20%22manoelnetocarvalho03%2Fmon-259-featstore-store-effects-cross-store-coordination%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22manoelnetocarvalho03%2Fmon-259-featstore-store-effects-cross-store-coordination%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Flib%2Fstore-effects.ts%3A11-14%0A**%60prevState%60%20fica%20desatualizado%20em%20chamadas%20%60setState%60%20aninhadas**%0A%0ASe%20o%20callback%20%60effect%60%20chamar%20%60store.setState%28...%29%60%20internamente%20%28como%20acontece%20no%20%60use-sidebar-nav.ts%60%29%2C%20o%20subscriber%20%C3%A9%20disparado%20recursivamente%20*antes*%20de%20%60prevState%20%3D%20nextState%60%20executar%20no%20frame%20externo.%20Quando%20a%20chamada%20interna%20termina%20e%20atualiza%20%60prevState%60%20corretamente%2C%20o%20frame%20externo%20sobrescreve%20esse%20valor%20com%20o%20%60nextState%60%20antigo%3A%0A%0A%60%60%60%0Aframe%20externo%3A%20%20nextState%20%3D%20B%2C%20prevState%20%3D%20A%20%E2%86%92%20effect%20chama%20setState%20%E2%86%92%20frame%20interno%20atualiza%20prevState%20%3D%20C%20%E2%86%92%20frame%20externo%20faz%20prevState%20%3D%20B%20%28sobrescreve%20C%29%0A%60%60%60%0A%0AAp%C3%B3s%20isso%2C%20%60prevState%60%20aponta%20para%20%60B%60%20%28estado%20intermedi%C3%A1rio%29%2C%20embora%20o%20estado%20real%20seja%20%60C%60.%20No%20uso%20atual%20isso%20n%C3%A3o%20causa%20bugs%20observ%C3%A1veis%20%28porque%20%60B.activeSection%20%3D%3D%3D%20null%60%20bloqueia%20o%20gatilho%29%2C%20mas%20como%20utilidade%20reutiliz%C3%A1vel%20o%20comportamento%20%C3%A9%20inesperado.%0A%0AUma%20solu%C3%A7%C3%A3o%20seria%20capturar%20%60prevState%60%20localmente%20antes%20de%20chamar%20o%20efeito%3A%0A%60%60%60typescript%0Aconst%20%7B%20unsubscribe%20%7D%20%3D%20store.subscribe%28%28%29%20%3D%3E%20%7B%0A%20%20%20const%20nextState%20%3D%20store.state%3B%0A%20%20%20const%20snapshot%20%3D%20prevState%3B%0A%20%20%20prevState%20%3D%20nextState%3B%20%20%20%20%20%20%20%20%20%20%2F%2F%20atualiza%20ANTES%20de%20chamar%20o%20efeito%0A%20%20%20effect%28nextState%2C%20snapshot%29%3B%0A%7D%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/web/src/lib/store-effects.ts
Line: 11-14

Comment:
**`prevState` fica desatualizado em chamadas `setState` aninhadas**

Se o callback `effect` chamar `store.setState(...)` internamente (como acontece no `use-sidebar-nav.ts`), o subscriber é disparado recursivamente *antes* de `prevState = nextState` executar no frame externo. Quando a chamada interna termina e atualiza `prevState` corretamente, o frame externo sobrescreve esse valor com o `nextState` antigo:

```
frame externo:  nextState = B, prevState = A → effect chama setState → frame interno atualiza prevState = C → frame externo faz prevState = B (sobrescreve C)
```

Após isso, `prevState` aponta para `B` (estado intermediário), embora o estado real seja `C`. No uso atual isso não causa bugs observáveis (porque `B.activeSection === null` bloqueia o gatilho), mas como utilidade reutilizável o comportamento é inesperado.

Uma solução seria capturar `prevState` localmente antes de chamar o efeito:
```typescript
const { unsubscribe } = store.subscribe(() => {
   const nextState = store.state;
   const snapshot = prevState;
   prevState = nextState;          // atualiza ANTES de chamar o efeito
   effect(nextState, snapshot);
});
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(store): address code review feedback..."](https://github.com/montte-erp/montte-nx/commit/e7c05e9baad536625dcd5146fea68a3946d519b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28570404)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->