### PR TITLE
test(tags-repository): add tests for getById method

### DIFF
--- a/core/database/__tests__/repositories/tags-repository.test.ts
+++ b/core/database/__tests__/repositories/tags-repository.test.ts
@@ -459,6 +459,43 @@ describe("tags-repository", () => {
       });
    });
 
+   describe("getById", () => {
+      it("returns tag when id and teamId match", async () => {
+         const teamId = randomTeamId();
+         const created = (
+            await repo.createTag(testDb.db, teamId, validCreateInput())
+         )._unsafeUnwrap();
+
+         const found = (
+            await repo.getById(testDb.db, created.id, teamId)
+         )._unsafeUnwrap();
+         expect(found).toMatchObject({ id: created.id, teamId });
+      });
+
+      it("returns notFound error when id does not exist", async () => {
+         const result = await repo.getById(
+            testDb.db,
+            crypto.randomUUID(),
+            randomTeamId(),
+         );
+         expect(result._unsafeUnwrapErr().message).toMatch(/não encontrad/);
+      });
+
+      it("returns notFound error when teamId does not match", async () => {
+         const teamId = randomTeamId();
+         const created = (
+            await repo.createTag(testDb.db, teamId, validCreateInput())
+         )._unsafeUnwrap();
+
+         const result = await repo.getById(
+            testDb.db,
+            created.id,
+            randomTeamId(),
+         );
+         expect(result._unsafeUnwrapErr().message).toMatch(/não encontrad/);
+      });
+   });
+
    describe("bulkDeleteTags — isDefault", () => {
       it("rejects bulk delete when any tag is default", async () => {
          const teamId = randomTeamId();

--- a/core/database/src/repositories/tags-repository.ts
+++ b/core/database/src/repositories/tags-repository.ts
@@ -69,6 +69,19 @@ export function listTags(
    );
 }
 
+export function getById(db: DatabaseInstance, id: string, teamId: string) {
+   return fromPromise(
+      db.query.tags.findFirst({
+         where: (fields, { and, eq }) =>
+            and(eq(fields.id, id), eq(fields.teamId, teamId)),
+      }),
+      (e) =>
+         AppError.database("Falha ao buscar centro de custo.", { cause: e }),
+   ).andThen((tag) =>
+      tag ? ok(tag) : err(AppError.notFound("Centro de custo não encontrado.")),
+   );
+}
+
 export function getTag(db: DatabaseInstance, id: string) {
    return fromPromise(
       db.query.tags.findFirst({ where: (fields, { eq }) => eq(fields.id, id) }),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Implementa `getById` no repositório de tags e adiciona testes cobrindo sucesso e erros. Atende parcialmente o MON-435 ao permitir busca por tag por `id` e `teamId` com mensagens de erro padronizadas.

- **New Features**
  - Repositório: adiciona `getById(db, id, teamId)` em `core/database/src/repositories/tags-repository.ts`, usando `db.query.tags.findFirst`, retornando `Result` (`ok/err`) com `AppError.notFound` e mapeando falhas de DB para `AppError.database`.
  - Camadas: Repositório alterado; Router, Componentes e Store sem mudanças.
  - Por quê: leitura consistente para suportar as validações de deleção e campos (MON-435), seguindo padrões de `AppError` e `Result` do projeto.

- **Checklist de Teste**
  - `returns tag when id and teamId match`.
  - `returns notFound error when id does not exist`.
  - `returns notFound error when teamId does not match`.
  - Testes em `core/database/__tests__/repositories/tags-repository.test.ts`.
  - `bun run typecheck` deve passar.

<sup>Written for commit 3d2243c38627407d03fba6c32cfe68c9cd883920. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/788">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

