### PR TITLE
Manoelnetocarvalho03/mon 483 refactordata table toolbar base busca chips de filtros

### DIFF
--- a/apps/web/src/components/data-table/data-table-toolbar.tsx
+++ b/apps/web/src/components/data-table/data-table-toolbar.tsx
@@ -1,9 +1,12 @@
-"use client";
-
 import { useAsyncDebouncedCallback } from "@tanstack/react-pacer";
+import { useForm } from "@tanstack/react-form";
+import type { FormApi } from "@tanstack/react-form";
 import { Link } from "@tanstack/react-router";
 import { FilterX, Plus, Search, X } from "lucide-react";
-import { useForm } from "@tanstack/react-form";
+import { createContextState } from "foxact/context-state";
+import { useIsomorphicLayoutEffect } from "foxact/use-isomorphic-layout-effect";
+import { useSingleton } from "foxact/use-singleton";
+import { useCallback, useMemo } from "react";
 import type React from "react";
 import { Badge } from "@packages/ui/components/badge";
 import { Button } from "@packages/ui/components/button";
@@ -15,6 +18,35 @@ import {
 } from "@packages/ui/components/input-group";
 import { cn } from "@packages/ui/lib/utils";
 import { useDataTable } from "./data-table-root";
+
+export type ToolbarValues = {
+   search: string;
+   filters: Record<string, unknown>;
+};
+
+type DataTableToolbarContextValue = {
+   form: FormApi<ToolbarValues>;
+   onSearch?: (value: string) => Promise<void> | void;
+};
+
+const [DataTableToolbarCtxProvider, useToolbarCtxValue, useSetToolbarCtx] =
+   createContextState<DataTableToolbarContextValue>();
+
+export function useDataTableToolbar() {
+   return useToolbarCtxValue();
+}
+
+function DataTableToolbarContextSync({
+   value,
+}: {
+   value: DataTableToolbarContextValue;
+}) {
+   const setCtx = useSetToolbarCtx();
+   useIsomorphicLayoutEffect(() => {
+      setCtx(value);
+   }, [setCtx, value]);
+   return null;
+}
 
 function filterValueLabel(value: unknown): string {
    if (Array.isArray(value)) return value.join(", ");
@@ -39,9 +71,22 @@ export function DataTableToolbar({
 }: DataTableToolbarProps) {
    const { table, columnFilters } = useDataTable();
 
-   const form = useForm({
-      defaultValues: { search: searchDefaultValue },
+   const defaultFilters = useSingleton(() =>
+      Object.fromEntries(columnFilters.map((f) => [f.id, f.value])),
+   ).current;
+
+   const form = useForm<ToolbarValues>({
+      defaultValues: { search: searchDefaultValue, filters: defaultFilters },
    });
+
+   const inputValue = form.useStore((s) => s.values.search);
+   const filterValues = form.useStore((s) => s.values.filters);
+
+   const activeFilters = Object.entries(filterValues).filter(
+      ([, v]) => v !== undefined && v !== null && v !== "",
+   );
+
+   const hasAnyFilter = activeFilters.length > 0 || inputValue !== "";
 
    const debouncedSearch = useAsyncDebouncedCallback(
       async (value: string) => {
@@ -50,106 +95,117 @@ export function DataTableToolbar({
       { wait: 350 },
    );
 
-   const activeFilters = columnFilters.filter(
-      (f) => f.value !== undefined && f.value !== null && f.value !== "",
+   const removeFilter = useCallback(
+      (columnId: string) => {
+         const current = form.getFieldValue("filters");
+         form.setFieldValue("filters", { ...current, [columnId]: undefined });
+         table.getColumn(columnId)?.setFilterValue(undefined);
+      },
+      [form, table],
    );
 
-   const inputValue = form.getFieldValue("search");
-   const hasAnyFilter = activeFilters.length > 0 || inputValue !== "";
-
-   function removeFilter(columnId: string) {
-      table.getColumn(columnId)?.setFilterValue(undefined);
-   }
-
-   async function clearSearch() {
+   const clearSearch = useCallback(async () => {
       form.setFieldValue("search", "");
       await onSearch?.("");
-   }
+   }, [form, onSearch]);
 
-   async function clearAll() {
+   const clearAll = useCallback(async () => {
+      form.setFieldValue("search", "");
+      form.setFieldValue("filters", {});
       table.resetColumnFilters();
-      if (inputValue !== "") {
-         form.setFieldValue("search", "");
-         await onSearch?.("");
-      }
-   }
+      await onSearch?.("");
+   }, [form, onSearch, table]);
+
+   const ctx = useMemo<DataTableToolbarContextValue>(
+      () => ({ form, onSearch }),
+      [form, onSearch],
+   );
 
    return (
-      <div className={cn("flex items-center gap-2", className)}>
-         <div className="flex flex-1 flex-wrap items-center gap-2 min-w-0">
-            {onSearch && (
-               <form.Field name="search">
-                  {(field) => (
-                     <InputGroup className="flex-1 min-w-0 max-w-sm">
-                        <InputGroupAddon>
-                           <Search className="text-muted-foreground" />
-                        </InputGroupAddon>
-                        <InputGroupInput
-                           placeholder={searchPlaceholder}
-                           value={field.state.value}
-                           onChange={(e) => {
-                              field.handleChange(e.target.value);
-                              debouncedSearch(e.target.value);
-                           }}
-                        />
-                        {field.state.value && (
-                           <InputGroupAddon align="inline-end">
-                              <InputGroupButton onClick={clearSearch}>
-                                 <X />
-                                 <span className="sr-only">Limpar busca</span>
-                              </InputGroupButton>
+      <DataTableToolbarCtxProvider initialState={ctx}>
+         <DataTableToolbarContextSync value={ctx} />
+         <div className={cn("flex items-center gap-2", className)}>
+            <div className="flex flex-1 flex-wrap items-center gap-2 min-w-0">
+               {onSearch && (
+                  <form.Field name="search">
+                     {(field) => (
+                        <InputGroup className="flex-1 min-w-0 max-w-sm">
+                           <InputGroupAddon>
+                              <Search className="text-muted-foreground" />
                            </InputGroupAddon>
-                        )}
-                     </InputGroup>
-                  )}
-               </form.Field>
-            )}
+                           <InputGroupInput
+                              placeholder={searchPlaceholder}
+                              value={field.state.value}
+                              onChange={(e) => {
+                                 field.handleChange(e.target.value);
+                                 debouncedSearch(e.target.value);
+                              }}
+                           />
+                           {field.state.value && (
+                              <InputGroupAddon align="inline-end">
+                                 <InputGroupButton onClick={clearSearch}>
+                                    <X />
+                                    <span className="sr-only">
+                                       Limpar busca
+                                    </span>
+                                 </InputGroupButton>
+                              </InputGroupAddon>
+                           )}
+                        </InputGroup>
+                     )}
+                  </form.Field>
+               )}
 
-            {activeFilters.map((filter) => {
-               const label =
-                  table.getColumn(filter.id)?.columnDef.meta?.label ??
-                  filter.id;
-               const valueLabel = filterValueLabel(filter.value);
-               return (
-                  <Badge
-                     key={filter.id}
-                     variant="secondary"
-                     className="shrink-0 gap-1.5 pr-1 font-normal"
-                  >
-                     <span className="text-muted-foreground">{label}</span>
-                     <span className="text-muted-foreground/40">·</span>
-                     <span className="font-medium text-foreground">
-                        {valueLabel}
-                     </span>
-                     <Button
-                        size="icon"
-                        variant="ghost"
-                        className="size-4 text-muted-foreground/50 hover:text-foreground hover:bg-accent"
-                        onClick={() => removeFilter(filter.id)}
+               {activeFilters.map(([columnId, value]) => {
+                  const label =
+                     table.getColumn(columnId)?.columnDef.meta?.label ??
+                     columnId;
+                  return (
+                     <Badge
+                        key={columnId}
+                        variant="secondary"
+                        className="shrink-0 gap-1.5 pr-1 font-normal"
                      >
-                        <X />
-                        <span className="sr-only">Remover filtro {label}</span>
-                     </Button>
-                  </Badge>
-               );
-            })}
+                        <span className="text-muted-foreground">{label}</span>
+                        <span className="text-muted-foreground/40">·</span>
+                        <span className="font-medium text-foreground">
+                           {filterValueLabel(value)}
+                        </span>
+                        <Button
+                           size="icon"
+                           variant="ghost"
+                           className="size-4 text-muted-foreground/50 hover:text-foreground hover:bg-accent"
+                           onClick={() => removeFilter(columnId)}
+                        >
+                           <X />
+                           <span className="sr-only">
+                              Remover filtro {label}
+                           </span>
+                        </Button>
+                     </Badge>
+                  );
+               })}
 
-            {hasAnyFilter && (
-               <Button
-                  variant="ghost"
-                  size="sm"
-                  className="shrink-0 text-muted-foreground hover:text-destructive hover:bg-destructive/10"
-                  onClick={clearAll}
-               >
-                  <FilterX data-icon="inline-start" />
-                  Limpar todos
-               </Button>
+               {hasAnyFilter && (
+                  <Button
+                     variant="ghost"
+                     size="sm"
+                     className="shrink-0 text-muted-foreground hover:text-destructive hover:bg-destructive/10"
+                     onClick={clearAll}
+                  >
+                     <FilterX data-icon="inline-start" />
+                     Limpar todos
+                  </Button>
+               )}
+            </div>
+
+            {children && (
+               <div className="flex shrink-0 items-center gap-2">
+                  {children}
+               </div>
             )}
          </div>
-         {children && (
-            <div className="flex shrink-0 items-center gap-2">{children}</div>
-         )}
-      </div>
+      </DataTableToolbarCtxProvider>
    );
 }
 

--- a/apps/web/src/components/data-table/data-table-toolbar.tsx
+++ b/apps/web/src/components/data-table/data-table-toolbar.tsx
@@ -1,6 +1,6 @@
 import { useAsyncDebouncedCallback } from "@tanstack/react-pacer";
-import { useForm } from "@tanstack/react-form";
-import type { FormApi } from "@tanstack/react-form";
+import { useForm, useStore } from "@tanstack/react-form";
+import type { AnyFormApi } from "@tanstack/react-form";
 import { Link } from "@tanstack/react-router";
 import { FilterX, Plus, Search, X } from "lucide-react";
 import { createContextState } from "foxact/context-state";
@@ -25,7 +25,7 @@ export type ToolbarValues = {
 };
 
 type DataTableToolbarContextValue = {
-   form: FormApi<ToolbarValues>;
+   form: AnyFormApi;
    onSearch?: (value: string) => Promise<void> | void;
 };
 
@@ -75,12 +75,12 @@ export function DataTableToolbar({
       Object.fromEntries(columnFilters.map((f) => [f.id, f.value])),
    ).current;
 
-   const form = useForm<ToolbarValues>({
+   const form = useForm({
       defaultValues: { search: searchDefaultValue, filters: defaultFilters },
    });
 
-   const inputValue = form.useStore((s) => s.values.search);
-   const filterValues = form.useStore((s) => s.values.filters);
+   const inputValue = useStore(form.store, (s) => s.values.search);
+   const filterValues = useStore(form.store, (s) => s.values.filters);
 
    const activeFilters = Object.entries(filterValues).filter(
       ([, v]) => v !== undefined && v !== null && v !== "",
@@ -127,13 +127,18 @@ export function DataTableToolbar({
          <div className={cn("flex items-center gap-2", className)}>
             <div className="flex flex-1 flex-wrap items-center gap-2 min-w-0">
                {onSearch && (
-                  <form.Field name="search">
-                     {(field) => (
+                  <form.Field
+                     name="search"
+                     children={(field) => (
                         <InputGroup className="flex-1 min-w-0 max-w-sm">
                            <InputGroupAddon>
-                              <Search className="text-muted-foreground" />
+                              <Search
+                                 className="text-muted-foreground"
+                                 aria-hidden="true"
+                              />
                            </InputGroupAddon>
                            <InputGroupInput
+                              aria-label={searchPlaceholder}
                               placeholder={searchPlaceholder}
                               value={field.state.value}
                               onChange={(e) => {
@@ -153,7 +158,7 @@ export function DataTableToolbar({
                            )}
                         </InputGroup>
                      )}
-                  </form.Field>
+                  />
                )}
 
                {activeFilters.map(([columnId, value]) => {

--- a/apps/web/src/components/data-table/data-table-toolbar.tsx
+++ b/apps/web/src/components/data-table/data-table-toolbar.tsx
@@ -3,7 +3,7 @@
 import { useDebouncedCallback } from "@tanstack/react-pacer";
 import { Link } from "@tanstack/react-router";
 import { FilterX, Plus, Search, X } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import type React from "react";
 import { Badge } from "@packages/ui/components/badge";
 import { Button } from "@packages/ui/components/button";
@@ -42,10 +42,6 @@ export function DataTableToolbar({
       : "";
 
    const [inputValue, setInputValue] = useState(currentSearchValue);
-
-   useEffect(() => {
-      setInputValue(currentSearchValue);
-   }, [currentSearchValue]);
 
    const applySearch = useDebouncedCallback(
       (value: string) => {

--- a/apps/web/src/components/data-table/data-table-toolbar.tsx
+++ b/apps/web/src/components/data-table/data-table-toolbar.tsx
@@ -82,7 +82,7 @@ export function DataTableToolbar({
    const inputValue = useStore(form.store, (s) => s.values.search);
 
    const activeFilters = columnFilters.filter(
-      ({ value }) => value !== undefined && value !== null && value !== "",
+      ({ value }) => value != null && value !== "",
    );
 
    const hasAnyFilter = activeFilters.length > 0 || inputValue !== "";

--- a/apps/web/src/components/data-table/data-table-toolbar.tsx
+++ b/apps/web/src/components/data-table/data-table-toolbar.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useDebouncedCallback } from "@tanstack/react-pacer";
+import { Link } from "@tanstack/react-router";
+import { FilterX, Plus, Search, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import type React from "react";
+import { Badge } from "@packages/ui/components/badge";
+import { Button } from "@packages/ui/components/button";
+import {
+   InputGroup,
+   InputGroupAddon,
+   InputGroupButton,
+   InputGroupInput,
+} from "@packages/ui/components/input-group";
+import { cn } from "@packages/ui/lib/utils";
+import { useDataTable } from "./data-table-root";
+
+function filterValueLabel(value: unknown): string {
+   if (Array.isArray(value)) return value.join(", ");
+   if (value === null || value === undefined) return "";
+   return String(value);
+}
+
+interface DataTableToolbarProps {
+   searchColumnId?: string;
+   searchPlaceholder?: string;
+   className?: string;
+   children?: React.ReactNode;
+}
+
+export function DataTableToolbar({
+   searchColumnId,
+   searchPlaceholder = "Buscar...",
+   className,
+   children,
+}: DataTableToolbarProps) {
+   const { table, columnFilters } = useDataTable();
+
+   const currentSearchValue = searchColumnId
+      ? String(columnFilters.find((f) => f.id === searchColumnId)?.value ?? "")
+      : "";
+
+   const [inputValue, setInputValue] = useState(currentSearchValue);
+
+   useEffect(() => {
+      setInputValue(currentSearchValue);
+   }, [currentSearchValue]);
+
+   const applySearch = useDebouncedCallback(
+      (value: string) => {
+         if (!searchColumnId) return;
+         table.getColumn(searchColumnId)?.setFilterValue(value || undefined);
+      },
+      { wait: 350 },
+   );
+
+   const activeFilters = columnFilters.filter((f) => {
+      if (f.id === searchColumnId) return false;
+      return f.value !== undefined && f.value !== null && f.value !== "";
+   });
+
+   const hasAnyFilter =
+      columnFilters.length > 0 &&
+      columnFilters.some((f) => {
+         if (f.id === searchColumnId) return inputValue !== "";
+         return f.value !== undefined && f.value !== null && f.value !== "";
+      });
+
+   function removeFilter(columnId: string) {
+      table.getColumn(columnId)?.setFilterValue(undefined);
+      if (columnId === searchColumnId) setInputValue("");
+   }
+
+   function clearSearch() {
+      setInputValue("");
+      if (searchColumnId)
+         table.getColumn(searchColumnId)?.setFilterValue(undefined);
+   }
+
+   function clearAll() {
+      table.resetColumnFilters();
+      setInputValue("");
+   }
+
+   return (
+      <div className={cn("flex flex-wrap items-center gap-2", className)}>
+         {searchColumnId && (
+            <InputGroup className="w-[220px]">
+               <InputGroupAddon>
+                  <Search className="text-muted-foreground" />
+               </InputGroupAddon>
+               <InputGroupInput
+                  placeholder={searchPlaceholder}
+                  value={inputValue}
+                  onChange={(e) => {
+                     setInputValue(e.target.value);
+                     applySearch(e.target.value);
+                  }}
+               />
+               {inputValue && (
+                  <InputGroupAddon align="inline-end">
+                     <InputGroupButton onClick={clearSearch}>
+                        <X />
+                        <span className="sr-only">Limpar busca</span>
+                     </InputGroupButton>
+                  </InputGroupAddon>
+               )}
+            </InputGroup>
+         )}
+
+         {activeFilters.map((filter) => {
+            const label =
+               table.getColumn(filter.id)?.columnDef.meta?.label ?? filter.id;
+            const valueLabel = filterValueLabel(filter.value);
+            return (
+               <Badge
+                  key={filter.id}
+                  variant="secondary"
+                  className="gap-1.5 pr-1 font-normal"
+               >
+                  <span className="text-muted-foreground">{label}</span>
+                  <span className="text-muted-foreground/40">·</span>
+                  <span className="font-medium text-foreground">
+                     {valueLabel}
+                  </span>
+                  <Button
+                     size="icon"
+                     variant="ghost"
+                     className="size-4 text-muted-foreground/50 hover:text-foreground hover:bg-accent"
+                     onClick={() => removeFilter(filter.id)}
+                  >
+                     <X />
+                     <span className="sr-only">Remover filtro {label}</span>
+                  </Button>
+               </Badge>
+            );
+         })}
+
+         {hasAnyFilter && (
+            <Button
+               variant="ghost"
+               size="sm"
+               className="h-7 gap-1 px-2 text-xs text-muted-foreground hover:text-destructive hover:bg-destructive/10"
+               onClick={clearAll}
+            >
+               <FilterX data-icon="inline-start" />
+               Limpar todos
+            </Button>
+         )}
+
+         {children && (
+            <div className="ml-auto flex items-center gap-2">{children}</div>
+         )}
+      </div>
+   );
+}
+
+interface DataTableNewActionProps {
+   label?: string;
+   onClick?: () => void;
+   href?: string;
+}
+
+export function DataTableNewAction({
+   label = "Novo",
+   onClick,
+   href,
+}: DataTableNewActionProps) {
+   if (href) {
+      return (
+         <Button asChild size="sm">
+            <Link to={href as never}>
+               <Plus data-icon="inline-start" />
+               {label}
+            </Link>
+         </Button>
+      );
+   }
+   return (
+      <Button size="sm" onClick={onClick}>
+         <Plus data-icon="inline-start" />
+         {label}
+      </Button>
+   );
+}

--- a/apps/web/src/components/data-table/data-table-toolbar.tsx
+++ b/apps/web/src/components/data-table/data-table-toolbar.tsx
@@ -80,10 +80,9 @@ export function DataTableToolbar({
    });
 
    const inputValue = useStore(form.store, (s) => s.values.search);
-   const filterValues = useStore(form.store, (s) => s.values.filters);
 
-   const activeFilters = Object.entries(filterValues).filter(
-      ([, v]) => v !== undefined && v !== null && v !== "",
+   const activeFilters = columnFilters.filter(
+      ({ value }) => value !== undefined && value !== null && value !== "",
    );
 
    const hasAnyFilter = activeFilters.length > 0 || inputValue !== "";
@@ -161,13 +160,12 @@ export function DataTableToolbar({
                   />
                )}
 
-               {activeFilters.map(([columnId, value]) => {
+               {activeFilters.map(({ id, value }) => {
                   const label =
-                     table.getColumn(columnId)?.columnDef.meta?.label ??
-                     columnId;
+                     table.getColumn(id)?.columnDef.meta?.label ?? id;
                   return (
                      <Badge
-                        key={columnId}
+                        key={id}
                         variant="secondary"
                         className="shrink-0 gap-1.5 pr-1 font-normal"
                      >
@@ -180,7 +178,7 @@ export function DataTableToolbar({
                            size="icon"
                            variant="ghost"
                            className="size-4 text-muted-foreground/50 hover:text-foreground hover:bg-accent"
-                           onClick={() => removeFilter(columnId)}
+                           onClick={() => removeFilter(id)}
                         >
                            <X />
                            <span className="sr-only">

--- a/apps/web/src/components/data-table/data-table-toolbar.tsx
+++ b/apps/web/src/components/data-table/data-table-toolbar.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useDebouncedCallback } from "@tanstack/react-pacer";
+import { useAsyncDebouncedCallback } from "@tanstack/react-pacer";
 import { Link } from "@tanstack/react-router";
 import { FilterX, Plus, Search, X } from "lucide-react";
-import { useState } from "react";
+import { useForm } from "@tanstack/react-form";
 import type React from "react";
 import { Badge } from "@packages/ui/components/badge";
 import { Button } from "@packages/ui/components/button";
@@ -23,130 +23,131 @@ function filterValueLabel(value: unknown): string {
 }
 
 interface DataTableToolbarProps {
-   searchColumnId?: string;
    searchPlaceholder?: string;
+   searchDefaultValue?: string;
+   onSearch?: (value: string) => Promise<void> | void;
    className?: string;
    children?: React.ReactNode;
 }
 
 export function DataTableToolbar({
-   searchColumnId,
    searchPlaceholder = "Buscar...",
+   searchDefaultValue = "",
+   onSearch,
    className,
    children,
 }: DataTableToolbarProps) {
    const { table, columnFilters } = useDataTable();
 
-   const currentSearchValue = searchColumnId
-      ? String(columnFilters.find((f) => f.id === searchColumnId)?.value ?? "")
-      : "";
+   const form = useForm({
+      defaultValues: { search: searchDefaultValue },
+   });
 
-   const [inputValue, setInputValue] = useState(currentSearchValue);
-
-   const applySearch = useDebouncedCallback(
-      (value: string) => {
-         if (!searchColumnId) return;
-         table.getColumn(searchColumnId)?.setFilterValue(value || undefined);
+   const debouncedSearch = useAsyncDebouncedCallback(
+      async (value: string) => {
+         await onSearch?.(value);
       },
       { wait: 350 },
    );
 
-   const activeFilters = columnFilters.filter((f) => {
-      if (f.id === searchColumnId) return false;
-      return f.value !== undefined && f.value !== null && f.value !== "";
-   });
+   const activeFilters = columnFilters.filter(
+      (f) => f.value !== undefined && f.value !== null && f.value !== "",
+   );
 
-   const hasAnyFilter =
-      columnFilters.length > 0 &&
-      columnFilters.some((f) => {
-         if (f.id === searchColumnId) return inputValue !== "";
-         return f.value !== undefined && f.value !== null && f.value !== "";
-      });
+   const inputValue = form.getFieldValue("search");
+   const hasAnyFilter = activeFilters.length > 0 || inputValue !== "";
 
    function removeFilter(columnId: string) {
       table.getColumn(columnId)?.setFilterValue(undefined);
-      if (columnId === searchColumnId) setInputValue("");
    }
 
-   function clearSearch() {
-      setInputValue("");
-      if (searchColumnId)
-         table.getColumn(searchColumnId)?.setFilterValue(undefined);
+   async function clearSearch() {
+      form.setFieldValue("search", "");
+      await onSearch?.("");
    }
 
-   function clearAll() {
+   async function clearAll() {
       table.resetColumnFilters();
-      setInputValue("");
+      if (inputValue !== "") {
+         form.setFieldValue("search", "");
+         await onSearch?.("");
+      }
    }
 
    return (
-      <div className={cn("flex flex-wrap items-center gap-2", className)}>
-         {searchColumnId && (
-            <InputGroup className="w-[220px]">
-               <InputGroupAddon>
-                  <Search className="text-muted-foreground" />
-               </InputGroupAddon>
-               <InputGroupInput
-                  placeholder={searchPlaceholder}
-                  value={inputValue}
-                  onChange={(e) => {
-                     setInputValue(e.target.value);
-                     applySearch(e.target.value);
-                  }}
-               />
-               {inputValue && (
-                  <InputGroupAddon align="inline-end">
-                     <InputGroupButton onClick={clearSearch}>
-                        <X />
-                        <span className="sr-only">Limpar busca</span>
-                     </InputGroupButton>
-                  </InputGroupAddon>
-               )}
-            </InputGroup>
-         )}
+      <div className={cn("flex items-center gap-2", className)}>
+         <div className="flex flex-1 flex-wrap items-center gap-2 min-w-0">
+            {onSearch && (
+               <form.Field name="search">
+                  {(field) => (
+                     <InputGroup className="flex-1 min-w-0 max-w-sm">
+                        <InputGroupAddon>
+                           <Search className="text-muted-foreground" />
+                        </InputGroupAddon>
+                        <InputGroupInput
+                           placeholder={searchPlaceholder}
+                           value={field.state.value}
+                           onChange={(e) => {
+                              field.handleChange(e.target.value);
+                              debouncedSearch(e.target.value);
+                           }}
+                        />
+                        {field.state.value && (
+                           <InputGroupAddon align="inline-end">
+                              <InputGroupButton onClick={clearSearch}>
+                                 <X />
+                                 <span className="sr-only">Limpar busca</span>
+                              </InputGroupButton>
+                           </InputGroupAddon>
+                        )}
+                     </InputGroup>
+                  )}
+               </form.Field>
+            )}
 
-         {activeFilters.map((filter) => {
-            const label =
-               table.getColumn(filter.id)?.columnDef.meta?.label ?? filter.id;
-            const valueLabel = filterValueLabel(filter.value);
-            return (
-               <Badge
-                  key={filter.id}
-                  variant="secondary"
-                  className="gap-1.5 pr-1 font-normal"
-               >
-                  <span className="text-muted-foreground">{label}</span>
-                  <span className="text-muted-foreground/40">·</span>
-                  <span className="font-medium text-foreground">
-                     {valueLabel}
-                  </span>
-                  <Button
-                     size="icon"
-                     variant="ghost"
-                     className="size-4 text-muted-foreground/50 hover:text-foreground hover:bg-accent"
-                     onClick={() => removeFilter(filter.id)}
+            {activeFilters.map((filter) => {
+               const label =
+                  table.getColumn(filter.id)?.columnDef.meta?.label ??
+                  filter.id;
+               const valueLabel = filterValueLabel(filter.value);
+               return (
+                  <Badge
+                     key={filter.id}
+                     variant="secondary"
+                     className="shrink-0 gap-1.5 pr-1 font-normal"
                   >
-                     <X />
-                     <span className="sr-only">Remover filtro {label}</span>
-                  </Button>
-               </Badge>
-            );
-         })}
+                     <span className="text-muted-foreground">{label}</span>
+                     <span className="text-muted-foreground/40">·</span>
+                     <span className="font-medium text-foreground">
+                        {valueLabel}
+                     </span>
+                     <Button
+                        size="icon"
+                        variant="ghost"
+                        className="size-4 text-muted-foreground/50 hover:text-foreground hover:bg-accent"
+                        onClick={() => removeFilter(filter.id)}
+                     >
+                        <X />
+                        <span className="sr-only">Remover filtro {label}</span>
+                     </Button>
+                  </Badge>
+               );
+            })}
 
-         {hasAnyFilter && (
-            <Button
-               variant="ghost"
-               size="sm"
-               className="h-7 gap-1 px-2 text-xs text-muted-foreground hover:text-destructive hover:bg-destructive/10"
-               onClick={clearAll}
-            >
-               <FilterX data-icon="inline-start" />
-               Limpar todos
-            </Button>
-         )}
-
+            {hasAnyFilter && (
+               <Button
+                  variant="ghost"
+                  size="sm"
+                  className="shrink-0 text-muted-foreground hover:text-destructive hover:bg-destructive/10"
+                  onClick={clearAll}
+               >
+                  <FilterX data-icon="inline-start" />
+                  Limpar todos
+               </Button>
+            )}
+         </div>
          {children && (
-            <div className="ml-auto flex items-center gap-2">{children}</div>
+            <div className="flex shrink-0 items-center gap-2">{children}</div>
          )}
       </div>
    );


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Implementa a toolbar padrão do DataTable com busca (debounce), chips de filtros e ação “Novo”, com estado via `@tanstack/react-form` + contexto. A UI passa a ler/escrever direto de `columnFilters` e a condição de filtros ativos foi corrigida (ignora vazio, preserva 0/false); atende MON-483 e remove o botão “Novo” do header.

- **New Features**
  - `<DataTableToolbar>` com busca debounced (350 ms via `@tanstack/react-pacer`), limpar e placeholder customizável; estado via `@tanstack/react-form` + `useStore`.
  - Filtros ativos como chips removíveis; “Limpar todos” reseta `filters`, input e chama `table.resetColumnFilters()`.
  - Fonte única de verdade: inicializa e sincroniza `filters` a partir de `columnFilters` (snapshot via `foxact/use-singleton`), incluindo correção da condição de ativo (`value != null && value !== ""`).
  - Contexto da toolbar (`foxact/context-state`) + sync isomórfico (`foxact/use-isomorphic-layout-effect`); `useDataTableToolbar()` expõe `form` e `onSearch`.
  - `<DataTableNewAction>` com `onClick` ou navegação via `@tanstack/react-router`.

- **Impacto e testes**
  - Por quê: padronizar a toolbar, manter UI/DataTable em sincronia e cumprir MON-483.
  - Camadas:
    - componente: novos `DataTableToolbar`/`DataTableNewAction`; integra com `useDataTable` para ler/limpar `columnFilters`.
    - store: sem global; estado local no `@tanstack/react-form` + contexto.
    - router: uso de `Link` de `@tanstack/react-router`; sem novas rotas.
    - repositório: sem mudanças.
  - Checklist:
    - Debounce de 350 ms dispara `onSearch`; limpar busca chama `onSearch("")`.
    - Chips exibem `meta.label` e valor; remover chip limpa filtro da coluna.
    - “Limpar todos” aparece só quando há input ou filtros; reseta form e `columnFilters`.
    - Condição de filtro ativo ignora string vazia, mas mantém `0`/`false` como válidos.

<sup>Written for commit 18f29ab195adf547544c1713f66e37f443289fa9. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/791">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

