### PR TITLE
feat(data-table): export nativo CSV e XLSX com suporte a selecionados

### DIFF
--- a/apps/web/src/components/data-table/data-table-export.tsx
+++ b/apps/web/src/components/data-table/data-table-export.tsx
@@ -5,6 +5,7 @@ import { Button } from "@packages/ui/components/button";
 import {
    DropdownMenu,
    DropdownMenuContent,
+   DropdownMenuGroup,
    DropdownMenuItem,
    DropdownMenuLabel,
    DropdownMenuSeparator,
@@ -20,7 +21,7 @@ function downloadBlob(blob: Blob, filename: string) {
    a.href = url;
    a.download = filename;
    a.click();
-   URL.revokeObjectURL(url);
+   setTimeout(() => URL.revokeObjectURL(url), 100);
 }
 
 interface DataTableExportButtonProps {
@@ -92,28 +93,36 @@ export function DataTableExportButton({
       <DropdownMenu>
          <DropdownMenuTrigger asChild>
             <Button tooltip="Exportar" variant="outline" size="icon-sm">
-               <Download className="size-4" />
+               <Download />
                <span className="sr-only">Exportar</span>
             </Button>
          </DropdownMenuTrigger>
          <DropdownMenuContent align="end">
-            <DropdownMenuLabel>Exportar</DropdownMenuLabel>
+            <DropdownMenuLabel id="export-label">Exportar</DropdownMenuLabel>
             <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={() => handleExport("csv", false)}>
-               Exportar CSV
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => handleExport("xlsx", false)}>
-               Exportar XLSX
-            </DropdownMenuItem>
+            <DropdownMenuGroup aria-labelledby="export-label">
+               <DropdownMenuItem onClick={() => handleExport("csv", false)}>
+                  Exportar CSV
+               </DropdownMenuItem>
+               <DropdownMenuItem onClick={() => handleExport("xlsx", false)}>
+                  Exportar XLSX
+               </DropdownMenuItem>
+            </DropdownMenuGroup>
             {hasSelection && (
                <>
                   <DropdownMenuSeparator />
-                  <DropdownMenuItem onClick={() => handleExport("csv", true)}>
-                     Exportar selecionados (CSV)
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => handleExport("xlsx", true)}>
-                     Exportar selecionados (XLSX)
-                  </DropdownMenuItem>
+                  <DropdownMenuGroup>
+                     <DropdownMenuItem
+                        onClick={() => handleExport("csv", true)}
+                     >
+                        Exportar selecionados (CSV)
+                     </DropdownMenuItem>
+                     <DropdownMenuItem
+                        onClick={() => handleExport("xlsx", true)}
+                     >
+                        Exportar selecionados (XLSX)
+                     </DropdownMenuItem>
+                  </DropdownMenuGroup>
                </>
             )}
          </DropdownMenuContent>

--- a/apps/web/src/components/data-table/data-table-export.tsx
+++ b/apps/web/src/components/data-table/data-table-export.tsx
@@ -1,0 +1,122 @@
+import dayjs from "dayjs";
+import { Download } from "lucide-react";
+import { useCallback, useMemo } from "react";
+import { Button } from "@packages/ui/components/button";
+import {
+   DropdownMenu,
+   DropdownMenuContent,
+   DropdownMenuItem,
+   DropdownMenuLabel,
+   DropdownMenuSeparator,
+   DropdownMenuTrigger,
+} from "@packages/ui/components/dropdown-menu";
+import { useCsvFile } from "@/hooks/use-csv-file";
+import { useXlsxFile } from "@/hooks/use-xlsx-file";
+import { useDataTable } from "./data-table-root";
+
+function downloadBlob(blob: Blob, filename: string) {
+   const url = URL.createObjectURL(blob);
+   const a = document.createElement("a");
+   a.href = url;
+   a.download = filename;
+   a.click();
+   URL.revokeObjectURL(url);
+}
+
+interface DataTableExportButtonProps {
+   exportFileName: string;
+}
+
+export function DataTableExportButton({
+   exportFileName,
+}: DataTableExportButtonProps) {
+   const { table } = useDataTable();
+   const { generate: generateCsv } = useCsvFile();
+   const { generate: generateXlsx } = useXlsxFile();
+
+   const exportCols = useMemo(
+      () =>
+         table
+            .getAllColumns()
+            .filter(
+               (col) =>
+                  col.id !== "__select" &&
+                  col.id !== "__actions" &&
+                  !col.columnDef.meta?.exportIgnore,
+            ),
+      [table],
+   );
+
+   const headers = useMemo(
+      () => exportCols.map((col) => col.columnDef.meta?.label ?? col.id),
+      [exportCols],
+   );
+
+   const buildRows = useCallback(
+      (rows: ReturnType<typeof table.getRowModel>["rows"]) =>
+         rows.map((row) => {
+            const record: Record<string, string> = {};
+            for (let i = 0; i < exportCols.length; i++) {
+               const col = exportCols[i];
+               const header = headers[i];
+               const value = row.getValue(col.id);
+               record[header] = value == null ? "" : String(value);
+            }
+            return record;
+         }),
+      [exportCols, headers],
+   );
+
+   const hasSelection = table.getSelectedRowModel().rows.length > 0;
+
+   const handleExport = useCallback(
+      (format: "csv" | "xlsx", selected: boolean) => {
+         const rows = selected
+            ? table.getSelectedRowModel().rows
+            : table.getRowModel().rows;
+         const data = buildRows(rows);
+         const suffix = selected ? "-selecionados" : "";
+         const dateStr = dayjs().format("YYYY-MM-DD");
+         const filename = `${exportFileName}${suffix}-${dateStr}.${format}`;
+
+         if (format === "csv") {
+            downloadBlob(generateCsv(data, headers), filename);
+            return;
+         }
+         downloadBlob(generateXlsx(data, headers), filename);
+      },
+      [table, buildRows, exportFileName, headers, generateCsv, generateXlsx],
+   );
+
+   return (
+      <DropdownMenu>
+         <DropdownMenuTrigger asChild>
+            <Button tooltip="Exportar" variant="outline" size="icon-sm">
+               <Download className="size-4" />
+               <span className="sr-only">Exportar</span>
+            </Button>
+         </DropdownMenuTrigger>
+         <DropdownMenuContent align="end">
+            <DropdownMenuLabel>Exportar</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => handleExport("csv", false)}>
+               Exportar CSV
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => handleExport("xlsx", false)}>
+               Exportar XLSX
+            </DropdownMenuItem>
+            {hasSelection && (
+               <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={() => handleExport("csv", true)}>
+                     Exportar selecionados (CSV)
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => handleExport("xlsx", true)}>
+                     Exportar selecionados (XLSX)
+                  </DropdownMenuItem>
+               </>
+            )}
+         </DropdownMenuContent>
+      </DropdownMenu>
+   );
+}

--- a/apps/web/src/components/data-table/data-table-export.tsx
+++ b/apps/web/src/components/data-table/data-table-export.tsx
@@ -24,14 +24,9 @@ function downloadBlob(blob: Blob, filename: string) {
    setTimeout(() => URL.revokeObjectURL(url), 100);
 }
 
-interface DataTableExportButtonProps {
-   exportFileName: string;
-}
-
-export function DataTableExportButton({
-   exportFileName,
-}: DataTableExportButtonProps) {
-   const { table } = useDataTable();
+export function DataTableExportButton() {
+   const { table, storageKey } = useDataTable();
+   const exportFileBase = storageKey.replace(/^montte:datatable:/, "");
    const { generate: generateCsv } = useCsvFile();
    const { generate: generateXlsx } = useXlsxFile();
 
@@ -78,7 +73,7 @@ export function DataTableExportButton({
          const data = buildRows(rows);
          const suffix = selected ? "-selecionados" : "";
          const dateStr = dayjs().format("YYYY-MM-DD");
-         const filename = `${exportFileName}${suffix}-${dateStr}.${format}`;
+         const filename = `${exportFileBase}${suffix}-${dateStr}.${format}`;
 
          if (format === "csv") {
             downloadBlob(generateCsv(data, headers), filename);
@@ -86,7 +81,7 @@ export function DataTableExportButton({
          }
          downloadBlob(generateXlsx(data, headers), filename);
       },
-      [table, buildRows, exportFileName, headers, generateCsv, generateXlsx],
+      [table, buildRows, storageKey, headers, generateCsv, generateXlsx],
    );
 
    return (

--- a/apps/web/src/components/data-table/data-table-root.tsx
+++ b/apps/web/src/components/data-table/data-table-root.tsx
@@ -55,6 +55,7 @@ declare module "@tanstack/react-table" {
       filterVariant?: "text" | "select" | "range" | "date";
       align?: "left" | "center" | "right";
       exportable?: boolean;
+      exportIgnore?: boolean;
    }
 }
 

--- a/apps/web/src/components/data-table/data-table-root.tsx
+++ b/apps/web/src/components/data-table/data-table-root.tsx
@@ -62,6 +62,7 @@ declare module "@tanstack/react-table" {
 type DataTableContextValue<TData> = {
    store: Store<DataTableStoreState>;
    table: Table<TData>;
+   storageKey: string;
    onTableStateChange: (state: DataTableStoredState) => void;
    groupBy?: (row: TData) => string;
    renderGroupHeader?: (key: string, rows: Row<TData>[]) => React.ReactNode;
@@ -91,6 +92,7 @@ export function useDataTable<TData>() {
    return {
       table: ctx.table,
       store: ctx.store,
+      storageKey: ctx.storageKey,
       onTableStateChange: ctx.onTableStateChange,
       groupBy: ctx.groupBy,
       renderGroupHeader: ctx.renderGroupHeader,
@@ -346,11 +348,19 @@ function useDataTableRoot<TData>({
       () => ({
          store,
          table,
+         storageKey,
          onTableStateChange,
          groupBy,
          renderGroupHeader,
       }),
-      [store, table, onTableStateChange, groupBy, renderGroupHeader],
+      [
+         store,
+         table,
+         storageKey,
+         onTableStateChange,
+         groupBy,
+         renderGroupHeader,
+      ],
    );
 }
 

--- a/apps/web/src/components/data-table/data-table-toolbar.tsx
+++ b/apps/web/src/components/data-table/data-table-toolbar.tsx
@@ -18,6 +18,7 @@ import {
 } from "@packages/ui/components/input-group";
 import { cn } from "@packages/ui/lib/utils";
 import { useDataTable } from "./data-table-root";
+import { DataTableExportButton } from "./data-table-export";
 
 export type ToolbarValues = {
    search: string;
@@ -202,11 +203,10 @@ export function DataTableToolbar({
                )}
             </div>
 
-            {children && (
-               <div className="flex shrink-0 items-center gap-2">
-                  {children}
-               </div>
-            )}
+            <div className="flex shrink-0 items-center gap-2">
+               <DataTableExportButton />
+               {children}
+            </div>
          </div>
       </DataTableToolbarCtxProvider>
    );

--- a/core/agents/README.md
+++ b/core/agents/README.md
@@ -1,36 +1,60 @@
 # @core/agents
 
-TanStack AI-powered agent framework with multi-model support via OpenRouter.
+TanStack AI primitives — model registry, PostHog observability middleware, and shared AI infrastructure. Domain-specific AI actions live inside each entity or feature module.
 
 ## Exports
 
-| Export     | Purpose                                    |
-| ---------- | ------------------------------------------ |
-| `.`        | `chatRubi()` — streaming chat function     |
-| `./models` | Model ID types and available model presets |
-| `./utils`  | Agent utility functions                    |
+| Export        | Purpose                                           |
+| ------------- | ------------------------------------------------- |
+| `.`           | `chatRubi()` — Rubi chat interface (not yet impl) |
+| `./models`    | `AVAILABLE_MODELS`, `getModelPreset`, `ModelId`   |
+| `./actions/*` | AI action functions per domain                    |
 
-## Usage
+## Model Registry
 
 ```typescript
-import { chatRubi } from "@core/agents";
+import { AVAILABLE_MODELS, getModelPreset, DEFAULT_MODEL_ID } from "@core/agents/models";
 
-const stream = chatRubi({
-   db,
-   userId,
-   teamId,
-   organizationId,
-   threadId,
-   messages,
-   modelId: "openrouter/moonshotai/kimi-k2.5",
-   language: "pt-BR",
-});
-
-for await (const chunk of stream) {
-   // stream TanStack AI chunks to the client
-}
+const preset = getModelPreset(AVAILABLE_MODELS, modelId, DEFAULT_MODEL_ID);
+// preset.temperature, preset.maxTokens, preset.label, ...
 ```
 
-## How It Works
+Available models (via OpenRouter):
+- `openrouter/moonshotai/kimi-k2.5` — default, Rubi's primary model
+- `openrouter/google/gemini-3-flash-preview` — long context (1M tokens)
+- `openrouter/openai/gpt-oss-20b` — fast and cheap
+- `openrouter/google/gemini-3.1-flash-lite-preview` — ultra-light, free tier
 
-`chatRubi()` wraps TanStack AI's `chat()` with an OpenRouter adapter. It builds a system prompt scoped to Rubi's persona, resolves the model preset (temperature, topP, maxTokens), and attaches a persistence middleware that saves user/assistant messages and auto-generates a thread title after the first exchange.
+## PostHog AI Middleware
+
+Captures `$ai_generation` events to PostHog for every `chat()` call.
+
+```typescript
+import { createPosthogAiMiddleware, type AiObservabilityContext } from "@core/agents/middleware/posthog";
+
+const obs: AiObservabilityContext = {
+   posthog,
+   distinctId: context.userId,
+   promptName: "categorize-transaction",
+   promptVersion: 1,
+};
+
+chat({
+   adapter: openRouterText(modelId),
+   messages: [...],
+   middleware: [createPosthogAiMiddleware(obs)],
+});
+```
+
+## AI Actions
+
+All actions use `@tanstack/ai` + `@tanstack/ai-openrouter` with `safeTry` from neverthrow. All return `ResultAsync<T, AppError>`.
+
+| Action | Import | Used by |
+|--------|--------|---------|
+| `inferCategoryWithAI` | `@core/agents/actions/categorize` | transactions categorization |
+| `deriveKeywordsWithAI` | `@core/agents/actions/keywords` | categories keyword derivation |
+| `deriveTagKeywordsWithAI` | `@core/agents/actions/keywords-tag` | tags keyword derivation |
+| `inferTagWithAI` | `@core/agents/actions/suggest-tag` | transactions tag suggestion |
+
+> In the target modular architecture, actions co-locate with their domains (`entities/categories/ai.ts`, `features/transactions/ai.ts`). The middleware and model registry stay in `core/agents/`.


### PR DESCRIPTION
## Summary

- Adiciona `exportIgnore?: boolean` ao `ColumnMeta` — opt-out por coluna; todas as colunas são exportáveis por padrão
- Cria `DataTableExportButton` em `apps/web/src/components/data-table/data-table-export.tsx` — botão de dropdown com opções CSV e XLSX; quando há linhas selecionadas, exibe opções adicionais "Exportar selecionados"

## Uso

```tsx
import { DataTableExportButton } from "@/components/data-table/data-table-export";

// dentro de <DataTableToolbar> children:
<DataTableExportButton exportFileName="transacoes" />
```

Para excluir uma coluna do export:
```ts
meta: { exportIgnore: true }
```

## Notas

- Export cobre apenas as linhas da página atual (paginação server-side)
- `DataTableExportButton` lê table e seleção via `useDataTable()` — sem props extras

Closes MON-490

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adiciona exportação nativa CSV/XLSX ao DataTable com opção “exportar selecionados”. Integra o botão na Toolbar, corrige WCAG 2.2, deriva o nome do arquivo do `storageKey` (remove `exportFileName`) e atualiza o README de `@core/agents`. Atende ao MON-490.

- **New Features**
  - Novo `DataTableExportButton` com dropdown CSV/XLSX e variantes “selecionados” quando há seleção; integrado por padrão na `DataTableToolbar` (mantém `children`).
  - Geração de arquivos via `useCsvFile` e `useXlsxFile`; lê tabela/seleção/`storageKey` de `useDataTable()` — sem props extras.
  - Nome do arquivo: `<storageKey>-YYYY-MM-DD.(csv|xlsx)` sem `montte:datatable:`; inclui “-selecionados” quando aplicável.
  - Exporta todas as colunas, exceto `__select`, `__actions` e as com `columnDef.meta.exportIgnore`; headers usam `columnDef.meta.label` (fallback `id`).
  - Escopo: apenas linhas da página atual (paginação server-side).
  - Tipagem: adiciona `exportIgnore?: boolean` em `ColumnMeta` de `@tanstack/react-table`; `useDataTable()` passa a expor `storageKey`.

- **Impacto e Testes**
  - Camadas
    - Router/Repositório: sem impacto.
    - Componente: adiciona `DataTableExportButton`; `DataTableToolbar` renderiza o botão por padrão; `data-table-root` expõe `storageKey`.
    - Store: usa seleção de `useDataTable`; sem mudanças no estado global.
    - Docs: README de `@core/agents` atualizado (registry de modelos e middleware); sem impacto no runtime.
  - Checklist
    - Opções variam com a seleção; exporta página atual ou só selecionados.
    - Colunas com `meta.exportIgnore: true` ficam fora; headers usam `meta.label`.
    - Nome do arquivo deriva do `storageKey` sem `montte:datatable:`; inclui “-selecionados” quando aplicável.
    - Valores nulos/undefined viram vazio; abre no Excel/Numbers.
    - Acessibilidade: trigger com nome acessível, grupos rotulados e navegação por teclado ok.

<sup>Written for commit dcbf9d2a04f86217807574db5042eaceaa88a36f. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/793">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

