### PR TITLE
Manoelnetocarvalho03/mon 481 feattags redesign centros de custo table native posthog

### DIFF
--- a/apps/web/src/components/data-table/data-table-bulk-actions.tsx
+++ b/apps/web/src/components/data-table/data-table-bulk-actions.tsx
@@ -4,6 +4,7 @@ import {
 } from "@packages/ui/components/selection-action-bar";
 import type React from "react";
 import { useDataTable } from "./data-table-root";
+import { DataTableExportSelectedButton } from "./data-table-export";
 
 export { SelectionActionButton };
 
@@ -31,6 +32,7 @@ export function DataTableBulkActions<TData>({
          onClear={clearSelection}
       >
          {children({ selectedRows, clearSelection })}
+         <DataTableExportSelectedButton />
       </SelectionActionBar>
    );
 }

--- a/apps/web/src/components/data-table/data-table-export.tsx
+++ b/apps/web/src/components/data-table/data-table-export.tsx
@@ -50,16 +50,16 @@ function useTableExport() {
 
    const buildRows = useCallback(
       (rows: ReturnType<typeof table.getRowModel>["rows"]) =>
-         rows.map((row) => {
-            const record: Record<string, string> = {};
-            for (let i = 0; i < exportCols.length; i++) {
-               const col = exportCols[i];
-               const header = headers[i];
-               const value = row.getValue(col.id);
-               record[header] = value == null ? "" : String(value);
-            }
-            return record;
-         }),
+         rows.map((row) =>
+            Object.fromEntries(
+               exportCols.map((col, i) => [
+                  headers[i],
+                  row.getValue(col.id) == null
+                     ? ""
+                     : String(row.getValue(col.id)),
+               ]),
+            ),
+         ),
       [exportCols, headers],
    );
 
@@ -84,6 +84,11 @@ function useTableExport() {
    return { table, exportRows };
 }
 
+const EXPORT_FORMATS: { format: "csv" | "xlsx"; label: string }[] = [
+   { format: "csv", label: "CSV" },
+   { format: "xlsx", label: "XLSX" },
+];
+
 export function DataTableExportButton() {
    const { table, exportRows } = useTableExport();
 
@@ -105,12 +110,14 @@ export function DataTableExportButton() {
             <DropdownMenuLabel id="export-label">Exportar</DropdownMenuLabel>
             <DropdownMenuSeparator />
             <DropdownMenuGroup aria-labelledby="export-label">
-               <DropdownMenuItem onClick={() => handleExport("csv")}>
-                  Exportar CSV
-               </DropdownMenuItem>
-               <DropdownMenuItem onClick={() => handleExport("xlsx")}>
-                  Exportar XLSX
-               </DropdownMenuItem>
+               {EXPORT_FORMATS.map(({ format, label }) => (
+                  <DropdownMenuItem
+                     key={format}
+                     onClick={() => handleExport(format)}
+                  >
+                     Exportar {label}
+                  </DropdownMenuItem>
+               ))}
             </DropdownMenuGroup>
          </DropdownMenuContent>
       </DropdownMenu>
@@ -138,12 +145,14 @@ export function DataTableExportSelectedButton() {
             <DropdownMenuLabel>Exportar selecionados</DropdownMenuLabel>
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
-               <DropdownMenuItem onClick={() => handleExport("csv")}>
-                  CSV
-               </DropdownMenuItem>
-               <DropdownMenuItem onClick={() => handleExport("xlsx")}>
-                  XLSX
-               </DropdownMenuItem>
+               {EXPORT_FORMATS.map(({ format, label }) => (
+                  <DropdownMenuItem
+                     key={format}
+                     onClick={() => handleExport(format)}
+                  >
+                     {label}
+                  </DropdownMenuItem>
+               ))}
             </DropdownMenuGroup>
          </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/web/src/components/data-table/data-table-export.tsx
+++ b/apps/web/src/components/data-table/data-table-export.tsx
@@ -24,7 +24,7 @@ function downloadBlob(blob: Blob, filename: string) {
    setTimeout(() => URL.revokeObjectURL(url), 100);
 }
 
-export function DataTableExportButton() {
+function useTableExport() {
    const { table, storageKey } = useDataTable();
    const exportFileBase = storageKey.replace(/^montte:datatable:/, "");
    const { generate: generateCsv } = useCsvFile();
@@ -63,23 +63,34 @@ export function DataTableExportButton() {
       [exportCols, headers],
    );
 
-   const handleExport = useCallback(
-      (format: "csv" | "xlsx", selected: boolean) => {
-         const rows = selected
-            ? table.getSelectedRowModel().rows
-            : table.getRowModel().rows;
+   const exportRows = useCallback(
+      (
+         format: "csv" | "xlsx",
+         rows: ReturnType<typeof table.getRowModel>["rows"],
+         suffix: string,
+      ) => {
          const data = buildRows(rows);
-         const suffix = selected ? "-selecionados" : "";
          const dateStr = dayjs().format("YYYY-MM-DD");
          const filename = `${exportFileBase}${suffix}-${dateStr}.${format}`;
-
          if (format === "csv") {
             downloadBlob(generateCsv(data, headers), filename);
             return;
          }
          downloadBlob(generateXlsx(data, headers), filename);
       },
-      [table, buildRows, storageKey, headers, generateCsv, generateXlsx],
+      [buildRows, exportFileBase, headers, generateCsv, generateXlsx],
+   );
+
+   return { table, exportRows };
+}
+
+export function DataTableExportButton() {
+   const { table, exportRows } = useTableExport();
+
+   const handleExport = useCallback(
+      (format: "csv" | "xlsx") =>
+         exportRows(format, table.getRowModel().rows, ""),
+      [table, exportRows],
    );
 
    return (
@@ -94,10 +105,10 @@ export function DataTableExportButton() {
             <DropdownMenuLabel id="export-label">Exportar</DropdownMenuLabel>
             <DropdownMenuSeparator />
             <DropdownMenuGroup aria-labelledby="export-label">
-               <DropdownMenuItem onClick={() => handleExport("csv", false)}>
+               <DropdownMenuItem onClick={() => handleExport("csv")}>
                   Exportar CSV
                </DropdownMenuItem>
-               <DropdownMenuItem onClick={() => handleExport("xlsx", false)}>
+               <DropdownMenuItem onClick={() => handleExport("xlsx")}>
                   Exportar XLSX
                </DropdownMenuItem>
             </DropdownMenuGroup>
@@ -107,57 +118,12 @@ export function DataTableExportButton() {
 }
 
 export function DataTableExportSelectedButton() {
-   const { table, storageKey } = useDataTable();
-   const exportFileBase = storageKey.replace(/^montte:datatable:/, "");
-   const { generate: generateCsv } = useCsvFile();
-   const { generate: generateXlsx } = useXlsxFile();
-
-   const exportCols = useMemo(
-      () =>
-         table
-            .getAllColumns()
-            .filter(
-               (col) =>
-                  col.id !== "__select" &&
-                  col.id !== "__actions" &&
-                  !col.columnDef.meta?.exportIgnore,
-            ),
-      [table],
-   );
-
-   const headers = useMemo(
-      () => exportCols.map((col) => col.columnDef.meta?.label ?? col.id),
-      [exportCols],
-   );
-
-   const buildRows = useCallback(
-      (rows: ReturnType<typeof table.getSelectedRowModel>["rows"]) =>
-         rows.map((row) => {
-            const record: Record<string, string> = {};
-            for (let i = 0; i < exportCols.length; i++) {
-               const col = exportCols[i];
-               const header = headers[i];
-               const value = row.getValue(col.id);
-               record[header] = value == null ? "" : String(value);
-            }
-            return record;
-         }),
-      [exportCols, headers],
-   );
+   const { table, exportRows } = useTableExport();
 
    const handleExport = useCallback(
-      (format: "csv" | "xlsx") => {
-         const rows = table.getSelectedRowModel().rows;
-         const data = buildRows(rows);
-         const dateStr = dayjs().format("YYYY-MM-DD");
-         const filename = `${exportFileBase}-selecionados-${dateStr}.${format}`;
-         if (format === "csv") {
-            downloadBlob(generateCsv(data, headers), filename);
-            return;
-         }
-         downloadBlob(generateXlsx(data, headers), filename);
-      },
-      [table, buildRows, exportFileBase, headers, generateCsv, generateXlsx],
+      (format: "csv" | "xlsx") =>
+         exportRows(format, table.getSelectedRowModel().rows, "-selecionados"),
+      [table, exportRows],
    );
 
    return (

--- a/apps/web/src/components/data-table/data-table-export.tsx
+++ b/apps/web/src/components/data-table/data-table-export.tsx
@@ -63,8 +63,6 @@ export function DataTableExportButton() {
       [exportCols, headers],
    );
 
-   const hasSelection = table.getSelectedRowModel().rows.length > 0;
-
    const handleExport = useCallback(
       (format: "csv" | "xlsx", selected: boolean) => {
          const rows = selected
@@ -103,23 +101,84 @@ export function DataTableExportButton() {
                   Exportar XLSX
                </DropdownMenuItem>
             </DropdownMenuGroup>
-            {hasSelection && (
-               <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuGroup>
-                     <DropdownMenuItem
-                        onClick={() => handleExport("csv", true)}
-                     >
-                        Exportar selecionados (CSV)
-                     </DropdownMenuItem>
-                     <DropdownMenuItem
-                        onClick={() => handleExport("xlsx", true)}
-                     >
-                        Exportar selecionados (XLSX)
-                     </DropdownMenuItem>
-                  </DropdownMenuGroup>
-               </>
-            )}
+         </DropdownMenuContent>
+      </DropdownMenu>
+   );
+}
+
+export function DataTableExportSelectedButton() {
+   const { table, storageKey } = useDataTable();
+   const exportFileBase = storageKey.replace(/^montte:datatable:/, "");
+   const { generate: generateCsv } = useCsvFile();
+   const { generate: generateXlsx } = useXlsxFile();
+
+   const exportCols = useMemo(
+      () =>
+         table
+            .getAllColumns()
+            .filter(
+               (col) =>
+                  col.id !== "__select" &&
+                  col.id !== "__actions" &&
+                  !col.columnDef.meta?.exportIgnore,
+            ),
+      [table],
+   );
+
+   const headers = useMemo(
+      () => exportCols.map((col) => col.columnDef.meta?.label ?? col.id),
+      [exportCols],
+   );
+
+   const buildRows = useCallback(
+      (rows: ReturnType<typeof table.getSelectedRowModel>["rows"]) =>
+         rows.map((row) => {
+            const record: Record<string, string> = {};
+            for (let i = 0; i < exportCols.length; i++) {
+               const col = exportCols[i];
+               const header = headers[i];
+               const value = row.getValue(col.id);
+               record[header] = value == null ? "" : String(value);
+            }
+            return record;
+         }),
+      [exportCols, headers],
+   );
+
+   const handleExport = useCallback(
+      (format: "csv" | "xlsx") => {
+         const rows = table.getSelectedRowModel().rows;
+         const data = buildRows(rows);
+         const dateStr = dayjs().format("YYYY-MM-DD");
+         const filename = `${exportFileBase}-selecionados-${dateStr}.${format}`;
+         if (format === "csv") {
+            downloadBlob(generateCsv(data, headers), filename);
+            return;
+         }
+         downloadBlob(generateXlsx(data, headers), filename);
+      },
+      [table, buildRows, exportFileBase, headers, generateCsv, generateXlsx],
+   );
+
+   return (
+      <DropdownMenu>
+         <DropdownMenuTrigger asChild>
+            <Button tooltip="Exportar selecionados" variant="outline" size="sm">
+               <Download data-icon="inline-start" />
+               Exportar
+            </Button>
+         </DropdownMenuTrigger>
+         <DropdownMenuContent align="end">
+            <DropdownMenuLabel>Exportar selecionados</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <DropdownMenuGroup>
+               <DropdownMenuItem onClick={() => handleExport("csv")}>
+                  CSV
+               </DropdownMenuItem>
+               <DropdownMenuItem onClick={() => handleExport("xlsx")}>
+                  XLSX
+               </DropdownMenuItem>
+            </DropdownMenuGroup>
          </DropdownMenuContent>
       </DropdownMenu>
    );

--- a/apps/web/src/features/services/ui/services-form.tsx
+++ b/apps/web/src/features/services/ui/services-form.tsx
@@ -91,12 +91,13 @@ function ExistingVariants({ serviceId }: { serviceId: string }) {
 export function ServiceForm({ mode, service, onSuccess }: ServiceFormProps) {
    const isCreate = mode === "create";
 
-   const [{ data: categories }, { data: tags }] = useSuspenseQueries({
+   const [{ data: categories }, { data: tagsResult }] = useSuspenseQueries({
       queries: [
          orpc.categories.getAll.queryOptions({}),
          orpc.tags.getAll.queryOptions({}),
       ],
    });
+   const tags = tagsResult.data;
 
    const { openAlertDialog } = useAlertDialog();
 

--- a/apps/web/src/features/services/ui/services-form.tsx
+++ b/apps/web/src/features/services/ui/services-form.tsx
@@ -94,7 +94,7 @@ export function ServiceForm({ mode, service, onSuccess }: ServiceFormProps) {
    const [{ data: categories }, { data: tagsResult }] = useSuspenseQueries({
       queries: [
          orpc.categories.getAll.queryOptions({}),
-         orpc.tags.getAll.queryOptions({}),
+         orpc.tags.getAll.queryOptions({ input: {} }),
       ],
    });
    const tags = tagsResult.data;

--- a/apps/web/src/features/transactions/ui/transaction-credenza.tsx
+++ b/apps/web/src/features/transactions/ui/transaction-credenza.tsx
@@ -135,7 +135,10 @@ function TagCombobox({
    selectedIds: string[];
    onChange: (ids: string[]) => void;
 }) {
-   const { data: tags } = useSuspenseQuery(orpc.tags.getAll.queryOptions({}));
+   const { data: tagsResult } = useSuspenseQuery(
+      orpc.tags.getAll.queryOptions({}),
+   );
+   const tags = tagsResult.data;
 
    return (
       <div className="flex flex-col gap-2">

--- a/apps/web/src/features/transactions/ui/transaction-credenza.tsx
+++ b/apps/web/src/features/transactions/ui/transaction-credenza.tsx
@@ -136,7 +136,7 @@ function TagCombobox({
    onChange: (ids: string[]) => void;
 }) {
    const { data: tagsResult } = useSuspenseQuery(
-      orpc.tags.getAll.queryOptions({}),
+      orpc.tags.getAll.queryOptions({ input: {} }),
    );
    const tags = tagsResult.data;
 

--- a/apps/web/src/integrations/orpc/router/tags.ts
+++ b/apps/web/src/integrations/orpc/router/tags.ts
@@ -1,5 +1,6 @@
 import {
    archiveTag,
+   bulkArchiveTags,
    bulkDeleteTags,
    createTag,
    deleteTag,
@@ -115,6 +116,18 @@ export const archive = protectedProcedure
             throw WebAppError.fromAppError(e);
          },
       );
+   });
+
+export const bulkArchive = protectedProcedure
+   .input(z.object({ ids: z.array(z.string().uuid()).min(1) }))
+   .handler(async ({ context, input }) => {
+      (await bulkArchiveTags(context.db, input.ids, context.teamId)).match(
+         () => null,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+      return { archived: input.ids.length };
    });
 
 export const bulkRemove = protectedProcedure

--- a/apps/web/src/integrations/orpc/router/tags.ts
+++ b/apps/web/src/integrations/orpc/router/tags.ts
@@ -5,7 +5,8 @@ import {
    createTag,
    deleteTag,
    ensureTagOwnership,
-   listTags,
+   listTagsPaginated,
+   reactivateTag,
    updateTag,
 } from "@core/database/repositories/tags-repository";
 import { createTagSchema, updateTagSchema } from "@core/database/schemas/tags";
@@ -46,14 +47,30 @@ export const create = protectedProcedure
       return tag;
    });
 
-export const getAll = protectedProcedure.handler(async ({ context }) => {
-   return (await listTags(context.db, context.teamId)).match(
-      (tags) => tags,
-      (e) => {
-         throw WebAppError.fromAppError(e);
-      },
-   );
-});
+export const getAll = protectedProcedure
+   .input(
+      z.object({
+         search: z.string().optional(),
+         includeArchived: z.boolean().optional(),
+         page: z.number().int().positive().default(1),
+         pageSize: z.number().int().positive().max(100).default(20),
+      }),
+   )
+   .handler(async ({ context, input }) => {
+      return (
+         await listTagsPaginated(context.db, context.teamId, {
+            includeArchived: input.includeArchived,
+            search: input.search,
+            page: input.page,
+            pageSize: input.pageSize,
+         })
+      ).match(
+         (result) => result,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+   });
 
 export const update = protectedProcedure
    .input(idSchema.merge(updateTagSchema))
@@ -128,6 +145,21 @@ export const bulkArchive = protectedProcedure
          },
       );
       return { archived: input.ids.length };
+   });
+
+export const unarchive = protectedProcedure
+   .input(idSchema)
+   .handler(async ({ context, input }) => {
+      return (
+         await ensureTagOwnership(context.db, input.id, context.teamId).andThen(
+            () => reactivateTag(context.db, input.id),
+         )
+      ).match(
+         (tag) => tag,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
    });
 
 export const bulkRemove = protectedProcedure

--- a/apps/web/src/integrations/orpc/router/tags.ts
+++ b/apps/web/src/integrations/orpc/router/tags.ts
@@ -14,7 +14,7 @@ import { user as userTable } from "@core/database/schemas/auth";
 import { WebAppError } from "@core/logging/errors";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
-import { enqueueDeriveTagKeywordsWorkflow } from "@packages/workflows/workflows/derive-tag-keywords-workflow";
+import { enqueueDeriveTagKeywordsWorkflow } from "@packages/workflows/workflows/derive-tag-keywords-enqueue";
 import { protectedProcedure } from "../server";
 
 const idSchema = z.object({ id: z.string().uuid() });

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-columns.tsx
@@ -27,7 +27,7 @@ export function buildTagColumns(): ColumnDef<TagRow>[] {
                return (
                   <Announcement className="cursor-default w-fit">
                      <AnnouncementTag>
-                        <ShieldCheck className="size-4" />
+                        <ShieldCheck className="size-4" aria-label="Padrão" />
                      </AnnouncementTag>
                      <AnnouncementTitle>
                         {name}

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-columns.tsx
@@ -27,7 +27,8 @@ export function buildTagColumns(): ColumnDef<TagRow>[] {
                return (
                   <Announcement className="cursor-default w-fit">
                      <AnnouncementTag>
-                        <ShieldCheck className="size-4" aria-label="Padrão" />
+                        <ShieldCheck aria-hidden="true" className="size-4" />
+                        <span className="sr-only">Padrão</span>
                      </AnnouncementTag>
                      <AnnouncementTitle>
                         {name}
@@ -35,10 +36,14 @@ export function buildTagColumns(): ColumnDef<TagRow>[] {
                            <Tooltip>
                               <TooltipTrigger asChild>
                                  <span
+                                    aria-label="Arquivado"
                                     className="inline-flex shrink-0 cursor-default"
                                     tabIndex={0}
                                  >
-                                    <Archive className="size-4 text-muted-foreground" />
+                                    <Archive
+                                       aria-hidden="true"
+                                       className="size-4 text-muted-foreground"
+                                    />
                                  </span>
                               </TooltipTrigger>
                               <TooltipContent>Arquivado</TooltipContent>
@@ -55,10 +60,14 @@ export function buildTagColumns(): ColumnDef<TagRow>[] {
                      <Tooltip>
                         <TooltipTrigger asChild>
                            <span
+                              aria-label="Arquivado"
                               className="inline-flex shrink-0 cursor-default"
                               tabIndex={0}
                            >
-                              <Archive className="size-4 text-muted-foreground" />
+                              <Archive
+                                 aria-hidden="true"
+                                 className="size-4 text-muted-foreground"
+                              />
                            </span>
                         </TooltipTrigger>
                         <TooltipContent>Arquivado</TooltipContent>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-columns.tsx
@@ -1,35 +1,130 @@
+import { Badge } from "@packages/ui/components/badge";
+import {
+   Tooltip,
+   TooltipContent,
+   TooltipTrigger,
+} from "@packages/ui/components/tooltip";
 import type { ColumnDef } from "@tanstack/react-table";
+import { Archive, ShieldCheck, Tags } from "lucide-react";
+import {
+   Announcement,
+   AnnouncementTag,
+   AnnouncementTitle,
+} from "@/components/blocks/announcement";
+import type { Outputs } from "@/integrations/orpc/client";
 
-export type TagRow = {
-   id: string;
-   name: string;
-   color: string;
-   description: string | null;
-};
+export type TagRow = Outputs["tags"]["getAll"][number];
 
 export function buildTagColumns(): ColumnDef<TagRow>[] {
    return [
       {
          accessorKey: "name",
-         header: "Nome",
-         cell: ({ row }) => (
-            <div className="flex items-center gap-2 min-w-0">
-               <span
-                  className="size-3 rounded-full shrink-0"
-                  style={{ backgroundColor: row.original.color }}
-               />
-               <div className="flex flex-col min-w-0">
-                  <span className="font-medium truncate">
-                     {row.original.name}
-                  </span>
-                  {row.original.description && (
-                     <span className="text-xs text-muted-foreground truncate">
-                        {row.original.description}
-                     </span>
-                  )}
-               </div>
-            </div>
-         ),
+         header: "",
+         meta: { label: "Nome", exportable: true },
+         enableSorting: false,
+         cell: ({ row }) => {
+            const { name, color, isDefault, isArchived } = row.original;
+            return (
+               <Announcement className="cursor-default w-fit">
+                  <AnnouncementTag>
+                     <span
+                        className="size-2.5 rounded-full"
+                        style={{ backgroundColor: color }}
+                     />
+                  </AnnouncementTag>
+                  <AnnouncementTitle>
+                     {name}
+                     {isDefault && (
+                        <Tooltip>
+                           <TooltipTrigger asChild>
+                              <span
+                                 className="inline-flex shrink-0 cursor-default"
+                                 tabIndex={0}
+                              >
+                                 <ShieldCheck className="size-3.5 text-muted-foreground" />
+                              </span>
+                           </TooltipTrigger>
+                           <TooltipContent>Padrão</TooltipContent>
+                        </Tooltip>
+                     )}
+                     {isArchived && (
+                        <Tooltip>
+                           <TooltipTrigger asChild>
+                              <span
+                                 className="inline-flex shrink-0 cursor-default"
+                                 tabIndex={0}
+                              >
+                                 <Archive className="size-3.5 text-muted-foreground" />
+                              </span>
+                           </TooltipTrigger>
+                           <TooltipContent>Arquivado</TooltipContent>
+                        </Tooltip>
+                     )}
+                  </AnnouncementTitle>
+               </Announcement>
+            );
+         },
+      },
+      {
+         accessorKey: "description",
+         header: "Descrição",
+         meta: { label: "Descrição", exportable: true },
+         enableSorting: false,
+         cell: ({ row }) =>
+            row.original.description ? (
+               <span className="text-sm text-muted-foreground truncate">
+                  {row.original.description}
+               </span>
+            ) : (
+               <span className="text-sm text-muted-foreground/40">—</span>
+            ),
+      },
+      {
+         id: "keywords",
+         header: "Palavras-chave",
+         meta: { label: "Palavras-chave" },
+         enableSorting: false,
+         accessorFn: (row) => row.keywords?.join(", ") ?? "",
+         cell: ({ row }) => {
+            const keywords = row.original.keywords;
+            const count = keywords?.length ?? 0;
+            if (count === 0)
+               return <span className="text-sm text-muted-foreground">—</span>;
+            return (
+               <Tooltip>
+                  <TooltipTrigger asChild>
+                     <Announcement className="cursor-default w-fit">
+                        <AnnouncementTag>
+                           <Tags className="size-3" />
+                        </AnnouncementTag>
+                        <AnnouncementTitle className="text-xs">
+                           {count} {count === 1 ? "palavra" : "palavras"}
+                        </AnnouncementTitle>
+                     </Announcement>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-72">
+                     <p className="font-semibold text-sm">Palavras-chave IA</p>
+                     <p className="text-xs text-muted-foreground">
+                        Geradas automaticamente com base no nome e descrição do
+                        centro de custo.
+                     </p>
+                     <p className="text-xs">{keywords!.join(", ")}</p>
+                  </TooltipContent>
+               </Tooltip>
+            );
+         },
+      },
+      {
+         id: "isDefault",
+         header: "Padrão",
+         meta: { label: "Padrão", exportIgnore: true },
+         enableSorting: false,
+         cell: ({ row }) =>
+            row.original.isDefault ? (
+               <Badge variant="secondary">Padrão</Badge>
+            ) : (
+               <span className="text-sm text-muted-foreground/40">—</span>
+            ),
       },
    ];
 }

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-columns.tsx
@@ -12,13 +12,13 @@ import {
 } from "@/components/blocks/announcement";
 import type { Outputs } from "@/integrations/orpc/client";
 
-export type TagRow = Outputs["tags"]["getAll"][number];
+export type TagRow = Outputs["tags"]["getAll"]["data"][number];
 
 export function buildTagColumns(): ColumnDef<TagRow>[] {
    return [
       {
          accessorKey: "name",
-         header: "",
+         header: "Nome",
          meta: { label: "Nome", exportable: true },
          enableSorting: false,
          cell: ({ row }) => {
@@ -27,7 +27,7 @@ export function buildTagColumns(): ColumnDef<TagRow>[] {
                return (
                   <Announcement className="cursor-default w-fit">
                      <AnnouncementTag>
-                        <ShieldCheck className="size-3" />
+                        <ShieldCheck className="size-4" />
                      </AnnouncementTag>
                      <AnnouncementTitle>
                         {name}
@@ -38,7 +38,7 @@ export function buildTagColumns(): ColumnDef<TagRow>[] {
                                     className="inline-flex shrink-0 cursor-default"
                                     tabIndex={0}
                                  >
-                                    <Archive className="size-3.5 text-muted-foreground" />
+                                    <Archive className="size-4 text-muted-foreground" />
                                  </span>
                               </TooltipTrigger>
                               <TooltipContent>Arquivado</TooltipContent>
@@ -58,7 +58,7 @@ export function buildTagColumns(): ColumnDef<TagRow>[] {
                               className="inline-flex shrink-0 cursor-default"
                               tabIndex={0}
                            >
-                              <Archive className="size-3.5 text-muted-foreground" />
+                              <Archive className="size-4 text-muted-foreground" />
                            </span>
                         </TooltipTrigger>
                         <TooltipContent>Arquivado</TooltipContent>
@@ -98,7 +98,7 @@ export function buildTagColumns(): ColumnDef<TagRow>[] {
                   <TooltipTrigger asChild>
                      <Announcement className="cursor-default w-fit">
                         <AnnouncementTag>
-                           <Tags className="size-3" />
+                           <Tags className="size-4" />
                         </AnnouncementTag>
                         <AnnouncementTitle className="text-xs">
                            {count} {count === 1 ? "palavra" : "palavras"}

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-columns.tsx
@@ -1,4 +1,3 @@
-import { Badge } from "@packages/ui/components/badge";
 import {
    Tooltip,
    TooltipContent,
@@ -23,45 +22,49 @@ export function buildTagColumns(): ColumnDef<TagRow>[] {
          meta: { label: "Nome", exportable: true },
          enableSorting: false,
          cell: ({ row }) => {
-            const { name, color, isDefault, isArchived } = row.original;
+            const { name, isDefault, isArchived } = row.original;
+            if (isDefault) {
+               return (
+                  <Announcement className="cursor-default w-fit">
+                     <AnnouncementTag>
+                        <ShieldCheck className="size-3" />
+                     </AnnouncementTag>
+                     <AnnouncementTitle>
+                        {name}
+                        {isArchived && (
+                           <Tooltip>
+                              <TooltipTrigger asChild>
+                                 <span
+                                    className="inline-flex shrink-0 cursor-default"
+                                    tabIndex={0}
+                                 >
+                                    <Archive className="size-3.5 text-muted-foreground" />
+                                 </span>
+                              </TooltipTrigger>
+                              <TooltipContent>Arquivado</TooltipContent>
+                           </Tooltip>
+                        )}
+                     </AnnouncementTitle>
+                  </Announcement>
+               );
+            }
             return (
-               <Announcement className="cursor-default w-fit">
-                  <AnnouncementTag>
-                     <span
-                        className="size-2.5 rounded-full"
-                        style={{ backgroundColor: color }}
-                     />
-                  </AnnouncementTag>
-                  <AnnouncementTitle>
-                     {name}
-                     {isDefault && (
-                        <Tooltip>
-                           <TooltipTrigger asChild>
-                              <span
-                                 className="inline-flex shrink-0 cursor-default"
-                                 tabIndex={0}
-                              >
-                                 <ShieldCheck className="size-3.5 text-muted-foreground" />
-                              </span>
-                           </TooltipTrigger>
-                           <TooltipContent>Padrão</TooltipContent>
-                        </Tooltip>
-                     )}
-                     {isArchived && (
-                        <Tooltip>
-                           <TooltipTrigger asChild>
-                              <span
-                                 className="inline-flex shrink-0 cursor-default"
-                                 tabIndex={0}
-                              >
-                                 <Archive className="size-3.5 text-muted-foreground" />
-                              </span>
-                           </TooltipTrigger>
-                           <TooltipContent>Arquivado</TooltipContent>
-                        </Tooltip>
-                     )}
-                  </AnnouncementTitle>
-               </Announcement>
+               <div className="flex items-center gap-2">
+                  <span className="text-sm">{name}</span>
+                  {isArchived && (
+                     <Tooltip>
+                        <TooltipTrigger asChild>
+                           <span
+                              className="inline-flex shrink-0 cursor-default"
+                              tabIndex={0}
+                           >
+                              <Archive className="size-3.5 text-muted-foreground" />
+                           </span>
+                        </TooltipTrigger>
+                        <TooltipContent>Arquivado</TooltipContent>
+                     </Tooltip>
+                  )}
+               </div>
             );
          },
       },
@@ -113,18 +116,6 @@ export function buildTagColumns(): ColumnDef<TagRow>[] {
                </Tooltip>
             );
          },
-      },
-      {
-         id: "isDefault",
-         header: "Padrão",
-         meta: { label: "Padrão", exportIgnore: true },
-         enableSorting: false,
-         cell: ({ row }) =>
-            row.original.isDefault ? (
-               <Badge variant="secondary">Padrão</Badge>
-            ) : (
-               <span className="text-sm text-muted-foreground/40">—</span>
-            ),
       },
    ];
 }

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/contatos.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/contatos.tsx
@@ -31,7 +31,7 @@ function ContatosSettingsForm() {
       orpc.contactSettings.getSettings.queryOptions({}),
    );
    const { data: tagsResult } = useSuspenseQuery(
-      orpc.tags.getAll.queryOptions({}),
+      orpc.tags.getAll.queryOptions({ input: {} }),
    );
    const tags = tagsResult.data;
 

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/contatos.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/contatos.tsx
@@ -30,7 +30,10 @@ function ContatosSettingsForm() {
    const { data: settings } = useSuspenseQuery(
       orpc.contactSettings.getSettings.queryOptions({}),
    );
-   const { data: tags } = useSuspenseQuery(orpc.tags.getAll.queryOptions({}));
+   const { data: tagsResult } = useSuspenseQuery(
+      orpc.tags.getAll.queryOptions({}),
+   );
+   const tags = tagsResult.data;
 
    const mutation = useMutation(
       orpc.contactSettings.upsertSettings.mutationOptions({

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
@@ -1,6 +1,4 @@
 import { Button } from "@packages/ui/components/button";
-import { DataTable } from "@packages/ui/components/data-table";
-import type { DataTableStoredState } from "@packages/ui/components/data-table";
 import {
    Empty,
    EmptyDescription,
@@ -8,54 +6,32 @@ import {
    EmptyMedia,
    EmptyTitle,
 } from "@packages/ui/components/empty";
-import {
-   SelectionActionBar,
-   SelectionActionButton,
-} from "@packages/ui/components/selection-action-bar";
-import { Skeleton } from "@packages/ui/components/skeleton";
-import { useRowSelection } from "@packages/ui/hooks/use-row-selection";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
-import type {
-   ColumnFiltersState,
-   OnChangeFn,
-   SortingState,
-} from "@tanstack/react-table";
 import { createFileRoute } from "@tanstack/react-router";
-import { createLocalStorageState } from "foxact/create-local-storage-state";
 import { Archive, Pencil, Plus, Tag, Trash2 } from "lucide-react";
-import { Suspense, useCallback, useMemo } from "react";
+import { Suspense, useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
-import { z } from "zod";
 import { DefaultHeader } from "@/components/default-header";
+import {
+   DataTableBulkActions,
+   SelectionActionButton,
+} from "@/components/data-table/data-table-bulk-actions";
+import { DataTableContent } from "@/components/data-table/data-table-content";
+import { DataTableEmptyState } from "@/components/data-table/data-table-empty-state";
+import { DataTableRoot } from "@/components/data-table/data-table-root";
+import { DataTableSkeleton } from "@/components/data-table/data-table-skeleton";
+import { DataTableToolbar } from "@/components/data-table/data-table-toolbar";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import { useCredenza } from "@/hooks/use-credenza";
 import { orpc } from "@/integrations/orpc/client";
 import { buildTagColumns, type TagRow } from "./-tags/tags-columns";
 import { TagForm } from "./-tags/tags-form";
 
-const tagsSearchSchema = z.object({
-   sorting: z
-      .array(z.object({ id: z.string(), desc: z.boolean() }))
-      .catch([])
-      .default([]),
-   columnFilters: z
-      .array(z.object({ id: z.string(), value: z.unknown() }))
-      .catch([])
-      .default([]),
-});
-
-export type TagsSearch = z.infer<typeof tagsSearchSchema>;
-
-const [useTagsTableState] =
-   createLocalStorageState<DataTableStoredState | null>(
-      "montte:datatable:tags",
-      null,
-   );
+const skeletonColumns = buildTagColumns();
 
 export const Route = createFileRoute(
    "/_authenticated/$slug/$teamSlug/_dashboard/tags",
 )({
-   validateSearch: tagsSearchSchema,
    loader: ({ context }) => {
       context.queryClient.prefetchQuery(orpc.tags.getAll.queryOptions({}));
    },
@@ -68,57 +44,33 @@ export const Route = createFileRoute(
 });
 
 function TagsSkeleton() {
-   return (
-      <div className="flex flex-col gap-4">
-         {Array.from({ length: 5 }).map((_, index) => (
-            <Skeleton className="h-12 w-full" key={`skeleton-${index + 1}`} />
-         ))}
-      </div>
-   );
+   return <DataTableSkeleton columns={skeletonColumns} />;
 }
 
-interface TagsListProps {
-   navigate: ReturnType<typeof Route.useNavigate>;
-}
-
-function TagsList({ navigate }: TagsListProps) {
-   const { sorting, columnFilters } = Route.useSearch();
-   const [tableState, setTableState] = useTagsTableState();
-
-   const handleSortingChange: OnChangeFn<SortingState> = useCallback(
-      (updater) => {
-         const next =
-            typeof updater === "function" ? updater(sorting) : updater;
-         navigate({
-            search: (prev: TagsSearch) => ({ ...prev, sorting: next }),
-         });
-      },
-      [sorting, navigate],
-   );
-
-   const handleColumnFiltersChange: OnChangeFn<ColumnFiltersState> =
-      useCallback(
-         (updater) => {
-            const next =
-               typeof updater === "function" ? updater(columnFilters) : updater;
-            navigate({
-               search: (prev: TagsSearch) => ({ ...prev, columnFilters: next }),
-            });
-         },
-         [columnFilters, navigate],
-      );
-
+function TagsList() {
    const { openCredenza, closeCredenza } = useCredenza();
    const { openAlertDialog } = useAlertDialog();
-   const {
-      rowSelection,
-      onRowSelectionChange,
-      selectedCount,
-      selectedIds,
-      onClear,
-   } = useRowSelection();
+   const [search, setSearch] = useState("");
+
+   const handleCreate = useCallback(() => {
+      openCredenza({
+         renderChildren: () => (
+            <TagForm mode="create" onSuccess={closeCredenza} />
+         ),
+      });
+   }, [openCredenza, closeCredenza]);
 
    const { data: tags } = useSuspenseQuery(orpc.tags.getAll.queryOptions({}));
+
+   const filteredTags = useMemo(() => {
+      if (!search) return tags;
+      const lower = search.toLowerCase();
+      return tags.filter(
+         (t) =>
+            t.name.toLowerCase().includes(lower) ||
+            (t.description?.toLowerCase().includes(lower) ?? false),
+      );
+   }, [tags, search]);
 
    const deleteMutation = useMutation(
       orpc.tags.remove.mutationOptions({
@@ -136,6 +88,13 @@ function TagsList({ navigate }: TagsListProps) {
          onError: (error) => {
             toast.error(error.message || "Erro ao excluir centros de custo.");
          },
+      }),
+   );
+
+   const bulkArchiveMutation = useMutation(
+      orpc.tags.bulkArchive.mutationOptions({
+         onError: (e) =>
+            toast.error(e.message || "Erro ao arquivar centros de custo."),
       }),
    );
 
@@ -190,123 +149,140 @@ function TagsList({ navigate }: TagsListProps) {
       [archiveMutation],
    );
 
-   const handleBulkDelete = useCallback(() => {
-      if (selectedIds.length === 0) return;
-      openAlertDialog({
-         title: `Excluir ${selectedIds.length} ${selectedIds.length === 1 ? "centro de custo" : "centros de custo"}`,
-         description:
-            "Tem certeza que deseja excluir os centros de custo selecionados? Esta ação não pode ser desfeita.",
-         actionLabel: "Excluir",
-         cancelLabel: "Cancelar",
-         variant: "destructive",
-         onAction: async () => {
-            await bulkDeleteMutation.mutateAsync({ ids: selectedIds });
-            toast.success(
-               `${selectedIds.length} ${selectedIds.length === 1 ? "centro de custo excluído" : "centros de custo excluídos"} com sucesso.`,
-            );
-            onClear();
-         },
-      });
-   }, [openAlertDialog, selectedIds, bulkDeleteMutation, onClear]);
-
    const columns = useMemo(() => buildTagColumns(), []);
 
-   if (tags.length === 0) {
-      return (
-         <Empty>
-            <EmptyHeader>
-               <EmptyMedia variant="icon">
-                  <Tag className="size-6" />
-               </EmptyMedia>
-               <EmptyTitle>Nenhum centro de custo</EmptyTitle>
-               <EmptyDescription>
-                  Adicione um centro de custo para categorizar suas transações.
-               </EmptyDescription>
-            </EmptyHeader>
-         </Empty>
-      );
-   }
-
    return (
-      <>
-         <DataTable
-            columns={columns}
-            data={tags}
-            getRowId={(row) => row.id}
-            sorting={sorting}
-            onSortingChange={handleSortingChange}
-            columnFilters={columnFilters}
-            onColumnFiltersChange={handleColumnFiltersChange}
-            tableState={tableState}
-            onTableStateChange={setTableState}
-            rowSelection={rowSelection}
-            onRowSelectionChange={onRowSelectionChange}
-            renderActions={({ row }) => (
-               <>
-                  <Button
-                     onClick={() => handleEdit(row.original)}
-                     tooltip="Editar"
-                     variant="outline"
-                  >
-                     <Pencil className="size-4" />
-                  </Button>
-                  <Button
-                     onClick={() => handleArchive(row.original)}
-                     tooltip="Arquivar"
-                     variant="outline"
-                  >
-                     <Archive className="size-4" />
-                  </Button>
-                  <Button
-                     className="text-destructive hover:text-destructive"
-                     onClick={() => handleDelete(row.original)}
-                     tooltip="Excluir"
-                     variant="outline"
-                  >
-                     <Trash2 className="size-4" />
-                  </Button>
-               </>
-            )}
-         />
-         <SelectionActionBar onClear={onClear} selectedCount={selectedCount}>
-            <SelectionActionButton
-               icon={<Trash2 className="size-3.5" />}
-               onClick={handleBulkDelete}
-               variant="destructive"
+      <DataTableRoot
+         storageKey="montte:datatable:tags"
+         columns={columns}
+         data={filteredTags}
+         getRowId={(row) => row.id}
+         renderActions={({ row }) => (
+            <>
+               <Button
+                  onClick={() => handleEdit(row.original)}
+                  tooltip="Editar"
+                  variant="outline"
+               >
+                  <Pencil className="size-4" />
+               </Button>
+               <Button
+                  onClick={() => handleArchive(row.original)}
+                  tooltip="Arquivar"
+                  variant="outline"
+               >
+                  <Archive className="size-4" />
+               </Button>
+               <Button
+                  className="text-destructive hover:text-destructive"
+                  onClick={() => handleDelete(row.original)}
+                  tooltip="Excluir"
+                  variant="outline"
+               >
+                  <Trash2 className="size-4" />
+               </Button>
+            </>
+         )}
+      >
+         <DataTableToolbar
+            searchPlaceholder="Buscar centros de custo..."
+            onSearch={setSearch}
+         >
+            <Button
+               onClick={handleCreate}
+               tooltip="Novo Centro de Custo"
+               variant="outline"
+               size="icon-sm"
             >
-               Excluir
-            </SelectionActionButton>
-         </SelectionActionBar>
-      </>
+               <Plus />
+               <span className="sr-only">Novo Centro de Custo</span>
+            </Button>
+         </DataTableToolbar>
+         <DataTableEmptyState>
+            <Empty>
+               <EmptyHeader>
+                  <EmptyMedia variant="icon">
+                     <Tag className="size-6" />
+                  </EmptyMedia>
+                  <EmptyTitle>Nenhum centro de custo</EmptyTitle>
+                  <EmptyDescription>
+                     Adicione um centro de custo para categorizar suas
+                     transações.
+                  </EmptyDescription>
+               </EmptyHeader>
+            </Empty>
+         </DataTableEmptyState>
+         <DataTableContent />
+         <DataTableBulkActions<TagRow>>
+            {({ selectedRows, clearSelection }) => {
+               const archivableIds = selectedRows
+                  .filter((r) => !r.isDefault && !r.isArchived)
+                  .map((r) => r.id);
+               const deletableIds = selectedRows
+                  .filter((r) => !r.isDefault)
+                  .map((r) => r.id);
+               return (
+                  <>
+                     {archivableIds.length > 0 && (
+                        <SelectionActionButton
+                           icon={<Archive className="size-3.5" />}
+                           onClick={async () => {
+                              await bulkArchiveMutation.mutateAsync({
+                                 ids: archivableIds,
+                              });
+                              toast.success(
+                                 `${archivableIds.length} ${archivableIds.length === 1 ? "centro de custo arquivado" : "centros de custo arquivados"}.`,
+                              );
+                              clearSelection();
+                           }}
+                        >
+                           Arquivar
+                        </SelectionActionButton>
+                     )}
+                     {deletableIds.length > 0 && (
+                        <SelectionActionButton
+                           icon={<Trash2 className="size-3.5" />}
+                           onClick={() => {
+                              openAlertDialog({
+                                 title: `Excluir ${deletableIds.length} ${deletableIds.length === 1 ? "centro de custo" : "centros de custo"}`,
+                                 description:
+                                    "Tem certeza que deseja excluir os centros de custo selecionados? Esta ação não pode ser desfeita.",
+                                 actionLabel: "Excluir",
+                                 cancelLabel: "Cancelar",
+                                 variant: "destructive",
+                                 onAction: async () => {
+                                    await bulkDeleteMutation.mutateAsync({
+                                       ids: deletableIds,
+                                    });
+                                    toast.success(
+                                       `${deletableIds.length} ${deletableIds.length === 1 ? "centro de custo excluído" : "centros de custo excluídos"} com sucesso.`,
+                                    );
+                                    clearSelection();
+                                 },
+                              });
+                           }}
+                           variant="destructive"
+                        >
+                           Excluir
+                        </SelectionActionButton>
+                     )}
+                  </>
+               );
+            }}
+         </DataTableBulkActions>
+      </DataTableRoot>
    );
 }
 
 function TagsPage() {
-   const navigate = Route.useNavigate();
-   const { openCredenza, closeCredenza } = useCredenza();
-
-   const handleCreate = useCallback(() => {
-      openCredenza({
-         renderChildren: () => (
-            <TagForm mode="create" onSuccess={closeCredenza} />
-         ),
-      });
-   }, [openCredenza, closeCredenza]);
-
    return (
       <main className="flex flex-col gap-4">
          <DefaultHeader
-            actions={
-               <Button onClick={handleCreate}>
-                  <Plus className="size-4" />
-                  Novo Centro de Custo
-               </Button>
-            }
             description="Gerencie seus centros de custo para categorizar transações"
             title="Centros de Custo"
          />
          <Suspense fallback={<TagsSkeleton />}>
-            <TagsList navigate={navigate} />
+            <TagsList />
          </Suspense>
       </main>
    );

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
@@ -49,7 +49,7 @@ const tagsSearchSchema = z.object({
    search: z.string().catch("").default(""),
    includeArchived: z.boolean().catch(false).default(false),
    page: z.number().int().min(1).catch(1).default(1),
-   pageSize: z.number().int().catch(20).default(20),
+   pageSize: z.number().int().min(1).max(100).catch(20).default(20),
 });
 
 const skeletonColumns = buildTagColumns();

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
@@ -7,9 +7,18 @@ import {
    EmptyTitle,
 } from "@packages/ui/components/empty";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
-import { Archive, Pencil, Plus, Tag, Trash2 } from "lucide-react";
-import { Suspense, useCallback, useMemo, useState } from "react";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import {
+   Archive,
+   ArchiveRestore,
+   Pencil,
+   Plus,
+   Tag,
+   Trash2,
+} from "lucide-react";
+import { useCallback, useMemo } from "react";
+import { DataTablePagination } from "@/components/data-table/data-table-pagination";
+import { z } from "zod";
 import { toast } from "sonner";
 import { DefaultHeader } from "@/components/default-header";
 import {
@@ -21,19 +30,51 @@ import { DataTableEmptyState } from "@/components/data-table/data-table-empty-st
 import { DataTableRoot } from "@/components/data-table/data-table-root";
 import { DataTableSkeleton } from "@/components/data-table/data-table-skeleton";
 import { DataTableToolbar } from "@/components/data-table/data-table-toolbar";
+import { QueryBoundary } from "@/components/query-boundary";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import { useCredenza } from "@/hooks/use-credenza";
 import { orpc } from "@/integrations/orpc/client";
 import { buildTagColumns, type TagRow } from "./-tags/tags-columns";
 import { TagForm } from "./-tags/tags-form";
 
+const tagsSearchSchema = z.object({
+   sorting: z
+      .array(z.object({ id: z.string(), desc: z.boolean() }))
+      .catch([])
+      .default([]),
+   columnFilters: z
+      .array(z.object({ id: z.string(), value: z.unknown() }))
+      .catch([])
+      .default([]),
+   search: z.string().catch("").default(""),
+   includeArchived: z.boolean().catch(false).default(false),
+   page: z.number().int().min(1).catch(1).default(1),
+   pageSize: z.number().int().catch(20).default(20),
+});
+
 const skeletonColumns = buildTagColumns();
 
 export const Route = createFileRoute(
    "/_authenticated/$slug/$teamSlug/_dashboard/tags",
 )({
-   loader: ({ context }) => {
-      context.queryClient.prefetchQuery(orpc.tags.getAll.queryOptions({}));
+   validateSearch: tagsSearchSchema,
+   loaderDeps: ({ search: { search, includeArchived, page, pageSize } }) => ({
+      search,
+      includeArchived,
+      page,
+      pageSize,
+   }),
+   loader: ({ context, deps }) => {
+      context.queryClient.prefetchQuery(
+         orpc.tags.getAll.queryOptions({
+            input: {
+               search: deps.search || undefined,
+               includeArchived: deps.includeArchived || undefined,
+               page: deps.page,
+               pageSize: deps.pageSize,
+            },
+         }),
+      );
    },
    pendingMs: 300,
    pendingComponent: TagsSkeleton,
@@ -50,7 +91,8 @@ function TagsSkeleton() {
 function TagsList() {
    const { openCredenza, closeCredenza } = useCredenza();
    const { openAlertDialog } = useAlertDialog();
-   const [search, setSearch] = useState("");
+   const navigate = useNavigate();
+   const { search, includeArchived, page, pageSize } = Route.useSearch();
 
    const handleCreate = useCallback(() => {
       openCredenza({
@@ -60,17 +102,18 @@ function TagsList() {
       });
    }, [openCredenza, closeCredenza]);
 
-   const { data: tags } = useSuspenseQuery(orpc.tags.getAll.queryOptions({}));
-
-   const filteredTags = useMemo(() => {
-      if (!search) return tags;
-      const lower = search.toLowerCase();
-      return tags.filter(
-         (t) =>
-            t.name.toLowerCase().includes(lower) ||
-            (t.description?.toLowerCase().includes(lower) ?? false),
-      );
-   }, [tags, search]);
+   const { data: result } = useSuspenseQuery(
+      orpc.tags.getAll.queryOptions({
+         input: {
+            search: search || undefined,
+            includeArchived: includeArchived || undefined,
+            page,
+            pageSize,
+         },
+      }),
+   );
+   const { data: tags, total } = result;
+   const totalPages = Math.max(1, Math.ceil(total / pageSize));
 
    const deleteMutation = useMutation(
       orpc.tags.remove.mutationOptions({
@@ -103,6 +146,14 @@ function TagsList() {
          onSuccess: () => toast.success("Centro de custo arquivado."),
          onError: (e) =>
             toast.error(e.message || "Erro ao arquivar centro de custo."),
+      }),
+   );
+
+   const unarchiveMutation = useMutation(
+      orpc.tags.unarchive.mutationOptions({
+         onSuccess: () => toast.success("Centro de custo reativado."),
+         onError: (e) =>
+            toast.error(e.message || "Erro ao reativar centro de custo."),
       }),
    );
 
@@ -149,128 +200,187 @@ function TagsList() {
       [archiveMutation],
    );
 
+   const handleUnarchive = useCallback(
+      (tag: TagRow) => {
+         unarchiveMutation.mutate({ id: tag.id });
+      },
+      [unarchiveMutation],
+   );
+
    const columns = useMemo(() => buildTagColumns(), []);
 
    return (
-      <DataTableRoot
-         storageKey="montte:datatable:tags"
-         columns={columns}
-         data={filteredTags}
-         getRowId={(row) => row.id}
-         renderActions={({ row }) => (
-            <>
-               <Button
-                  onClick={() => handleEdit(row.original)}
-                  tooltip="Editar"
-                  variant="outline"
-               >
-                  <Pencil className="size-4" />
-               </Button>
-               <Button
-                  onClick={() => handleArchive(row.original)}
-                  tooltip="Arquivar"
-                  variant="outline"
-               >
-                  <Archive className="size-4" />
-               </Button>
-               <Button
-                  className="text-destructive hover:text-destructive"
-                  onClick={() => handleDelete(row.original)}
-                  tooltip="Excluir"
-                  variant="outline"
-               >
-                  <Trash2 className="size-4" />
-               </Button>
-            </>
-         )}
-      >
-         <DataTableToolbar
-            searchPlaceholder="Buscar centros de custo..."
-            onSearch={setSearch}
-         >
-            <Button
-               onClick={handleCreate}
-               tooltip="Novo Centro de Custo"
-               variant="outline"
-               size="icon-sm"
-            >
-               <Plus />
-               <span className="sr-only">Novo Centro de Custo</span>
-            </Button>
-         </DataTableToolbar>
-         <DataTableEmptyState>
-            <Empty>
-               <EmptyHeader>
-                  <EmptyMedia variant="icon">
-                     <Tag className="size-6" />
-                  </EmptyMedia>
-                  <EmptyTitle>Nenhum centro de custo</EmptyTitle>
-                  <EmptyDescription>
-                     Adicione um centro de custo para categorizar suas
-                     transações.
-                  </EmptyDescription>
-               </EmptyHeader>
-            </Empty>
-         </DataTableEmptyState>
-         <DataTableContent />
-         <DataTableBulkActions<TagRow>>
-            {({ selectedRows, clearSelection }) => {
-               const archivableIds = selectedRows
-                  .filter((r) => !r.isDefault && !r.isArchived)
-                  .map((r) => r.id);
-               const deletableIds = selectedRows
-                  .filter((r) => !r.isDefault)
-                  .map((r) => r.id);
+      <>
+         <DataTableRoot
+            storageKey="montte:datatable:tags"
+            columns={columns}
+            data={tags}
+            getRowId={(row) => row.id}
+            renderActions={({ row }) => {
+               if (row.original.isArchived) {
+                  return (
+                     <>
+                        <Button
+                           onClick={() => handleUnarchive(row.original)}
+                           tooltip="Reativar"
+                           variant="outline"
+                        >
+                           <ArchiveRestore className="size-4" />
+                        </Button>
+                        <Button
+                           className="text-destructive hover:text-destructive"
+                           onClick={() => handleDelete(row.original)}
+                           tooltip="Excluir"
+                           variant="outline"
+                        >
+                           <Trash2 className="size-4" />
+                        </Button>
+                     </>
+                  );
+               }
                return (
                   <>
-                     {archivableIds.length > 0 && (
-                        <SelectionActionButton
-                           icon={<Archive className="size-3.5" />}
-                           onClick={async () => {
-                              await bulkArchiveMutation.mutateAsync({
-                                 ids: archivableIds,
-                              });
-                              toast.success(
-                                 `${archivableIds.length} ${archivableIds.length === 1 ? "centro de custo arquivado" : "centros de custo arquivados"}.`,
-                              );
-                              clearSelection();
-                           }}
-                        >
-                           Arquivar
-                        </SelectionActionButton>
-                     )}
-                     {deletableIds.length > 0 && (
-                        <SelectionActionButton
-                           icon={<Trash2 className="size-3.5" />}
-                           onClick={() => {
-                              openAlertDialog({
-                                 title: `Excluir ${deletableIds.length} ${deletableIds.length === 1 ? "centro de custo" : "centros de custo"}`,
-                                 description:
-                                    "Tem certeza que deseja excluir os centros de custo selecionados? Esta ação não pode ser desfeita.",
-                                 actionLabel: "Excluir",
-                                 cancelLabel: "Cancelar",
-                                 variant: "destructive",
-                                 onAction: async () => {
-                                    await bulkDeleteMutation.mutateAsync({
-                                       ids: deletableIds,
-                                    });
-                                    toast.success(
-                                       `${deletableIds.length} ${deletableIds.length === 1 ? "centro de custo excluído" : "centros de custo excluídos"} com sucesso.`,
-                                    );
-                                    clearSelection();
-                                 },
-                              });
-                           }}
-                           variant="destructive"
-                        >
-                           Excluir
-                        </SelectionActionButton>
-                     )}
+                     <Button
+                        onClick={() => handleEdit(row.original)}
+                        tooltip="Editar"
+                        variant="outline"
+                     >
+                        <Pencil className="size-4" />
+                     </Button>
+                     <Button
+                        onClick={() => handleArchive(row.original)}
+                        tooltip="Arquivar"
+                        variant="outline"
+                     >
+                        <Archive className="size-4" />
+                     </Button>
+                     <Button
+                        className="text-destructive hover:text-destructive"
+                        onClick={() => handleDelete(row.original)}
+                        tooltip="Excluir"
+                        variant="outline"
+                     >
+                        <Trash2 className="size-4" />
+                     </Button>
                   </>
                );
             }}
-         </DataTableBulkActions>
-      </DataTableRoot>
+         >
+            <DataTableToolbar
+               searchPlaceholder="Buscar centros de custo..."
+               onSearch={(value) =>
+                  navigate({
+                     search: (prev) => ({ ...prev, search: value, page: 1 }),
+                     replace: true,
+                  })
+               }
+            >
+               <Button
+                  onClick={handleCreate}
+                  tooltip="Novo Centro de Custo"
+                  variant="outline"
+                  size="icon-sm"
+               >
+                  <Plus />
+                  <span className="sr-only">Novo Centro de Custo</span>
+               </Button>
+            </DataTableToolbar>
+            <DataTableEmptyState>
+               <Empty>
+                  <EmptyHeader>
+                     <EmptyMedia variant="icon">
+                        <Tag className="size-6" />
+                     </EmptyMedia>
+                     <EmptyTitle>Nenhum centro de custo</EmptyTitle>
+                     <EmptyDescription>
+                        Adicione um centro de custo para categorizar suas
+                        transações.
+                     </EmptyDescription>
+                  </EmptyHeader>
+               </Empty>
+            </DataTableEmptyState>
+            <DataTableContent />
+            <DataTableBulkActions<TagRow>>
+               {({ selectedRows, clearSelection }) => {
+                  const archivableIds = selectedRows
+                     .filter((r) => !r.isDefault && !r.isArchived)
+                     .map((r) => r.id);
+                  const deletableIds = selectedRows
+                     .filter((r) => !r.isDefault)
+                     .map((r) => r.id);
+                  return (
+                     <>
+                        {archivableIds.length > 0 && (
+                           <SelectionActionButton
+                              icon={<Archive className="size-4" />}
+                              onClick={async () => {
+                                 await bulkArchiveMutation.mutateAsync({
+                                    ids: archivableIds,
+                                 });
+                                 toast.success(
+                                    `${archivableIds.length} ${archivableIds.length === 1 ? "centro de custo arquivado" : "centros de custo arquivados"}.`,
+                                 );
+                                 clearSelection();
+                              }}
+                           >
+                              Arquivar
+                           </SelectionActionButton>
+                        )}
+                        {deletableIds.length > 0 && (
+                           <SelectionActionButton
+                              icon={<Trash2 className="size-4" />}
+                              onClick={() => {
+                                 openAlertDialog({
+                                    title: `Excluir ${deletableIds.length} ${deletableIds.length === 1 ? "centro de custo" : "centros de custo"}`,
+                                    description:
+                                       "Tem certeza que deseja excluir os centros de custo selecionados? Esta ação não pode ser desfeita.",
+                                    actionLabel: "Excluir",
+                                    cancelLabel: "Cancelar",
+                                    variant: "destructive",
+                                    onAction: async () => {
+                                       await bulkDeleteMutation.mutateAsync({
+                                          ids: deletableIds,
+                                       });
+                                       toast.success(
+                                          `${deletableIds.length} ${deletableIds.length === 1 ? "centro de custo excluído" : "centros de custo excluídos"} com sucesso.`,
+                                       );
+                                       clearSelection();
+                                    },
+                                 });
+                              }}
+                              variant="destructive"
+                           >
+                              Excluir
+                           </SelectionActionButton>
+                        )}
+                     </>
+                  );
+               }}
+            </DataTableBulkActions>
+         </DataTableRoot>
+         <DataTablePagination
+            currentPage={page}
+            totalPages={totalPages}
+            totalCount={total}
+            pageSize={pageSize}
+            onPageChange={(newPage) =>
+               navigate({
+                  search: (prev) => ({ ...prev, page: newPage }),
+                  replace: true,
+               })
+            }
+            onPageSizeChange={(newPageSize) =>
+               navigate({
+                  search: (prev) => ({
+                     ...prev,
+                     pageSize: newPageSize,
+                     page: 1,
+                  }),
+                  replace: true,
+               })
+            }
+         />
+      </>
    );
 }
 
@@ -281,9 +391,12 @@ function TagsPage() {
             description="Gerencie seus centros de custo para categorizar transações"
             title="Centros de Custo"
          />
-         <Suspense fallback={<TagsSkeleton />}>
+         <QueryBoundary
+            fallback={<TagsSkeleton />}
+            errorTitle="Erro ao carregar centros de custo"
+         >
             <TagsList />
-         </Suspense>
+         </QueryBoundary>
       </main>
    );
 }

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
@@ -7,7 +7,7 @@ import {
    EmptyTitle,
 } from "@packages/ui/components/empty";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import {
    Archive,
    ArchiveRestore,
@@ -91,7 +91,7 @@ function TagsSkeleton() {
 function TagsList() {
    const { openCredenza, closeCredenza } = useCredenza();
    const { openAlertDialog } = useAlertDialog();
-   const navigate = useNavigate();
+   const navigate = Route.useNavigate();
    const { search, includeArchived, page, pageSize } = Route.useSearch();
 
    const handleCreate = useCallback(() => {

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
@@ -268,6 +268,7 @@ function TagsList() {
          >
             <DataTableToolbar
                searchPlaceholder="Buscar centros de custo..."
+               searchDefaultValue={search}
                onSearch={(value) =>
                   navigate({
                      search: (prev) => ({ ...prev, search: value, page: 1 }),

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
@@ -225,7 +225,7 @@ function TagsList() {
                            tooltip="Reativar"
                            variant="outline"
                         >
-                           <ArchiveRestore className="size-4" />
+                           <ArchiveRestore />
                         </Button>
                         <Button
                            className="text-destructive hover:text-destructive"
@@ -233,7 +233,7 @@ function TagsList() {
                            tooltip="Excluir"
                            variant="outline"
                         >
-                           <Trash2 className="size-4" />
+                           <Trash2 />
                         </Button>
                      </>
                   );
@@ -245,14 +245,14 @@ function TagsList() {
                         tooltip="Editar"
                         variant="outline"
                      >
-                        <Pencil className="size-4" />
+                        <Pencil />
                      </Button>
                      <Button
                         onClick={() => handleArchive(row.original)}
                         tooltip="Arquivar"
                         variant="outline"
                      >
-                        <Archive className="size-4" />
+                        <Archive />
                      </Button>
                      <Button
                         className="text-destructive hover:text-destructive"
@@ -260,7 +260,7 @@ function TagsList() {
                         tooltip="Excluir"
                         variant="outline"
                      >
-                        <Trash2 className="size-4" />
+                        <Trash2 />
                      </Button>
                   </>
                );
@@ -313,7 +313,7 @@ function TagsList() {
                      <>
                         {archivableIds.length > 0 && (
                            <SelectionActionButton
-                              icon={<Archive className="size-4" />}
+                              icon={<Archive />}
                               onClick={async () => {
                                  await bulkArchiveMutation.mutateAsync({
                                     ids: archivableIds,
@@ -329,7 +329,7 @@ function TagsList() {
                         )}
                         {deletableIds.length > 0 && (
                            <SelectionActionButton
-                              icon={<Trash2 className="size-4" />}
+                              icon={<Trash2 />}
                               onClick={() => {
                                  openAlertDialog({
                                     title: `Excluir ${deletableIds.length} ${deletableIds.length === 1 ? "centro de custo" : "centros de custo"}`,

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/transactions.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/transactions.tsx
@@ -51,7 +51,9 @@ export const Route = createFileRoute(
       context.queryClient.prefetchQuery(
          orpc.categories.getAll.queryOptions({}),
       );
-      context.queryClient.prefetchQuery(orpc.tags.getAll.queryOptions({}));
+      context.queryClient.prefetchQuery(
+         orpc.tags.getAll.queryOptions({ input: {} }),
+      );
       context.queryClient.prefetchQuery(
          orpc.creditCards.getAll.queryOptions({ input: {} }),
       );

--- a/core/database/src/repositories/tags-repository.ts
+++ b/core/database/src/repositories/tags-repository.ts
@@ -1,6 +1,6 @@
 import dayjs from "dayjs";
 import { AppError, validateInput } from "@core/logging/errors";
-import { and, asc, count, eq, ilike, inArray, or, sql } from "drizzle-orm";
+import { and, asc, count, eq, inArray, sql } from "drizzle-orm";
 import { fromPromise, fromThrowable, ok, err, okAsync } from "neverthrow";
 import type { DatabaseInstance } from "@core/database/client";
 import {
@@ -84,11 +84,12 @@ export function listTagsPaginated(
          const conditions = [eq(tags.teamId, teamId)];
          if (!opts.includeArchived) conditions.push(eq(tags.isArchived, false));
          if (search) {
-            const searchCond = or(
-               ilike(tags.name, `%${search}%`),
-               ilike(tags.description, `%${search}%`),
+            conditions.push(
+               sql`(
+                  ${tags.name} ilike ${"%" + search + "%"}
+                  or coalesce(${tags.description}, '') ilike ${"%" + search + "%"}
+               )`,
             );
-            if (searchCond) conditions.push(searchCond);
          }
          const whereClause = and(...conditions);
          const [countResult] = await db

--- a/core/database/src/repositories/tags-repository.ts
+++ b/core/database/src/repositories/tags-repository.ts
@@ -1,6 +1,6 @@
 import dayjs from "dayjs";
 import { AppError, validateInput } from "@core/logging/errors";
-import { eq, inArray, sql } from "drizzle-orm";
+import { and, asc, count, eq, ilike, inArray, or, sql } from "drizzle-orm";
 import { fromPromise, fromThrowable, ok, err, okAsync } from "neverthrow";
 import type { DatabaseInstance } from "@core/database/client";
 import {
@@ -63,9 +63,49 @@ export function listTags(
               and(eq(fields.teamId, teamId), eq(fields.isArchived, false)),
            orderBy: (fields, { asc }) => [asc(fields.name)],
         });
-
    return fromPromise(query, (e) =>
       AppError.database("Falha ao listar centros de custo.", { cause: e }),
+   );
+}
+
+export function listTagsPaginated(
+   db: DatabaseInstance,
+   teamId: string,
+   opts: {
+      includeArchived?: boolean;
+      search?: string;
+      page: number;
+      pageSize: number;
+   },
+) {
+   const search = opts.search?.trim();
+   return fromPromise(
+      (async () => {
+         const conditions = [eq(tags.teamId, teamId)];
+         if (!opts.includeArchived) conditions.push(eq(tags.isArchived, false));
+         if (search) {
+            const searchCond = or(
+               ilike(tags.name, `%${search}%`),
+               ilike(tags.description, `%${search}%`),
+            );
+            if (searchCond) conditions.push(searchCond);
+         }
+         const whereClause = and(...conditions);
+         const [countResult] = await db
+            .select({ total: count() })
+            .from(tags)
+            .where(whereClause);
+         const data = await db
+            .select()
+            .from(tags)
+            .where(whereClause)
+            .orderBy(asc(tags.name))
+            .limit(opts.pageSize)
+            .offset((opts.page - 1) * opts.pageSize);
+         return { data, total: countResult?.total ?? 0 };
+      })(),
+      (e) =>
+         AppError.database("Falha ao listar centros de custo.", { cause: e }),
    );
 }
 

--- a/core/database/src/repositories/tags-repository.ts
+++ b/core/database/src/repositories/tags-repository.ts
@@ -196,6 +196,42 @@ export function deleteTag(db: DatabaseInstance, id: string) {
       );
 }
 
+export function bulkArchiveTags(
+   db: DatabaseInstance,
+   ids: string[],
+   teamId: string,
+) {
+   return fromPromise(
+      db.query.tags.findMany({
+         where: (fields, { and, inArray: inArr, eq }) =>
+            and(inArr(fields.id, ids), eq(fields.teamId, teamId)),
+      }),
+      (e) =>
+         AppError.database("Falha ao arquivar centros de custo.", { cause: e }),
+   )
+      .andThen((existing) => {
+         if (existing.length !== ids.length)
+            return err(
+               AppError.notFound(
+                  "Um ou mais centros de custo não foram encontrados.",
+               ),
+            );
+         return ok(undefined);
+      })
+      .andThen(() =>
+         fromPromise(
+            db
+               .update(tags)
+               .set({ isArchived: true, updatedAt: dayjs().toDate() })
+               .where(inArray(tags.id, ids)),
+            (e) =>
+               AppError.database("Falha ao arquivar centros de custo.", {
+                  cause: e,
+               }),
+         ),
+      );
+}
+
 export function bulkDeleteTags(
    db: DatabaseInstance,
    ids: string[],

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -59,6 +59,7 @@ function Button({
 
    const button = (
       <Comp
+         aria-label={tooltip}
          className={cn(buttonVariants({ variant, size, className }))}
          data-size={size}
          data-slot="button"

--- a/packages/workflows/src/setup.ts
+++ b/packages/workflows/src/setup.ts
@@ -1,12 +1,17 @@
-import { DBOS } from "@dbos-inc/dbos-sdk";
+import { DBOS, WorkflowQueue } from "@dbos-inc/dbos-sdk";
 import { getLogger } from "@core/logging/root";
 import { initContext } from "./context";
 import type { WorkflowDeps } from "./context";
 import { backfillKeywordsWorkflow } from "./workflows/backfill-keywords-workflow";
 import "./workflows/categorization-workflow";
 import "./workflows/derive-keywords-workflow";
-import "./workflows/derive-tag-keywords-workflow";
+import { DERIVE_TAG_KEYWORDS_QUEUE_NAME } from "./workflows/derive-tag-keywords-workflow";
 import "./workflows/suggest-tag-workflow";
+
+export const deriveTagKeywordsQueue = new WorkflowQueue(
+   DERIVE_TAG_KEYWORDS_QUEUE_NAME,
+   { workerConcurrency: 5 },
+);
 
 type LaunchConfig = WorkflowDeps & {
    systemDatabaseUrl: string;

--- a/packages/workflows/src/workflows/derive-tag-keywords-enqueue.ts
+++ b/packages/workflows/src/workflows/derive-tag-keywords-enqueue.ts
@@ -1,0 +1,24 @@
+import type { DBOSClient } from "@dbos-inc/dbos-sdk";
+
+export type DeriveTagKeywordsInput = {
+   tagId: string;
+   teamId: string;
+   organizationId: string;
+   name: string;
+   description?: string | null;
+   userId?: string;
+   stripeCustomerId?: string | null;
+};
+
+export async function enqueueDeriveTagKeywordsWorkflow(
+   client: DBOSClient,
+   input: DeriveTagKeywordsInput,
+): Promise<void> {
+   await client.enqueue(
+      {
+         workflowName: "deriveTagKeywordsWorkflowFn",
+         queueName: "workflow:derive-tag-keywords",
+      },
+      input,
+   );
+}

--- a/packages/workflows/src/workflows/derive-tag-keywords-enqueue.ts
+++ b/packages/workflows/src/workflows/derive-tag-keywords-enqueue.ts
@@ -1,4 +1,5 @@
 import type { DBOSClient } from "@dbos-inc/dbos-sdk";
+import { DERIVE_TAG_KEYWORDS_QUEUE_NAME } from "./derive-tag-keywords-workflow";
 
 export type DeriveTagKeywordsInput = {
    tagId: string;
@@ -17,7 +18,7 @@ export async function enqueueDeriveTagKeywordsWorkflow(
    await client.enqueue(
       {
          workflowName: "deriveTagKeywordsWorkflowFn",
-         queueName: "workflow:derive-tag-keywords",
+         queueName: DERIVE_TAG_KEYWORDS_QUEUE_NAME,
       },
       input,
    );

--- a/packages/workflows/src/workflows/derive-tag-keywords-workflow.ts
+++ b/packages/workflows/src/workflows/derive-tag-keywords-workflow.ts
@@ -1,7 +1,7 @@
 import type { DBOSClient } from "@dbos-inc/dbos-sdk";
 import { fromPromise } from "neverthrow";
 import dayjs from "dayjs";
-import { DBOS, WorkflowQueue } from "@dbos-inc/dbos-sdk";
+import { DBOS } from "@dbos-inc/dbos-sdk";
 import { updateTagKeywords } from "@core/database/repositories/tags-repository";
 import { emitAiTagKeywordDerived } from "@packages/events/ai";
 import { createEmitFn } from "@packages/events/emit";
@@ -13,10 +13,8 @@ import { getDeps, getPublisher } from "../context";
 
 const MODEL = "google/gemini-3.1-flash-lite-preview";
 
-export const deriveTagKeywordsQueue = new WorkflowQueue(
-   "workflow:derive-tag-keywords",
-   { workerConcurrency: 5 },
-);
+export const DERIVE_TAG_KEYWORDS_QUEUE_NAME =
+   "workflow:derive-tag-keywords" as const;
 
 export type DeriveTagKeywordsInput = {
    tagId: string;
@@ -216,7 +214,7 @@ export async function enqueueDeriveTagKeywordsWorkflow(
    await client.enqueue(
       {
          workflowName: deriveTagKeywordsWorkflowFn.name,
-         queueName: deriveTagKeywordsQueue.name,
+         queueName: DERIVE_TAG_KEYWORDS_QUEUE_NAME,
       },
       input,
    );

--- a/packages/workflows/src/workflows/derive-tag-keywords-workflow.ts
+++ b/packages/workflows/src/workflows/derive-tag-keywords-workflow.ts
@@ -1,4 +1,3 @@
-import type { DBOSClient } from "@dbos-inc/dbos-sdk";
 import { fromPromise } from "neverthrow";
 import dayjs from "dayjs";
 import { DBOS } from "@dbos-inc/dbos-sdk";
@@ -206,16 +205,3 @@ async function deriveTagKeywordsWorkflowFn(input: DeriveTagKeywordsInput) {
 export const deriveTagKeywordsWorkflow = DBOS.registerWorkflow(
    deriveTagKeywordsWorkflowFn,
 );
-
-export async function enqueueDeriveTagKeywordsWorkflow(
-   client: DBOSClient,
-   input: DeriveTagKeywordsInput,
-): Promise<void> {
-   await client.enqueue(
-      {
-         workflowName: deriveTagKeywordsWorkflowFn.name,
-         queueName: DERIVE_TAG_KEYWORDS_QUEUE_NAME,
-      },
-      input,
-   );
-}

--- a/scripts/db-push.ts
+++ b/scripts/db-push.ts
@@ -55,6 +55,7 @@ async function ensureSchemas(envFile: string): Promise<void> {
    await client.connect();
 
    try {
+      await client.query(`CREATE EXTENSION IF NOT EXISTS pg_trgm`);
       for (const schema of REQUIRED_SCHEMAS) {
          await client.query(`CREATE SCHEMA IF NOT EXISTS "${schema}"`);
       }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Redesenha a página de Centros de Custo para o padrão table-native com busca e paginação no servidor, ações em massa (arquivar, excluir), export (todos/selecionados) e reativação. Atende à MON-481 com filter bar (busca), colunas ricas e export CSV/XLSX.

- **Mudanças**
  - Router (`orpc`)
    - `tags.getAll({ search?, includeArchived?, page=1, pageSize=20 })` passa a retornar `{ data, total }` com paginação server-side.
    - Novas procedures: `tags.bulkArchive({ ids })` e `tags.unarchive({ id })`.
    - Import de enqueue movido para `@packages/workflows/workflows/derive-tag-keywords-enqueue`.
  - Repositório
    - `listTagsPaginated(db, teamId, { search?, includeArchived?, page, pageSize })` com filtro por time/arquivados/busca (`ilike` em nome/descrição), ordenação por nome e retorno `{ data, total }`.
    - `bulkArchiveTags(db, ids, teamId)`: valida pertencimento/existência e seta `isArchived`/`updatedAt`.
    - `scripts/db-push.ts`: garante extensão `pg_trgm` para melhorar busca.
  - Componentes/Página
    - Colunas (`-tags/tags-columns.tsx`): `TagRow` alinhado a `Outputs['tags']['getAll']['data'][number]`; badge “Padrão” (`ShieldCheck`) e ícone “Arquivado” (`Archive`) com tooltip; “Descrição” com fallback “—”; “Palavras‑chave” com contagem, tooltip “Palavras‑chave IA” e preview; `meta.label` para export.
    - Página (`tags.tsx`): migração para `DataTableRoot/Toolbar/Content/EmptyState/Pagination/Skeleton` + `QueryBoundary`; busca e paginação server‑side com estado na URL (`search`, `page`, `pageSize`); ações por linha condicionais (Editar/Arquivar/Excluir ou Reativar/Excluir); ações em massa com `DataTableBulkActions`: arquivar em lote (ignora `isDefault`/já arquivados) e excluir em lote (bloqueia `isDefault`).
    - Exportação (`data-table-export.tsx`): separa export “todos” (`DataTableExportButton`) e “selecionados” (`DataTableExportSelectedButton`, agora na barra de seleção); filenames com data e sufixo “-selecionados”; ignora colunas não exportáveis; usa `meta.label` como cabeçalho; refatora para `useTableExport`/`exportRows` e `EXPORT_FORMATS`.
    - Acessibilidade: `Button` propaga `aria-label` a partir do `tooltip`.
    - Integrações: `ServiceForm`, `Transaction Credenza`, `ContatosSettingsForm` e `transactions` atualizados para `orpc.tags.getAll.queryOptions({ input: {} })` e leitura de `result.data`.
  - Workflows
    - Extrai `DERIVE_TAG_KEYWORDS_QUEUE_NAME` e registra `WorkflowQueue` compartilhada (concorrência 5) em `packages/workflows/src/setup.ts`; função de enqueue separada em `workflows/derive-tag-keywords-enqueue.ts`.
  - Store
    - Sem mudanças.

Checklist de testes
- Router/Repositório
  - `getAll`: aplica `search` (case-insensitive), `includeArchived`, pagina corretamente e retorna `{ data, total }`.
  - `bulkArchive`: arquiva múltiplos IDs do mesmo time; falha para IDs inexistentes/fora do time; retorna `{ archived: n }`.
  - `unarchive`: reativa tag do time; falha em caso de ownership inválido.
- Página/Componentes
  - Busca/paginação: estado em URL; navegação entre páginas; alteração de `pageSize`; `total`/`totalPages` corretos.
  - Colunas: badges/ícones/tooltips; “Descrição” com “—” quando vazia; “Palavras‑chave” com contagem, tooltip e preview.
  - Ações: arquivar/reativar/excluir por linha com toasts; em massa respeitando `isDefault` e limpando seleção.
  - Exportação: “todos” na toolbar; “selecionados” na barra de seleção; CSV/XLSX com cabeçalhos de `meta.label`, sufixo “-selecionados” quando aplicável e sem colunas não exportáveis.
- Integrações
  - Telas que usam `tags.getAll` passam `{ input: {} }` (ou filtros) e consomem `result.data` sem regressões.

<sup>Written for commit 125b3b0d7443b60fc71f2a9c211b6e1000b134fb. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/794">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

