### PR TITLE
Manoelnetocarvalho03/mon 487 refactordata table inline editing via columnmeta

### DIFF
--- a/apps/web/src/components/data-table/data-table-content.tsx
+++ b/apps/web/src/components/data-table/data-table-content.tsx
@@ -21,6 +21,7 @@ import {
 import {
    Select,
    SelectContent,
+   SelectGroup,
    SelectItem,
    SelectTrigger,
    SelectValue,
@@ -40,6 +41,20 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type React from "react";
 import { useDataTable } from "./data-table-root";
 
+// Structural interface — compatible with TanStack Form FieldApi instances
+// whose value type is string | string[].
+interface CellFieldApi {
+   state: {
+      value: string | string[];
+      meta: {
+         isTouched: boolean;
+         errors: unknown[];
+      };
+   };
+   handleChange: (value: string | string[]) => void;
+   handleBlur: () => void;
+}
+
 function useGroupedRows<TData>(
    rows: Row<TData>[],
    groupBy?: (row: TData) => string,
@@ -57,47 +72,213 @@ function useGroupedRows<TData>(
    }, [rows, groupBy]);
 }
 
+function toStringArray(v: unknown): string[] {
+   if (!Array.isArray(v)) return [];
+   return v.filter((x): x is string => typeof x === "string");
+}
+
+function FieldError({
+   errors,
+   isTouched,
+}: {
+   errors: unknown[];
+   isTouched: boolean;
+}) {
+   if (!isTouched || errors.length === 0) return null;
+   const message = errors
+      .map((e) => {
+         if (typeof e === "string") return e;
+         if (e !== null && typeof e === "object" && "message" in e)
+            return String((e as { message: unknown }).message);
+         return null;
+      })
+      .find((m): m is string => m !== null);
+   if (!message) return null;
+   return (
+      <span className="text-xs text-destructive" role="alert">
+         {message}
+      </span>
+   );
+}
+
+function EditFormActions({ onCancel }: { onCancel: () => void }) {
+   return (
+      <div className="flex justify-end gap-2">
+         <Button onClick={onCancel} size="sm" type="button" variant="outline">
+            Cancelar
+         </Button>
+         <Button size="sm" type="submit">
+            Salvar
+         </Button>
+      </div>
+   );
+}
+
+function CellInput({
+   cellComponent,
+   field,
+   options,
+   label,
+   autoFocus,
+   inputRef,
+   onCommit,
+   onCancel,
+}: {
+   cellComponent: "text" | "textarea" | "select" | "tags";
+   field: CellFieldApi;
+   options?: Array<{ label: string; value: string }>;
+   label?: string;
+   autoFocus?: boolean;
+   inputRef?: React.RefObject<HTMLInputElement | HTMLTextAreaElement | null>;
+   onCommit?: () => void;
+   onCancel?: () => void;
+}) {
+   const stringValue =
+      typeof field.state.value === "string" ? field.state.value : "";
+   const arrayValue = Array.isArray(field.state.value)
+      ? toStringArray(field.state.value)
+      : [];
+   const isInvalid =
+      field.state.meta.isTouched && field.state.meta.errors.length > 0;
+
+   if (cellComponent === "text") {
+      return (
+         <Input
+            ref={inputRef as React.RefObject<HTMLInputElement>}
+            aria-invalid={isInvalid}
+            aria-label={label}
+            autoFocus={autoFocus}
+            className="h-7 aria-invalid:border-destructive"
+            value={stringValue}
+            onBlur={() => field.handleBlur()}
+            onChange={(e) => field.handleChange(e.target.value)}
+            onKeyDown={(e) => {
+               if (e.key === "Escape") {
+                  e.preventDefault();
+                  onCancel?.();
+               }
+               if (e.key === "Enter") {
+                  e.preventDefault();
+                  field.handleChange((e.target as HTMLInputElement).value);
+                  onCommit?.();
+               }
+            }}
+         />
+      );
+   }
+
+   if (cellComponent === "textarea") {
+      return (
+         <Textarea
+            ref={inputRef as React.RefObject<HTMLTextAreaElement>}
+            aria-invalid={isInvalid}
+            aria-label={label}
+            autoFocus={autoFocus}
+            className="min-h-0 resize-none overflow-hidden aria-invalid:border-destructive"
+            rows={1}
+            value={stringValue}
+            onBlur={() => field.handleBlur()}
+            onChange={(e) => {
+               e.target.style.height = "auto";
+               e.target.style.height = `${e.target.scrollHeight}px`;
+               field.handleChange(e.target.value);
+            }}
+            onKeyDown={(e) => {
+               if (e.key === "Escape") {
+                  e.preventDefault();
+                  onCancel?.();
+               }
+               if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+                  e.preventDefault();
+                  onCommit?.();
+               }
+            }}
+         />
+      );
+   }
+
+   if (cellComponent === "select") {
+      return (
+         <Select
+            value={stringValue}
+            onValueChange={(v) => {
+               field.handleChange(v);
+               onCommit?.();
+            }}
+         >
+            <SelectTrigger className="h-7 text-sm">
+               <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+               <SelectGroup>
+                  {options?.map((opt) => (
+                     <SelectItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                     </SelectItem>
+                  ))}
+               </SelectGroup>
+            </SelectContent>
+         </Select>
+      );
+   }
+
+   if (cellComponent === "tags") {
+      return (
+         <MultiSelect
+            onChange={(v) => field.handleChange(v)}
+            onCreate={(name) => field.handleChange([...arrayValue, name])}
+            options={arrayValue.map((kw) => ({ label: kw, value: kw }))}
+            placeholder="Adicionar palavra-chave..."
+            selected={arrayValue}
+         />
+      );
+   }
+
+   return null;
+}
+
 function EditableCell({
    value: initialValue,
    cellComponent,
+   label,
    options,
    schema,
    onSave,
    rowId,
-   cellId,
    children,
 }: {
    value: unknown;
    cellComponent: "text" | "textarea" | "select" | "tags";
+   label?: string;
    options?: Array<{ label: string; value: string }>;
-   schema?: StandardSchemaV1<any>;
+   schema?: StandardSchemaV1<unknown>;
    onSave?: (rowId: string, value: unknown) => Promise<void>;
    rowId: string;
-   cellId: string;
    children?: React.ReactNode;
 }) {
    const [open, setOpen] = useState(false);
-   const [localValue, setLocalValue] = useState<unknown>(initialValue);
-   const [pendingTags, setPendingTags] = useState<string[]>(
-      Array.isArray(initialValue) ? (initialValue as string[]) : [],
+   const [localValue, setLocalValue] = useState<string | string[]>(
+      cellComponent === "tags"
+         ? toStringArray(initialValue)
+         : String(initialValue ?? ""),
    );
-   const inputRef = useRef<HTMLInputElement & HTMLTextAreaElement>(null);
+   const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
 
    useEffect(() => {
-      setLocalValue(initialValue);
-   }, [initialValue]);
-
-   useEffect(() => {
-      if (open && cellComponent === "tags") {
-         setPendingTags(
-            Array.isArray(localValue) ? (localValue as string[]) : [],
+      if (!open)
+         setLocalValue(
+            cellComponent === "tags"
+               ? toStringArray(initialValue)
+               : String(initialValue ?? ""),
          );
-      }
-   }, [open, cellComponent, localValue]);
+   }, [initialValue, open, cellComponent]);
+
+   const defaultFormValue: string | string[] =
+      cellComponent === "tags" ? toStringArray(localValue) : String(localValue);
 
    const form = useForm({
-      defaultValues: { value: String(localValue ?? "") },
-      onSubmit: async ({ value }: { value: { value: string } }) => {
+      defaultValues: { value: defaultFormValue },
+      onSubmit: async ({ value }) => {
          const prev = localValue;
          setLocalValue(value.value);
          setOpen(false);
@@ -114,47 +295,50 @@ function EditableCell({
       setOpen(false);
    }, [form]);
 
-   const displayValue = String(localValue ?? "");
+   const commit = useCallback(() => form.handleSubmit(), [form]);
 
-   const trigger = (
-      <div
-         data-editable-cell
-         data-editable-cell-id={cellId}
-         className={cn(
-            "group/cell cursor-pointer min-h-[1.5rem] flex items-center gap-2 w-full text-sm",
-            open && "opacity-60",
-         )}
-         role="button"
-         tabIndex={0}
-      >
-         {children ?? (
-            <span className="flex-1 truncate">
-               {cellComponent === "select"
-                  ? (options?.find((o) => o.value === displayValue)?.label ??
-                    displayValue)
-                  : displayValue || (
-                       <span className="text-muted-foreground/40">—</span>
-                    )}
-            </span>
-         )}
-         <Pencil className="size-3 shrink-0 text-muted-foreground opacity-0 group-hover/cell:opacity-100 transition-opacity" />
-      </div>
-   );
+   const ariaLabel = label ? `Editar ${label}` : "Editar";
+   const displayValue = Array.isArray(localValue)
+      ? localValue.join(", ")
+      : localValue;
 
    return (
       <Popover
          open={open}
          onOpenChange={(next) => {
-            if (!next) cancel();
-            else setOpen(true);
+            if (next) setOpen(true);
+            else cancel();
          }}
       >
-         <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+         <PopoverTrigger asChild>
+            <button
+               aria-expanded={open}
+               aria-haspopup="dialog"
+               aria-label={ariaLabel}
+               className={cn(
+                  "group/cell cursor-pointer min-h-[1.5rem] flex items-center gap-2 w-full text-sm text-left",
+                  open && "opacity-60",
+               )}
+               type="button"
+            >
+               {children ?? (
+                  <span className="flex-1 truncate">
+                     {cellComponent === "select"
+                        ? (options?.find((o) => o.value === displayValue)
+                             ?.label ?? displayValue)
+                        : displayValue || (
+                             <span className="text-muted-foreground/40">—</span>
+                          )}
+                  </span>
+               )}
+               <Pencil className="size-3 shrink-0 text-muted-foreground opacity-0 group-hover/cell:opacity-100 transition-opacity" />
+            </button>
+         </PopoverTrigger>
          <PopoverContent
             align="start"
+            className="w-[var(--radix-popover-trigger-width)] min-w-64 p-2"
             side="bottom"
             sideOffset={-36}
-            className="w-[var(--radix-popover-trigger-width)] min-w-64 p-2"
             onOpenAutoFocus={(e) => {
                e.preventDefault();
                inputRef.current?.focus();
@@ -167,203 +351,44 @@ function EditableCell({
                   form.handleSubmit();
                }}
             >
-               {cellComponent === "tags" && (
-                  <div className="flex flex-col gap-2">
-                     <MultiSelect
-                        onChange={setPendingTags}
-                        onCreate={(name) =>
-                           setPendingTags((prev) => [...prev, name])
-                        }
-                        options={pendingTags.map((kw) => ({
-                           label: kw,
-                           value: kw,
-                        }))}
-                        placeholder="Adicionar palavra-chave..."
-                        selected={pendingTags}
-                     />
-                     <div className="flex justify-end gap-2">
-                        <Button
-                           onClick={cancel}
-                           size="sm"
-                           type="button"
-                           variant="outline"
-                        >
-                           Cancelar
-                        </Button>
-                        <Button
-                           onClick={() => {
-                              const prev = localValue;
-                              setLocalValue(pendingTags);
-                              setOpen(false);
-                              onSave?.(rowId, pendingTags).catch(() =>
-                                 setLocalValue(prev),
-                              );
-                           }}
-                           size="sm"
-                           type="button"
-                        >
-                           Salvar
-                        </Button>
-                     </div>
-                  </div>
-               )}
-
-               {cellComponent === "select" && (
-                  <Select
-                     value={String(localValue ?? "")}
-                     onValueChange={(v) => {
-                        setLocalValue(v);
-                        setOpen(false);
-                        onSave?.(rowId, v).catch(() =>
-                           setLocalValue(localValue),
-                        );
-                     }}
-                  >
-                     <SelectTrigger className="h-7 text-sm">
-                        <SelectValue />
-                     </SelectTrigger>
-                     <SelectContent>
-                        {options?.map((opt) => (
-                           <SelectItem key={opt.value} value={opt.value}>
-                              {opt.label}
-                           </SelectItem>
-                        ))}
-                     </SelectContent>
-                  </Select>
-               )}
-
-               {cellComponent === "text" && (
-                  <form.Field
-                     name="value"
-                     validators={
-                        schema
-                           ? { onChange: schema, onBlur: schema }
-                           : undefined
-                     }
-                  >
-                     {(field) => (
-                        <div className="flex flex-col gap-2">
-                           <Input
-                              ref={inputRef}
-                              type="text"
-                              aria-invalid={
-                                 field.state.meta.isTouched &&
-                                 field.state.meta.errors.length > 0
-                              }
-                              className="h-7 aria-invalid:border-destructive"
-                              defaultValue={field.state.value}
-                              onChange={(e) =>
-                                 field.handleChange(e.target.value)
-                              }
-                              onBlur={(e) => {
-                                 field.handleChange(e.target.value);
-                                 field.handleBlur();
-                              }}
-                              onKeyDown={(e) => {
-                                 if (e.key === "Escape") {
-                                    e.preventDefault();
-                                    cancel();
-                                 }
-                                 if (e.key === "Enter") {
-                                    e.preventDefault();
-                                    field.handleChange(
-                                       (e.target as HTMLInputElement).value,
-                                    );
-                                    form.handleSubmit();
-                                 }
-                              }}
-                           />
-                           {field.state.meta.isTouched &&
-                              field.state.meta.errors.length > 0 && (
-                                 <span className="text-xs text-destructive">
-                                    {field.state.meta.errors[0]?.message}
-                                 </span>
-                              )}
-                           <div className="flex justify-end gap-2">
-                              <Button
-                                 type="button"
-                                 variant="outline"
-                                 size="sm"
-                                 onClick={cancel}
-                              >
-                                 Cancelar
-                              </Button>
-                              <Button type="submit" size="sm">
-                                 Salvar
-                              </Button>
-                           </div>
-                        </div>
-                     )}
-                  </form.Field>
-               )}
-
-               {cellComponent === "textarea" && (
-                  <div className="flex flex-col gap-2">
-                     <form.Field
-                        name="value"
-                        validators={
-                           schema
-                              ? { onChange: schema, onBlur: schema }
-                              : undefined
-                        }
-                     >
-                        {(field) => (
-                           <>
-                              <Textarea
-                                 ref={inputRef}
-                                 aria-invalid={
-                                    field.state.meta.isTouched &&
-                                    field.state.meta.errors.length > 0
-                                 }
-                                 className="min-h-[80px] text-sm resize-none aria-invalid:border-destructive"
-                                 defaultValue={field.state.value}
-                                 onChange={(e) =>
-                                    field.handleChange(e.target.value)
-                                 }
-                                 onBlur={() => field.handleBlur()}
-                                 onKeyDown={(e) => {
-                                    if (e.key === "Escape") {
-                                       e.preventDefault();
-                                       cancel();
-                                    }
-                                    if (
-                                       e.key === "Enter" &&
-                                       (e.ctrlKey || e.metaKey)
-                                    ) {
-                                       e.preventDefault();
-                                       field.handleChange(
-                                          (e.target as HTMLTextAreaElement)
-                                             .value,
-                                       );
-                                       form.handleSubmit();
-                                    }
-                                 }}
-                                 placeholder="Adicionar descrição..."
-                              />
-                              {field.state.meta.isTouched &&
-                                 field.state.meta.errors.length > 0 && (
-                                    <span className="text-xs text-destructive">
-                                       {field.state.meta.errors[0]?.message}
-                                    </span>
-                                 )}
-                           </>
+               <form.Field
+                  name="value"
+                  validators={
+                     schema
+                        ? {
+                             onChange: ({ value }) => {
+                                const result =
+                                   schema["~standard"].validate(value);
+                                if (result instanceof Promise) return undefined;
+                                return result.issues
+                                   ?.map((i) => i.message)
+                                   .join(", ");
+                             },
+                          }
+                        : undefined
+                  }
+               >
+                  {(field) => (
+                     <div className="flex flex-col gap-2">
+                        <CellInput
+                           cellComponent={cellComponent}
+                           field={field as unknown as CellFieldApi}
+                           inputRef={inputRef}
+                           label={ariaLabel}
+                           options={options}
+                           onCancel={cancel}
+                           onCommit={commit}
+                        />
+                        <FieldError
+                           errors={field.state.meta.errors}
+                           isTouched={field.state.meta.isTouched}
+                        />
+                        {cellComponent !== "select" && (
+                           <EditFormActions onCancel={cancel} />
                         )}
-                     </form.Field>
-                     <div className="flex justify-end gap-2">
-                        <Button
-                           type="button"
-                           variant="outline"
-                           size="sm"
-                           onClick={cancel}
-                        >
-                           Cancelar
-                        </Button>
-                        <Button type="submit" size="sm">
-                           Salvar
-                        </Button>
                      </div>
-                  </div>
-               )}
+                  )}
+               </form.Field>
             </form>
          </PopoverContent>
       </Popover>
@@ -414,12 +439,12 @@ function DataTableBodyRow<TData>({ row }: { row: Row<TData> }) {
                   {isEditable ? (
                      <EditableCell
                         cellComponent={meta!.cellComponent!}
-                        cellId={cell.id}
+                        label={meta?.label}
                         options={meta?.editOptions}
-                        schema={meta?.editSchema}
-                        onSave={meta?.onSave}
                         rowId={row.id}
+                        schema={meta?.editSchema}
                         value={cell.getValue()}
+                        onSave={meta?.onSave}
                      >
                         {flexRender(
                            cell.column.columnDef.cell,
@@ -437,15 +462,42 @@ function DataTableBodyRow<TData>({ row }: { row: Row<TData> }) {
 }
 
 function DraftRow() {
-   const { table, addRowForm, onDiscardAddRow } = useDataTable();
-   if (!addRowForm) return null;
-
+   const { table, isDraftRowActive, onAddRow, onDiscardAddRow } =
+      useDataTable();
    const visibleColumns = table.getVisibleLeafColumns();
-   let autoFocused = false;
+
+   const defaultValues = useMemo(() => {
+      const values: Record<string, string | string[]> = {};
+      for (const col of visibleColumns) {
+         const meta = col.columnDef.meta;
+         if (!meta?.cellComponent) continue;
+         const fieldName = String(
+            (col.columnDef as { accessorKey?: string }).accessorKey ?? col.id,
+         );
+         values[fieldName] = meta.cellComponent === "tags" ? [] : "";
+      }
+      return values;
+   }, [visibleColumns]);
+
+   const form = useForm({
+      defaultValues,
+      onSubmit: async ({ value }) => {
+         await onAddRow?.(value);
+      },
+   });
+
+   if (!isDraftRowActive) return null;
+
+   const firstEditableIdx = visibleColumns.findIndex(
+      (col) =>
+         col.id !== "__select" &&
+         col.id !== "__actions" &&
+         col.columnDef.meta?.cellComponent,
+   );
 
    return (
       <TableRow className="bg-card">
-         {visibleColumns.map((column) => {
+         {visibleColumns.map((column, colIdx) => {
             const meta = column.columnDef.meta;
 
             if (column.id === "__select") {
@@ -462,25 +514,23 @@ function DraftRow() {
                            type="button"
                            variant="outline"
                         >
-                           <X />
+                           <X data-icon />
                         </Button>
-                        <addRowForm.Subscribe
-                           // oxlint-ignore no-explicit-any
-                           selector={(s: any) => s.canSubmit && !s.isSubmitting}
+                        <form.Subscribe
+                           selector={(s) => s.canSubmit && !s.isSubmitting}
                         >
-                           {/* oxlint-ignore no-explicit-any */}
-                           {(canSubmit: any) => (
+                           {(canSubmit) => (
                               <Button
                                  disabled={!canSubmit}
-                                 onClick={() => addRowForm.handleSubmit()}
+                                 onClick={() => form.handleSubmit()}
                                  tooltip="Salvar"
                                  type="button"
                                  variant="outline"
                               >
-                                 <Check />
+                                 <Check data-icon />
                               </Button>
                            )}
-                        </addRowForm.Subscribe>
+                        </form.Subscribe>
                      </div>
                   </TableCell>
                );
@@ -493,114 +543,35 @@ function DraftRow() {
                (column.columnDef as { accessorKey?: string }).accessorKey ??
                   column.id,
             );
-            const schema = meta?.editSchema;
-            const shouldFocus = !autoFocused;
-            autoFocused = true;
 
             return (
                <TableCell className="py-2 truncate" key={column.id}>
-                  {cellComp === "text" && (
-                     <addRowForm.Field
-                        name={fieldName}
-                        validators={
-                           schema
-                              ? { onChange: schema, onBlur: schema }
-                              : undefined
-                        }
-                     >
-                        {/* oxlint-ignore no-explicit-any */}
-                        {(field: any) => (
-                           <div className="flex flex-col gap-1">
-                              <Input
-                                 aria-invalid={
-                                    field.state.meta.isTouched &&
-                                    field.state.meta.errors.length > 0
-                                 }
-                                 aria-label={meta?.label}
-                                 autoFocus={shouldFocus}
-                                 className="h-7 aria-invalid:border-destructive"
-                                 id={field.name}
-                                 name={field.name}
-                                 onBlur={() => field.handleBlur()}
-                                 onChange={(
-                                    e: React.ChangeEvent<HTMLInputElement>,
-                                 ) => field.handleChange(e.target.value)}
-                                 value={field.state.value as string}
-                              />
-                              {field.state.meta.isTouched &&
-                                 field.state.meta.errors.length > 0 && (
-                                    <span className="text-xs text-destructive">
-                                       {field.state.meta.errors[0]?.message}
-                                    </span>
-                                 )}
-                           </div>
-                        )}
-                     </addRowForm.Field>
-                  )}
-                  {cellComp === "textarea" && (
-                     <addRowForm.Field
-                        name={fieldName}
-                        validators={
-                           schema
-                              ? { onChange: schema, onBlur: schema }
-                              : undefined
-                        }
-                     >
-                        {/* oxlint-ignore no-explicit-any */}
-                        {(field: any) => (
-                           <div className="flex flex-col gap-1">
-                              <Textarea
-                                 aria-invalid={
-                                    field.state.meta.isTouched &&
-                                    field.state.meta.errors.length > 0
-                                 }
-                                 aria-label={meta?.label}
-                                 autoFocus={shouldFocus}
-                                 className="min-h-0 resize-none overflow-hidden aria-invalid:border-destructive"
-                                 id={field.name}
-                                 name={field.name}
-                                 onBlur={() => field.handleBlur()}
-                                 onChange={(
-                                    e: React.ChangeEvent<HTMLTextAreaElement>,
-                                 ) => {
-                                    e.target.style.height = "auto";
-                                    e.target.style.height = `${e.target.scrollHeight}px`;
-                                    field.handleChange(e.target.value);
-                                 }}
-                                 rows={1}
-                                 value={field.state.value as string}
-                              />
-                              {field.state.meta.isTouched &&
-                                 field.state.meta.errors.length > 0 && (
-                                    <span className="text-xs text-destructive">
-                                       {field.state.meta.errors[0]?.message}
-                                    </span>
-                                 )}
-                           </div>
-                        )}
-                     </addRowForm.Field>
-                  )}
-                  {cellComp === "tags" && (
-                     <addRowForm.Field name={fieldName}>
-                        {/* oxlint-ignore no-explicit-any */}
-                        {(field: any) => (
-                           <MultiSelect
-                              onChange={(v) => field.handleChange(v)}
-                              onCreate={(name) =>
-                                 field.handleChange([
-                                    ...(field.state.value as string[]),
-                                    name,
-                                 ])
-                              }
-                              options={(field.state.value as string[]).map(
-                                 (kw: string) => ({ label: kw, value: kw }),
-                              )}
-                              placeholder="Adicionar palavra-chave..."
-                              selected={field.state.value as string[]}
+                  <form.Field
+                     name={fieldName}
+                     validators={
+                        meta?.editSchema
+                           ? {
+                                onChange: meta.editSchema,
+                                onBlur: meta.editSchema,
+                             }
+                           : undefined
+                     }
+                  >
+                     {(field) => (
+                        <div className="flex flex-col gap-1">
+                           <CellInput
+                              autoFocus={colIdx === firstEditableIdx}
+                              cellComponent={cellComp}
+                              field={field as unknown as CellFieldApi}
+                              label={meta?.label}
                            />
-                        )}
-                     </addRowForm.Field>
-                  )}
+                           <FieldError
+                              errors={field.state.meta.errors}
+                              isTouched={field.state.meta.isTouched}
+                           />
+                        </div>
+                     )}
+                  </form.Field>
                </TableCell>
             );
          })}
@@ -674,10 +645,10 @@ export function DataTableContent<TData>({ maxHeight }: DataTableContentProps) {
 
    const virtualizer = useVirtualizer({
       count: rows.length,
-      getScrollElement: () => scrollEl,
-      estimateSize: () => 53,
-      overscan: 5,
       enabled: isVirtualized,
+      estimateSize: () => 53,
+      getScrollElement: () => scrollEl,
+      overscan: 5,
    });
 
    if (table.getCoreRowModel().rows.length === 0 && hasEmptyState) return null;
@@ -723,15 +694,6 @@ export function DataTableContent<TData>({ maxHeight }: DataTableContentProps) {
                         }
                         return (
                            <TableHead
-                              className={cn(
-                                 "text-xs font-medium",
-                                 header.column.columnDef.meta?.align ===
-                                    "right" && "text-right",
-                                 header.column.columnDef.meta?.align ===
-                                    "center" && "text-center",
-                              )}
-                              colSpan={header.colSpan}
-                              key={header.id}
                               aria-sort={
                                  header.column.getCanSort()
                                     ? header.column.getIsSorted() === "asc"
@@ -741,6 +703,15 @@ export function DataTableContent<TData>({ maxHeight }: DataTableContentProps) {
                                          : "none"
                                     : undefined
                               }
+                              className={cn(
+                                 "text-xs font-medium",
+                                 header.column.columnDef.meta?.align ===
+                                    "right" && "text-right",
+                                 header.column.columnDef.meta?.align ===
+                                    "center" && "text-center",
+                              )}
+                              colSpan={header.colSpan}
+                              key={header.id}
                            >
                               {header.isPlaceholder ? null : header.column.getCanSort() ? (
                                  <Button

--- a/apps/web/src/components/data-table/data-table-content.tsx
+++ b/apps/web/src/components/data-table/data-table-content.tsx
@@ -382,7 +382,10 @@ function DataTableBodyRows<TData>({
 
    const renderRow = (row: Row<TData>) => (
       <TableRow
-         className={cn("bg-card", row.getIsSelected() && "bg-muted/50")}
+         className={cn(
+            "bg-card hover:bg-card",
+            row.getIsSelected() && "bg-muted/50",
+         )}
          data-state={row.getIsSelected() ? "selected" : undefined}
          key={row.id}
       >

--- a/apps/web/src/components/data-table/data-table-content.tsx
+++ b/apps/web/src/components/data-table/data-table-content.tsx
@@ -98,7 +98,7 @@ function EditableCell({
       <div
          data-editable-cell
          data-editable-cell-id={cellId}
-         className="group/cell cursor-pointer min-h-[1.5rem] flex items-center gap-2 w-full text-sm"
+         className="group/cell cursor-pointer rounded px-2 py-0.5 -mx-2 hover:bg-muted/60 min-h-[1.5rem] flex items-center gap-2 w-full text-sm transition-colors"
          role="button"
          tabIndex={0}
       >
@@ -382,10 +382,7 @@ function DataTableBodyRows<TData>({
 
    const renderRow = (row: Row<TData>) => (
       <TableRow
-         className={cn(
-            "bg-card hover:bg-muted/40",
-            row.getIsSelected() && "bg-muted/50",
-         )}
+         className={cn("bg-card", row.getIsSelected() && "bg-muted/50")}
          data-state={row.getIsSelected() ? "selected" : undefined}
          key={row.id}
       >

--- a/apps/web/src/components/data-table/data-table-content.tsx
+++ b/apps/web/src/components/data-table/data-table-content.tsx
@@ -382,7 +382,10 @@ function DataTableBodyRows<TData>({
 
    const renderRow = (row: Row<TData>) => (
       <TableRow
-         className={cn("bg-card", row.getIsSelected() && "bg-muted/50")}
+         className={cn(
+            "bg-card hover:bg-muted/40",
+            row.getIsSelected() && "bg-muted/50",
+         )}
          data-state={row.getIsSelected() ? "selected" : undefined}
          key={row.id}
       >

--- a/apps/web/src/components/data-table/data-table-content.tsx
+++ b/apps/web/src/components/data-table/data-table-content.tsx
@@ -3,8 +3,16 @@ import { flexRender } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import { useForm } from "@tanstack/react-form";
-import { ArrowDown, ArrowUp, ArrowUpDown, Pencil } from "lucide-react";
+import {
+   ArrowDown,
+   ArrowUp,
+   ArrowUpDown,
+   Check,
+   Pencil,
+   X,
+} from "lucide-react";
 import { Button } from "@packages/ui/components/button";
+import { MultiSelect } from "@packages/ui/components/multi-select";
 import {
    Popover,
    PopoverContent,
@@ -25,6 +33,7 @@ import {
    TableHeader,
    TableRow,
 } from "@packages/ui/components/table";
+import { Input } from "@packages/ui/components/input";
 import { Textarea } from "@packages/ui/components/textarea";
 import { cn } from "@packages/ui/lib/utils";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -56,22 +65,35 @@ function EditableCell({
    onSave,
    rowId,
    cellId,
+   children,
 }: {
    value: unknown;
-   cellComponent: "text" | "textarea" | "select";
+   cellComponent: "text" | "textarea" | "select" | "tags";
    options?: Array<{ label: string; value: string }>;
    schema?: StandardSchemaV1<any>;
    onSave?: (rowId: string, value: unknown) => Promise<void>;
    rowId: string;
    cellId: string;
+   children?: React.ReactNode;
 }) {
    const [open, setOpen] = useState(false);
    const [localValue, setLocalValue] = useState<unknown>(initialValue);
+   const [pendingTags, setPendingTags] = useState<string[]>(
+      Array.isArray(initialValue) ? (initialValue as string[]) : [],
+   );
    const inputRef = useRef<HTMLInputElement & HTMLTextAreaElement>(null);
 
    useEffect(() => {
       setLocalValue(initialValue);
    }, [initialValue]);
+
+   useEffect(() => {
+      if (open && cellComponent === "tags") {
+         setPendingTags(
+            Array.isArray(localValue) ? (localValue as string[]) : [],
+         );
+      }
+   }, [open, cellComponent, localValue]);
 
    const form = useForm({
       defaultValues: { value: String(localValue ?? "") },
@@ -98,18 +120,23 @@ function EditableCell({
       <div
          data-editable-cell
          data-editable-cell-id={cellId}
-         className="group/cell cursor-pointer rounded px-2 py-0.5 -mx-2 hover:bg-muted/60 min-h-[1.5rem] flex items-center gap-2 w-full text-sm transition-colors"
+         className={cn(
+            "group/cell cursor-pointer min-h-[1.5rem] flex items-center gap-2 w-full text-sm",
+            open && "opacity-60",
+         )}
          role="button"
          tabIndex={0}
       >
-         <span className="flex-1 truncate">
-            {cellComponent === "select"
-               ? (options?.find((o) => o.value === displayValue)?.label ??
-                 displayValue)
-               : displayValue || (
-                    <span className="text-muted-foreground/40">—</span>
-                 )}
-         </span>
+         {children ?? (
+            <span className="flex-1 truncate">
+               {cellComponent === "select"
+                  ? (options?.find((o) => o.value === displayValue)?.label ??
+                    displayValue)
+                  : displayValue || (
+                       <span className="text-muted-foreground/40">—</span>
+                    )}
+            </span>
+         )}
          <Pencil className="size-3 shrink-0 text-muted-foreground opacity-0 group-hover/cell:opacity-100 transition-opacity" />
       </div>
    );
@@ -124,7 +151,10 @@ function EditableCell({
       >
          <PopoverTrigger asChild>{trigger}</PopoverTrigger>
          <PopoverContent
-            className="w-80"
+            align="start"
+            side="bottom"
+            sideOffset={-36}
+            className="w-[var(--radix-popover-trigger-width)] min-w-64 p-2"
             onOpenAutoFocus={(e) => {
                e.preventDefault();
                inputRef.current?.focus();
@@ -137,6 +167,47 @@ function EditableCell({
                   form.handleSubmit();
                }}
             >
+               {cellComponent === "tags" && (
+                  <div className="flex flex-col gap-2">
+                     <MultiSelect
+                        onChange={setPendingTags}
+                        onCreate={(name) =>
+                           setPendingTags((prev) => [...prev, name])
+                        }
+                        options={pendingTags.map((kw) => ({
+                           label: kw,
+                           value: kw,
+                        }))}
+                        placeholder="Adicionar palavra-chave..."
+                        selected={pendingTags}
+                     />
+                     <div className="flex justify-end gap-2">
+                        <Button
+                           onClick={cancel}
+                           size="sm"
+                           type="button"
+                           variant="outline"
+                        >
+                           Cancelar
+                        </Button>
+                        <Button
+                           onClick={() => {
+                              const prev = localValue;
+                              setLocalValue(pendingTags);
+                              setOpen(false);
+                              onSave?.(rowId, pendingTags).catch(() =>
+                                 setLocalValue(prev),
+                              );
+                           }}
+                           size="sm"
+                           type="button"
+                        >
+                           Salvar
+                        </Button>
+                     </div>
+                  </div>
+               )}
+
                {cellComponent === "select" && (
                   <Select
                      value={String(localValue ?? "")}
@@ -172,14 +243,14 @@ function EditableCell({
                   >
                      {(field) => (
                         <div className="flex flex-col gap-2">
-                           <input
+                           <Input
                               ref={inputRef}
                               type="text"
                               aria-invalid={
                                  field.state.meta.isTouched &&
                                  field.state.meta.errors.length > 0
                               }
-                              className="h-7 w-full rounded border border-input bg-background px-2 text-sm outline-none focus:ring-2 focus:ring-ring/50 aria-invalid:border-destructive"
+                              className="h-7 aria-invalid:border-destructive"
                               defaultValue={field.state.value}
                               onChange={(e) =>
                                  field.handleChange(e.target.value)
@@ -335,6 +406,7 @@ function DataTableBodyRow<TData>({ row }: { row: Row<TData> }) {
                      cell.column.id === "__select" ? "w-10 px-2" : "truncate",
                      meta?.align === "right" && "text-right",
                      meta?.align === "center" && "text-center",
+                     isEditable && "hover:bg-muted/60 transition-colors",
                   )}
                   key={cell.id}
                   style={{ maxWidth: cell.column.columnDef.maxSize }}
@@ -348,7 +420,12 @@ function DataTableBodyRow<TData>({ row }: { row: Row<TData> }) {
                         onSave={meta?.onSave}
                         rowId={row.id}
                         value={cell.getValue()}
-                     />
+                     >
+                        {flexRender(
+                           cell.column.columnDef.cell,
+                           cell.getContext(),
+                        )}
+                     </EditableCell>
                   ) : (
                      flexRender(cell.column.columnDef.cell, cell.getContext())
                   )}
@@ -356,6 +433,178 @@ function DataTableBodyRow<TData>({ row }: { row: Row<TData> }) {
             );
          })}
       </>
+   );
+}
+
+function DraftRow() {
+   const { table, addRowForm, onDiscardAddRow } = useDataTable();
+   if (!addRowForm) return null;
+
+   const visibleColumns = table.getVisibleLeafColumns();
+   let autoFocused = false;
+
+   return (
+      <TableRow className="bg-card">
+         {visibleColumns.map((column) => {
+            const meta = column.columnDef.meta;
+
+            if (column.id === "__select") {
+               return <TableCell className="w-10 px-2" key={column.id} />;
+            }
+
+            if (column.id === "__actions") {
+               return (
+                  <TableCell key={column.id}>
+                     <div className="flex items-center justify-end gap-2">
+                        <Button
+                           onClick={onDiscardAddRow}
+                           tooltip="Descartar"
+                           type="button"
+                           variant="outline"
+                        >
+                           <X />
+                        </Button>
+                        <addRowForm.Subscribe
+                           // oxlint-ignore no-explicit-any
+                           selector={(s: any) => s.canSubmit && !s.isSubmitting}
+                        >
+                           {/* oxlint-ignore no-explicit-any */}
+                           {(canSubmit: any) => (
+                              <Button
+                                 disabled={!canSubmit}
+                                 onClick={() => addRowForm.handleSubmit()}
+                                 tooltip="Salvar"
+                                 type="button"
+                                 variant="outline"
+                              >
+                                 <Check />
+                              </Button>
+                           )}
+                        </addRowForm.Subscribe>
+                     </div>
+                  </TableCell>
+               );
+            }
+
+            const cellComp = meta?.cellComponent;
+            if (!cellComp) return <TableCell key={column.id} />;
+
+            const fieldName = String(
+               (column.columnDef as { accessorKey?: string }).accessorKey ??
+                  column.id,
+            );
+            const schema = meta?.editSchema;
+            const shouldFocus = !autoFocused;
+            autoFocused = true;
+
+            return (
+               <TableCell className="py-2 truncate" key={column.id}>
+                  {cellComp === "text" && (
+                     <addRowForm.Field
+                        name={fieldName}
+                        validators={
+                           schema
+                              ? { onChange: schema, onBlur: schema }
+                              : undefined
+                        }
+                     >
+                        {/* oxlint-ignore no-explicit-any */}
+                        {(field: any) => (
+                           <div className="flex flex-col gap-1">
+                              <Input
+                                 aria-invalid={
+                                    field.state.meta.isTouched &&
+                                    field.state.meta.errors.length > 0
+                                 }
+                                 aria-label={meta?.label}
+                                 autoFocus={shouldFocus}
+                                 className="h-7 aria-invalid:border-destructive"
+                                 id={field.name}
+                                 name={field.name}
+                                 onBlur={() => field.handleBlur()}
+                                 onChange={(
+                                    e: React.ChangeEvent<HTMLInputElement>,
+                                 ) => field.handleChange(e.target.value)}
+                                 value={field.state.value as string}
+                              />
+                              {field.state.meta.isTouched &&
+                                 field.state.meta.errors.length > 0 && (
+                                    <span className="text-xs text-destructive">
+                                       {field.state.meta.errors[0]?.message}
+                                    </span>
+                                 )}
+                           </div>
+                        )}
+                     </addRowForm.Field>
+                  )}
+                  {cellComp === "textarea" && (
+                     <addRowForm.Field
+                        name={fieldName}
+                        validators={
+                           schema
+                              ? { onChange: schema, onBlur: schema }
+                              : undefined
+                        }
+                     >
+                        {/* oxlint-ignore no-explicit-any */}
+                        {(field: any) => (
+                           <div className="flex flex-col gap-1">
+                              <Textarea
+                                 aria-invalid={
+                                    field.state.meta.isTouched &&
+                                    field.state.meta.errors.length > 0
+                                 }
+                                 aria-label={meta?.label}
+                                 autoFocus={shouldFocus}
+                                 className="min-h-0 resize-none overflow-hidden aria-invalid:border-destructive"
+                                 id={field.name}
+                                 name={field.name}
+                                 onBlur={() => field.handleBlur()}
+                                 onChange={(
+                                    e: React.ChangeEvent<HTMLTextAreaElement>,
+                                 ) => {
+                                    e.target.style.height = "auto";
+                                    e.target.style.height = `${e.target.scrollHeight}px`;
+                                    field.handleChange(e.target.value);
+                                 }}
+                                 rows={1}
+                                 value={field.state.value as string}
+                              />
+                              {field.state.meta.isTouched &&
+                                 field.state.meta.errors.length > 0 && (
+                                    <span className="text-xs text-destructive">
+                                       {field.state.meta.errors[0]?.message}
+                                    </span>
+                                 )}
+                           </div>
+                        )}
+                     </addRowForm.Field>
+                  )}
+                  {cellComp === "tags" && (
+                     <addRowForm.Field name={fieldName}>
+                        {/* oxlint-ignore no-explicit-any */}
+                        {(field: any) => (
+                           <MultiSelect
+                              onChange={(v) => field.handleChange(v)}
+                              onCreate={(name) =>
+                                 field.handleChange([
+                                    ...(field.state.value as string[]),
+                                    name,
+                                 ])
+                              }
+                              options={(field.state.value as string[]).map(
+                                 (kw: string) => ({ label: kw, value: kw }),
+                              )}
+                              placeholder="Adicionar palavra-chave..."
+                              selected={field.state.value as string[]}
+                           />
+                        )}
+                     </addRowForm.Field>
+                  )}
+               </TableCell>
+            );
+         })}
+      </TableRow>
    );
 }
 
@@ -530,6 +779,7 @@ export function DataTableContent<TData>({ maxHeight }: DataTableContentProps) {
                ))}
             </TableHeader>
             <TableBody>
+               <DraftRow />
                {isVirtualized && virtualItems ? (
                   <>
                      {paddingTop > 0 && (

--- a/apps/web/src/components/data-table/data-table-content.tsx
+++ b/apps/web/src/components/data-table/data-table-content.tsx
@@ -1,8 +1,22 @@
 import type { Row } from "@tanstack/react-table";
 import { flexRender } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import { useForm } from "@tanstack/react-form";
+import { ArrowDown, ArrowUp, ArrowUpDown, Pencil } from "lucide-react";
 import { Button } from "@packages/ui/components/button";
+import {
+   Popover,
+   PopoverContent,
+   PopoverTrigger,
+} from "@packages/ui/components/popover";
+import {
+   Select,
+   SelectContent,
+   SelectItem,
+   SelectTrigger,
+   SelectValue,
+} from "@packages/ui/components/select";
 import {
    Table,
    TableBody,
@@ -11,8 +25,9 @@ import {
    TableHeader,
    TableRow,
 } from "@packages/ui/components/table";
+import { Textarea } from "@packages/ui/components/textarea";
 import { cn } from "@packages/ui/lib/utils";
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type React from "react";
 import { useDataTable } from "./data-table-root";
 
@@ -31,6 +46,267 @@ function useGroupedRows<TData>(
       }
       return groups;
    }, [rows, groupBy]);
+}
+
+function EditableCell({
+   value: initialValue,
+   cellComponent,
+   editMode = "inline",
+   options,
+   schema,
+   onSave,
+   rowId,
+   cellId,
+}: {
+   value: unknown;
+   cellComponent: "text" | "textarea" | "select";
+   editMode?: "inline" | "popover";
+   options?: Array<{ label: string; value: string }>;
+   schema?: StandardSchemaV1<any>;
+   onSave?: (rowId: string, value: unknown) => Promise<void>;
+   rowId: string;
+   cellId: string;
+}) {
+   const [editing, setEditing] = useState(false);
+   const [localValue, setLocalValue] = useState<unknown>(initialValue);
+   const inputRef = useRef<HTMLInputElement & HTMLTextAreaElement>(null);
+
+   useEffect(() => {
+      setLocalValue(initialValue);
+   }, [initialValue]);
+
+   useEffect(() => {
+      if (editing && editMode === "inline") {
+         inputRef.current?.focus();
+      }
+   }, [editing, editMode]);
+
+   const form = useForm({
+      defaultValues: { value: String(localValue ?? "") },
+      onSubmit: async ({ value }: { value: { value: string } }) => {
+         const prev = localValue;
+         setLocalValue(value.value);
+         setEditing(false);
+         try {
+            await onSave?.(rowId, value.value);
+         } catch {
+            setLocalValue(prev);
+         }
+      },
+   });
+
+   const cancel = useCallback(() => {
+      form.reset();
+      setEditing(false);
+   }, [form]);
+
+   const focusNext = useCallback(() => {
+      const all = Array.from(
+         document.querySelectorAll<HTMLElement>("[data-editable-cell]"),
+      );
+      const idx = all.findIndex((el) => el.dataset.editableCellId === cellId);
+      all[idx + 1]?.click();
+   }, [cellId]);
+
+   const displayValue = String(localValue ?? "");
+
+   const displayNode = (
+      <div
+         data-editable-cell
+         data-editable-cell-id={cellId}
+         className="group/cell cursor-pointer rounded px-2 py-0.5 -mx-2 hover:bg-muted/60 hover:ring-1 hover:ring-border min-h-[1.5rem] flex items-center gap-2 w-full text-sm transition-colors"
+         onClick={() => setEditing(true)}
+         onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") setEditing(true);
+         }}
+         role="button"
+         tabIndex={0}
+      >
+         <span className="flex-1 truncate">
+            {cellComponent === "select"
+               ? (options?.find((o) => o.value === displayValue)?.label ??
+                 displayValue)
+               : displayValue || (
+                    <span className="text-muted-foreground/40">—</span>
+                 )}
+         </span>
+         <Pencil className="size-3 shrink-0 text-muted-foreground opacity-0 group-hover/cell:opacity-100 transition-opacity" />
+      </div>
+   );
+
+   if (!editing) return displayNode;
+
+   const editFields = (
+      <form
+         onSubmit={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            form.handleSubmit();
+         }}
+      >
+         {cellComponent === "select" && (
+            <Select
+               value={String(localValue ?? "")}
+               onValueChange={(v) => {
+                  setLocalValue(v);
+                  setEditing(false);
+                  onSave?.(rowId, v).catch(() => setLocalValue(localValue));
+               }}
+               open
+               onOpenChange={(open) => {
+                  if (!open) cancel();
+               }}
+            >
+               <SelectTrigger className="h-7 text-sm">
+                  <SelectValue />
+               </SelectTrigger>
+               <SelectContent>
+                  {options?.map((opt) => (
+                     <SelectItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                     </SelectItem>
+                  ))}
+               </SelectContent>
+            </Select>
+         )}
+
+         {cellComponent === "text" && (
+            <form.Field
+               name="value"
+               validators={
+                  schema ? { onChange: schema, onBlur: schema } : undefined
+               }
+            >
+               {(field) => (
+                  <div className="flex flex-col gap-2">
+                     <input
+                        ref={inputRef}
+                        type="text"
+                        aria-invalid={
+                           field.state.meta.isTouched &&
+                           field.state.meta.errors.length > 0
+                        }
+                        className="h-7 w-full rounded border border-input bg-background px-2 text-sm outline-none focus:ring-2 focus:ring-ring/50 aria-invalid:border-destructive"
+                        defaultValue={field.state.value}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                        onBlur={(e) => {
+                           field.handleChange(e.target.value);
+                           field.handleBlur();
+                           form.handleSubmit();
+                        }}
+                        onKeyDown={(e) => {
+                           if (e.key === "Escape") {
+                              e.preventDefault();
+                              cancel();
+                           }
+                           if (e.key === "Tab") {
+                              e.preventDefault();
+                              field.handleChange(
+                                 (e.target as HTMLInputElement).value,
+                              );
+                              form.handleSubmit().then(focusNext);
+                           }
+                        }}
+                     />
+                     {field.state.meta.isTouched &&
+                        field.state.meta.errors.length > 0 && (
+                           <span className="text-xs text-destructive">
+                              {field.state.meta.errors[0]?.message}
+                           </span>
+                        )}
+                  </div>
+               )}
+            </form.Field>
+         )}
+
+         {cellComponent === "textarea" && (
+            <div className="flex flex-col gap-2">
+               <form.Field
+                  name="value"
+                  validators={
+                     schema ? { onChange: schema, onBlur: schema } : undefined
+                  }
+               >
+                  {(field) => (
+                     <>
+                        <Textarea
+                           ref={inputRef}
+                           aria-invalid={
+                              field.state.meta.isTouched &&
+                              field.state.meta.errors.length > 0
+                           }
+                           className="min-h-[80px] text-sm resize-none aria-invalid:border-destructive"
+                           defaultValue={field.state.value}
+                           onChange={(e) => field.handleChange(e.target.value)}
+                           onBlur={() => field.handleBlur()}
+                           onKeyDown={(e) => {
+                              if (e.key === "Escape") {
+                                 e.preventDefault();
+                                 cancel();
+                              }
+                              if (
+                                 e.key === "Enter" &&
+                                 (e.ctrlKey || e.metaKey)
+                              ) {
+                                 e.preventDefault();
+                                 field.handleChange(
+                                    (e.target as HTMLTextAreaElement).value,
+                                 );
+                                 form.handleSubmit();
+                              }
+                           }}
+                           placeholder="Adicionar descrição..."
+                        />
+                        {field.state.meta.isTouched &&
+                           field.state.meta.errors.length > 0 && (
+                              <span className="text-xs text-destructive">
+                                 {field.state.meta.errors[0]?.message}
+                              </span>
+                           )}
+                     </>
+                  )}
+               </form.Field>
+               <div className="flex justify-end gap-2">
+                  <Button
+                     type="button"
+                     variant="outline"
+                     size="sm"
+                     onClick={cancel}
+                  >
+                     Cancelar
+                  </Button>
+                  <Button type="submit" size="sm">
+                     Salvar
+                  </Button>
+               </div>
+            </div>
+         )}
+      </form>
+   );
+
+   if (editMode === "popover") {
+      return (
+         <Popover
+            open
+            onOpenChange={(open) => {
+               if (!open) cancel();
+            }}
+         >
+            <PopoverTrigger asChild>{displayNode}</PopoverTrigger>
+            <PopoverContent
+               className="w-80"
+               onOpenAutoFocus={(e) => {
+                  e.preventDefault();
+                  inputRef.current?.focus();
+               }}
+            >
+               {editFields}
+            </PopoverContent>
+         </Popover>
+      );
+   }
+
+   return editFields;
 }
 
 function DataTableBodyRow<TData>({ row }: { row: Row<TData> }) {
@@ -57,20 +333,39 @@ function DataTableBodyRow<TData>({ row }: { row: Row<TData> }) {
 
    return (
       <>
-         {row.getVisibleCells().map((cell) => (
-            <TableCell
-               className={cn(
-                  cell.column.id === "__select" ? "w-10 px-2" : "truncate",
-                  cell.column.columnDef.meta?.align === "right" && "text-right",
-                  cell.column.columnDef.meta?.align === "center" &&
-                     "text-center",
-               )}
-               key={cell.id}
-               style={{ maxWidth: cell.column.columnDef.maxSize }}
-            >
-               {flexRender(cell.column.columnDef.cell, cell.getContext())}
-            </TableCell>
-         ))}
+         {row.getVisibleCells().map((cell) => {
+            const meta = cell.column.columnDef.meta;
+            const isEditable =
+               meta?.isEditable &&
+               meta.cellComponent &&
+               (!meta.isEditableForRow || meta.isEditableForRow(row.original));
+            return (
+               <TableCell
+                  className={cn(
+                     cell.column.id === "__select" ? "w-10 px-2" : "truncate",
+                     meta?.align === "right" && "text-right",
+                     meta?.align === "center" && "text-center",
+                  )}
+                  key={cell.id}
+                  style={{ maxWidth: cell.column.columnDef.maxSize }}
+               >
+                  {isEditable ? (
+                     <EditableCell
+                        cellComponent={meta!.cellComponent!}
+                        cellId={cell.id}
+                        editMode={meta?.editMode}
+                        options={meta?.editOptions}
+                        schema={meta?.editSchema}
+                        onSave={meta?.onSave}
+                        rowId={row.id}
+                        value={cell.getValue()}
+                     />
+                  ) : (
+                     flexRender(cell.column.columnDef.cell, cell.getContext())
+                  )}
+               </TableCell>
+            );
+         })}
       </>
    );
 }

--- a/apps/web/src/components/data-table/data-table-content.tsx
+++ b/apps/web/src/components/data-table/data-table-content.tsx
@@ -37,6 +37,7 @@ import {
 import { Input } from "@packages/ui/components/input";
 import { Textarea } from "@packages/ui/components/textarea";
 import { cn } from "@packages/ui/lib/utils";
+import { fromPromise } from "neverthrow";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type React from "react";
 import { useDataTable } from "./data-table-root";
@@ -120,6 +121,7 @@ function CellInput({
    options,
    label,
    autoFocus,
+   autoCommitOnBlur,
    inputRef,
    onCommit,
    onCancel,
@@ -129,6 +131,7 @@ function CellInput({
    options?: Array<{ label: string; value: string }>;
    label?: string;
    autoFocus?: boolean;
+   autoCommitOnBlur?: boolean;
    inputRef?: React.RefObject<HTMLInputElement | HTMLTextAreaElement | null>;
    onCommit?: () => void;
    onCancel?: () => void;
@@ -150,7 +153,10 @@ function CellInput({
             autoFocus={autoFocus}
             className="h-7 aria-invalid:border-destructive"
             value={stringValue}
-            onBlur={() => field.handleBlur()}
+            onBlur={() => {
+               field.handleBlur();
+               if (autoCommitOnBlur) onCommit?.();
+            }}
             onChange={(e) => field.handleChange(e.target.value)}
             onKeyDown={(e) => {
                if (e.key === "Escape") {
@@ -177,7 +183,10 @@ function CellInput({
             className="min-h-0 resize-none overflow-hidden aria-invalid:border-destructive"
             rows={1}
             value={stringValue}
-            onBlur={() => field.handleBlur()}
+            onBlur={() => {
+               field.handleBlur();
+               if (autoCommitOnBlur) onCommit?.();
+            }}
             onChange={(e) => {
                e.target.style.height = "auto";
                e.target.style.height = `${e.target.scrollHeight}px`;
@@ -206,7 +215,7 @@ function CellInput({
                onCommit?.();
             }}
          >
-            <SelectTrigger className="h-7 text-sm">
+            <SelectTrigger aria-label={label} className="h-7 text-sm">
                <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -225,6 +234,7 @@ function CellInput({
    if (cellComponent === "tags") {
       return (
          <MultiSelect
+            aria-label={label}
             onChange={(v) => field.handleChange(v)}
             onCreate={(name) => field.handleChange([...arrayValue, name])}
             options={arrayValue.map((kw) => ({ label: kw, value: kw }))}
@@ -240,6 +250,7 @@ function CellInput({
 function EditableCell({
    value: initialValue,
    cellComponent,
+   editMode = "popover",
    label,
    options,
    schema,
@@ -249,6 +260,7 @@ function EditableCell({
 }: {
    value: unknown;
    cellComponent: "text" | "textarea" | "select" | "tags";
+   editMode?: "inline" | "popover";
    label?: string;
    options?: Array<{ label: string; value: string }>;
    schema?: StandardSchemaV1<unknown>;
@@ -282,10 +294,12 @@ function EditableCell({
          const prev = localValue;
          setLocalValue(value.value);
          setOpen(false);
-         try {
-            await onSave?.(rowId, value.value);
-         } catch {
-            setLocalValue(prev);
+         if (onSave) {
+            const result = await fromPromise(
+               onSave(rowId, value.value),
+               (e) => e,
+            );
+            if (result.isErr()) setLocalValue(prev);
          }
       },
    });
@@ -301,6 +315,67 @@ function EditableCell({
    const displayValue = Array.isArray(localValue)
       ? localValue.join(", ")
       : localValue;
+
+   const fieldValidators = schema
+      ? {
+           onChange: ({ value }: { value: string | string[] }) => {
+              const result = schema["~standard"].validate(value);
+              if (result instanceof Promise) return undefined;
+              return result.issues?.map((i) => i.message).join(", ");
+           },
+        }
+      : undefined;
+
+   if (editMode === "inline") {
+      if (!open) {
+         return (
+            <button
+               aria-label={ariaLabel}
+               className="group/cell cursor-pointer min-h-[1.5rem] flex items-center gap-2 w-full text-sm text-left"
+               type="button"
+               onClick={() => setOpen(true)}
+            >
+               {children ?? (
+                  <span className="flex-1 truncate">
+                     {cellComponent === "select"
+                        ? (options?.find((o) => o.value === displayValue)
+                             ?.label ?? displayValue)
+                        : displayValue || (
+                             <span className="text-muted-foreground/40">—</span>
+                          )}
+                  </span>
+               )}
+               <Pencil className="size-3 shrink-0 text-muted-foreground opacity-0 group-hover/cell:opacity-100 transition-opacity" />
+            </button>
+         );
+      }
+
+      return (
+         <form
+            onSubmit={(e) => {
+               e.preventDefault();
+               e.stopPropagation();
+               form.handleSubmit();
+            }}
+         >
+            <form.Field name="value" validators={fieldValidators}>
+               {(field) => (
+                  <CellInput
+                     autoCommitOnBlur
+                     autoFocus
+                     cellComponent={cellComponent}
+                     field={field as unknown as CellFieldApi}
+                     inputRef={inputRef}
+                     label={ariaLabel}
+                     options={options}
+                     onCancel={cancel}
+                     onCommit={commit}
+                  />
+               )}
+            </form.Field>
+         </form>
+      );
+   }
 
    return (
       <Popover
@@ -351,23 +426,7 @@ function EditableCell({
                   form.handleSubmit();
                }}
             >
-               <form.Field
-                  name="value"
-                  validators={
-                     schema
-                        ? {
-                             onChange: ({ value }) => {
-                                const result =
-                                   schema["~standard"].validate(value);
-                                if (result instanceof Promise) return undefined;
-                                return result.issues
-                                   ?.map((i) => i.message)
-                                   .join(", ");
-                             },
-                          }
-                        : undefined
-                  }
-               >
+               <form.Field name="value" validators={fieldValidators}>
                   {(field) => (
                      <div className="flex flex-col gap-2">
                         <CellInput
@@ -439,6 +498,7 @@ function DataTableBodyRow<TData>({ row }: { row: Row<TData> }) {
                   {isEditable ? (
                      <EditableCell
                         cellComponent={meta!.cellComponent!}
+                        editMode={meta?.editMode}
                         label={meta?.label}
                         options={meta?.editOptions}
                         rowId={row.id}

--- a/apps/web/src/components/data-table/data-table-content.tsx
+++ b/apps/web/src/components/data-table/data-table-content.tsx
@@ -98,7 +98,7 @@ function EditableCell({
       <div
          data-editable-cell
          data-editable-cell-id={cellId}
-         className="group/cell cursor-pointer rounded px-2 py-0.5 -mx-2 hover:bg-muted/60 hover:ring-1 hover:ring-border min-h-[1.5rem] flex items-center gap-2 w-full text-sm transition-colors"
+         className="group/cell cursor-pointer min-h-[1.5rem] flex items-center gap-2 w-full text-sm"
          role="button"
          tabIndex={0}
       >

--- a/apps/web/src/components/data-table/data-table-content.tsx
+++ b/apps/web/src/components/data-table/data-table-content.tsx
@@ -51,7 +51,6 @@ function useGroupedRows<TData>(
 function EditableCell({
    value: initialValue,
    cellComponent,
-   editMode = "inline",
    options,
    schema,
    onSave,
@@ -60,14 +59,13 @@ function EditableCell({
 }: {
    value: unknown;
    cellComponent: "text" | "textarea" | "select";
-   editMode?: "inline" | "popover";
    options?: Array<{ label: string; value: string }>;
    schema?: StandardSchemaV1<any>;
    onSave?: (rowId: string, value: unknown) => Promise<void>;
    rowId: string;
    cellId: string;
 }) {
-   const [editing, setEditing] = useState(false);
+   const [open, setOpen] = useState(false);
    const [localValue, setLocalValue] = useState<unknown>(initialValue);
    const inputRef = useRef<HTMLInputElement & HTMLTextAreaElement>(null);
 
@@ -75,18 +73,12 @@ function EditableCell({
       setLocalValue(initialValue);
    }, [initialValue]);
 
-   useEffect(() => {
-      if (editing && editMode === "inline") {
-         inputRef.current?.focus();
-      }
-   }, [editing, editMode]);
-
    const form = useForm({
       defaultValues: { value: String(localValue ?? "") },
       onSubmit: async ({ value }: { value: { value: string } }) => {
          const prev = localValue;
          setLocalValue(value.value);
-         setEditing(false);
+         setOpen(false);
          try {
             await onSave?.(rowId, value.value);
          } catch {
@@ -97,28 +89,16 @@ function EditableCell({
 
    const cancel = useCallback(() => {
       form.reset();
-      setEditing(false);
+      setOpen(false);
    }, [form]);
-
-   const focusNext = useCallback(() => {
-      const all = Array.from(
-         document.querySelectorAll<HTMLElement>("[data-editable-cell]"),
-      );
-      const idx = all.findIndex((el) => el.dataset.editableCellId === cellId);
-      all[idx + 1]?.click();
-   }, [cellId]);
 
    const displayValue = String(localValue ?? "");
 
-   const displayNode = (
+   const trigger = (
       <div
          data-editable-cell
          data-editable-cell-id={cellId}
          className="group/cell cursor-pointer rounded px-2 py-0.5 -mx-2 hover:bg-muted/60 hover:ring-1 hover:ring-border min-h-[1.5rem] flex items-center gap-2 w-full text-sm transition-colors"
-         onClick={() => setEditing(true)}
-         onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") setEditing(true);
-         }}
          role="button"
          tabIndex={0}
       >
@@ -134,179 +114,189 @@ function EditableCell({
       </div>
    );
 
-   if (!editing) return displayNode;
-
-   const editFields = (
-      <form
-         onSubmit={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            form.handleSubmit();
+   return (
+      <Popover
+         open={open}
+         onOpenChange={(next) => {
+            if (!next) cancel();
+            else setOpen(true);
          }}
       >
-         {cellComponent === "select" && (
-            <Select
-               value={String(localValue ?? "")}
-               onValueChange={(v) => {
-                  setLocalValue(v);
-                  setEditing(false);
-                  onSave?.(rowId, v).catch(() => setLocalValue(localValue));
-               }}
-               open
-               onOpenChange={(open) => {
-                  if (!open) cancel();
-               }}
-            >
-               <SelectTrigger className="h-7 text-sm">
-                  <SelectValue />
-               </SelectTrigger>
-               <SelectContent>
-                  {options?.map((opt) => (
-                     <SelectItem key={opt.value} value={opt.value}>
-                        {opt.label}
-                     </SelectItem>
-                  ))}
-               </SelectContent>
-            </Select>
-         )}
-
-         {cellComponent === "text" && (
-            <form.Field
-               name="value"
-               validators={
-                  schema ? { onChange: schema, onBlur: schema } : undefined
-               }
-            >
-               {(field) => (
-                  <div className="flex flex-col gap-2">
-                     <input
-                        ref={inputRef}
-                        type="text"
-                        aria-invalid={
-                           field.state.meta.isTouched &&
-                           field.state.meta.errors.length > 0
-                        }
-                        className="h-7 w-full rounded border border-input bg-background px-2 text-sm outline-none focus:ring-2 focus:ring-ring/50 aria-invalid:border-destructive"
-                        defaultValue={field.state.value}
-                        onChange={(e) => field.handleChange(e.target.value)}
-                        onBlur={(e) => {
-                           field.handleChange(e.target.value);
-                           field.handleBlur();
-                           form.handleSubmit();
-                        }}
-                        onKeyDown={(e) => {
-                           if (e.key === "Escape") {
-                              e.preventDefault();
-                              cancel();
-                           }
-                           if (e.key === "Tab") {
-                              e.preventDefault();
-                              field.handleChange(
-                                 (e.target as HTMLInputElement).value,
-                              );
-                              form.handleSubmit().then(focusNext);
-                           }
-                        }}
-                     />
-                     {field.state.meta.isTouched &&
-                        field.state.meta.errors.length > 0 && (
-                           <span className="text-xs text-destructive">
-                              {field.state.meta.errors[0]?.message}
-                           </span>
-                        )}
-                  </div>
-               )}
-            </form.Field>
-         )}
-
-         {cellComponent === "textarea" && (
-            <div className="flex flex-col gap-2">
-               <form.Field
-                  name="value"
-                  validators={
-                     schema ? { onChange: schema, onBlur: schema } : undefined
-                  }
-               >
-                  {(field) => (
-                     <>
-                        <Textarea
-                           ref={inputRef}
-                           aria-invalid={
-                              field.state.meta.isTouched &&
-                              field.state.meta.errors.length > 0
-                           }
-                           className="min-h-[80px] text-sm resize-none aria-invalid:border-destructive"
-                           defaultValue={field.state.value}
-                           onChange={(e) => field.handleChange(e.target.value)}
-                           onBlur={() => field.handleBlur()}
-                           onKeyDown={(e) => {
-                              if (e.key === "Escape") {
-                                 e.preventDefault();
-                                 cancel();
-                              }
-                              if (
-                                 e.key === "Enter" &&
-                                 (e.ctrlKey || e.metaKey)
-                              ) {
-                                 e.preventDefault();
-                                 field.handleChange(
-                                    (e.target as HTMLTextAreaElement).value,
-                                 );
-                                 form.handleSubmit();
-                              }
-                           }}
-                           placeholder="Adicionar descrição..."
-                        />
-                        {field.state.meta.isTouched &&
-                           field.state.meta.errors.length > 0 && (
-                              <span className="text-xs text-destructive">
-                                 {field.state.meta.errors[0]?.message}
-                              </span>
-                           )}
-                     </>
-                  )}
-               </form.Field>
-               <div className="flex justify-end gap-2">
-                  <Button
-                     type="button"
-                     variant="outline"
-                     size="sm"
-                     onClick={cancel}
-                  >
-                     Cancelar
-                  </Button>
-                  <Button type="submit" size="sm">
-                     Salvar
-                  </Button>
-               </div>
-            </div>
-         )}
-      </form>
-   );
-
-   if (editMode === "popover") {
-      return (
-         <Popover
-            open
-            onOpenChange={(open) => {
-               if (!open) cancel();
+         <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+         <PopoverContent
+            className="w-80"
+            onOpenAutoFocus={(e) => {
+               e.preventDefault();
+               inputRef.current?.focus();
             }}
          >
-            <PopoverTrigger asChild>{displayNode}</PopoverTrigger>
-            <PopoverContent
-               className="w-80"
-               onOpenAutoFocus={(e) => {
+            <form
+               onSubmit={(e) => {
                   e.preventDefault();
-                  inputRef.current?.focus();
+                  e.stopPropagation();
+                  form.handleSubmit();
                }}
             >
-               {editFields}
-            </PopoverContent>
-         </Popover>
-      );
-   }
+               {cellComponent === "select" && (
+                  <Select
+                     value={String(localValue ?? "")}
+                     onValueChange={(v) => {
+                        setLocalValue(v);
+                        setOpen(false);
+                        onSave?.(rowId, v).catch(() =>
+                           setLocalValue(localValue),
+                        );
+                     }}
+                  >
+                     <SelectTrigger className="h-7 text-sm">
+                        <SelectValue />
+                     </SelectTrigger>
+                     <SelectContent>
+                        {options?.map((opt) => (
+                           <SelectItem key={opt.value} value={opt.value}>
+                              {opt.label}
+                           </SelectItem>
+                        ))}
+                     </SelectContent>
+                  </Select>
+               )}
 
-   return editFields;
+               {cellComponent === "text" && (
+                  <form.Field
+                     name="value"
+                     validators={
+                        schema
+                           ? { onChange: schema, onBlur: schema }
+                           : undefined
+                     }
+                  >
+                     {(field) => (
+                        <div className="flex flex-col gap-2">
+                           <input
+                              ref={inputRef}
+                              type="text"
+                              aria-invalid={
+                                 field.state.meta.isTouched &&
+                                 field.state.meta.errors.length > 0
+                              }
+                              className="h-7 w-full rounded border border-input bg-background px-2 text-sm outline-none focus:ring-2 focus:ring-ring/50 aria-invalid:border-destructive"
+                              defaultValue={field.state.value}
+                              onChange={(e) =>
+                                 field.handleChange(e.target.value)
+                              }
+                              onBlur={(e) => {
+                                 field.handleChange(e.target.value);
+                                 field.handleBlur();
+                              }}
+                              onKeyDown={(e) => {
+                                 if (e.key === "Escape") {
+                                    e.preventDefault();
+                                    cancel();
+                                 }
+                                 if (e.key === "Enter") {
+                                    e.preventDefault();
+                                    field.handleChange(
+                                       (e.target as HTMLInputElement).value,
+                                    );
+                                    form.handleSubmit();
+                                 }
+                              }}
+                           />
+                           {field.state.meta.isTouched &&
+                              field.state.meta.errors.length > 0 && (
+                                 <span className="text-xs text-destructive">
+                                    {field.state.meta.errors[0]?.message}
+                                 </span>
+                              )}
+                           <div className="flex justify-end gap-2">
+                              <Button
+                                 type="button"
+                                 variant="outline"
+                                 size="sm"
+                                 onClick={cancel}
+                              >
+                                 Cancelar
+                              </Button>
+                              <Button type="submit" size="sm">
+                                 Salvar
+                              </Button>
+                           </div>
+                        </div>
+                     )}
+                  </form.Field>
+               )}
+
+               {cellComponent === "textarea" && (
+                  <div className="flex flex-col gap-2">
+                     <form.Field
+                        name="value"
+                        validators={
+                           schema
+                              ? { onChange: schema, onBlur: schema }
+                              : undefined
+                        }
+                     >
+                        {(field) => (
+                           <>
+                              <Textarea
+                                 ref={inputRef}
+                                 aria-invalid={
+                                    field.state.meta.isTouched &&
+                                    field.state.meta.errors.length > 0
+                                 }
+                                 className="min-h-[80px] text-sm resize-none aria-invalid:border-destructive"
+                                 defaultValue={field.state.value}
+                                 onChange={(e) =>
+                                    field.handleChange(e.target.value)
+                                 }
+                                 onBlur={() => field.handleBlur()}
+                                 onKeyDown={(e) => {
+                                    if (e.key === "Escape") {
+                                       e.preventDefault();
+                                       cancel();
+                                    }
+                                    if (
+                                       e.key === "Enter" &&
+                                       (e.ctrlKey || e.metaKey)
+                                    ) {
+                                       e.preventDefault();
+                                       field.handleChange(
+                                          (e.target as HTMLTextAreaElement)
+                                             .value,
+                                       );
+                                       form.handleSubmit();
+                                    }
+                                 }}
+                                 placeholder="Adicionar descrição..."
+                              />
+                              {field.state.meta.isTouched &&
+                                 field.state.meta.errors.length > 0 && (
+                                    <span className="text-xs text-destructive">
+                                       {field.state.meta.errors[0]?.message}
+                                    </span>
+                                 )}
+                           </>
+                        )}
+                     </form.Field>
+                     <div className="flex justify-end gap-2">
+                        <Button
+                           type="button"
+                           variant="outline"
+                           size="sm"
+                           onClick={cancel}
+                        >
+                           Cancelar
+                        </Button>
+                        <Button type="submit" size="sm">
+                           Salvar
+                        </Button>
+                     </div>
+                  </div>
+               )}
+            </form>
+         </PopoverContent>
+      </Popover>
+   );
 }
 
 function DataTableBodyRow<TData>({ row }: { row: Row<TData> }) {
@@ -353,7 +343,6 @@ function DataTableBodyRow<TData>({ row }: { row: Row<TData> }) {
                      <EditableCell
                         cellComponent={meta!.cellComponent!}
                         cellId={cell.id}
-                        editMode={meta?.editMode}
                         options={meta?.editOptions}
                         schema={meta?.editSchema}
                         onSave={meta?.onSave}

--- a/apps/web/src/components/data-table/data-table-root.tsx
+++ b/apps/web/src/components/data-table/data-table-root.tsx
@@ -1,4 +1,3 @@
-import { useForm } from "@tanstack/react-form";
 import type {
    ColumnDef,
    ColumnFiltersState,
@@ -11,9 +10,6 @@ import type {
    Table,
    VisibilityState,
 } from "@tanstack/react-table";
-
-// oxlint-ignore no-explicit-any
-type AnyFormApi = ReturnType<typeof useForm<Record<string, any>>>;
 import {
    getCoreRowModel,
    getExpandedRowModel,
@@ -70,7 +66,8 @@ type DataTableContextValue<TData> = {
    onTableStateChange: (state: DataTableStoredState) => void;
    groupBy?: (row: TData) => string;
    renderGroupHeader?: (key: string, rows: Row<TData>[]) => React.ReactNode;
-   addRowForm?: AnyFormApi;
+   isDraftRowActive?: boolean;
+   onAddRow?: (data: Record<string, string | string[]>) => Promise<void>;
    onDiscardAddRow?: () => void;
 };
 
@@ -102,7 +99,8 @@ export function useDataTable<TData>() {
       onTableStateChange: ctx.onTableStateChange,
       groupBy: ctx.groupBy,
       renderGroupHeader: ctx.renderGroupHeader,
-      addRowForm: ctx.addRowForm,
+      isDraftRowActive: ctx.isDraftRowActive,
+      onAddRow: ctx.onAddRow,
       onDiscardAddRow: ctx.onDiscardAddRow,
       sorting,
       columnFilters,
@@ -140,7 +138,8 @@ interface DataTableRootProps<TData> {
    groupBy?: (row: TData) => string;
    renderGroupHeader?: (key: string, rows: Row<TData>[]) => React.ReactNode;
    getSubRows?: (row: TData) => TData[] | undefined;
-   addRowForm?: AnyFormApi;
+   isDraftRowActive?: boolean;
+   onAddRow?: (data: Record<string, string | string[]>) => Promise<void>;
    onDiscardAddRow?: () => void;
 }
 
@@ -159,7 +158,8 @@ function useDataTableRoot<TData>({
    groupBy,
    renderGroupHeader,
    getSubRows,
-   addRowForm,
+   isDraftRowActive,
+   onAddRow,
    onDiscardAddRow,
 }: Omit<DataTableRootProps<TData>, "children">): DataTableContextValue<TData> {
    const [persisted, setPersisted] =
@@ -364,7 +364,8 @@ function useDataTableRoot<TData>({
          onTableStateChange,
          groupBy,
          renderGroupHeader,
-         addRowForm,
+         isDraftRowActive,
+         onAddRow,
          onDiscardAddRow,
       }),
       [
@@ -374,7 +375,8 @@ function useDataTableRoot<TData>({
          onTableStateChange,
          groupBy,
          renderGroupHeader,
-         addRowForm,
+         isDraftRowActive,
+         onAddRow,
          onDiscardAddRow,
       ],
    );

--- a/apps/web/src/components/data-table/data-table-root.tsx
+++ b/apps/web/src/components/data-table/data-table-root.tsx
@@ -1,3 +1,4 @@
+import { useForm } from "@tanstack/react-form";
 import type {
    ColumnDef,
    ColumnFiltersState,
@@ -10,6 +11,9 @@ import type {
    Table,
    VisibilityState,
 } from "@tanstack/react-table";
+
+// oxlint-ignore no-explicit-any
+type AnyFormApi = ReturnType<typeof useForm<Record<string, any>>>;
 import {
    getCoreRowModel,
    getExpandedRowModel,
@@ -66,6 +70,8 @@ type DataTableContextValue<TData> = {
    onTableStateChange: (state: DataTableStoredState) => void;
    groupBy?: (row: TData) => string;
    renderGroupHeader?: (key: string, rows: Row<TData>[]) => React.ReactNode;
+   addRowForm?: AnyFormApi;
+   onDiscardAddRow?: () => void;
 };
 
 // oxlint-ignore no-explicit-any
@@ -96,6 +102,8 @@ export function useDataTable<TData>() {
       onTableStateChange: ctx.onTableStateChange,
       groupBy: ctx.groupBy,
       renderGroupHeader: ctx.renderGroupHeader,
+      addRowForm: ctx.addRowForm,
+      onDiscardAddRow: ctx.onDiscardAddRow,
       sorting,
       columnFilters,
       rowSelection,
@@ -132,6 +140,8 @@ interface DataTableRootProps<TData> {
    groupBy?: (row: TData) => string;
    renderGroupHeader?: (key: string, rows: Row<TData>[]) => React.ReactNode;
    getSubRows?: (row: TData) => TData[] | undefined;
+   addRowForm?: AnyFormApi;
+   onDiscardAddRow?: () => void;
 }
 
 function useDataTableRoot<TData>({
@@ -149,6 +159,8 @@ function useDataTableRoot<TData>({
    groupBy,
    renderGroupHeader,
    getSubRows,
+   addRowForm,
+   onDiscardAddRow,
 }: Omit<DataTableRootProps<TData>, "children">): DataTableContextValue<TData> {
    const [persisted, setPersisted] =
       useLocalStorage<DataTablePersistedState | null>(storageKey, null);
@@ -352,6 +364,8 @@ function useDataTableRoot<TData>({
          onTableStateChange,
          groupBy,
          renderGroupHeader,
+         addRowForm,
+         onDiscardAddRow,
       }),
       [
          store,
@@ -360,6 +374,8 @@ function useDataTableRoot<TData>({
          onTableStateChange,
          groupBy,
          renderGroupHeader,
+         addRowForm,
+         onDiscardAddRow,
       ],
    );
 }

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-columns.tsx
@@ -42,7 +42,6 @@ export function buildTagColumns(options?: {
             exportable: true,
             isEditable: true,
             cellComponent: "text",
-            editMode: "inline",
             editSchema: tagNameSchema,
             isEditableForRow: (row: TagRow) =>
                !row.isDefault && !row.isArchived,
@@ -117,7 +116,6 @@ export function buildTagColumns(options?: {
             exportable: true,
             isEditable: true,
             cellComponent: "textarea",
-            editMode: "popover",
             editSchema: tagDescriptionSchema,
             isEditableForRow: (row: TagRow) => !row.isArchived,
             onSave: options?.onUpdate

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-columns.tsx
@@ -120,6 +120,7 @@ export function buildTagColumns(options?: {
             label: "Descrição",
             exportable: true,
             isEditable: true,
+            editMode: "inline",
             cellComponent: "textarea",
             editSchema: tagDescriptionSchema,
             isEditableForRow: (row: TagRow) => !row.isArchived,

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-columns.tsx
@@ -11,6 +11,7 @@ import {
    AnnouncementTag,
    AnnouncementTitle,
 } from "@/components/blocks/announcement";
+
 import type { Outputs } from "@/integrations/orpc/client";
 
 const tagNameSchema = z
@@ -27,7 +28,11 @@ export type TagRow = Outputs["tags"]["getAll"]["data"][number];
 
 type OnUpdate = (
    id: string,
-   patch: { name?: string; description?: string | null },
+   patch: {
+      name?: string;
+      description?: string | null;
+      keywords?: string[] | null;
+   },
 ) => Promise<void>;
 
 export function buildTagColumns(options?: {
@@ -139,10 +144,24 @@ export function buildTagColumns(options?: {
       },
       {
          id: "keywords",
+         accessorFn: (row) => row.keywords ?? [],
          header: "Palavras-chave",
-         meta: { label: "Palavras-chave" },
+         meta: {
+            label: "Palavras-chave",
+            exportable: true,
+            isEditable: true,
+            cellComponent: "tags",
+            isEditableForRow: (row: TagRow) => !row.isArchived,
+            onSave: options?.onUpdate
+               ? async (rowId, value) => {
+                    const kws = Array.isArray(value) ? (value as string[]) : [];
+                    await options.onUpdate!(rowId, {
+                       keywords: kws.length > 0 ? kws : null,
+                    });
+                 }
+               : undefined,
+         },
          enableSorting: false,
-         accessorFn: (row) => row.keywords?.join(", ") ?? "",
          cell: ({ row }) => {
             const keywords = row.original.keywords;
             const count = keywords?.length ?? 0;

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-columns.tsx
@@ -5,6 +5,7 @@ import {
 } from "@packages/ui/components/tooltip";
 import type { ColumnDef } from "@tanstack/react-table";
 import { Archive, ShieldCheck, Tags } from "lucide-react";
+import { z } from "zod";
 import {
    Announcement,
    AnnouncementTag,
@@ -12,14 +13,45 @@ import {
 } from "@/components/blocks/announcement";
 import type { Outputs } from "@/integrations/orpc/client";
 
+const tagNameSchema = z
+   .string()
+   .min(2, "Mínimo 2 caracteres")
+   .max(120, "Máximo 120 caracteres");
+
+const tagDescriptionSchema = z
+   .string()
+   .max(255, "Máximo 255 caracteres")
+   .optional();
+
 export type TagRow = Outputs["tags"]["getAll"]["data"][number];
 
-export function buildTagColumns(): ColumnDef<TagRow>[] {
+type OnUpdate = (
+   id: string,
+   patch: { name?: string; description?: string | null },
+) => Promise<void>;
+
+export function buildTagColumns(options?: {
+   onUpdate?: OnUpdate;
+}): ColumnDef<TagRow>[] {
    return [
       {
          accessorKey: "name",
          header: "Nome",
-         meta: { label: "Nome", exportable: true },
+         meta: {
+            label: "Nome",
+            exportable: true,
+            isEditable: true,
+            cellComponent: "text",
+            editMode: "inline",
+            editSchema: tagNameSchema,
+            isEditableForRow: (row: TagRow) =>
+               !row.isDefault && !row.isArchived,
+            onSave: options?.onUpdate
+               ? async (rowId, value) => {
+                    await options.onUpdate!(rowId, { name: String(value) });
+                 }
+               : undefined,
+         },
          enableSorting: false,
          cell: ({ row }) => {
             const { name, isDefault, isArchived } = row.original;
@@ -80,7 +112,23 @@ export function buildTagColumns(): ColumnDef<TagRow>[] {
       {
          accessorKey: "description",
          header: "Descrição",
-         meta: { label: "Descrição", exportable: true },
+         meta: {
+            label: "Descrição",
+            exportable: true,
+            isEditable: true,
+            cellComponent: "textarea",
+            editMode: "popover",
+            editSchema: tagDescriptionSchema,
+            isEditableForRow: (row: TagRow) => !row.isArchived,
+            onSave: options?.onUpdate
+               ? async (rowId, value) => {
+                    const trimmed = String(value).trim();
+                    await options.onUpdate!(rowId, {
+                       description: trimmed.length > 0 ? trimmed : null,
+                    });
+                 }
+               : undefined,
+         },
          enableSorting: false,
          cell: ({ row }) =>
             row.original.description ? (

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
@@ -8,14 +8,7 @@ import {
 } from "@packages/ui/components/empty";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import {
-   Archive,
-   ArchiveRestore,
-   Pencil,
-   Plus,
-   Tag,
-   Trash2,
-} from "lucide-react";
+import { Archive, ArchiveRestore, Plus, Tag, Trash2 } from "lucide-react";
 import { useCallback, useMemo } from "react";
 import { DataTablePagination } from "@/components/data-table/data-table-pagination";
 import { z } from "zod";
@@ -157,24 +150,11 @@ function TagsList() {
       }),
    );
 
-   const handleEdit = useCallback(
-      (tag: TagRow) => {
-         openCredenza({
-            renderChildren: () => (
-               <TagForm
-                  mode="edit"
-                  onSuccess={closeCredenza}
-                  tag={{
-                     id: tag.id,
-                     name: tag.name,
-                     color: tag.color,
-                     description: tag.description,
-                  }}
-               />
-            ),
-         });
-      },
-      [openCredenza, closeCredenza],
+   const updateMutation = useMutation(
+      orpc.tags.update.mutationOptions({
+         onError: (e) =>
+            toast.error(e.message || "Erro ao atualizar centro de custo."),
+      }),
    );
 
    const handleDelete = useCallback(
@@ -207,7 +187,15 @@ function TagsList() {
       [unarchiveMutation],
    );
 
-   const columns = useMemo(() => buildTagColumns(), []);
+   const columns = useMemo(
+      () =>
+         buildTagColumns({
+            onUpdate: async (id, patch) => {
+               await updateMutation.mutateAsync({ id, ...patch });
+            },
+         }),
+      [updateMutation],
+   );
 
    return (
       <>
@@ -240,13 +228,6 @@ function TagsList() {
                }
                return (
                   <>
-                     <Button
-                        onClick={() => handleEdit(row.original)}
-                        tooltip="Editar"
-                        variant="outline"
-                     >
-                        <Pencil />
-                     </Button>
                      <Button
                         onClick={() => handleArchive(row.original)}
                         tooltip="Arquivar"

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
@@ -6,11 +6,9 @@ import {
    EmptyMedia,
    EmptyTitle,
 } from "@packages/ui/components/empty";
-import { useForm } from "@tanstack/react-form";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { Archive, ArchiveRestore, Plus, Tag, Trash2 } from "lucide-react";
-import { fromPromise } from "neverthrow";
 import { useCallback, useMemo, useState } from "react";
 import { DataTablePagination } from "@/components/data-table/data-table-pagination";
 import { z } from "zod";
@@ -157,37 +155,30 @@ function TagsList() {
       }),
    );
 
-   const draftForm = useForm({
-      defaultValues: {
-         name: "",
-         description: "",
-         keywords: [] as string[],
-      },
-      onSubmit: async ({ value }) => {
-         const result = await fromPromise(
-            createMutation.mutateAsync({
-               name: value.name,
-               description: value.description.trim() || null,
-               keywords: value.keywords.length > 0 ? value.keywords : undefined,
-            }),
-            (e) => e,
-         );
-         if (result.isOk()) {
-            setIsDraftActive(false);
-            draftForm.reset();
-         }
-      },
-   });
-
    const handleCreate = useCallback(() => {
-      draftForm.reset();
       setIsDraftActive(true);
-   }, [draftForm]);
+   }, []);
 
    const handleDiscardDraft = useCallback(() => {
       setIsDraftActive(false);
-      draftForm.reset();
-   }, [draftForm]);
+   }, []);
+
+   const handleCreateTag = useCallback(
+      async (data: Record<string, string | string[]>) => {
+         const name = String(data.name ?? "");
+         const description = String(data.description ?? "").trim() || null;
+         const keywords = Array.isArray(data.keywords)
+            ? (data.keywords as string[])
+            : [];
+         await createMutation.mutateAsync({
+            name,
+            description,
+            keywords: keywords.length > 0 ? keywords : undefined,
+         });
+         setIsDraftActive(false);
+      },
+      [createMutation],
+   );
 
    const handleDelete = useCallback(
       (tag: TagRow) => {
@@ -232,10 +223,11 @@ function TagsList() {
    return (
       <>
          <DataTableRoot
-            addRowForm={isDraftActive ? draftForm : undefined}
             columns={columns}
             data={tags}
             getRowId={(row) => row.id}
+            isDraftRowActive={isDraftActive}
+            onAddRow={handleCreateTag}
             onDiscardAddRow={handleDiscardDraft}
             renderActions={({ row }) => {
                if (row.original.isArchived) {

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
@@ -6,10 +6,12 @@ import {
    EmptyMedia,
    EmptyTitle,
 } from "@packages/ui/components/empty";
+import { useForm } from "@tanstack/react-form";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { Archive, ArchiveRestore, Plus, Tag, Trash2 } from "lucide-react";
-import { useCallback, useMemo } from "react";
+import { fromPromise } from "neverthrow";
+import { useCallback, useMemo, useState } from "react";
 import { DataTablePagination } from "@/components/data-table/data-table-pagination";
 import { z } from "zod";
 import { toast } from "sonner";
@@ -25,10 +27,8 @@ import { DataTableSkeleton } from "@/components/data-table/data-table-skeleton";
 import { DataTableToolbar } from "@/components/data-table/data-table-toolbar";
 import { QueryBoundary } from "@/components/query-boundary";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
-import { useCredenza } from "@/hooks/use-credenza";
 import { orpc } from "@/integrations/orpc/client";
 import { buildTagColumns, type TagRow } from "./-tags/tags-columns";
-import { TagForm } from "./-tags/tags-form";
 
 const tagsSearchSchema = z.object({
    sorting: z
@@ -82,18 +82,10 @@ function TagsSkeleton() {
 }
 
 function TagsList() {
-   const { openCredenza, closeCredenza } = useCredenza();
    const { openAlertDialog } = useAlertDialog();
    const navigate = Route.useNavigate();
    const { search, includeArchived, page, pageSize } = Route.useSearch();
-
-   const handleCreate = useCallback(() => {
-      openCredenza({
-         renderChildren: () => (
-            <TagForm mode="create" onSuccess={closeCredenza} />
-         ),
-      });
-   }, [openCredenza, closeCredenza]);
+   const [isDraftActive, setIsDraftActive] = useState(false);
 
    const { data: result } = useSuspenseQuery(
       orpc.tags.getAll.queryOptions({
@@ -150,12 +142,52 @@ function TagsList() {
       }),
    );
 
+   const createMutation = useMutation(
+      orpc.tags.create.mutationOptions({
+         onSuccess: () => toast.success("Centro de custo criado com sucesso."),
+         onError: (e) =>
+            toast.error(e.message || "Erro ao criar centro de custo."),
+      }),
+   );
+
    const updateMutation = useMutation(
       orpc.tags.update.mutationOptions({
          onError: (e) =>
             toast.error(e.message || "Erro ao atualizar centro de custo."),
       }),
    );
+
+   const draftForm = useForm({
+      defaultValues: {
+         name: "",
+         description: "",
+         keywords: [] as string[],
+      },
+      onSubmit: async ({ value }) => {
+         const result = await fromPromise(
+            createMutation.mutateAsync({
+               name: value.name,
+               description: value.description.trim() || null,
+               keywords: value.keywords.length > 0 ? value.keywords : undefined,
+            }),
+            (e) => e,
+         );
+         if (result.isOk()) {
+            setIsDraftActive(false);
+            draftForm.reset();
+         }
+      },
+   });
+
+   const handleCreate = useCallback(() => {
+      draftForm.reset();
+      setIsDraftActive(true);
+   }, [draftForm]);
+
+   const handleDiscardDraft = useCallback(() => {
+      setIsDraftActive(false);
+      draftForm.reset();
+   }, [draftForm]);
 
    const handleDelete = useCallback(
       (tag: TagRow) => {
@@ -200,10 +232,11 @@ function TagsList() {
    return (
       <>
          <DataTableRoot
-            storageKey="montte:datatable:tags"
+            addRowForm={isDraftActive ? draftForm : undefined}
             columns={columns}
             data={tags}
             getRowId={(row) => row.id}
+            onDiscardAddRow={handleDiscardDraft}
             renderActions={({ row }) => {
                if (row.original.isArchived) {
                   return (
@@ -246,6 +279,7 @@ function TagsList() {
                   </>
                );
             }}
+            storageKey="montte:datatable:tags"
          >
             <DataTableToolbar
                searchPlaceholder="Buscar centros de custo..."

--- a/docs/plans/2026-04-19-data-table-inline-editing.md
+++ b/docs/plans/2026-04-19-data-table-inline-editing.md
@@ -1,0 +1,878 @@
+# Data Table Inline Editing via ColumnMeta — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add generic inline cell editing to `DataTable` via `ColumnMeta` — no modals, TanStack Form per cell with dynamic Zod schema validation, optimistic updates, Tab navigation, optional popover mode for larger inputs (e.g. textarea for description). Wire it into Centro de Custo (tags) table, removing the edit credenza.
+
+**Architecture:** Extend `ColumnMeta` with `isEditable`, `cellComponent`, `editMode`, `editOptions`, `editSchema` (Zod), `onSave`, and `isEditableForRow`. Add an `EditableCell` component inside `data-table.tsx` that uses `useForm` from `@tanstack/react-form` for submission/reset/validation, owns a `localValue` for optimistic display, and renders either inline or inside a `Popover`. Zod v4 implements Standard Schema, so schemas pass directly to `form.Field validators.onChange` — no adapter needed. Wire it into `DataTableBodyRow` by detecting `meta.isEditable && meta.cellComponent`. For tags: remove the Pencil edit button, remove `handleEdit`/`useCredenza` for edits, add an `update` mutation, pass `onUpdate` to `buildTagColumns`.
+
+**Tech Stack:** `@tanstack/react-form` v1.29 + Zod v4 Standard Schema (native, no adapter), `packages/ui/src/components/data-table.tsx`, `packages/ui/src/components/popover.tsx`, shadcn `Input`, `Select`, `Textarea`.
+
+---
+
+## Task 1: Extend ColumnMeta
+
+**Files:**
+- Modify: `packages/ui/src/components/data-table.tsx:99-107`
+
+**Step 1: Replace the ColumnMeta declaration block**
+
+Lines 99–107 become:
+
+```ts
+import type { ZodTypeAny } from "zod";
+
+declare module "@tanstack/react-table" {
+   // oxlint-ignore @typescript-eslint/no-unused-vars
+   interface ColumnMeta<TData extends RowData, TValue> {
+      label?: string;
+      filterVariant?: "text" | "select" | "range" | "date";
+      align?: "left" | "center" | "right";
+      exportable?: boolean;
+      isEditable?: boolean;
+      cellComponent?: "text" | "textarea" | "select";
+      editMode?: "inline" | "popover";
+      editOptions?: Array<{ label: string; value: string }>;
+      editSchema?: ZodTypeAny;
+      onSave?: (rowId: string, value: unknown) => Promise<void>;
+      isEditableForRow?: (row: TData) => boolean;
+   }
+}
+```
+
+The `import type { ZodTypeAny } from "zod"` must go at the top of `data-table.tsx` with the other imports. Add it there.
+
+**Why Zod v4 + TanStack Form v1 works without an adapter:** Zod v4 implements the [Standard Schema spec](https://standardschema.dev). TanStack Form v1 accepts any Standard Schema value directly in `validators.onChange` — the same object shape works for validation. No `@tanstack/zod-form-adapter` needed.
+
+**Step 2: Add Popover + Textarea to the import block at the top of the file**
+
+`data-table.tsx` already imports from `./select`. Add:
+
+```ts
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
+import { Textarea } from "./textarea";
+```
+
+Also add `useForm` to existing imports (add a new import line):
+
+```ts
+import { useForm } from "@tanstack/react-form";
+```
+
+**Step 3: Run typecheck**
+
+```bash
+bun run typecheck
+```
+
+Expected: passes (only added optional fields, and new imports resolve).
+
+**Step 4: Commit**
+
+```bash
+git add packages/ui/src/components/data-table.tsx
+git commit -m "feat(data-table): extend ColumnMeta with inline editing fields"
+```
+
+---
+
+## Task 2: Build EditableCell component
+
+**Files:**
+- Modify: `packages/ui/src/components/data-table.tsx` — insert `EditableCell` after the helpers section (after `getPageNumbers`, before `SortableHeaderCell`)
+
+### Architecture
+
+`EditableCell` owns:
+- `editing` boolean — controls whether to show display or edit UI
+- `localValue` — optimistic display value; updated immediately on save, reverted on error
+- A `useForm` instance per edit session — handles submission, async error boundary, reset on cancel
+- Inline or popover rendering based on `editMode`
+
+**Display mode** (shared between inline and popover — always renders as a clickable div):
+
+```tsx
+<div
+   data-editable-cell
+   data-editable-cell-id={cellId}
+   className="cursor-pointer rounded px-1 -mx-1 hover:bg-muted/50 min-h-[1.5rem] flex items-center w-full"
+   onClick={() => setEditing(true)}
+   onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setEditing(true); }}
+   role="button"
+   tabIndex={0}
+>
+   {cellComponent === "select"
+      ? options?.find((o) => o.value === displayValue)?.label ?? displayValue
+      : displayValue}
+</div>
+```
+
+**Edit fields** (reused by both inline and popover):
+
+- `"text"` → `<input type="text" />` (uncontrolled, reads `e.currentTarget.value` on blur/submit)
+- `"textarea"` → `<Textarea />` (popover only — auto-focus, submit on Ctrl+Enter or the Save button)
+- `"select"` → `<Select open onOpenChange={...} />` — commits immediately on value change, no explicit Save
+
+**Step 1: Insert EditableCell component**
+
+Insert this entire block after the `getPageNumbers` function and before `SortableHeaderCell`:
+
+```tsx
+// =============================================================================
+// Editable cell
+// =============================================================================
+
+function EditableCell<TData>({
+   value: initialValue,
+   cellComponent,
+   editMode = "inline",
+   options,
+   schema,
+   onSave,
+   rowId,
+   cellId,
+}: {
+   value: unknown;
+   cellComponent: "text" | "textarea" | "select";
+   editMode?: "inline" | "popover";
+   options?: Array<{ label: string; value: string }>;
+   schema?: ZodTypeAny;
+   onSave?: (rowId: string, value: unknown) => Promise<void>;
+   rowId: string;
+   cellId: string;
+}) {
+   const [editing, setEditing] = useState(false);
+   const [localValue, setLocalValue] = useState<unknown>(initialValue);
+   const inputRef = useRef<HTMLInputElement & HTMLTextAreaElement>(null);
+
+   useEffect(() => {
+      setLocalValue(initialValue);
+   }, [initialValue]);
+
+   useEffect(() => {
+      if (editing && editMode === "inline") {
+         inputRef.current?.focus();
+      }
+   }, [editing, editMode]);
+
+   const form = useForm({
+      defaultValues: { value: String(localValue ?? "") },
+      onSubmitAsync: async ({ value }) => {
+         const prev = localValue;
+         setLocalValue(value.value);
+         setEditing(false);
+         try {
+            await onSave?.(rowId, value.value);
+         } catch {
+            setLocalValue(prev);
+         }
+      },
+   });
+
+   const cancel = useCallback(() => {
+      form.reset();
+      setEditing(false);
+   }, [form]);
+
+   const focusNext = useCallback(() => {
+      const all = Array.from(
+         document.querySelectorAll<HTMLElement>("[data-editable-cell]"),
+      );
+      const idx = all.findIndex(
+         (el) => el.dataset.editableCellId === cellId,
+      );
+      all[idx + 1]?.click();
+   }, [cellId]);
+
+   const displayValue = String(localValue ?? "");
+
+   const displayNode = (
+      <div
+         data-editable-cell
+         data-editable-cell-id={cellId}
+         className="cursor-pointer rounded px-1 -mx-1 hover:bg-muted/50 min-h-[1.5rem] flex items-center w-full text-sm"
+         onClick={() => setEditing(true)}
+         onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") setEditing(true);
+         }}
+         role="button"
+         tabIndex={0}
+      >
+         {cellComponent === "select"
+            ? (options?.find((o) => o.value === displayValue)?.label ??
+               displayValue)
+            : displayValue || (
+               <span className="text-muted-foreground/40">—</span>
+            )}
+      </div>
+   );
+
+   if (!editing) return displayNode;
+
+   const editFields = (
+      <form
+         onSubmit={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            form.handleSubmit();
+         }}
+      >
+         {cellComponent === "select" && (
+            <Select
+               value={String(localValue ?? "")}
+               onValueChange={(v) => {
+                  setLocalValue(v);
+                  setEditing(false);
+                  onSave?.(rowId, v).catch(() => setLocalValue(localValue));
+               }}
+               open
+               onOpenChange={(open) => {
+                  if (!open) cancel();
+               }}
+            >
+               <SelectTrigger className="h-7 text-sm">
+                  <SelectValue />
+               </SelectTrigger>
+               <SelectContent>
+                  {options?.map((opt) => (
+                     <SelectItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                     </SelectItem>
+                  ))}
+               </SelectContent>
+            </Select>
+         )}
+
+         {cellComponent === "text" && (
+            <form.Field
+               name="value"
+               validators={schema ? { onChange: schema, onBlur: schema } : undefined}
+            >
+               {(field) => (
+                  <div className="flex flex-col gap-1">
+                     <input
+                        ref={inputRef}
+                        type="text"
+                        aria-invalid={
+                           field.state.meta.isTouched &&
+                           field.state.meta.errors.length > 0
+                        }
+                        className="h-7 w-full rounded border border-input bg-background px-2 text-sm outline-none focus:ring-2 focus:ring-ring/50 aria-invalid:border-destructive"
+                        defaultValue={field.state.value}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                        onBlur={(e) => {
+                           field.handleChange(e.target.value);
+                           field.handleBlur();
+                           form.handleSubmit();
+                        }}
+                        onKeyDown={(e) => {
+                           if (e.key === "Escape") {
+                              e.preventDefault();
+                              cancel();
+                           }
+                           if (e.key === "Tab") {
+                              e.preventDefault();
+                              field.handleChange(
+                                 (e.target as HTMLInputElement).value,
+                              );
+                              form.handleSubmit().then(focusNext);
+                           }
+                        }}
+                     />
+                     {field.state.meta.isTouched &&
+                        field.state.meta.errors.length > 0 && (
+                           <span className="text-xs text-destructive">
+                              {field.state.meta.errors[0]?.message}
+                           </span>
+                        )}
+                  </div>
+               )}
+            </form.Field>
+         )}
+
+         {cellComponent === "textarea" && (
+            <div className="flex flex-col gap-2">
+               <form.Field
+                  name="value"
+                  validators={schema ? { onChange: schema, onBlur: schema } : undefined}
+               >
+                  {(field) => (
+                     <>
+                        <Textarea
+                           ref={inputRef}
+                           aria-invalid={
+                              field.state.meta.isTouched &&
+                              field.state.meta.errors.length > 0
+                           }
+                           className="min-h-[80px] text-sm resize-none aria-invalid:border-destructive"
+                           defaultValue={field.state.value}
+                           onChange={(e) => field.handleChange(e.target.value)}
+                           onBlur={() => field.handleBlur()}
+                           onKeyDown={(e) => {
+                              if (e.key === "Escape") {
+                                 e.preventDefault();
+                                 cancel();
+                              }
+                              if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+                                 e.preventDefault();
+                                 field.handleChange(
+                                    (e.target as HTMLTextAreaElement).value,
+                                 );
+                                 form.handleSubmit();
+                              }
+                           }}
+                           placeholder="Adicionar descrição..."
+                        />
+                        {field.state.meta.isTouched &&
+                           field.state.meta.errors.length > 0 && (
+                              <span className="text-xs text-destructive">
+                                 {field.state.meta.errors[0]?.message}
+                              </span>
+                           )}
+                     </>
+                  )}
+               </form.Field>
+               <div className="flex justify-end gap-2">
+                  <Button
+                     type="button"
+                     variant="outline"
+                     size="sm"
+                     onClick={cancel}
+                  >
+                     Cancelar
+                  </Button>
+                  <Button type="submit" size="sm">
+                     Salvar
+                  </Button>
+               </div>
+            </div>
+         )}
+      </form>
+   );
+
+   if (editMode === "popover") {
+      return (
+         <Popover
+            open
+            onOpenChange={(open) => {
+               if (!open) cancel();
+            }}
+         >
+            <PopoverTrigger asChild>{displayNode}</PopoverTrigger>
+            <PopoverContent
+               className="w-80"
+               onOpenAutoFocus={(e) => {
+                  e.preventDefault();
+                  inputRef.current?.focus();
+               }}
+            >
+               {editFields}
+            </PopoverContent>
+         </Popover>
+      );
+   }
+
+   return editFields;
+}
+```
+
+**Step 2: Run typecheck**
+
+```bash
+bun run typecheck
+```
+
+Expected: passes.
+
+**Step 3: Commit**
+
+```bash
+git add packages/ui/src/components/data-table.tsx
+git commit -m "feat(data-table): add EditableCell with TanStack Form and popover support"
+```
+
+---
+
+## Task 3: Wire EditableCell into DataTableBodyRow
+
+**Files:**
+- Modify: `packages/ui/src/components/data-table.tsx` — the depth-0 cell rendering in `DataTableBodyRow` (~line 497)
+
+Currently:
+
+```tsx
+{row.getVisibleCells().map((cell) => (
+   <TableCell ...>
+      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+   </TableCell>
+))}
+```
+
+**Step 1: Replace with editable-aware rendering**
+
+```tsx
+{row.getVisibleCells().map((cell) => {
+   const meta = cell.column.columnDef.meta;
+   const isEditable =
+      meta?.isEditable &&
+      meta.cellComponent &&
+      (!meta.isEditableForRow ||
+         meta.isEditableForRow(row.original));
+   return (
+      <TableCell
+         className={cn(
+            "truncate",
+            cell.column.getIsPinned() && "sticky z-[1] bg-inherit",
+            meta?.align === "right" && "text-right",
+            meta?.align === "center" && "text-center",
+         )}
+         key={cell.id}
+         style={{
+            maxWidth: cell.column.columnDef.maxSize,
+            ...getPinningOffsets(cell.column),
+         }}
+      >
+         {isEditable ? (
+            <EditableCell
+               cellComponent={meta!.cellComponent!}
+               cellId={cell.id}
+               editMode={meta?.editMode}
+               options={meta?.editOptions}
+               schema={meta?.editSchema}
+               onSave={meta?.onSave}
+               rowId={row.id}
+               value={cell.getValue()}
+            />
+         ) : (
+            flexRender(cell.column.columnDef.cell, cell.getContext())
+         )}
+      </TableCell>
+   );
+})}
+```
+
+**Step 2: Run typecheck**
+
+```bash
+bun run typecheck
+```
+
+Expected: passes.
+
+**Step 3: Commit**
+
+```bash
+git add packages/ui/src/components/data-table.tsx
+git commit -m "feat(data-table): wire EditableCell into DataTableBodyRow"
+```
+
+---
+
+## Task 4: Verify generic implementation
+
+**Step 1: Run full typecheck + lint**
+
+```bash
+bun run typecheck && bun run check
+```
+
+Expected: both pass. No existing column defs break because all new fields are optional.
+
+**Step 2: Commit any lint auto-fixes**
+
+```bash
+git add -p
+git commit -m "fix(data-table): lint after inline editing implementation"
+```
+
+---
+
+## Task 5: Update Centro de Custo table
+
+**Files:**
+- Modify: `apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-columns.tsx`
+- Modify: `apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx`
+
+### 5a — Rewrite tags-columns.tsx
+
+Remove the `color` column entirely. Add inline editing for `name` and popover-textarea editing for `description`. `buildTagColumns` now accepts an optional `onUpdate` (optional so skeleton usage at module level still works without args).
+
+Full replacement:
+
+```tsx
+import {
+   Tooltip,
+   TooltipContent,
+   TooltipTrigger,
+} from "@packages/ui/components/tooltip";
+import type { ColumnDef } from "@tanstack/react-table";
+import { Archive, ShieldCheck, Tags } from "lucide-react";
+import { z } from "zod";
+import {
+   Announcement,
+   AnnouncementTag,
+   AnnouncementTitle,
+} from "@/components/blocks/announcement";
+import type { Outputs } from "@/integrations/orpc/client";
+
+const tagNameSchema = z
+   .string()
+   .min(2, "Mínimo 2 caracteres")
+   .max(120, "Máximo 120 caracteres");
+
+const tagDescriptionSchema = z
+   .string()
+   .max(255, "Máximo 255 caracteres")
+   .optional();
+
+export type TagRow = Outputs["tags"]["getAll"]["data"][number];
+
+type OnUpdate = (
+   id: string,
+   patch: { name?: string; description?: string | null },
+) => Promise<void>;
+
+export function buildTagColumns(options?: {
+   onUpdate?: OnUpdate;
+}): ColumnDef<TagRow>[] {
+   return [
+      {
+         accessorKey: "name",
+         header: "Nome",
+         meta: {
+            label: "Nome",
+            exportable: true,
+            isEditable: true,
+            cellComponent: "text",
+            editMode: "inline",
+            editSchema: tagNameSchema,
+            isEditableForRow: (row: TagRow) =>
+               !row.isDefault && !row.isArchived,
+            onSave: options?.onUpdate
+               ? async (rowId, value) => {
+                    await options.onUpdate!(rowId, { name: String(value) });
+                 }
+               : undefined,
+         },
+         enableSorting: false,
+         cell: ({ row }) => {
+            const { name, isDefault, isArchived } = row.original;
+            if (isDefault) {
+               return (
+                  <Announcement className="cursor-default w-fit">
+                     <AnnouncementTag>
+                        <ShieldCheck aria-hidden="true" className="size-4" />
+                        <span className="sr-only">Padrão</span>
+                     </AnnouncementTag>
+                     <AnnouncementTitle>
+                        {name}
+                        {isArchived && (
+                           <Tooltip>
+                              <TooltipTrigger asChild>
+                                 <span
+                                    aria-label="Arquivado"
+                                    className="inline-flex shrink-0 cursor-default"
+                                    tabIndex={0}
+                                 >
+                                    <Archive
+                                       aria-hidden="true"
+                                       className="size-4 text-muted-foreground"
+                                    />
+                                 </span>
+                              </TooltipTrigger>
+                              <TooltipContent>Arquivado</TooltipContent>
+                           </Tooltip>
+                        )}
+                     </AnnouncementTitle>
+                  </Announcement>
+               );
+            }
+            return (
+               <div className="flex items-center gap-2">
+                  <span className="text-sm">{name}</span>
+                  {isArchived && (
+                     <Tooltip>
+                        <TooltipTrigger asChild>
+                           <span
+                              aria-label="Arquivado"
+                              className="inline-flex shrink-0 cursor-default"
+                              tabIndex={0}
+                           >
+                              <Archive
+                                 aria-hidden="true"
+                                 className="size-4 text-muted-foreground"
+                              />
+                           </span>
+                        </TooltipTrigger>
+                        <TooltipContent>Arquivado</TooltipContent>
+                     </Tooltip>
+                  )}
+               </div>
+            );
+         },
+      },
+      {
+         accessorKey: "description",
+         header: "Descrição",
+         meta: {
+            label: "Descrição",
+            exportable: true,
+            isEditable: true,
+            cellComponent: "textarea",
+            editMode: "popover",
+            editSchema: tagDescriptionSchema,
+            isEditableForRow: (row: TagRow) => !row.isArchived,
+            onSave: options?.onUpdate
+               ? async (rowId, value) => {
+                    const trimmed = String(value).trim();
+                    await options.onUpdate!(rowId, {
+                       description: trimmed.length > 0 ? trimmed : null,
+                    });
+                 }
+               : undefined,
+         },
+         enableSorting: false,
+         cell: ({ row }) =>
+            row.original.description ? (
+               <span className="text-sm text-muted-foreground truncate">
+                  {row.original.description}
+               </span>
+            ) : (
+               <span className="text-sm text-muted-foreground/40">—</span>
+            ),
+      },
+      {
+         id: "keywords",
+         header: "Palavras-chave",
+         meta: { label: "Palavras-chave" },
+         enableSorting: false,
+         accessorFn: (row) => row.keywords?.join(", ") ?? "",
+         cell: ({ row }) => {
+            const keywords = row.original.keywords;
+            const count = keywords?.length ?? 0;
+            if (count === 0)
+               return (
+                  <span className="text-sm text-muted-foreground">—</span>
+               );
+            return (
+               <Tooltip>
+                  <TooltipTrigger asChild>
+                     <Announcement className="cursor-default w-fit">
+                        <AnnouncementTag>
+                           <Tags className="size-4" />
+                        </AnnouncementTag>
+                        <AnnouncementTitle className="text-xs">
+                           {count} {count === 1 ? "palavra" : "palavras"}
+                        </AnnouncementTitle>
+                     </Announcement>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-72">
+                     <p className="font-semibold text-sm">Palavras-chave IA</p>
+                     <p className="text-xs text-muted-foreground">
+                        Geradas automaticamente com base no nome e descrição do
+                        centro de custo.
+                     </p>
+                     <p className="text-xs">{keywords!.join(", ")}</p>
+                  </TooltipContent>
+               </Tooltip>
+            );
+         },
+      },
+   ];
+}
+```
+
+**Key decisions:**
+- `color` column dropped entirely
+- `name`: `editMode: "inline"`, only for `!isDefault && !isArchived`; default tags keep their `Announcement` badge (rendered by `cell` function since `isEditableForRow` returns false)
+- `description`: `editMode: "popover"` with `cellComponent: "textarea"`, editable for all non-archived; empty string → `null`
+- `onUpdate` optional — skeleton call at module level (`buildTagColumns()`) works without args
+
+### 5b — Update tags.tsx
+
+Changes needed:
+1. Remove `handleEdit` callback and its `openCredenza` / `TagForm` usage for the edit case
+2. Remove `Pencil` import from lucide-react (keep `Archive`, `ArchiveRestore`, `Trash2`, `Plus`, `Tag`)
+3. Remove `useCredenza` import and usage (if not used elsewhere — check; it's used for `handleCreate`, so keep it)
+4. Add `updateMutation` using `orpc.tags.update`
+5. Pass `onUpdate` to `buildTagColumns` inside `useMemo`
+6. Remove the Pencil button from `renderActions` for non-archived rows
+
+**The `renderActions` for non-archived rows** goes from three buttons (Pencil, Archive, Trash) to two (Archive, Trash):
+
+```tsx
+// Non-archived rows — remove Pencil button
+return (
+   <>
+      <Button
+         onClick={() => handleArchive(row.original)}
+         tooltip="Arquivar"
+         variant="outline"
+      >
+         <Archive />
+      </Button>
+      <Button
+         className="text-destructive hover:text-destructive"
+         onClick={() => handleDelete(row.original)}
+         tooltip="Excluir"
+         variant="outline"
+      >
+         <Trash2 />
+      </Button>
+   </>
+);
+```
+
+**Add `updateMutation`** (alongside existing mutations):
+
+```tsx
+const updateMutation = useMutation(
+   orpc.tags.update.mutationOptions({
+      onError: (e) =>
+         toast.error(e.message || "Erro ao atualizar centro de custo."),
+   }),
+);
+```
+
+**Update `columns` useMemo**:
+
+```tsx
+const teamId = useActiveTeam().id; // or however teamId is accessed in this component
+
+const columns = useMemo(
+   () =>
+      buildTagColumns({
+         onUpdate: async (id, patch) => {
+            await updateMutation.mutateAsync({ id, teamId, ...patch });
+         },
+      }),
+   [updateMutation, teamId],
+);
+```
+
+**Check how `teamId` is obtained in this file:** Look for existing `useActiveTeam` or `Route.useParams()` usage in the file. The route is `/_authenticated/$slug/$teamSlug/_dashboard/tags` — use `useTeamSlug()` from `@/hooks/use-dashboard-slugs` if needed, or look for existing team context usage in the component.
+
+**Remove unused imports** after the above changes:
+- `Pencil` from `lucide-react`
+- `handleEdit` callback and its body
+- `TagForm` import from `./-tags/tags-form` (only if not used elsewhere in the file — the create credenza still uses it, so keep it)
+
+**Step 1: Apply tags-columns.tsx replacement**
+
+Replace file content with the full version from 5a above.
+
+**Step 2: Apply tags.tsx changes**
+
+- Add `updateMutation`
+- Remove `handleEdit` and the Pencil button
+- Update `columns` useMemo with `onUpdate`
+- Remove `Pencil` from lucide imports
+
+**Step 3: Run typecheck**
+
+```bash
+bun run typecheck
+```
+
+Expected: passes.
+
+**Step 4: Run lint**
+
+```bash
+bun run check
+```
+
+Expected: passes.
+
+**Step 5: Commit**
+
+```bash
+git add \
+  packages/ui/src/components/data-table.tsx \
+  apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-columns.tsx \
+  apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
+git commit -m "feat(tags): inline editing for name and description, remove edit credenza"
+```
+
+---
+
+## Summary of changes
+
+| File | Change |
+|------|--------|
+| `packages/ui/src/components/data-table.tsx` | Extend `ColumnMeta`, add `EditableCell` (TanStack Form + popover), wire in `DataTableBodyRow` |
+| `apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-columns.tsx` | Drop color column, add inline editing for name, popover-textarea for description |
+| `apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx` | Remove Pencil/edit credenza, add `updateMutation`, wire `onUpdate` into columns |
+
+No new files. No new dependencies (all already in `packages/ui/package.json`). No modals or credenzas added.
+
+## Consumer pattern (for reference — other tables)
+
+Schemas must be defined at **module level** (never inside a component/useMemo — CLAUDE.md rule).
+
+```tsx
+import { z } from "zod";
+
+// Module level — never inside useMemo or component
+const nameSchema = z.string().min(2, "Mínimo 2 caracteres").max(120);
+const notesSchema = z.string().max(500, "Máximo 500 caracteres").optional();
+
+function MyTable() {
+   const columns = useMemo(
+      () => [
+         {
+            accessorKey: "name",
+            header: "Nome",
+            meta: {
+               isEditable: true,
+               cellComponent: "text" as const,
+               editMode: "inline" as const,
+               editSchema: nameSchema,
+               onSave: async (rowId: string, value: unknown) => {
+                  await updateMutation.mutateAsync({ id: rowId, name: String(value) });
+               },
+            },
+         },
+         {
+            accessorKey: "notes",
+            header: "Observações",
+            meta: {
+               isEditable: true,
+               cellComponent: "textarea" as const,
+               editMode: "popover" as const,
+               editSchema: notesSchema,
+               onSave: async (rowId: string, value: unknown) => {
+                  await updateMutation.mutateAsync({ id: rowId, notes: String(value) || null });
+               },
+            },
+         },
+         {
+            accessorKey: "status",
+            header: "Status",
+            meta: {
+               isEditable: true,
+               cellComponent: "select" as const,
+               editMode: "inline" as const,
+               // select has no editSchema — validation is implicit (must be one of editOptions)
+               editOptions: [
+                  { label: "Ativo", value: "active" },
+                  { label: "Inativo", value: "inactive" },
+               ],
+               onSave: async (rowId: string, value: unknown) => {
+                  await updateMutation.mutateAsync({ id: rowId, status: String(value) });
+               },
+            },
+         },
+      ],
+      [updateMutation],
+   );
+}
+```
+
+### How validation works
+
+- `editSchema` is a Zod v4 schema — passed to `form.Field validators={{ onChange: schema, onBlur: schema }}`
+- Zod v4 implements Standard Schema — TanStack Form v1 accepts it natively, no adapter
+- Field shows `field.state.meta.errors[0]?.message` when `isTouched && errors.length > 0`
+- `onSubmitAsync` is NOT called when validation fails — TanStack Form blocks it automatically
+- For `"select"`, `editSchema` is ignored (commits immediately on change, no input to validate)

--- a/packages/ui/src/components/data-table.tsx
+++ b/packages/ui/src/components/data-table.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import * as React from "react";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import { useForm } from "@tanstack/react-form";
 import {
    closestCenter,
    DndContext,
@@ -74,6 +76,7 @@ import {
    PaginationNext,
    PaginationPrevious,
 } from "./pagination";
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
 import {
    Select,
    SelectContent,
@@ -81,6 +84,7 @@ import {
    SelectTrigger,
    SelectValue,
 } from "./select";
+import { Textarea } from "./textarea";
 import {
    Table,
    TableBody,
@@ -103,6 +107,13 @@ declare module "@tanstack/react-table" {
       filterVariant?: "text" | "select" | "range" | "date";
       align?: "left" | "center" | "right";
       exportable?: boolean;
+      isEditable?: boolean;
+      cellComponent?: "text" | "textarea" | "select";
+      editMode?: "inline" | "popover";
+      editOptions?: Array<{ label: string; value: string }>;
+      editSchema?: StandardSchemaV1<any>;
+      onSave?: (rowId: string, value: unknown) => Promise<void>;
+      isEditableForRow?: (row: TData) => boolean;
    }
 }
 
@@ -185,6 +196,268 @@ function getPageNumbers(currentPage: number, totalPages: number): number[] {
 // =============================================================================
 // DnD — Sortable header cell
 // =============================================================================
+
+// =============================================================================
+// Editable cell
+// =============================================================================
+
+function EditableCell({
+   value: initialValue,
+   cellComponent,
+   editMode = "inline",
+   options,
+   schema,
+   onSave,
+   rowId,
+   cellId,
+}: {
+   value: unknown;
+   cellComponent: "text" | "textarea" | "select";
+   editMode?: "inline" | "popover";
+   options?: Array<{ label: string; value: string }>;
+   schema?: StandardSchemaV1<any>;
+   onSave?: (rowId: string, value: unknown) => Promise<void>;
+   rowId: string;
+   cellId: string;
+}) {
+   const [editing, setEditing] = useState(false);
+   const [localValue, setLocalValue] = useState<unknown>(initialValue);
+   const inputRef = useRef<HTMLInputElement & HTMLTextAreaElement>(null);
+
+   useEffect(() => {
+      setLocalValue(initialValue);
+   }, [initialValue]);
+
+   useEffect(() => {
+      if (editing && editMode === "inline") {
+         inputRef.current?.focus();
+      }
+   }, [editing, editMode]);
+
+   const form = useForm({
+      defaultValues: { value: String(localValue ?? "") },
+      onSubmit: async ({ value }: { value: { value: string } }) => {
+         const prev = localValue;
+         setLocalValue(value.value);
+         setEditing(false);
+         try {
+            await onSave?.(rowId, value.value);
+         } catch {
+            setLocalValue(prev);
+         }
+      },
+   });
+
+   const cancel = useCallback(() => {
+      form.reset();
+      setEditing(false);
+   }, [form]);
+
+   const focusNext = useCallback(() => {
+      const all = Array.from(
+         document.querySelectorAll<HTMLElement>("[data-editable-cell]"),
+      );
+      const idx = all.findIndex((el) => el.dataset.editableCellId === cellId);
+      all[idx + 1]?.click();
+   }, [cellId]);
+
+   const displayValue = String(localValue ?? "");
+
+   const displayNode = (
+      <div
+         data-editable-cell
+         data-editable-cell-id={cellId}
+         className="cursor-pointer rounded px-1 -mx-1 hover:bg-muted/50 min-h-[1.5rem] flex items-center w-full text-sm"
+         onClick={() => setEditing(true)}
+         onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") setEditing(true);
+         }}
+         role="button"
+         tabIndex={0}
+      >
+         {cellComponent === "select"
+            ? (options?.find((o) => o.value === displayValue)?.label ??
+              displayValue)
+            : displayValue || (
+                 <span className="text-muted-foreground/40">—</span>
+              )}
+      </div>
+   );
+
+   if (!editing) return displayNode;
+
+   const editFields = (
+      <form
+         onSubmit={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            form.handleSubmit();
+         }}
+      >
+         {cellComponent === "select" && (
+            <Select
+               value={String(localValue ?? "")}
+               onValueChange={(v) => {
+                  setLocalValue(v);
+                  setEditing(false);
+                  onSave?.(rowId, v).catch(() => setLocalValue(localValue));
+               }}
+               open
+               onOpenChange={(open) => {
+                  if (!open) cancel();
+               }}
+            >
+               <SelectTrigger className="h-7 text-sm">
+                  <SelectValue />
+               </SelectTrigger>
+               <SelectContent>
+                  {options?.map((opt) => (
+                     <SelectItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                     </SelectItem>
+                  ))}
+               </SelectContent>
+            </Select>
+         )}
+
+         {cellComponent === "text" && (
+            <form.Field
+               name="value"
+               validators={
+                  schema ? { onChange: schema, onBlur: schema } : undefined
+               }
+            >
+               {(field) => (
+                  <div className="flex flex-col gap-2">
+                     <input
+                        ref={inputRef}
+                        type="text"
+                        aria-invalid={
+                           field.state.meta.isTouched &&
+                           field.state.meta.errors.length > 0
+                        }
+                        className="h-7 w-full rounded border border-input bg-background px-2 text-sm outline-none focus:ring-2 focus:ring-ring/50 aria-invalid:border-destructive"
+                        defaultValue={field.state.value}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                        onBlur={(e) => {
+                           field.handleChange(e.target.value);
+                           field.handleBlur();
+                           form.handleSubmit();
+                        }}
+                        onKeyDown={(e) => {
+                           if (e.key === "Escape") {
+                              e.preventDefault();
+                              cancel();
+                           }
+                           if (e.key === "Tab") {
+                              e.preventDefault();
+                              field.handleChange(
+                                 (e.target as HTMLInputElement).value,
+                              );
+                              form.handleSubmit().then(focusNext);
+                           }
+                        }}
+                     />
+                     {field.state.meta.isTouched &&
+                        field.state.meta.errors.length > 0 && (
+                           <span className="text-xs text-destructive">
+                              {field.state.meta.errors[0]?.message}
+                           </span>
+                        )}
+                  </div>
+               )}
+            </form.Field>
+         )}
+
+         {cellComponent === "textarea" && (
+            <div className="flex flex-col gap-2">
+               <form.Field
+                  name="value"
+                  validators={
+                     schema ? { onChange: schema, onBlur: schema } : undefined
+                  }
+               >
+                  {(field) => (
+                     <>
+                        <Textarea
+                           ref={inputRef}
+                           aria-invalid={
+                              field.state.meta.isTouched &&
+                              field.state.meta.errors.length > 0
+                           }
+                           className="min-h-[80px] text-sm resize-none aria-invalid:border-destructive"
+                           defaultValue={field.state.value}
+                           onChange={(e) => field.handleChange(e.target.value)}
+                           onBlur={() => field.handleBlur()}
+                           onKeyDown={(e) => {
+                              if (e.key === "Escape") {
+                                 e.preventDefault();
+                                 cancel();
+                              }
+                              if (
+                                 e.key === "Enter" &&
+                                 (e.ctrlKey || e.metaKey)
+                              ) {
+                                 e.preventDefault();
+                                 field.handleChange(
+                                    (e.target as HTMLTextAreaElement).value,
+                                 );
+                                 form.handleSubmit();
+                              }
+                           }}
+                           placeholder="Adicionar descrição..."
+                        />
+                        {field.state.meta.isTouched &&
+                           field.state.meta.errors.length > 0 && (
+                              <span className="text-xs text-destructive">
+                                 {field.state.meta.errors[0]?.message}
+                              </span>
+                           )}
+                     </>
+                  )}
+               </form.Field>
+               <div className="flex justify-end gap-2">
+                  <Button
+                     type="button"
+                     variant="outline"
+                     size="sm"
+                     onClick={cancel}
+                  >
+                     Cancelar
+                  </Button>
+                  <Button type="submit" size="sm">
+                     Salvar
+                  </Button>
+               </div>
+            </div>
+         )}
+      </form>
+   );
+
+   if (editMode === "popover") {
+      return (
+         <Popover
+            open
+            onOpenChange={(open) => {
+               if (!open) cancel();
+            }}
+         >
+            <PopoverTrigger asChild>{displayNode}</PopoverTrigger>
+            <PopoverContent
+               className="w-80"
+               onOpenAutoFocus={(e) => {
+                  e.preventDefault();
+                  inputRef.current?.focus();
+               }}
+            >
+               {editFields}
+            </PopoverContent>
+         </Popover>
+      );
+   }
+
+   return editFields;
+}
 
 function SortableHeaderCell<TData>({
    headerId,
@@ -494,24 +767,43 @@ function DataTableBodyRow<TData>({
                />
             </div>
          </TableCell>
-         {row.getVisibleCells().map((cell) => (
-            <TableCell
-               className={cn(
-                  "truncate",
-                  cell.column.getIsPinned() && "sticky z-[1] bg-inherit",
-                  cell.column.columnDef.meta?.align === "right" && "text-right",
-                  cell.column.columnDef.meta?.align === "center" &&
-                     "text-center",
-               )}
-               key={cell.id}
-               style={{
-                  maxWidth: cell.column.columnDef.maxSize,
-                  ...getPinningOffsets(cell.column),
-               }}
-            >
-               {flexRender(cell.column.columnDef.cell, cell.getContext())}
-            </TableCell>
-         ))}
+         {row.getVisibleCells().map((cell) => {
+            const meta = cell.column.columnDef.meta;
+            const isEditable =
+               meta?.isEditable &&
+               meta.cellComponent &&
+               (!meta.isEditableForRow || meta.isEditableForRow(row.original));
+            return (
+               <TableCell
+                  className={cn(
+                     "truncate",
+                     cell.column.getIsPinned() && "sticky z-[1] bg-inherit",
+                     meta?.align === "right" && "text-right",
+                     meta?.align === "center" && "text-center",
+                  )}
+                  key={cell.id}
+                  style={{
+                     maxWidth: cell.column.columnDef.maxSize,
+                     ...getPinningOffsets(cell.column),
+                  }}
+               >
+                  {isEditable ? (
+                     <EditableCell
+                        cellComponent={meta!.cellComponent!}
+                        cellId={cell.id}
+                        editMode={meta?.editMode}
+                        options={meta?.editOptions}
+                        schema={meta?.editSchema}
+                        onSave={meta?.onSave}
+                        rowId={row.id}
+                        value={cell.getValue()}
+                     />
+                  ) : (
+                     flexRender(cell.column.columnDef.cell, cell.getContext())
+                  )}
+               </TableCell>
+            );
+         })}
       </>
    );
 }

--- a/packages/ui/src/components/data-table.tsx
+++ b/packages/ui/src/components/data-table.tsx
@@ -2,7 +2,6 @@
 
 import * as React from "react";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
-import { useForm } from "@tanstack/react-form";
 import {
    closestCenter,
    DndContext,
@@ -76,7 +75,6 @@ import {
    PaginationNext,
    PaginationPrevious,
 } from "./pagination";
-import { Popover, PopoverContent, PopoverTrigger } from "./popover";
 import {
    Select,
    SelectContent,
@@ -84,7 +82,6 @@ import {
    SelectTrigger,
    SelectValue,
 } from "./select";
-import { Textarea } from "./textarea";
 import {
    Table,
    TableBody,
@@ -196,268 +193,6 @@ function getPageNumbers(currentPage: number, totalPages: number): number[] {
 // =============================================================================
 // DnD — Sortable header cell
 // =============================================================================
-
-// =============================================================================
-// Editable cell
-// =============================================================================
-
-function EditableCell({
-   value: initialValue,
-   cellComponent,
-   editMode = "inline",
-   options,
-   schema,
-   onSave,
-   rowId,
-   cellId,
-}: {
-   value: unknown;
-   cellComponent: "text" | "textarea" | "select";
-   editMode?: "inline" | "popover";
-   options?: Array<{ label: string; value: string }>;
-   schema?: StandardSchemaV1<any>;
-   onSave?: (rowId: string, value: unknown) => Promise<void>;
-   rowId: string;
-   cellId: string;
-}) {
-   const [editing, setEditing] = useState(false);
-   const [localValue, setLocalValue] = useState<unknown>(initialValue);
-   const inputRef = useRef<HTMLInputElement & HTMLTextAreaElement>(null);
-
-   useEffect(() => {
-      setLocalValue(initialValue);
-   }, [initialValue]);
-
-   useEffect(() => {
-      if (editing && editMode === "inline") {
-         inputRef.current?.focus();
-      }
-   }, [editing, editMode]);
-
-   const form = useForm({
-      defaultValues: { value: String(localValue ?? "") },
-      onSubmit: async ({ value }: { value: { value: string } }) => {
-         const prev = localValue;
-         setLocalValue(value.value);
-         setEditing(false);
-         try {
-            await onSave?.(rowId, value.value);
-         } catch {
-            setLocalValue(prev);
-         }
-      },
-   });
-
-   const cancel = useCallback(() => {
-      form.reset();
-      setEditing(false);
-   }, [form]);
-
-   const focusNext = useCallback(() => {
-      const all = Array.from(
-         document.querySelectorAll<HTMLElement>("[data-editable-cell]"),
-      );
-      const idx = all.findIndex((el) => el.dataset.editableCellId === cellId);
-      all[idx + 1]?.click();
-   }, [cellId]);
-
-   const displayValue = String(localValue ?? "");
-
-   const displayNode = (
-      <div
-         data-editable-cell
-         data-editable-cell-id={cellId}
-         className="cursor-pointer rounded px-1 -mx-1 hover:bg-muted/50 min-h-[1.5rem] flex items-center w-full text-sm"
-         onClick={() => setEditing(true)}
-         onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") setEditing(true);
-         }}
-         role="button"
-         tabIndex={0}
-      >
-         {cellComponent === "select"
-            ? (options?.find((o) => o.value === displayValue)?.label ??
-              displayValue)
-            : displayValue || (
-                 <span className="text-muted-foreground/40">—</span>
-              )}
-      </div>
-   );
-
-   if (!editing) return displayNode;
-
-   const editFields = (
-      <form
-         onSubmit={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            form.handleSubmit();
-         }}
-      >
-         {cellComponent === "select" && (
-            <Select
-               value={String(localValue ?? "")}
-               onValueChange={(v) => {
-                  setLocalValue(v);
-                  setEditing(false);
-                  onSave?.(rowId, v).catch(() => setLocalValue(localValue));
-               }}
-               open
-               onOpenChange={(open) => {
-                  if (!open) cancel();
-               }}
-            >
-               <SelectTrigger className="h-7 text-sm">
-                  <SelectValue />
-               </SelectTrigger>
-               <SelectContent>
-                  {options?.map((opt) => (
-                     <SelectItem key={opt.value} value={opt.value}>
-                        {opt.label}
-                     </SelectItem>
-                  ))}
-               </SelectContent>
-            </Select>
-         )}
-
-         {cellComponent === "text" && (
-            <form.Field
-               name="value"
-               validators={
-                  schema ? { onChange: schema, onBlur: schema } : undefined
-               }
-            >
-               {(field) => (
-                  <div className="flex flex-col gap-2">
-                     <input
-                        ref={inputRef}
-                        type="text"
-                        aria-invalid={
-                           field.state.meta.isTouched &&
-                           field.state.meta.errors.length > 0
-                        }
-                        className="h-7 w-full rounded border border-input bg-background px-2 text-sm outline-none focus:ring-2 focus:ring-ring/50 aria-invalid:border-destructive"
-                        defaultValue={field.state.value}
-                        onChange={(e) => field.handleChange(e.target.value)}
-                        onBlur={(e) => {
-                           field.handleChange(e.target.value);
-                           field.handleBlur();
-                           form.handleSubmit();
-                        }}
-                        onKeyDown={(e) => {
-                           if (e.key === "Escape") {
-                              e.preventDefault();
-                              cancel();
-                           }
-                           if (e.key === "Tab") {
-                              e.preventDefault();
-                              field.handleChange(
-                                 (e.target as HTMLInputElement).value,
-                              );
-                              form.handleSubmit().then(focusNext);
-                           }
-                        }}
-                     />
-                     {field.state.meta.isTouched &&
-                        field.state.meta.errors.length > 0 && (
-                           <span className="text-xs text-destructive">
-                              {field.state.meta.errors[0]?.message}
-                           </span>
-                        )}
-                  </div>
-               )}
-            </form.Field>
-         )}
-
-         {cellComponent === "textarea" && (
-            <div className="flex flex-col gap-2">
-               <form.Field
-                  name="value"
-                  validators={
-                     schema ? { onChange: schema, onBlur: schema } : undefined
-                  }
-               >
-                  {(field) => (
-                     <>
-                        <Textarea
-                           ref={inputRef}
-                           aria-invalid={
-                              field.state.meta.isTouched &&
-                              field.state.meta.errors.length > 0
-                           }
-                           className="min-h-[80px] text-sm resize-none aria-invalid:border-destructive"
-                           defaultValue={field.state.value}
-                           onChange={(e) => field.handleChange(e.target.value)}
-                           onBlur={() => field.handleBlur()}
-                           onKeyDown={(e) => {
-                              if (e.key === "Escape") {
-                                 e.preventDefault();
-                                 cancel();
-                              }
-                              if (
-                                 e.key === "Enter" &&
-                                 (e.ctrlKey || e.metaKey)
-                              ) {
-                                 e.preventDefault();
-                                 field.handleChange(
-                                    (e.target as HTMLTextAreaElement).value,
-                                 );
-                                 form.handleSubmit();
-                              }
-                           }}
-                           placeholder="Adicionar descrição..."
-                        />
-                        {field.state.meta.isTouched &&
-                           field.state.meta.errors.length > 0 && (
-                              <span className="text-xs text-destructive">
-                                 {field.state.meta.errors[0]?.message}
-                              </span>
-                           )}
-                     </>
-                  )}
-               </form.Field>
-               <div className="flex justify-end gap-2">
-                  <Button
-                     type="button"
-                     variant="outline"
-                     size="sm"
-                     onClick={cancel}
-                  >
-                     Cancelar
-                  </Button>
-                  <Button type="submit" size="sm">
-                     Salvar
-                  </Button>
-               </div>
-            </div>
-         )}
-      </form>
-   );
-
-   if (editMode === "popover") {
-      return (
-         <Popover
-            open
-            onOpenChange={(open) => {
-               if (!open) cancel();
-            }}
-         >
-            <PopoverTrigger asChild>{displayNode}</PopoverTrigger>
-            <PopoverContent
-               className="w-80"
-               onOpenAutoFocus={(e) => {
-                  e.preventDefault();
-                  inputRef.current?.focus();
-               }}
-            >
-               {editFields}
-            </PopoverContent>
-         </Popover>
-      );
-   }
-
-   return editFields;
-}
 
 function SortableHeaderCell<TData>({
    headerId,
@@ -767,43 +502,24 @@ function DataTableBodyRow<TData>({
                />
             </div>
          </TableCell>
-         {row.getVisibleCells().map((cell) => {
-            const meta = cell.column.columnDef.meta;
-            const isEditable =
-               meta?.isEditable &&
-               meta.cellComponent &&
-               (!meta.isEditableForRow || meta.isEditableForRow(row.original));
-            return (
-               <TableCell
-                  className={cn(
-                     "truncate",
-                     cell.column.getIsPinned() && "sticky z-[1] bg-inherit",
-                     meta?.align === "right" && "text-right",
-                     meta?.align === "center" && "text-center",
-                  )}
-                  key={cell.id}
-                  style={{
-                     maxWidth: cell.column.columnDef.maxSize,
-                     ...getPinningOffsets(cell.column),
-                  }}
-               >
-                  {isEditable ? (
-                     <EditableCell
-                        cellComponent={meta!.cellComponent!}
-                        cellId={cell.id}
-                        editMode={meta?.editMode}
-                        options={meta?.editOptions}
-                        schema={meta?.editSchema}
-                        onSave={meta?.onSave}
-                        rowId={row.id}
-                        value={cell.getValue()}
-                     />
-                  ) : (
-                     flexRender(cell.column.columnDef.cell, cell.getContext())
-                  )}
-               </TableCell>
-            );
-         })}
+         {row.getVisibleCells().map((cell) => (
+            <TableCell
+               className={cn(
+                  "truncate",
+                  cell.column.getIsPinned() && "sticky z-[1] bg-inherit",
+                  cell.column.columnDef.meta?.align === "right" && "text-right",
+                  cell.column.columnDef.meta?.align === "center" &&
+                     "text-center",
+               )}
+               key={cell.id}
+               style={{
+                  maxWidth: cell.column.columnDef.maxSize,
+                  ...getPinningOffsets(cell.column),
+               }}
+            >
+               {flexRender(cell.column.columnDef.cell, cell.getContext())}
+            </TableCell>
+         ))}
       </>
    );
 }

--- a/packages/ui/src/components/data-table.tsx
+++ b/packages/ui/src/components/data-table.tsx
@@ -105,7 +105,7 @@ declare module "@tanstack/react-table" {
       align?: "left" | "center" | "right";
       exportable?: boolean;
       isEditable?: boolean;
-      cellComponent?: "text" | "textarea" | "select";
+      cellComponent?: "text" | "textarea" | "select" | "tags";
       editMode?: "inline" | "popover";
       editOptions?: Array<{ label: string; value: string }>;
       editSchema?: StandardSchemaV1<any>;

--- a/packages/ui/src/components/multi-select.tsx
+++ b/packages/ui/src/components/multi-select.tsx
@@ -27,6 +27,7 @@ interface MultiSelectProps {
    emptyMessage?: string;
    onCreate?: (name: string) => void;
    createLabel?: string;
+   "aria-label"?: string;
 }
 
 export function MultiSelect({
@@ -37,6 +38,7 @@ export function MultiSelect({
    placeholder = "Select options...",
    onCreate,
    createLabel = "Criar",
+   "aria-label": ariaLabel,
 }: MultiSelectProps) {
    const inputRef = React.useRef<HTMLInputElement>(null);
    const [open, setOpen] = React.useState(false);
@@ -133,6 +135,7 @@ export function MultiSelect({
                   );
                })}
                <CommandPrimitive.Input
+                  aria-label={ariaLabel}
                   className="ml-2 flex-1 bg-transparent outline-none placeholder:text-muted-foreground"
                   onBlur={() => setOpen(false)}
                   onFocus={() => setOpen(true)}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refatora o DataTable para suportar edição inline ou por popover via `columnMeta`, adiciona linha de rascunho para criação e aplica no módulo de Tags (inclui “palavras‑chave”). Atende MON‑487: sem modal/credenza, validação por campo e salvamento otimista com rollback.

- **New Features**
  - DataTable (`apps/web`)
    - `EditableCell` controlado por `columnMeta` (`isEditable`, `cellComponent`: `text` | `textarea` | `select` | `tags`, `editMode`: `inline` | `popover`, `editOptions`, `editSchema` `StandardSchemaV1`, `onSave`, `isEditableForRow`).
    - Atalhos: `Escape` cancela; `Enter`/`Ctrl/Cmd+Enter` salva; `select` confirma no `onChange`. Rollback em erro.
    - Criação inline com `DraftRow` (foco no primeiro campo). `DataTableRoot` expõe `isDraftRowActive`, `onAddRow`, `onDiscardAddRow`.
  - UI (`packages/ui`)
    - `ColumnMeta` estendido com campos de edição; `MultiSelect` com `aria-label`.
  - Tags
    - Colunas: `name` (texto; popover; bloqueado se `isDefault`/`isArchived`), `description` (textarea; agora inline; vazio → `null`; bloqueada se arquivada), `keywords` (novo; múltiplo via `tags`; bloqueado se arquivada).
    - Tela `tags.tsx`: remove credenza/“editar”; adiciona `createMutation` e `updateMutation` (`orpc.tags.*`); criação via linha de rascunho.
  - Por quê: unificar UX sem modais e acelerar edição/criação inline conforme MON‑487.
  - Impacto
    - Router: sem novas rotas.
    - Componente: `DataTableContent` renderiza `EditableCell` e `DraftRow`; `DataTableRoot` recebe novas props.
    - Store: mutations `orpc.tags.create`/`orpc.tags.update` com `@tanstack/react-query`; UI otimista por célula.
    - Repositório: sem mudanças; uso de `orpc.tags.*` existente.

- **Checklist de teste**
  - Nome: popover ao clicar; `Enter`/Salvar confirma; `Escape` cancela; valida `min(2)`/`max(120)`.
  - Descrição: edição inline com textarea; `Ctrl/Cmd+Enter`/Salvar confirma; `Escape` cancela; `max(255)`; vazio vira `null`.
  - Palavras‑chave: adicionar/remover no `tags`; bloqueado se arquivado.
  - Criação: “novo” ativa rascunho; foco no primeiro campo; `Cancelar` descarta; `Salvar` cria e fecha rascunho.
  - Restrições: respeitar `isDefault` e `isArchived`.
  - Erros: update falho reverte valor e mostra toast; sem regressões de ordenação/paginação; células não editáveis rendem normal; foco automático ao abrir edição.

<sup>Written for commit d89ac6b103ed50a12a03ee7ba6dfb813d33d41f1. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/795">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

