### PR TITLE
Manoelnetocarvalho03/mon 495 featweb redesign context panel move tab icons to right side

### DIFF
--- a/apps/web/src/components/data-table/data-table-export.tsx
+++ b/apps/web/src/components/data-table/data-table-export.tsx
@@ -136,7 +136,7 @@ export function DataTableExportSelectedButton() {
    return (
       <DropdownMenu>
          <DropdownMenuTrigger asChild>
-            <Button tooltip="Exportar selecionados" variant="outline" size="sm">
+            <Button variant="outline" size="sm">
                <Download data-icon="inline-start" />
                Exportar
             </Button>

--- a/apps/web/src/components/data-table/data-table-root.tsx
+++ b/apps/web/src/components/data-table/data-table-root.tsx
@@ -40,12 +40,22 @@ export type DataTablePersistedState = DataTableStoredState & {
    columnFilters?: ColumnFiltersState;
 };
 
+export type ExternalFilter = {
+   id: string;
+   label: string;
+   group: string;
+   active: boolean;
+   renderIcon?: () => React.ReactNode;
+   onToggle: (active: boolean) => void;
+};
+
 export type DataTableStoreState = {
    sorting: SortingState;
    columnFilters: ColumnFiltersState;
    tableState: DataTableStoredState | null;
    rowSelection: RowSelectionState;
    hasEmptyState: boolean;
+   externalFilters: Record<string, ExternalFilter>;
 };
 
 declare module "@tanstack/react-table" {
@@ -178,6 +188,7 @@ function useDataTableRoot<TData>({
             : null,
          rowSelection: externalRowSelection ?? {},
          hasEmptyState: false,
+         externalFilters: {},
       }),
    ).current;
 
@@ -379,6 +390,32 @@ function useDataTableRoot<TData>({
          onAddRow,
          onDiscardAddRow,
       ],
+   );
+}
+
+export function DataTableExternalFilter(config: ExternalFilter) {
+   useRegisterDataTableFilter(config);
+   return null;
+}
+
+export function useRegisterDataTableFilter(config: ExternalFilter) {
+   const { store } = useDataTableContext();
+
+   // Write directly during render — always in sync with the latest config
+   store.setState((s) => ({
+      ...s,
+      externalFilters: { ...s.externalFilters, [config.id]: config },
+   }));
+
+   // Cleanup only on unmount
+   useEffect(
+      () => () => {
+         store.setState((s) => {
+            const { [config.id]: _, ...rest } = s.externalFilters;
+            return { ...s, externalFilters: rest };
+         });
+      },
+      [store, config.id],
    );
 }
 

--- a/apps/web/src/components/data-table/data-table-toolbar.tsx
+++ b/apps/web/src/components/data-table/data-table-toolbar.tsx
@@ -2,7 +2,7 @@ import { useAsyncDebouncedCallback } from "@tanstack/react-pacer";
 import { useForm, useStore } from "@tanstack/react-form";
 import type { AnyFormApi } from "@tanstack/react-form";
 import { Link } from "@tanstack/react-router";
-import { FilterX, Plus, Search, X } from "lucide-react";
+import { FilterX, ListFilter, Plus, Search, X } from "lucide-react";
 import { createContextState } from "foxact/context-state";
 import { useIsomorphicLayoutEffect } from "foxact/use-isomorphic-layout-effect";
 import { useSingleton } from "foxact/use-singleton";
@@ -16,14 +16,98 @@ import {
    InputGroupButton,
    InputGroupInput,
 } from "@packages/ui/components/input-group";
+import {
+   DropdownMenu,
+   DropdownMenuContent,
+   DropdownMenuGroup,
+   DropdownMenuItem,
+   DropdownMenuLabel,
+   DropdownMenuSeparator,
+   DropdownMenuTrigger,
+} from "@packages/ui/components/dropdown-menu";
+import { Switch } from "@packages/ui/components/switch";
 import { cn } from "@packages/ui/lib/utils";
-import { useDataTable } from "./data-table-root";
+import { useDataTable, useDataTableStore } from "./data-table-root";
 import { DataTableExportButton } from "./data-table-export";
 
 export type ToolbarValues = {
    search: string;
    filters: Record<string, unknown>;
 };
+
+function DataTableFilterDropdown() {
+   const externalFilters = useDataTableStore((s) => s.externalFilters);
+
+   const allFilters = Object.values(externalFilters);
+   if (allFilters.length === 0) return null;
+
+   const activeCount = allFilters.filter((f) => f.active).length;
+
+   const groups = allFilters.reduce<Record<string, typeof allFilters>>(
+      (acc, f) => {
+         if (!acc[f.group]) acc[f.group] = [];
+         acc[f.group].push(f);
+         return acc;
+      },
+      {},
+   );
+
+   return (
+      <DropdownMenu>
+         <DropdownMenuTrigger asChild>
+            <Button
+               className={cn(
+                  "relative shrink-0",
+                  activeCount > 0 &&
+                     "border-primary/50 bg-primary/5 text-primary hover:bg-primary/10 hover:text-primary",
+               )}
+               size="icon-sm"
+               tooltip="Filtros"
+               variant="outline"
+            >
+               <ListFilter />
+               {activeCount > 0 && (
+                  <span className="absolute -top-1.5 -right-1.5 flex size-4 items-center justify-center rounded-full bg-primary text-[10px] font-semibold text-primary-foreground">
+                     {activeCount}
+                  </span>
+               )}
+               <span className="sr-only">Filtros</span>
+            </Button>
+         </DropdownMenuTrigger>
+         <DropdownMenuContent align="end" className="w-64">
+            {Object.entries(groups).map(([groupLabel, filters], gi) => (
+               <DropdownMenuGroup key={groupLabel}>
+                  {gi > 0 && <DropdownMenuSeparator />}
+                  <DropdownMenuLabel>{groupLabel}</DropdownMenuLabel>
+                  {filters.map((filter) => (
+                     <DropdownMenuItem
+                        className="cursor-pointer justify-between gap-4 py-2.5"
+                        key={filter.id}
+                        onSelect={(e) => {
+                           e.preventDefault();
+                           filter.onToggle(!filter.active);
+                        }}
+                     >
+                        <span className="flex items-center gap-2 text-sm">
+                           {filter.renderIcon && (
+                              <span className="text-muted-foreground shrink-0">
+                                 {filter.renderIcon()}
+                              </span>
+                           )}
+                           {filter.label}
+                        </span>
+                        <Switch
+                           checked={filter.active}
+                           className="pointer-events-none shrink-0"
+                        />
+                     </DropdownMenuItem>
+                  ))}
+               </DropdownMenuGroup>
+            ))}
+         </DropdownMenuContent>
+      </DropdownMenu>
+   );
+}
 
 type DataTableToolbarContextValue = {
    form: AnyFormApi;
@@ -71,6 +155,7 @@ export function DataTableToolbar({
    children,
 }: DataTableToolbarProps) {
    const { table, columnFilters } = useDataTable();
+   const externalFilters = useDataTableStore((s) => s.externalFilters);
 
    const defaultFilters = useSingleton(() =>
       Object.fromEntries(columnFilters.map((f) => [f.id, f.value])),
@@ -82,11 +167,18 @@ export function DataTableToolbar({
 
    const inputValue = useStore(form.store, (s) => s.values.search);
 
-   const activeFilters = columnFilters.filter(
+   const activeColumnFilters = columnFilters.filter(
       ({ value }) => value != null && value !== "",
    );
 
-   const hasAnyFilter = activeFilters.length > 0 || inputValue !== "";
+   const activeExternalCount = Object.values(externalFilters).filter(
+      (f) => f.active,
+   ).length;
+
+   const hasAnyFilter =
+      activeColumnFilters.length > 0 ||
+      inputValue !== "" ||
+      activeExternalCount > 0;
 
    const debouncedSearch = useAsyncDebouncedCallback(
       async (value: string) => {
@@ -114,7 +206,10 @@ export function DataTableToolbar({
       form.setFieldValue("filters", {});
       table.resetColumnFilters();
       await onSearch?.("");
-   }, [form, onSearch, table]);
+      for (const filter of Object.values(externalFilters)) {
+         if (filter.active) filter.onToggle(false);
+      }
+   }, [form, onSearch, table, externalFilters]);
 
    const ctx = useMemo<DataTableToolbarContextValue>(
       () => ({ form, onSearch }),
@@ -161,7 +256,9 @@ export function DataTableToolbar({
                   />
                )}
 
-               {activeFilters.map(({ id, value }) => {
+               <DataTableFilterDropdown />
+
+               {activeColumnFilters.map(({ id, value }) => {
                   const label =
                      table.getColumn(id)?.columnDef.meta?.label ?? id;
                   return (

--- a/apps/web/src/components/page-header.tsx
+++ b/apps/web/src/components/page-header.tsx
@@ -242,20 +242,7 @@ export function PageHeader({
 
          {/* Desktop: actions */}
          <div className="hidden sm:flex items-center gap-2 shrink-0">
-            {!isOpen &&
-               panelActions?.map((action) => (
-                  <Button
-                     key={action.label}
-                     onClick={action.onClick}
-                     tooltip={action.label}
-                     type="button"
-                     variant="outline"
-                  >
-                     <action.icon className="size-4" />
-                  </Button>
-               ))}
             {actions}
-            {!isOpen && <ContextPanelHeaderActions />}
          </div>
       </header>
    );

--- a/apps/web/src/features/context-panel/context-panel-rail.tsx
+++ b/apps/web/src/features/context-panel/context-panel-rail.tsx
@@ -1,5 +1,4 @@
 import { shallow, useStore } from "@tanstack/react-store";
-import { cn } from "@packages/ui/lib/utils";
 import { allTabMetasStore, contextPanelStore } from "./context-panel-store";
 import {
    closeContextPanel,

--- a/apps/web/src/features/context-panel/context-panel-rail.tsx
+++ b/apps/web/src/features/context-panel/context-panel-rail.tsx
@@ -1,0 +1,48 @@
+import { Button } from "@packages/ui/components/button";
+import { shallow, useStore } from "@tanstack/react-store";
+import { cn } from "@packages/ui/lib/utils";
+import { allTabMetasStore, contextPanelStore } from "./context-panel-store";
+import {
+   closeContextPanel,
+   openContextPanel,
+   setActiveTab,
+} from "./use-context-panel";
+
+export function ContextPanelRail() {
+   const allTabMetas = useStore(allTabMetasStore, (s) => s, shallow);
+   const isOpen = useStore(contextPanelStore, (s) => s.isOpen);
+   const activeTabId = useStore(contextPanelStore, (s) => s.activeTabId);
+
+   const handleTabClick = (tabId: string) => {
+      if (isOpen && activeTabId === tabId) {
+         closeContextPanel();
+         return;
+      }
+      setActiveTab(tabId);
+      if (!isOpen) openContextPanel();
+   };
+
+   return (
+      <div className="hidden md:flex flex-col items-center py-2 w-10 shrink-0 gap-2 border-l">
+         {allTabMetas.map((tab) => (
+            <Button
+               className={cn(
+                  "size-8 p-0",
+                  isOpen &&
+                     activeTabId === tab.id &&
+                     "bg-accent text-accent-foreground",
+               )}
+               key={tab.id}
+               onClick={() => handleTabClick(tab.id)}
+               size="icon"
+               tooltip={tab.label}
+               tooltipSide="left"
+               type="button"
+               variant="ghost"
+            >
+               <tab.icon className="size-4" />
+            </Button>
+         ))}
+      </div>
+   );
+}

--- a/apps/web/src/features/context-panel/context-panel-rail.tsx
+++ b/apps/web/src/features/context-panel/context-panel-rail.tsx
@@ -90,7 +90,7 @@ export function ContextPanelRail() {
                   type="button"
                >
                   <tab.icon className="size-4 shrink-0" />
-                  <span className="text-[10px] font-medium [writing-mode:vertical-lr] [text-orientation:upright]">
+                  <span className="text-[10px] font-medium [writing-mode:vertical-lr]">
                      {tab.label}
                   </span>
                </button>

--- a/apps/web/src/features/context-panel/context-panel-rail.tsx
+++ b/apps/web/src/features/context-panel/context-panel-rail.tsx
@@ -42,7 +42,7 @@ function RailMenuButton() {
                variant="ghost"
             >
                <Sparkles className="size-4" />
-               Sugestão de funcionalidade
+               Dar feedback
             </Button>
             <Button
                asChild
@@ -80,8 +80,8 @@ export function ContextPanelRail() {
    if (isOpen) return null;
 
    return (
-      <div className="hidden md:flex flex-col shrink-0 justify-between">
-         <div className="flex flex-col">
+      <div className="hidden md:flex flex-col shrink-0 h-full">
+         <div className="flex flex-col flex-1">
             {allTabMetas.map((tab) => (
                <button
                   className="flex flex-col items-center gap-2 px-2 py-4 text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
@@ -90,11 +90,10 @@ export function ContextPanelRail() {
                   type="button"
                >
                   <tab.icon className="size-4 shrink-0" />
-                  <span
-                     className="text-xs font-medium leading-none"
-                     style={{ writingMode: "vertical-lr" }}
-                  >
-                     {tab.label}
+                  <span className="flex flex-col items-center text-[10px] font-medium leading-tight">
+                     {tab.label.split("").map((char, i) => (
+                        <span key={i}>{char}</span>
+                     ))}
                   </span>
                </button>
             ))}

--- a/apps/web/src/features/context-panel/context-panel-rail.tsx
+++ b/apps/web/src/features/context-panel/context-panel-rail.tsx
@@ -34,7 +34,6 @@ export function ContextPanelRail() {
                )}
                key={tab.id}
                onClick={() => handleTabClick(tab.id)}
-               size="icon"
                tooltip={tab.label}
                tooltipSide="left"
                type="button"

--- a/apps/web/src/features/context-panel/context-panel-rail.tsx
+++ b/apps/web/src/features/context-panel/context-panel-rail.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@packages/ui/components/button";
 import { shallow, useStore } from "@tanstack/react-store";
 import { cn } from "@packages/ui/lib/utils";
 import { allTabMetasStore, contextPanelStore } from "./context-panel-store";
@@ -23,24 +22,24 @@ export function ContextPanelRail() {
    };
 
    return (
-      <div className="absolute right-3 top-20 hidden md:flex flex-col gap-2 z-10">
+      <div className="hidden md:flex flex-col shrink-0">
          {allTabMetas.map((tab) => (
-            <Button
+            <button
                className={cn(
-                  "size-9 rounded-full shadow-sm border bg-background hover:bg-accent",
+                  "flex flex-col items-center gap-2 px-2 py-4 text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground",
                   isOpen &&
                      activeTabId === tab.id &&
-                     "bg-primary text-primary-foreground hover:bg-primary/90 border-primary shadow-md",
+                     "bg-accent/70 text-foreground",
                )}
                key={tab.id}
                onClick={() => handleTabClick(tab.id)}
-               tooltip={tab.label}
-               tooltipSide="left"
                type="button"
-               variant="ghost"
             >
-               <tab.icon className="size-4" />
-            </Button>
+               <tab.icon className="size-4 shrink-0" />
+               <span className="rotate-180 text-[10px] font-medium leading-none [writing-mode:vertical-rl]">
+                  {tab.label}
+               </span>
+            </button>
          ))}
       </div>
    );

--- a/apps/web/src/features/context-panel/context-panel-rail.tsx
+++ b/apps/web/src/features/context-panel/context-panel-rail.tsx
@@ -28,12 +28,9 @@ function RailMenuButton() {
    return (
       <Popover onOpenChange={setOpen} open={open}>
          <PopoverTrigger asChild>
-            <button
-               className="flex flex-col items-center px-2 py-3 text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground rounded-md mx-1 w-[calc(100%-0.5rem)]"
-               type="button"
-            >
+            <Button variant="ghost" size="icon" className="mx-1 size-8">
                <Ellipsis className="size-4" />
-            </button>
+            </Button>
          </PopoverTrigger>
          <PopoverContent align="end" className="w-auto p-1" side="left">
             <Button

--- a/apps/web/src/features/context-panel/context-panel-rail.tsx
+++ b/apps/web/src/features/context-panel/context-panel-rail.tsx
@@ -90,7 +90,7 @@ export function ContextPanelRail() {
                   type="button"
                >
                   <tab.icon className="size-4 shrink-0" />
-                  <span className="text-[10px] font-medium [writing-mode:vertical-lr]">
+                  <span className="text-sm font-medium [writing-mode:vertical-lr]">
                      {tab.label}
                   </span>
                </button>

--- a/apps/web/src/features/context-panel/context-panel-rail.tsx
+++ b/apps/web/src/features/context-panel/context-panel-rail.tsx
@@ -21,22 +21,19 @@ export function ContextPanelRail() {
       if (!isOpen) openContextPanel();
    };
 
+   if (isOpen) return null;
+
    return (
       <div className="hidden md:flex flex-col shrink-0">
          {allTabMetas.map((tab) => (
             <button
-               className={cn(
-                  "flex flex-col items-center gap-2 px-2 py-4 text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground",
-                  isOpen &&
-                     activeTabId === tab.id &&
-                     "bg-accent/70 text-foreground",
-               )}
+               className="flex flex-col items-center gap-2 px-2 py-4 text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
                key={tab.id}
                onClick={() => handleTabClick(tab.id)}
                type="button"
             >
                <tab.icon className="size-4 shrink-0" />
-               <span className="rotate-180 text-[10px] font-medium leading-none [writing-mode:vertical-rl]">
+               <span className="text-xs font-medium leading-none [writing-mode:vertical-lr]">
                   {tab.label}
                </span>
             </button>

--- a/apps/web/src/features/context-panel/context-panel-rail.tsx
+++ b/apps/web/src/features/context-panel/context-panel-rail.tsx
@@ -1,10 +1,67 @@
+import { Button } from "@packages/ui/components/button";
+import {
+   Popover,
+   PopoverContent,
+   PopoverTrigger,
+} from "@packages/ui/components/popover";
 import { shallow, useStore } from "@tanstack/react-store";
+import { Ellipsis, ExternalLink, Sparkles } from "lucide-react";
+import { useState } from "react";
+import { POSTHOG_SURVEYS } from "@core/posthog/config";
+import { useSurveyModal } from "@/hooks/use-survey-modal";
 import { allTabMetasStore, contextPanelStore } from "./context-panel-store";
 import {
    closeContextPanel,
    openContextPanel,
    setActiveTab,
 } from "./use-context-panel";
+
+function RailMenuButton() {
+   const [open, setOpen] = useState(false);
+   const { openSurveyModal } = useSurveyModal();
+
+   const handleFeedback = () => {
+      setOpen(false);
+      openSurveyModal(POSTHOG_SURVEYS.featureRequest.id);
+   };
+
+   return (
+      <Popover onOpenChange={setOpen} open={open}>
+         <PopoverTrigger asChild>
+            <button
+               className="flex flex-col items-center px-2 py-3 text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground w-full"
+               type="button"
+            >
+               <Ellipsis className="size-4" />
+            </button>
+         </PopoverTrigger>
+         <PopoverContent align="end" className="w-auto p-1" side="left">
+            <Button
+               className="w-full justify-start gap-2"
+               onClick={handleFeedback}
+               variant="ghost"
+            >
+               <Sparkles className="size-4" />
+               Sugestão de funcionalidade
+            </Button>
+            <Button
+               asChild
+               className="w-full justify-start gap-2"
+               variant="ghost"
+            >
+               <a
+                  href="https://docs.montte.app"
+                  rel="noopener noreferrer"
+                  target="_blank"
+               >
+                  <ExternalLink className="size-4" />
+                  Documentação
+               </a>
+            </Button>
+         </PopoverContent>
+      </Popover>
+   );
+}
 
 export function ContextPanelRail() {
    const allTabMetas = useStore(allTabMetasStore, (s) => s, shallow);
@@ -23,23 +80,26 @@ export function ContextPanelRail() {
    if (isOpen) return null;
 
    return (
-      <div className="hidden md:flex flex-col shrink-0">
-         {allTabMetas.map((tab) => (
-            <button
-               className="flex flex-col items-center gap-2 px-2 py-4 text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
-               key={tab.id}
-               onClick={() => handleTabClick(tab.id)}
-               type="button"
-            >
-               <tab.icon className="size-4 shrink-0" />
-               <span
-                  className="text-xs font-medium leading-none"
-                  style={{ writingMode: "vertical-lr" }}
+      <div className="hidden md:flex flex-col shrink-0 justify-between">
+         <div className="flex flex-col">
+            {allTabMetas.map((tab) => (
+               <button
+                  className="flex flex-col items-center gap-2 px-2 py-4 text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+                  key={tab.id}
+                  onClick={() => handleTabClick(tab.id)}
+                  type="button"
                >
-                  {tab.label}
-               </span>
-            </button>
-         ))}
+                  <tab.icon className="size-4 shrink-0" />
+                  <span
+                     className="text-xs font-medium leading-none"
+                     style={{ writingMode: "vertical-lr" }}
+                  >
+                     {tab.label}
+                  </span>
+               </button>
+            ))}
+         </div>
+         <RailMenuButton />
       </div>
    );
 }

--- a/apps/web/src/features/context-panel/context-panel-rail.tsx
+++ b/apps/web/src/features/context-panel/context-panel-rail.tsx
@@ -29,7 +29,7 @@ function RailMenuButton() {
       <Popover onOpenChange={setOpen} open={open}>
          <PopoverTrigger asChild>
             <button
-               className="flex flex-col items-center px-2 py-3 text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground w-full"
+               className="flex flex-col items-center px-2 py-3 text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground rounded-md mx-1 w-[calc(100%-0.5rem)]"
                type="button"
             >
                <Ellipsis className="size-4" />
@@ -84,16 +84,14 @@ export function ContextPanelRail() {
          <div className="flex flex-col flex-1">
             {allTabMetas.map((tab) => (
                <button
-                  className="flex flex-col items-center gap-2 px-2 py-4 text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+                  className="flex flex-col items-center gap-2 px-2 py-4 text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground rounded-md mx-1"
                   key={tab.id}
                   onClick={() => handleTabClick(tab.id)}
                   type="button"
                >
                   <tab.icon className="size-4 shrink-0" />
-                  <span className="flex flex-col items-center text-[10px] font-medium leading-tight">
-                     {tab.label.split("").map((char, i) => (
-                        <span key={i}>{char}</span>
-                     ))}
+                  <span className="text-[10px] font-medium [writing-mode:vertical-lr] [text-orientation:upright]">
+                     {tab.label}
                   </span>
                </button>
             ))}

--- a/apps/web/src/features/context-panel/context-panel-rail.tsx
+++ b/apps/web/src/features/context-panel/context-panel-rail.tsx
@@ -23,14 +23,14 @@ export function ContextPanelRail() {
    };
 
    return (
-      <div className="hidden md:flex flex-col items-center py-2 w-10 shrink-0 gap-2 border-l">
+      <div className="absolute right-3 top-20 hidden md:flex flex-col gap-2 z-10">
          {allTabMetas.map((tab) => (
             <Button
                className={cn(
-                  "size-8 p-0",
+                  "size-9 rounded-full shadow-sm border bg-background hover:bg-accent",
                   isOpen &&
                      activeTabId === tab.id &&
-                     "bg-accent text-accent-foreground",
+                     "bg-primary text-primary-foreground hover:bg-primary/90 border-primary shadow-md",
                )}
                key={tab.id}
                onClick={() => handleTabClick(tab.id)}

--- a/apps/web/src/features/context-panel/context-panel-rail.tsx
+++ b/apps/web/src/features/context-panel/context-panel-rail.tsx
@@ -1,12 +1,19 @@
 import { Button } from "@packages/ui/components/button";
 import {
-   Popover,
-   PopoverContent,
-   PopoverTrigger,
-} from "@packages/ui/components/popover";
+   DropdownMenu,
+   DropdownMenuContent,
+   DropdownMenuItem,
+   DropdownMenuLabel,
+   DropdownMenuSeparator,
+   DropdownMenuTrigger,
+} from "@packages/ui/components/dropdown-menu";
+import {
+   Tooltip,
+   TooltipContent,
+   TooltipTrigger,
+} from "@packages/ui/components/tooltip";
 import { shallow, useStore } from "@tanstack/react-store";
-import { Ellipsis, ExternalLink, Sparkles } from "lucide-react";
-import { useState } from "react";
+import { Ellipsis, ExternalLink, Sparkles, X } from "lucide-react";
 import { POSTHOG_SURVEYS } from "@core/posthog/config";
 import { useSurveyModal } from "@/hooks/use-survey-modal";
 import { allTabMetasStore, contextPanelStore } from "./context-panel-store";
@@ -17,46 +24,44 @@ import {
 } from "./use-context-panel";
 
 function RailMenuButton() {
-   const [open, setOpen] = useState(false);
    const { openSurveyModal } = useSurveyModal();
 
-   const handleFeedback = () => {
-      setOpen(false);
-      openSurveyModal(POSTHOG_SURVEYS.featureRequest.id);
-   };
-
    return (
-      <Popover onOpenChange={setOpen} open={open}>
-         <PopoverTrigger asChild>
-            <Button variant="ghost" size="icon" className="mx-1 size-8">
-               <Ellipsis className="size-4" />
-            </Button>
-         </PopoverTrigger>
-         <PopoverContent align="end" className="w-auto p-1" side="left">
-            <Button
-               className="w-full justify-start gap-2"
-               onClick={handleFeedback}
-               variant="ghost"
-            >
-               <Sparkles className="size-4" />
-               Dar feedback
-            </Button>
-            <Button
-               asChild
-               className="w-full justify-start gap-2"
-               variant="ghost"
-            >
-               <a
-                  href="https://docs.montte.app"
-                  rel="noopener noreferrer"
-                  target="_blank"
+      <Tooltip>
+         <DropdownMenu>
+            <TooltipTrigger asChild>
+               <DropdownMenuTrigger asChild>
+                  <Button aria-label="Mais opções" size="icon" variant="ghost">
+                     <Ellipsis className="size-4" />
+                  </Button>
+               </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <DropdownMenuContent align="end" side="left">
+               <DropdownMenuLabel>Ajuda</DropdownMenuLabel>
+               <DropdownMenuSeparator />
+               <DropdownMenuItem
+                  className="cursor-pointer gap-2"
+                  onClick={() =>
+                     openSurveyModal(POSTHOG_SURVEYS.featureRequest.id)
+                  }
                >
-                  <ExternalLink className="size-4" />
-                  Documentação
-               </a>
-            </Button>
-         </PopoverContent>
-      </Popover>
+                  <Sparkles className="size-4" />
+                  Dar feedback
+               </DropdownMenuItem>
+               <DropdownMenuItem asChild className="cursor-pointer gap-2">
+                  <a
+                     href="https://docs.montte.app"
+                     rel="noopener noreferrer"
+                     target="_blank"
+                  >
+                     <ExternalLink className="size-4" />
+                     Documentação
+                  </a>
+               </DropdownMenuItem>
+            </DropdownMenuContent>
+         </DropdownMenu>
+         <TooltipContent side="left">Mais opções</TooltipContent>
+      </Tooltip>
    );
 }
 
@@ -74,20 +79,31 @@ export function ContextPanelRail() {
       if (!isOpen) openContextPanel();
    };
 
-   if (isOpen) return null;
-
    return (
-      <div className="hidden md:flex flex-col shrink-0 h-full">
+      <div className="hidden sm:flex flex-col shrink-0 h-full">
          <div className="flex flex-col flex-1">
             {allTabMetas.map((tab) => (
                <button
-                  className="flex flex-col items-center gap-2 px-2 py-4 text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground rounded-md mx-1"
+                  aria-label={
+                     isOpen && activeTabId === tab.id
+                        ? `Fechar ${tab.label}`
+                        : tab.label
+                  }
+                  aria-pressed={isOpen && activeTabId === tab.id}
+                  className={`group flex flex-col items-center gap-2 px-2 py-4 transition-colors rounded-md cursor-pointer ${isOpen && activeTabId === tab.id ? "bg-accent text-foreground hover:bg-destructive/10 hover:text-destructive" : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"}`}
                   key={tab.id}
                   onClick={() => handleTabClick(tab.id)}
                   type="button"
                >
-                  <tab.icon className="size-4 shrink-0" />
-                  <span className="text-sm font-medium [writing-mode:vertical-lr]">
+                  {isOpen && activeTabId === tab.id ? (
+                     <>
+                        <X className="size-4 shrink-0 hidden group-hover:block" />
+                        <tab.icon className="size-4 shrink-0 group-hover:hidden" />
+                     </>
+                  ) : (
+                     <tab.icon className="size-4 shrink-0" />
+                  )}
+                  <span className="text-xs font-medium [writing-mode:vertical-lr]">
                      {tab.label}
                   </span>
                </button>

--- a/apps/web/src/features/context-panel/context-panel-rail.tsx
+++ b/apps/web/src/features/context-panel/context-panel-rail.tsx
@@ -32,7 +32,10 @@ export function ContextPanelRail() {
                type="button"
             >
                <tab.icon className="size-4 shrink-0" />
-               <span className="text-xs font-medium leading-none [writing-mode:vertical-lr]">
+               <span
+                  className="text-xs font-medium leading-none"
+                  style={{ writingMode: "vertical-lr" }}
+               >
                   {tab.label}
                </span>
             </button>

--- a/apps/web/src/features/context-panel/context-panel.tsx
+++ b/apps/web/src/features/context-panel/context-panel.tsx
@@ -16,11 +16,10 @@ import {
 import {
    Sidebar,
    SidebarContent,
-   SidebarHeader,
    SidebarManager,
 } from "@packages/ui/components/sidebar";
 import { useStore, shallow } from "@tanstack/react-store";
-import { Check, ChevronDown, Info, X } from "lucide-react";
+import { Check, ChevronDown, Info } from "lucide-react";
 import type React from "react";
 import { ContextPanelAction } from "./context-panel-info";
 import {
@@ -146,29 +145,7 @@ function ContextPanelInner() {
          side="right"
          variant="inset"
       >
-         <SidebarHeader className="bg-background rounded-t-xl">
-            <div className="flex items-center gap-2">
-               {activeTabMeta && (
-                  <div className="flex items-center gap-2 flex-1 min-w-0">
-                     <activeTabMeta.icon className="size-4 shrink-0 text-muted-foreground" />
-                     <span className="text-sm font-medium truncate">
-                        {activeTabMeta.label}
-                     </span>
-                  </div>
-               )}
-               <Button
-                  className="shrink-0 ml-auto"
-                  onClick={closeContextPanel}
-                  tooltip="Fechar painel"
-                  type="button"
-                  variant="ghost"
-               >
-                  <X className="" />
-               </Button>
-            </div>
-         </SidebarHeader>
-
-         <SidebarContent className="h-full overflow-hidden rounded-b-xl bg-muted">
+         <SidebarContent className="h-full overflow-hidden rounded-xl bg-muted">
             {activeTab?.renderContent()}
          </SidebarContent>
       </Sidebar>

--- a/apps/web/src/features/context-panel/context-panel.tsx
+++ b/apps/web/src/features/context-panel/context-panel.tsx
@@ -19,7 +19,6 @@ import {
    SidebarHeader,
    SidebarManager,
 } from "@packages/ui/components/sidebar";
-import { cn } from "@packages/ui/lib/utils";
 import { useStore, shallow } from "@tanstack/react-store";
 import { Check, ChevronDown, Info, X } from "lucide-react";
 import type React from "react";
@@ -27,15 +26,10 @@ import { ContextPanelAction } from "./context-panel-info";
 import {
    type ContextPanelTab,
    contextPanelStore,
-   allTabMetasStore,
    activeTabMetaStore,
    type PageViewSwitchConfig,
 } from "./context-panel-store";
-import {
-   closeContextPanel,
-   openContextPanel,
-   setActiveTab,
-} from "./use-context-panel";
+import { closeContextPanel, openContextPanel } from "./use-context-panel";
 
 function ViewSwitchPanelAction({ config }: { config: PageViewSwitchConfig }) {
    const active =
@@ -137,7 +131,6 @@ const INFO_TAB: ContextPanelTab = {
 };
 
 function ContextPanelInner() {
-   const allTabMetas = useStore(allTabMetasStore, (s) => s);
    const activeTabMeta = useStore(activeTabMetaStore, (s) => s);
 
    const dynamicTabs = useStore(contextPanelStore, (s) => s.dynamicTabs);
@@ -154,30 +147,21 @@ function ContextPanelInner() {
          variant="inset"
       >
          <SidebarHeader className="bg-background rounded-t-xl">
-            <div className="flex-row flex items-center gap-2">
-               {allTabMetas.map((tab) => (
-                  <Button
-                     className={cn(
-                        "",
-                        activeTabMeta?.id === tab.id &&
-                           "bg-accent text-accent-foreground",
-                     )}
-                     key={tab.id}
-                     onClick={() => setActiveTab(tab.id)}
-                     tooltip={tab.label}
-                     tooltipSide="bottom"
-                     type="button"
-                     variant="outline"
-                  >
-                     <tab.icon className="" />
-                  </Button>
-               ))}
-               <div className="flex-1" />
+            <div className="flex items-center gap-2">
+               {activeTabMeta && (
+                  <div className="flex items-center gap-2 flex-1 min-w-0">
+                     <activeTabMeta.icon className="size-4 shrink-0 text-muted-foreground" />
+                     <span className="text-sm font-medium truncate">
+                        {activeTabMeta.label}
+                     </span>
+                  </div>
+               )}
                <Button
+                  className="shrink-0 ml-auto"
                   onClick={closeContextPanel}
                   tooltip="Fechar painel"
                   type="button"
-                  variant="outline"
+                  variant="ghost"
                >
                   <X className="" />
                </Button>

--- a/apps/web/src/integrations/devtools/config.tsx
+++ b/apps/web/src/integrations/devtools/config.tsx
@@ -7,7 +7,7 @@ import type {
 } from "@tanstack/react-devtools";
 
 export const devtoolsConfig: TanStackDevtoolsReactInit["config"] = {
-   position: "top-right",
+   position: "bottom-right",
    openHotkey: ["Shift", "D"],
    hideUntilHover: true,
    requireUrlFlag: true,

--- a/apps/web/src/integrations/orpc/router/categories.ts
+++ b/apps/web/src/integrations/orpc/router/categories.ts
@@ -99,7 +99,7 @@ export const update = protectedProcedure
    .input(idSchema.merge(updateCategorySchema))
    .handler(async ({ context, input }) => {
       const { id, ...data } = input;
-      const category = (
+      return (
          await ensureCategoryOwnership(
             context.db,
             input.id,
@@ -111,22 +111,33 @@ export const update = protectedProcedure
             throw WebAppError.fromAppError(e);
          },
       );
-      if (data.name !== undefined || data.description !== undefined) {
-         const userRecord = await context.db.query.user.findFirst({
-            where: eq(userTable.id, context.userId),
-            columns: { stripeCustomerId: true },
-         });
-         await enqueueDeriveKeywordsWorkflow(context.workflowClient, {
-            categoryId: category.id,
-            teamId: context.teamId,
-            organizationId: context.organizationId,
-            userId: context.userId,
-            name: category.name,
-            description: category.description,
-            stripeCustomerId: userRecord?.stripeCustomerId ?? null,
-         });
-      }
-      return category;
+   });
+
+export const regenerateKeywords = protectedProcedure
+   .input(idSchema)
+   .handler(async ({ context, input }) => {
+      const category = (
+         await ensureCategoryOwnership(context.db, input.id, context.teamId)
+      ).match(
+         (v) => v,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+      const userRecord = await context.db.query.user.findFirst({
+         where: eq(userTable.id, context.userId),
+         columns: { stripeCustomerId: true },
+      });
+      await enqueueDeriveKeywordsWorkflow(context.workflowClient, {
+         categoryId: category.id,
+         teamId: context.teamId,
+         organizationId: context.organizationId,
+         userId: context.userId,
+         name: category.name,
+         description: category.description,
+         stripeCustomerId: userRecord?.stripeCustomerId ?? null,
+      });
+      return { success: true };
    });
 
 export const remove = protectedProcedure

--- a/apps/web/src/layout/dashboard/ui/app-sidebar.tsx
+++ b/apps/web/src/layout/dashboard/ui/app-sidebar.tsx
@@ -1,9 +1,3 @@
-import { Button } from "@packages/ui/components/button";
-import {
-   Popover,
-   PopoverContent,
-   PopoverTrigger,
-} from "@packages/ui/components/popover";
 import { Separator } from "@packages/ui/components/separator";
 import {
    Sidebar,
@@ -15,18 +9,9 @@ import {
    useSidebar,
 } from "@packages/ui/components/sidebar";
 import { Link } from "@tanstack/react-router";
-import {
-   Bug,
-   MessageSquarePlus,
-   PanelLeftClose,
-   Settings,
-   Sparkles,
-} from "lucide-react";
+import { PanelLeftClose, Settings } from "lucide-react";
 import type * as React from "react";
-import { useState } from "react";
-import { POSTHOG_SURVEYS } from "@core/posthog/config";
 import { useDashboardSlugs } from "@/hooks/use-dashboard-slugs";
-import { useSurveyModal } from "@/hooks/use-survey-modal";
 import { EarlyAccessSidebarBanner } from "./early-access-sidebar-banner";
 import { SidebarDefaultItems, SidebarNav } from "./sidebar-nav";
 import { SidebarScopeSwitcher } from "./sidebar-scope-switcher";
@@ -49,49 +34,6 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
             <SidebarScopeSwitcher />
          </SidebarFooter>
       </Sidebar>
-   );
-}
-
-function SidebarFeedbackButton() {
-   const { openSurveyModal } = useSurveyModal();
-   const [open, setOpen] = useState(false);
-
-   const handleSelect = (surveyId: string) => {
-      setOpen(false);
-      openSurveyModal(surveyId);
-   };
-
-   return (
-      <SidebarMenuItem>
-         <Popover onOpenChange={setOpen} open={open}>
-            <PopoverTrigger asChild>
-               <SidebarMenuButton tooltip="Feedback">
-                  <MessageSquarePlus className="size-4" />
-                  <span>Feedback</span>
-               </SidebarMenuButton>
-            </PopoverTrigger>
-            <PopoverContent align="start" className="w-auto p-1" side="right">
-               <Button
-                  className="w-full justify-start gap-2"
-                  onClick={() =>
-                     handleSelect(POSTHOG_SURVEYS.featureRequest.id)
-                  }
-                  variant="ghost"
-               >
-                  <Sparkles className="size-4" />
-                  Sugestão de funcionalidade
-               </Button>
-               <Button
-                  className="w-full justify-start gap-2"
-                  onClick={() => handleSelect(POSTHOG_SURVEYS.bugReport.id)}
-                  variant="ghost"
-               >
-                  <Bug className="size-4" />
-                  Reportar bug
-               </Button>
-            </PopoverContent>
-         </Popover>
-      </SidebarMenuItem>
    );
 }
 
@@ -120,7 +62,6 @@ function SidebarFooterContent() {
                </Link>
             </SidebarMenuButton>
          </SidebarMenuItem>
-         <SidebarFeedbackButton />
       </SidebarMenu>
    );
 }

--- a/apps/web/src/layout/dashboard/ui/dashboard-layout.tsx
+++ b/apps/web/src/layout/dashboard/ui/dashboard-layout.tsx
@@ -90,7 +90,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
 
                <SidebarInset className="flex flex-col overflow-hidden bg-sidebar">
                   <SidebarSubPanel />
-                  <div className="flex flex-1 overflow-hidden rounded-xl bg-background">
+                  <div className="relative flex flex-1 flex-col overflow-hidden rounded-xl bg-background">
                      <main
                         className={cn(
                            "relative flex-1",

--- a/apps/web/src/layout/dashboard/ui/dashboard-layout.tsx
+++ b/apps/web/src/layout/dashboard/ui/dashboard-layout.tsx
@@ -12,6 +12,7 @@ import { useEffect } from "react";
 import { useSingleton } from "foxact/use-singleton";
 import { useJobNotifications } from "@/features/notifications/use-job-notifications";
 import { GlobalContextPanel } from "@/features/context-panel/context-panel";
+import { ContextPanelRail } from "@/features/context-panel/context-panel-rail";
 import { AutoBugReporter } from "@/features/feedback/ui/auto-bug-reporter";
 import { MonthlySatisfactionSurvey } from "@/features/feedback/ui/monthly-satisfaction-survey";
 import { useActiveOrganization } from "@/hooks/use-active-organization";
@@ -89,7 +90,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
 
                <SidebarInset className="flex flex-col overflow-hidden bg-sidebar">
                   <SidebarSubPanel />
-                  <div className=" flex flex-1 flex-col overflow-hidden rounded-xl bg-background">
+                  <div className="flex flex-1 overflow-hidden rounded-xl bg-background">
                      <main
                         className={cn(
                            "relative flex-1",
@@ -100,6 +101,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
                      >
                         {children}
                      </main>
+                     <ContextPanelRail />
                   </div>
                   <AutoBugReporter />
                   <MonthlySatisfactionSurvey />

--- a/apps/web/src/layout/dashboard/ui/dashboard-layout.tsx
+++ b/apps/web/src/layout/dashboard/ui/dashboard-layout.tsx
@@ -90,17 +90,19 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
 
                <SidebarInset className="flex flex-col overflow-hidden bg-sidebar">
                   <SidebarSubPanel />
-                  <div className="relative flex flex-1 flex-col overflow-hidden rounded-xl bg-background">
-                     <main
-                        className={cn(
-                           "relative flex-1",
-                           isSettingsPage
-                              ? "overflow-hidden p-4"
-                              : "overflow-y-auto p-4",
-                        )}
-                     >
-                        {children}
-                     </main>
+                  <div className="flex flex-1 overflow-hidden">
+                     <div className="flex flex-1 flex-col overflow-hidden rounded-xl bg-background">
+                        <main
+                           className={cn(
+                              "relative flex-1",
+                              isSettingsPage
+                                 ? "overflow-hidden p-4"
+                                 : "overflow-y-auto p-4",
+                           )}
+                        >
+                           {children}
+                        </main>
+                     </div>
                      <ContextPanelRail />
                   </div>
                   <AutoBugReporter />

--- a/apps/web/src/layout/dashboard/ui/dashboard-layout.tsx
+++ b/apps/web/src/layout/dashboard/ui/dashboard-layout.tsx
@@ -88,7 +88,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
                   <AppSidebar />
                </SidebarManager>
 
-               <SidebarInset className="flex flex-col overflow-hidden bg-sidebar">
+               <SidebarInset className="flex flex-col overflow-hidden bg-sidebar mr-0">
                   <SidebarSubPanel />
                   <div className="flex flex-1 overflow-hidden">
                      <div className="flex flex-1 flex-col overflow-hidden rounded-xl bg-background">

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-categories/categories-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-categories/categories-columns.tsx
@@ -202,7 +202,7 @@ export function buildCategoryColumns(): ColumnDef<CategoryRow>[] {
                   return (
                      <Tooltip>
                         <TooltipTrigger asChild>
-                           <span className="inline-flex items-center gap-1 text-sm text-amber-500 cursor-default">
+                           <span className="inline-flex items-center gap-2 text-sm text-amber-500 cursor-default">
                               <TriangleAlert className="size-3.5" />
                               Não geradas
                            </span>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-categories/categories-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-categories/categories-columns.tsx
@@ -33,6 +33,7 @@ import {
    ShieldCheck,
    Star,
    Tags,
+   TriangleAlert,
    Utensils,
    Wallet,
    Zap,
@@ -188,31 +189,76 @@ export function buildCategoryColumns(): ColumnDef<CategoryRow>[] {
          id: "keywords",
          header: "Palavras-chave",
          cell: ({ row }) => {
-            const keywords = row.original.keywords;
-            const count = keywords?.length ?? 0;
-            if (count === 0)
+            if (row.depth > 0)
                return <span className="text-sm text-muted-foreground">—</span>;
+            const { keywords, keywordsUpdatedAt, updatedAt } = row.original;
+            const count = keywords?.length ?? 0;
+            const isStale =
+               !keywordsUpdatedAt ||
+               new Date(updatedAt) > new Date(keywordsUpdatedAt);
+
+            if (count === 0) {
+               if (isStale) {
+                  return (
+                     <Tooltip>
+                        <TooltipTrigger asChild>
+                           <span className="inline-flex items-center gap-1 text-sm text-amber-500 cursor-default">
+                              <TriangleAlert className="size-3.5" />
+                              Não geradas
+                           </span>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                           Palavras-chave ainda não foram geradas para esta
+                           categoria. Use "Regerar palavras-chave" para gerar.
+                        </TooltipContent>
+                     </Tooltip>
+                  );
+               }
+               return <span className="text-sm text-muted-foreground">—</span>;
+            }
+
             return (
-               <Tooltip>
-                  <TooltipTrigger asChild>
-                     <Announcement className="cursor-default w-fit">
-                        <AnnouncementTag>
-                           <Tags className="size-3" />
-                        </AnnouncementTag>
-                        <AnnouncementTitle className="text-xs">
-                           {count} {count === 1 ? "palavra" : "palavras"}
-                        </AnnouncementTitle>
-                     </Announcement>
-                  </TooltipTrigger>
-                  <TooltipContent className="max-w-72">
-                     <p className="font-semibold text-sm">Palavras-chave IA</p>
-                     <p className="text-xs text-muted-foreground">
-                        Geradas automaticamente com base no nome e descrição da
-                        categoria.
-                     </p>
-                     <p className="text-xs">{keywords!.join(", ")}</p>
-                  </TooltipContent>
-               </Tooltip>
+               <div className="flex items-center gap-2">
+                  <Tooltip>
+                     <TooltipTrigger asChild>
+                        <Announcement className="cursor-default w-fit">
+                           <AnnouncementTag>
+                              <Tags className="size-3" />
+                           </AnnouncementTag>
+                           <AnnouncementTitle className="text-xs">
+                              {count} {count === 1 ? "palavra" : "palavras"}
+                           </AnnouncementTitle>
+                        </Announcement>
+                     </TooltipTrigger>
+                     <TooltipContent className="max-w-72">
+                        <p className="font-semibold text-sm">
+                           Palavras-chave IA
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                           Geradas automaticamente com base no nome e descrição
+                           da categoria.
+                        </p>
+                        <p className="text-xs">{keywords!.join(", ")}</p>
+                     </TooltipContent>
+                  </Tooltip>
+                  {isStale && (
+                     <Tooltip>
+                        <TooltipTrigger asChild>
+                           <span
+                              className="inline-flex cursor-default"
+                              tabIndex={0}
+                           >
+                              <TriangleAlert className="size-3.5 text-amber-500" />
+                           </span>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                           Categoria foi atualizada desde a última geração de
+                           palavras-chave. Use "Regerar palavras-chave" para
+                           atualizar.
+                        </TooltipContent>
+                     </Tooltip>
+                  )}
+               </div>
             );
          },
       },

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/categories.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/categories.tsx
@@ -39,6 +39,7 @@ import {
    FolderOpen,
    Pencil,
    Plus,
+   RefreshCw,
    Trash2,
    Upload,
 } from "lucide-react";
@@ -353,6 +354,18 @@ function CategoriesList({ navigate }: CategoriesListProps) {
       }),
    );
 
+   const regenerateKeywordsMutation = useMutation(
+      orpc.categories.regenerateKeywords.mutationOptions({
+         meta: { skipGlobalInvalidation: true },
+         onSuccess: () =>
+            toast.success(
+               "Geração de palavras-chave iniciada. Isso pode levar alguns segundos.",
+            ),
+         onError: (e) =>
+            toast.error(e.message || "Erro ao gerar palavras-chave."),
+      }),
+   );
+
    const handleEdit = useCallback(
       (category: CategoryRow) => {
          if (category.parentId !== null) {
@@ -577,6 +590,20 @@ function CategoriesList({ navigate }: CategoriesListProps) {
                      >
                         <Pencil />
                      </Button>
+                     {!isSub && (
+                        <Button
+                           disabled={regenerateKeywordsMutation.isPending}
+                           onClick={() =>
+                              regenerateKeywordsMutation.mutate({
+                                 id: row.original.id,
+                              })
+                           }
+                           tooltip="Regerar palavras-chave"
+                           variant="outline"
+                        >
+                           <RefreshCw />
+                        </Button>
+                     )}
                      {!isSub && (
                         <Button
                            onClick={() => handleArchive(row.original)}

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
@@ -9,6 +9,7 @@ import {
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { Archive, ArchiveRestore, Plus, Tag, Trash2 } from "lucide-react";
+import { DataTableExternalFilter } from "@/components/data-table/data-table-root";
 import { useCallback, useMemo, useState } from "react";
 import { DataTablePagination } from "@/components/data-table/data-table-pagination";
 import { z } from "zod";
@@ -273,6 +274,23 @@ function TagsList() {
             }}
             storageKey="montte:datatable:tags"
          >
+            <DataTableExternalFilter
+               id="includeArchived"
+               label="Mostrar arquivados"
+               group="Filtros"
+               active={includeArchived}
+               renderIcon={() => <Archive className="size-4" />}
+               onToggle={(checked) =>
+                  navigate({
+                     search: (prev) => ({
+                        ...prev,
+                        includeArchived: checked,
+                        page: 1,
+                     }),
+                     replace: true,
+                  })
+               }
+            />
             <DataTableToolbar
                searchPlaceholder="Buscar centros de custo..."
                searchDefaultValue={search}

--- a/core/database/src/repositories/categories-repository.ts
+++ b/core/database/src/repositories/categories-repository.ts
@@ -659,6 +659,31 @@ export function updateCategory(
    );
 }
 
+export function updateCategoryKeywords(
+   db: DatabaseInstance,
+   id: string,
+   keywords: string[],
+) {
+   return fromPromise(
+      (async () => {
+         const now = dayjs().toDate();
+         const [updated] = await db
+            .update(categories)
+            .set({ keywords, keywordsUpdatedAt: now, updatedAt: now })
+            .where(eq(categories.id, id))
+            .returning();
+         if (!updated) throw AppError.notFound("Categoria não encontrada.");
+         return updated;
+      })(),
+      (e) =>
+         e instanceof AppError
+            ? e
+            : AppError.database("Falha ao salvar palavras-chave.", {
+                 cause: e,
+              }),
+   );
+}
+
 export function archiveCategory(db: DatabaseInstance, id: string) {
    return fromPromise(
       (async () => {

--- a/core/database/src/repositories/categories-repository.ts
+++ b/core/database/src/repositories/categories-repository.ts
@@ -666,6 +666,24 @@ export function updateCategoryKeywords(
 ) {
    return fromPromise(
       (async () => {
+         const existing = await db.query.categories.findFirst({
+            where: (fields, { eq }) => eq(fields.id, id),
+         });
+         if (!existing) throw AppError.notFound("Categoria não encontrada.");
+         if (existing.isDefault) {
+            throw AppError.conflict(
+               "Palavras-chave de categorias padrão não podem ser atualizadas.",
+            );
+         }
+         if (keywords.length) {
+            const vResult = await validateKeywordsUniqueness(
+               db,
+               existing.teamId,
+               keywords,
+               id,
+            );
+            if (vResult.isErr()) throw vResult.error;
+         }
          const now = dayjs().toDate();
          const [updated] = await db
             .update(categories)

--- a/core/database/src/schemas/categories.ts
+++ b/core/database/src/schemas/categories.ts
@@ -36,6 +36,9 @@ export const categories = financeSchema.table(
       icon: text("icon"),
       isArchived: boolean("is_archived").notNull().default(false),
       keywords: text("keywords").array(),
+      keywordsUpdatedAt: timestamp("keywords_updated_at", {
+         withTimezone: true,
+      }),
       notes: text("notes"),
       participatesDre: boolean("participates_dre").notNull().default(false),
       dreGroupId: text("dre_group_id"),

--- a/docs/plans/2026-04-19-context-panel-rail.md
+++ b/docs/plans/2026-04-19-context-panel-rail.md
@@ -1,0 +1,395 @@
+# Context Panel Rail Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Move context panel tab icons from the panel header into a permanent vertical rail on the right edge of the content area, so tabs are always visible regardless of panel state.
+
+**Architecture:** A new `ContextPanelRail` component reads from the existing `allTabMetasStore` and `contextPanelStore` and renders a narrow icon strip. The rail is placed inside `SidebarInset` as a row sibling to `main`. The panel header loses tab buttons; only the close button remains. On mobile the rail is hidden and the existing `ContextPanelHeaderActions` stays for mobile users.
+
+**Tech Stack:** TanStack React Store, Tailwind CSS, Lucide icons, `@packages/ui/components/button` (has `tooltip` / `tooltipSide` props), existing context panel store + mutators.
+
+---
+
+## Context — Current Structure
+
+```
+SidebarProvider
+├── SidebarManager (main) → AppSidebar
+├── SidebarInset
+│   ├── SidebarSubPanel
+│   ├── div.flex.flex-col (rounded bg-background)   ← CHANGE THIS
+│   │   └── main (flex-1, overflow-y-auto)
+│   ├── AutoBugReporter
+│   └── MonthlySatisfactionSurvey
+└── GlobalContextPanel (SidebarManager right panel)
+     └── ContextPanelInner
+          ├── SidebarHeader  ← tab buttons live here NOW → REMOVE
+          └── SidebarContent → active tab content
+```
+
+Target:
+
+```
+SidebarInset
+├── SidebarSubPanel
+├── div.flex.flex-row (rounded bg-background)   ← flex-row now
+│   ├── main (flex-1)
+│   └── ContextPanelRail (w-10, hidden on mobile)  ← NEW
+```
+
+---
+
+## Task 1: Create `ContextPanelRail` component
+
+**Files:**
+- Create: `apps/web/src/features/context-panel/context-panel-rail.tsx`
+
+No tests needed — pure UI, no logic to unit-test in isolation.
+
+**Step 1: Create the file**
+
+```tsx
+import { Button } from "@packages/ui/components/button";
+import { useStore } from "@tanstack/react-store";
+import { cn } from "@packages/ui/lib/utils";
+import {
+   allTabMetasStore,
+   contextPanelStore,
+} from "./context-panel-store";
+import {
+   closeContextPanel,
+   openContextPanel,
+   setActiveTab,
+} from "./use-context-panel";
+
+export function ContextPanelRail() {
+   const allTabMetas = useStore(allTabMetasStore, (s) => s);
+   const isOpen = useStore(contextPanelStore, (s) => s.isOpen);
+   const activeTabId = useStore(contextPanelStore, (s) => s.activeTabId);
+
+   const handleTabClick = (tabId: string) => {
+      if (isOpen && activeTabId === tabId) {
+         closeContextPanel();
+      } else if (isOpen) {
+         setActiveTab(tabId);
+      } else {
+         setActiveTab(tabId);
+         openContextPanel();
+      }
+   };
+
+   return (
+      <div className="hidden md:flex flex-col items-center py-2 w-10 shrink-0 gap-1 border-l">
+         {allTabMetas.map((tab) => (
+            <Button
+               className={cn(
+                  "size-8 p-0",
+                  isOpen &&
+                     activeTabId === tab.id &&
+                     "bg-accent text-accent-foreground",
+               )}
+               key={tab.id}
+               onClick={() => handleTabClick(tab.id)}
+               size="icon"
+               tooltip={tab.label}
+               tooltipSide="left"
+               type="button"
+               variant="ghost"
+            >
+               <tab.icon className="size-4" />
+            </Button>
+         ))}
+      </div>
+   );
+}
+```
+
+**Step 2: Verify TypeScript compiles**
+
+```bash
+cd apps/web && bun run typecheck 2>&1 | grep "context-panel-rail"
+```
+
+Expected: no errors for this file.
+
+**Step 3: Commit**
+
+```bash
+git add apps/web/src/features/context-panel/context-panel-rail.tsx
+git commit -m "feat(context-panel): add ContextPanelRail component"
+```
+
+---
+
+## Task 2: Update `ContextPanelInner` — strip tab buttons from panel header
+
+**Files:**
+- Modify: `apps/web/src/features/context-panel/context-panel.tsx`
+
+The `SidebarHeader` currently renders all tab buttons in a row. Replace with just the active tab label + close button (or just the close button).
+
+**Step 1: Edit `ContextPanelInner` in `context-panel.tsx`**
+
+Find this block (lines 156–185):
+
+```tsx
+<SidebarHeader className="bg-background rounded-t-xl">
+   <div className="flex-row flex items-center gap-2">
+      {allTabMetas.map((tab) => (
+         <Button
+            className={cn(
+               "",
+               activeTabMeta?.id === tab.id &&
+                  "bg-accent text-accent-foreground",
+            )}
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            tooltip={tab.label}
+            tooltipSide="bottom"
+            type="button"
+            variant="outline"
+         >
+            <tab.icon className="" />
+         </Button>
+      ))}
+      <div className="flex-1" />
+      <Button
+         onClick={closeContextPanel}
+         tooltip="Fechar painel"
+         type="button"
+         variant="outline"
+      >
+         <X className="" />
+      </Button>
+   </div>
+</SidebarHeader>
+```
+
+Replace with:
+
+```tsx
+<SidebarHeader className="bg-background rounded-t-xl">
+   <div className="flex items-center gap-2">
+      {activeTabMeta && (
+         <div className="flex items-center gap-2 flex-1 min-w-0">
+            <activeTabMeta.icon className="size-4 shrink-0 text-muted-foreground" />
+            <span className="text-sm font-medium truncate">
+               {activeTabMeta.label}
+            </span>
+         </div>
+      )}
+      <Button
+         className="shrink-0 ml-auto"
+         onClick={closeContextPanel}
+         tooltip="Fechar painel"
+         type="button"
+         variant="ghost"
+      >
+         <X className="" />
+      </Button>
+   </div>
+</SidebarHeader>
+```
+
+**Step 2: Remove now-unused imports**
+
+`allTabMetas` is no longer used inside `ContextPanelInner`. Remove:
+- `const allTabMetas = useStore(allTabMetasStore, (s) => s);` from `ContextPanelInner`
+- Remove `openContextPanel` from imports at top (line 36) if unused elsewhere in the file
+- Remove `setActiveTab` from imports (line 37) if unused elsewhere in the file
+
+Check: `openContextPanel` and `setActiveTab` are imported at line 36–38. After this change they are no longer called inside `context-panel.tsx`. Remove them from the import.
+
+**Step 3: Verify TypeScript**
+
+```bash
+cd apps/web && bun run typecheck 2>&1 | grep "context-panel"
+```
+
+Expected: no errors.
+
+**Step 4: Commit**
+
+```bash
+git add apps/web/src/features/context-panel/context-panel.tsx
+git commit -m "feat(context-panel): remove tab buttons from panel header, show active tab label"
+```
+
+---
+
+## Task 3: Update `dashboard-layout.tsx` — place rail in content area
+
+**Files:**
+- Modify: `apps/web/src/layout/dashboard/ui/dashboard-layout.tsx`
+
+**Step 1: Add import for `ContextPanelRail`**
+
+At line 14 (after `GlobalContextPanel` import), add:
+
+```tsx
+import { ContextPanelRail } from "@/features/context-panel/context-panel-rail";
+```
+
+**Step 2: Restructure content div**
+
+Find (lines 92–103):
+
+```tsx
+<div className=" flex flex-1 flex-col overflow-hidden rounded-xl bg-background">
+   <main
+      className={cn(
+         "relative flex-1",
+         isSettingsPage
+            ? "overflow-hidden p-4"
+            : "overflow-y-auto p-4",
+      )}
+   >
+      {children}
+   </main>
+</div>
+```
+
+Replace with:
+
+```tsx
+<div className="flex flex-1 overflow-hidden rounded-xl bg-background">
+   <main
+      className={cn(
+         "relative flex-1",
+         isSettingsPage
+            ? "overflow-hidden p-4"
+            : "overflow-y-auto p-4",
+      )}
+   >
+      {children}
+   </main>
+   <ContextPanelRail />
+</div>
+```
+
+Note: removing `flex-col` makes this a row (default flex-direction). `main` still has `flex-1` so it fills remaining width. `ContextPanelRail` is `w-10 shrink-0` so it takes exactly 40px.
+
+**Step 3: Verify TypeScript**
+
+```bash
+cd apps/web && bun run typecheck 2>&1 | grep "dashboard-layout"
+```
+
+Expected: no errors.
+
+**Step 4: Commit**
+
+```bash
+git add apps/web/src/layout/dashboard/ui/dashboard-layout.tsx
+git commit -m "feat(dashboard): add ContextPanelRail to right side of content area"
+```
+
+---
+
+## Task 4: Update `page-header.tsx` — hide desktop `ContextPanelHeaderActions`
+
+**Files:**
+- Modify: `apps/web/src/components/page-header.tsx`
+
+The `ContextPanelHeaderActions` buttons (Info + AI chat) open the panel. On desktop the rail replaces this affordance. On mobile the rail is hidden, so keep the buttons there.
+
+**Step 1: Remove desktop `ContextPanelHeaderActions` render**
+
+In `PageHeader`, find the desktop actions section (lines 244–259):
+
+```tsx
+{/* Desktop: actions */}
+<div className="hidden sm:flex items-center gap-2 shrink-0">
+   {!isOpen &&
+      panelActions?.map((action) => (
+         <Button
+            key={action.label}
+            onClick={action.onClick}
+            tooltip={action.label}
+            type="button"
+            variant="outline"
+         >
+            <action.icon className="size-4" />
+         </Button>
+      ))}
+   {actions}
+   {!isOpen && <ContextPanelHeaderActions />}  {/* ← REMOVE this line */}
+</div>
+```
+
+Remove the last line: `{!isOpen && <ContextPanelHeaderActions />}`.
+
+Also remove the `panelActions` desktop render since those actions are now always in the panel (panel is always accessible via rail):
+
+```tsx
+{/* Desktop: actions */}
+<div className="hidden sm:flex items-center gap-2 shrink-0">
+   {actions}
+</div>
+```
+
+Wait — the panelActions on desktop are a "show in toolbar when panel is closed" affordance. With the rail always visible, users open the panel to access those actions. Remove the desktop panelActions toolbar render too.
+
+**Step 2: Keep mobile `ContextPanelHeaderActions` unchanged**
+
+Mobile section (lines 181–208) already conditionally shows `ContextPanelHeaderActions`. Leave it as-is — rail is hidden on mobile so users still need the mobile open button.
+
+**Step 3: Check if `isOpen` is still needed in `PageHeader`**
+
+After removal, `isOpen` is used:
+- line 171: `const hasMobileOverflow = !isOpen && (panelActions?.length ?? 0) > 0;`
+- line 187: `{!isOpen && <ContextPanelHeaderActions />}` (mobile)
+- line 245–248: desktop panelActions — removed
+- line 258: desktop `ContextPanelHeaderActions` — removed
+
+`isOpen` is still needed for mobile rendering. Keep the `useStore` call.
+
+**Step 4: Verify TypeScript**
+
+```bash
+cd apps/web && bun run typecheck 2>&1 | grep "page-header"
+```
+
+Expected: no errors.
+
+**Step 5: Commit**
+
+```bash
+git add apps/web/src/components/page-header.tsx
+git commit -m "feat(page-header): remove desktop ContextPanelHeaderActions (replaced by rail)"
+```
+
+---
+
+## Task 5: Visual verification
+
+No automated tests for layout — verify manually in browser.
+
+**Step 1: Start dev server**
+
+```bash
+bun dev
+```
+
+**Step 2: Verify checklist**
+
+Open a dashboard page (e.g. `/transactions`) and check:
+
+- [ ] Narrow rail (~40px) visible on right edge of content area
+- [ ] Rail shows correct icons (Info icon + any dynamic tabs for the page)
+- [ ] Clicking a rail icon opens panel on that tab
+- [ ] Clicking the active tab icon while panel is open closes the panel
+- [ ] Clicking a different tab icon switches tab without closing
+- [ ] Panel header shows: active tab icon + tab label + X close button (no row of tab buttons)
+- [ ] Clicking X in panel header closes panel
+- [ ] After close, rail still shows icons (always visible)
+- [ ] Tooltip appears to the LEFT of each rail icon on hover
+- [ ] On mobile viewport (< 640px): rail is hidden, mobile header still shows open button
+- [ ] Settings page layout not broken (rail still appears but panel may not have dynamic tabs)
+
+**Step 3: Final commit (if any polish needed)**
+
+```bash
+git add -p
+git commit -m "fix(context-panel): polish rail and panel header styles"
+```

--- a/docs/plans/2026-04-19-sidebar-posthog-redesign.md
+++ b/docs/plans/2026-04-19-sidebar-posthog-redesign.md
@@ -2,9 +2,9 @@
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** Redesign AppSidebar to match PostHog layout — org selector + project selector at top, account at bottom, nav groups collapsible at group level with Tailwind animation, inline edit mode for nav config (no modal).
+**Goal:** Redesign AppSidebar to match PostHog layout — one combined org+team selector at top header, chat button stub below it, account at bottom footer, all nav sections are shadcn Collapsible groups (including a new "PROJETO" group wrapping the current main items: Home/Dashboards/Insights/Data), inline edit mode for nav config (no modal).
 
-**Architecture:** Split the single `SidebarScopeSwitcher` (537 lines, does too much) into three focused components: `SidebarOrgSelector`, `SidebarProjectSelector`, `SidebarAccountMenu`. Move selectors to `SidebarHeader`. Add a `ChatButton` stub. Make `NavGroup` headers into collapsible triggers at the group level. Replace the modal-based nav config with an inline toggle mode triggered by the pencil icon.
+**Architecture:** Move `SidebarScopeSwitcher` (combined org+team) into `SidebarHeader`. Extract `SidebarAccountMenu` (user/logout/theme) as separate footer component. Convert `SidebarDefaultItems` (the unlabeled main group) into a labeled `"PROJETO"` shadcn Collapsible section. Make all `NavGroup` labels collapsible triggers. Replace modal nav config with inline checkbox toggle mode.
 
 **Tech Stack:** shadcn/ui Sidebar primitives, Radix Collapsible, TanStack Query, Better Auth authClient, Tailwind CSS transitions, Lucide icons.
 
@@ -15,239 +15,91 @@
 ```
 <Sidebar>
   <SidebarHeader>
-    <SidebarOrgSelector />      ← org dropdown (top)
-    <SidebarProjectSelector />  ← team/project dropdown
-    <ChatButton />              ← chat stub (disabled, tooltip)
+    <SidebarScopeSwitcher />    ← combined org+team dropdown (existing, just moved here)
+    <Separator />
+    <SidebarChatButton />       ← chat stub (disabled, "Em breve")
   </SidebarHeader>
+
   <SidebarContent>
-    <SidebarDefaultItems />     ← unchanged
-    <SidebarNav />              ← groups now collapsible at group level
+    {/* "PROJETO" — shadcn Collapsible, wraps current SidebarDefaultItems */}
+    <SidebarGroup>
+      <Collapsible defaultOpen>
+        <SidebarGroupLabel asChild>
+          <CollapsibleTrigger>PROJETO <ChevronRight /></CollapsibleTrigger>
+        </SidebarGroupLabel>
+        <CollapsibleContent>
+          Home, Dashboards, Insights, Gestão de Dados
+        </CollapsibleContent>
+      </Collapsible>
+    </SidebarGroup>
+
+    <Separator />
+
+    {/* Finanças, ERP — each NavGroup header is also a CollapsibleTrigger */}
+    <SidebarNav />
   </SidebarContent>
+
   <SidebarFooter>
     <EarlyAccessSidebarBanner />
     <Separator />
-    <SidebarAccountMenu />      ← user avatar, theme, logout
-    <SidebarFooterContent />    ← hide/settings buttons
+    <SidebarAccountMenu />      ← extracted: user avatar + theme + logout
+    <Separator />
+    <SidebarFooterContent />    ← hide/settings (unchanged)
   </SidebarFooter>
 </Sidebar>
 ```
 
----
-
-## Task 1: Split SidebarScopeSwitcher → OrgSelector
-
-**Files:**
-- Create: `apps/web/src/layout/dashboard/ui/sidebar-org-selector.tsx`
-- Modify: `apps/web/src/layout/dashboard/ui/sidebar-scope-switcher.tsx` (keep only what task 2 and 3 need)
-
-**What to build:**
-
-`SidebarOrgSelector` renders a `DropdownMenu` triggered by a `SidebarMenuButton` that shows:
-- Active org avatar + name
-- `ChevronsUpDown` chevron on the right
-- Dropdown content: list of orgs with check mark on active, "Nova organização" at bottom
-- Links to org settings + billing
-
-Copy the org-related logic from `SidebarScopeSwitcherContent` (lines 159–186, 272–278, 460–479 in current file).
-
-```tsx
-// sidebar-org-selector.tsx
-import { ... } from "@packages/ui/components/dropdown-menu";
-import { SidebarMenu, SidebarMenuButton, SidebarMenuItem, useSidebar } from "@packages/ui/components/sidebar";
-import { useActiveOrganization } from "@/hooks/use-active-organization";
-import { useSetActiveOrganization } from "./-sidebar-scope-switcher/use-set-active-organization";
-import { orpc } from "@/integrations/orpc/client";
-import { useSuspenseQuery } from "@tanstack/react-query";
-import { ManageOrganizationForm } from "./-sidebar-scope-switcher/manage-organization-form";
-import { useCredenza } from "@/hooks/use-credenza";
-import { QueryBoundary } from "@/components/query-boundary";
-import { OrgAvatar } from "./sidebar-org-avatar"; // see Task 0
-
-export function SidebarOrgSelector() {
-  return (
-    <QueryBoundary fallback={<SidebarOrgSelectorSkeleton />} errorTitle="Erro ao carregar organização">
-      <SidebarOrgSelectorContent />
-    </QueryBoundary>
-  );
-}
-
-function SidebarOrgSelectorContent() {
-  const { activeOrganization } = useActiveOrganization();
-  const { isMobile } = useSidebar();
-  const { openCredenza } = useCredenza();
-  const { setActiveOrganization } = useSetActiveOrganization();
-  const [isPending, startTransition] = useTransition();
-  const { pathname } = useLocation();
-  const { slug, teamSlug } = useDashboardSlugs();
-  const router = useRouter();
-  const { data: organizations } = useSuspenseQuery(orpc.organization.getOrganizations.queryOptions({}));
-
-  // handleOrganizationSwitch — same logic as current SidebarScopeSwitcherContent
-  // handleNewOrganization — same as current
-
-  return (
-    <SidebarMenu>
-      <SidebarMenuItem>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <SidebarMenuButton
-              size="sm"
-              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
-            >
-              <OrgAvatar name={activeOrganization.name} logo={activeOrganization.logo} size="sm" />
-              <span className="truncate text-xs font-medium">{activeOrganization.name}</span>
-              <ChevronsUpDown className="ml-auto size-3.5 shrink-0" />
-            </SidebarMenuButton>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            align="start"
-            side={isMobile ? "bottom" : "right"}
-            sideOffset={4}
-            className="min-w-56 rounded-lg"
-          >
-            <DropdownMenuLabel className="py-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-              Organizações
-            </DropdownMenuLabel>
-            {organizations?.map((org, i) => (
-              <DropdownMenuItem key={`org-${i + 1}`} onSelect={() => handleOrganizationSwitch(org)}>
-                {org.id === activeOrganization.id ? <Check className="size-4 shrink-0" /> : <span className="size-4 shrink-0" />}
-                <OrgAvatar name={org.name} logo={org.logo} size="md" />
-                <span className="truncate">{org.name}</span>
-                {org.role && <span className="ml-auto text-[10px] text-muted-foreground">{org.role}</span>}
-              </DropdownMenuItem>
-            ))}
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onSelect={() => handleNewOrganization()}>
-              <Plus className="size-4" />
-              Nova organização
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem asChild>
-              <Link params={{ slug, teamSlug }} to="/$slug/$teamSlug/settings/organization/general">
-                <Settings className="size-4" /> Configurações da organização
-              </Link>
-            </DropdownMenuItem>
-            <DropdownMenuItem asChild>
-              <Link params={{ slug, teamSlug }} to="/$slug/$teamSlug/billing">
-                <CreditCard className="size-4" /> Cobrança & uso
-              </Link>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </SidebarMenuItem>
-    </SidebarMenu>
-  );
-}
-```
-
-**Step 1:** Extract `OrgAvatar`, `getInitials`, `getOrgColor`, `ORG_AVATAR_COLORS` to a new shared file `sidebar-org-avatar.tsx` — these are needed by multiple components.
-
-**Step 2:** Create `sidebar-org-selector.tsx` with `SidebarOrgSelectorContent` + `SidebarOrgSelectorSkeleton` + `SidebarOrgSelector` (boundary wrapper).
-
-**Step 3:** Run `bun run typecheck` — fix any errors.
-
-**Step 4:** Commit.
-
-```bash
-git add apps/web/src/layout/dashboard/ui/sidebar-org-avatar.tsx
-git add apps/web/src/layout/dashboard/ui/sidebar-org-selector.tsx
-git commit -m "feat(sidebar): extract OrgAvatar + SidebarOrgSelector component"
-```
+**Key clarifications:**
+- ONE selector at top: org+team combined (current `SidebarScopeSwitcher` logic, just relocated to header)
+- "PROJETO" in nav body = shadcn `Collapsible`, NOT a dropdown — wraps Home/Dashboards/Insights/Data
+- Account section extracted from `SidebarScopeSwitcher` into its own `SidebarAccountMenu` at footer
 
 ---
 
-## Task 2: Split SidebarScopeSwitcher → ProjectSelector
-
-**Files:**
-- Create: `apps/web/src/layout/dashboard/ui/-sidebar-scope-switcher/sidebar-project-selector.tsx`
-
-**What to build:**
-
-`SidebarProjectSelector` shows active team/project with a dropdown to switch between teams or create new one. Smaller than org selector since projects are within an org.
-
-```tsx
-function SidebarProjectSelectorContent() {
-  const { activeTeam, teams } = useActiveTeam();
-  const { projectLimit, projectCount } = useActiveOrganization();
-  const { isMobile } = useSidebar();
-  const { openCredenza, closeCredenza } = useCredenza();
-  // handleTeamSwitch, handleNewProject — same logic as current
-  const { slug, teamSlug } = useDashboardSlugs();
-
-  return (
-    <SidebarMenu>
-      <SidebarMenuItem>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <SidebarMenuButton
-              size="sm"
-              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
-            >
-              <LayoutGrid className="size-4 shrink-0 text-muted-foreground" />
-              <span className="truncate text-sm font-medium">{activeTeam?.name ?? "Sem espaço"}</span>
-              <ChevronsUpDown className="ml-auto size-3.5 shrink-0" />
-            </SidebarMenuButton>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" side={isMobile ? "bottom" : "right"} sideOffset={4} className="min-w-56 rounded-lg">
-            <DropdownMenuLabel className="py-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-              Espaços
-            </DropdownMenuLabel>
-            {teams.map((team, i) => (
-              <DropdownMenuItem key={`team-${i + 1}`} onSelect={() => handleTeamSwitch(team)}>
-                {team.id === activeTeam?.id ? <Check className="size-4 shrink-0" /> : <span className="size-4 shrink-0" />}
-                <span className="truncate">{team.name}</span>
-              </DropdownMenuItem>
-            ))}
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onSelect={() => handleNewProject()}>
-              <Plus className="size-4" />
-              {projectLimit !== null && projectLimit !== Number.POSITIVE_INFINITY
-                ? `Novo espaço (${projectCount}/${projectLimit})`
-                : "Novo espaço"}
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem asChild>
-              <Link params={{ slug, teamSlug }} to="/$slug/$teamSlug/settings/project/general">
-                <Settings className="size-4" /> Configurações do espaço
-              </Link>
-            </DropdownMenuItem>
-            <DropdownMenuItem asChild>
-              <Link params={{ slug, teamSlug }} to="/$slug/$teamSlug/settings/organization/members">
-                <UserPlus className="size-4" /> Convidar membros
-              </Link>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </SidebarMenuItem>
-    </SidebarMenu>
-  );
-}
-```
-
-**Step 1:** Create `sidebar-project-selector.tsx` — copy team/project logic from `SidebarScopeSwitcherContent`.
-
-**Step 2:** `bun run typecheck` — fix errors.
-
-**Step 3:** Commit.
-
-```bash
-git add apps/web/src/layout/dashboard/ui/sidebar-project-selector.tsx
-git commit -m "feat(sidebar): extract SidebarProjectSelector component"
-```
-
----
-
-## Task 3: Split SidebarScopeSwitcher → AccountMenu
+## Task 1: Extract SidebarAccountMenu from SidebarScopeSwitcher
 
 **Files:**
 - Create: `apps/web/src/layout/dashboard/ui/sidebar-account-menu.tsx`
-- Delete or gut: `apps/web/src/layout/dashboard/ui/sidebar-scope-switcher.tsx` (replace with thin re-exports or delete)
+- Modify: `apps/web/src/layout/dashboard/ui/sidebar-scope-switcher.tsx` (remove account section)
 
 **What to build:**
 
-`SidebarAccountMenu` at the bottom — user avatar, name, email, theme switcher, logout.
+Extract the "Conta" section (user avatar, theme switcher, logout) from `SidebarScopeSwitcherContent` into a standalone `SidebarAccountMenu`. This goes in `SidebarFooter`. The existing `SidebarScopeSwitcher` keeps org+team switching logic but drops account.
 
 ```tsx
+// sidebar-account-menu.tsx
+import { Avatar, AvatarFallback, AvatarImage } from "@packages/ui/components/avatar";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@packages/ui/components/dropdown-menu";
+import { SidebarMenu, SidebarMenuButton, SidebarMenuItem, useSidebar } from "@packages/ui/components/sidebar";
+import { useSuspenseQuery, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "@tanstack/react-router";
+import { ChevronsUpDown, LogOut, Settings } from "lucide-react";
+import { useCallback, useTransition } from "react";
+import { QueryBoundary } from "@/components/query-boundary";
+import { Skeleton } from "@packages/ui/components/skeleton";
+import { toast } from "sonner";
+import { useAlertDialog } from "@/hooks/use-alert-dialog";
+import { useDashboardSlugs } from "@/hooks/use-dashboard-slugs";
+import { authClient } from "@/integrations/better-auth/auth-client";
+import { orpc } from "@/integrations/orpc/client";
+import { ThemeSwitcher } from "./theme-switcher";
+
+function SidebarAccountMenuSkeleton() {
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <SidebarMenuButton className="pointer-events-none" size="lg">
+          <Skeleton className="size-8 rounded-full" />
+          <div className="grid flex-1 gap-2">
+            <Skeleton className="h-3.5 w-24" />
+            <Skeleton className="h-3 w-32" />
+          </div>
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  );
+}
+
 function SidebarAccountMenuContent() {
   const { data: session } = useSuspenseQuery(orpc.session.getSession.queryOptions({}));
   const { slug, teamSlug } = useDashboardSlugs();
@@ -255,7 +107,33 @@ function SidebarAccountMenuContent() {
   const { isMobile, setOpenMobile } = useSidebar();
   const queryClient = useQueryClient();
   const router = useRouter();
-  // handleLogout, handleLogoutClick — same as current
+  const [, startTransition] = useTransition();
+
+  const handleLogout = useCallback(async () => {
+    await authClient.signOut({
+      fetchOptions: {
+        onError: ({ error }) => toast.error(error.message, { id: "logout" }),
+        onRequest: () => toast.loading("Saindo...", { id: "logout" }),
+        onSuccess: async () => {
+          await queryClient.invalidateQueries({ queryKey: orpc.session.getSession.queryKey({}) });
+          router.navigate({ to: "/auth/sign-in" });
+          toast.success("Você saiu com sucesso", { id: "logout" });
+        },
+      },
+    });
+    setOpenMobile(false);
+  }, [queryClient, router, setOpenMobile]);
+
+  const handleLogoutClick = useCallback(() => {
+    openAlertDialog({
+      actionLabel: "Sair",
+      cancelLabel: "Cancelar",
+      description: "Tem certeza que deseja sair da sua conta?",
+      onAction: handleLogout,
+      title: "Sair da Conta",
+      variant: "destructive",
+    });
+  }, [openAlertDialog, handleLogout]);
 
   return (
     <SidebarMenu>
@@ -272,7 +150,7 @@ function SidebarAccountMenuContent() {
                   {session?.user.name?.charAt(0) ?? "?"}
                 </AvatarFallback>
               </Avatar>
-              <div className="grid min-w-0 flex-1 leading-tight text-left">
+              <div className="grid min-w-0 flex-1 text-left leading-tight">
                 <span className="truncate text-sm font-medium">{session?.user.name}</span>
                 <span className="truncate text-xs text-muted-foreground">{session?.user.email}</span>
               </div>
@@ -308,7 +186,10 @@ function SidebarAccountMenuContent() {
                 <Settings className="size-4" /> Meu perfil
               </Link>
             </DropdownMenuItem>
-            <DropdownMenuItem onSelect={handleLogoutClick} className="text-destructive focus:text-destructive">
+            <DropdownMenuItem
+              onSelect={handleLogoutClick}
+              className="text-destructive focus:text-destructive"
+            >
               <LogOut className="size-4" />
               Sair
             </DropdownMenuItem>
@@ -318,31 +199,41 @@ function SidebarAccountMenuContent() {
     </SidebarMenu>
   );
 }
+
+export function SidebarAccountMenu() {
+  return (
+    <QueryBoundary fallback={<SidebarAccountMenuSkeleton />} errorTitle="Erro ao carregar conta">
+      <SidebarAccountMenuContent />
+    </QueryBoundary>
+  );
+}
 ```
 
-**Step 1:** Create `sidebar-account-menu.tsx` with `SidebarAccountMenuContent` + skeleton + `SidebarAccountMenu` (QueryBoundary wrapper).
+In `sidebar-scope-switcher.tsx`: delete the "Conta" `DropdownMenuLabel` block and everything under it (theme switcher, profile link, logout). The component now only handles org+team.
 
-**Step 2:** Delete `sidebar-scope-switcher.tsx` (all its consumers will be replaced in Task 4).
+**Step 1:** Create `sidebar-account-menu.tsx` with code above.
 
-**Step 3:** `bun run typecheck` — fix broken imports.
+**Step 2:** Remove account section from `sidebar-scope-switcher.tsx` (lines 483–521 in current file — the `DropdownMenuLabel` "Conta" through end of dropdown content).
+
+**Step 3:** `bun run typecheck` — fix errors.
 
 **Step 4:** Commit.
 
 ```bash
 git add apps/web/src/layout/dashboard/ui/sidebar-account-menu.tsx
-git rm apps/web/src/layout/dashboard/ui/sidebar-scope-switcher.tsx
-git commit -m "feat(sidebar): extract SidebarAccountMenu, remove old scope switcher"
+git add apps/web/src/layout/dashboard/ui/sidebar-scope-switcher.tsx
+git commit -m "feat(sidebar): extract SidebarAccountMenu from scope switcher"
 ```
 
 ---
 
-## Task 4: Rewire app-sidebar.tsx + add ChatButton
+## Task 2: Rewire app-sidebar.tsx — move scope switcher to header, account to footer, add chat button
 
 **Files:**
 - Modify: `apps/web/src/layout/dashboard/ui/app-sidebar.tsx`
 - Create: `apps/web/src/layout/dashboard/ui/sidebar-chat-button.tsx`
 
-**ChatButton** — just a button that shows a "em breve" tooltip. No infra needed.
+**ChatButton** — disabled button, "Em breve" badge, tooltip.
 
 ```tsx
 // sidebar-chat-button.tsx
@@ -356,7 +247,7 @@ export function SidebarChatButton() {
       <SidebarMenuItem>
         <Tooltip>
           <TooltipTrigger asChild>
-            <SidebarMenuButton className="cursor-not-allowed opacity-60" size="sm">
+            <SidebarMenuButton size="sm" className="cursor-not-allowed opacity-60" disabled>
               <MessageSquare className="size-4" />
               <span>Chat</span>
               <span className="ml-auto rounded-sm bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
@@ -376,15 +267,17 @@ export function SidebarChatButton() {
 
 ```tsx
 import { Separator } from "@packages/ui/components/separator";
-import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem, useSidebar } from "@packages/ui/components/sidebar";
+import {
+  Sidebar, SidebarContent, SidebarFooter, SidebarHeader,
+  SidebarMenu, SidebarMenuButton, SidebarMenuItem, useSidebar,
+} from "@packages/ui/components/sidebar";
 import { Link } from "@tanstack/react-router";
 import { PanelLeftClose, Settings } from "lucide-react";
 import type * as React from "react";
 import { useDashboardSlugs } from "@/hooks/use-dashboard-slugs";
 import { EarlyAccessSidebarBanner } from "./early-access-sidebar-banner";
 import { SidebarDefaultItems, SidebarNav } from "./sidebar-nav";
-import { SidebarOrgSelector } from "./sidebar-org-selector";
-import { SidebarProjectSelector } from "./sidebar-project-selector";
+import { SidebarScopeSwitcher } from "./sidebar-scope-switcher";
 import { SidebarChatButton } from "./sidebar-chat-button";
 import { SidebarAccountMenu } from "./sidebar-account-menu";
 
@@ -392,8 +285,7 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
   return (
     <Sidebar className="px-0" collapsible="icon" variant="inset" {...props}>
       <SidebarHeader className="gap-1 pb-2">
-        <SidebarOrgSelector />
-        <SidebarProjectSelector />
+        <SidebarScopeSwitcher />
         <Separator className="my-1" />
         <SidebarChatButton />
       </SidebarHeader>
@@ -444,7 +336,7 @@ function SidebarFooterContent() {
 
 **Step 1:** Create `sidebar-chat-button.tsx`.
 
-**Step 2:** Rewrite `app-sidebar.tsx` with new structure above.
+**Step 2:** Rewrite `app-sidebar.tsx`.
 
 **Step 3:** `bun run typecheck` — fix errors.
 
@@ -453,27 +345,122 @@ function SidebarFooterContent() {
 ```bash
 git add apps/web/src/layout/dashboard/ui/sidebar-chat-button.tsx
 git add apps/web/src/layout/dashboard/ui/app-sidebar.tsx
-git commit -m "feat(sidebar): new PostHog-style layout — org+project header, account footer, chat button stub"
+git commit -m "feat(sidebar): PostHog layout — scope switcher to header, account to footer, chat stub"
 ```
 
 ---
 
-## Task 5: Collapsible NavGroups at group level with Tailwind animation
+## Task 3: "PROJETO" collapsible nav section (wrap SidebarDefaultItems)
 
 **Files:**
 - Modify: `apps/web/src/layout/dashboard/ui/sidebar-nav.tsx`
 
-Currently `NavGroup` has a static `SidebarGroupLabel` header. Make each group with a `label` collapsible — clicking the label toggles the whole group.
+`SidebarDefaultItems` currently renders the unlabeled main group (Home, Dashboards, Insights, Data Management) with no section header. Wrap it in a shadcn `Collapsible` with a "PROJETO" label, matching PostHog's "PROJECT ˅" section.
 
-**Key change in `NavGroup`:**
+**Replace `SidebarDefaultItems` in `sidebar-nav.tsx`:**
 
 ```tsx
-function NavGroup({ group, ... }) {
-  // ...existing logic...
+import {
+  Collapsible, CollapsibleContent, CollapsibleTrigger,
+} from "@packages/ui/components/collapsible";
+import {
+  SidebarGroup, SidebarGroupContent, SidebarGroupLabel,
+  SidebarMenu, useSidebarManager,
+} from "@packages/ui/components/sidebar";
+import { ChevronRight } from "lucide-react";
 
-  // Groups are open by default; state stored in component (no persistence needed)
+export function SidebarDefaultItems() {
+  const {
+    slug, teamSlug,
+    handleSubPanelToggle, handleMainItemClick, isItemActive,
+  } = useNavHandlers();
+  const { pathname } = useLocation();
+  const { isEnrolled } = useEarlyAccess();
+  const { isVisible } = useSidebarVisibility();
+
+  const mainGroup = navGroups.find((g) => !g.label);
+  const visibleMainItems = (mainGroup?.items ?? [])
+    .filter((item) => (!item.earlyAccessFlag) || isEnrolled(item.earlyAccessFlag))
+    .filter((item) => isVisible(item.id));
+
+  const resolvedSlug = slug || pathname.split("/")[1] || "";
+
   return (
-    <Collapsible asChild defaultOpen className="group/nav-group pt-0">
+    <Collapsible defaultOpen className="group/projeto">
+      <SidebarGroup className="py-0">
+        <SidebarGroupLabel asChild className="justify-between pr-2 group-data-[collapsible=icon]:hidden">
+          <CollapsibleTrigger className="w-full cursor-pointer hover:text-foreground transition-colors duration-150">
+            <span className="text-[11px] font-semibold uppercase tracking-wider">Projeto</span>
+            <ChevronRight className="size-3 transition-transform duration-200 group-data-[state=open]/projeto:rotate-90" />
+          </CollapsibleTrigger>
+        </SidebarGroupLabel>
+        <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {visibleMainItems.map((item) => (
+                <NavItem
+                  isActive={isItemActive(item)}
+                  item={item}
+                  key={item.id}
+                  onMainItemClick={handleMainItemClick}
+                  onSubPanelToggle={handleSubPanelToggle}
+                  slug={resolvedSlug}
+                  teamSlug={teamSlug}
+                />
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </CollapsibleContent>
+      </SidebarGroup>
+    </Collapsible>
+  );
+}
+```
+
+**Step 1:** Add `Collapsible`, `CollapsibleContent`, `CollapsibleTrigger` to imports in `sidebar-nav.tsx`.
+
+**Step 2:** Rewrite `SidebarDefaultItems` as shown above.
+
+**Step 3:** `bun run typecheck` — fix errors.
+
+**Step 4:** Commit.
+
+```bash
+git add apps/web/src/layout/dashboard/ui/sidebar-nav.tsx
+git commit -m "feat(sidebar): PROJETO collapsible section wrapping main nav items"
+```
+
+---
+
+## Task 4: Collapsible NavGroup headers (Finanças, ERP, etc.)
+
+**Files:**
+- Modify: `apps/web/src/layout/dashboard/ui/sidebar-nav.tsx`
+
+Make each `NavGroup` with a `label` collapsible at group level — clicking the section header toggles the group. Uses the same shadcn `Collapsible` pattern.
+
+**Replace `NavGroup`:**
+
+```tsx
+function NavGroup({ group, slug, teamSlug, isItemActive, onSubPanelToggle, onMainItemClick, onConfigure }) {
+  const { isEnrolled } = useEarlyAccess();
+  const { isVisible } = useSidebarVisibility();
+  const { isWanted } = useFinanceNavPreferences();
+
+  const visibleItems = group.items
+    .filter((item) => {
+      if (!item.earlyAccessFlag) return true;
+      if (group.label) return isWanted(item.id) || isEnrolled(item.earlyAccessFlag);
+      return isEnrolled(item.earlyAccessFlag);
+    })
+    .filter((item) => isVisible(item.id));
+
+  if (visibleItems.length === 0 && !onConfigure) return null;
+
+  const groupKey = `nav-group-${group.id}`;
+
+  return (
+    <Collapsible defaultOpen className={`group/${groupKey} pt-0`}>
       <SidebarGroup className="pt-0">
         {group.label && (
           <SidebarGroupLabel asChild className="justify-between pr-1">
@@ -489,15 +476,36 @@ function NavGroup({ group, ... }) {
                     <Settings2 className="size-3.5" />
                   </button>
                 )}
-                <ChevronRight className="size-3 text-muted-foreground transition-transform duration-200 group-data-[state=open]/nav-group:rotate-90 group-data-[collapsible=icon]:hidden" />
+                <ChevronRight className={`size-3 text-muted-foreground transition-transform duration-200 group-data-[state=open]/${groupKey}:rotate-90 group-data-[collapsible=icon]:hidden`} />
               </div>
             </CollapsibleTrigger>
           </SidebarGroupLabel>
         )}
-        <CollapsibleContent className="overflow-hidden transition-all duration-200 data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
+        <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
           <SidebarGroupContent>
             <SidebarMenu>
-              {visibleItems.map((item) => ...)}
+              {visibleItems.map((item) =>
+                item.children ? (
+                  <CollapsibleNavItem
+                    isItemActive={isItemActive}
+                    item={item}
+                    key={item.id}
+                    onMainItemClick={onMainItemClick}
+                    slug={slug}
+                    teamSlug={teamSlug}
+                  />
+                ) : (
+                  <NavItem
+                    isActive={isItemActive(item)}
+                    item={item}
+                    key={item.id}
+                    onMainItemClick={onMainItemClick}
+                    onSubPanelToggle={onSubPanelToggle}
+                    slug={slug}
+                    teamSlug={teamSlug}
+                  />
+                ),
+              )}
             </SidebarMenu>
           </SidebarGroupContent>
         </CollapsibleContent>
@@ -507,15 +515,24 @@ function NavGroup({ group, ... }) {
 }
 ```
 
-**Note on Tailwind animation classes:** shadcn/ui already ships `animate-accordion-up` and `animate-accordion-down` via `tailwindcss-animate` in `globals.css`. These work on `CollapsibleContent`. No extra config needed.
+**Note on dynamic Tailwind group names:** `group-data-[state=open]/${groupKey}` uses Tailwind's arbitrary group variant. This requires the class to be present as a complete string at build time — Tailwind can't detect dynamically interpolated class names. Use a fixed set instead: wrap in `className="group/nav-group"` and use `group-data-[state=open]/nav-group:rotate-90`. Since all groups share the same variant name, it's fine — each `Collapsible` scopes its own state independently via the DOM tree.
 
-**Step 1:** Wrap `NavGroup` body in `<Collapsible asChild defaultOpen>`.
+**Simplified approach (avoids dynamic class issue):**
 
-**Step 2:** Make `SidebarGroupLabel` a `CollapsibleTrigger` — add chevron to right side.
+```tsx
+// Always use the same group name — each Collapsible scopes independently
+<Collapsible defaultOpen className="group/nav-group pt-0">
+  ...
+  <ChevronRight className="size-3 ... transition-transform duration-200 group-data-[state=open]/nav-group:rotate-90 ..." />
+```
 
-**Step 3:** Wrap `SidebarGroupContent` in `<CollapsibleContent className="overflow-hidden transition-all duration-200 data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">`.
+**Step 1:** Wrap `NavGroup` body in `<Collapsible defaultOpen className="group/nav-group pt-0">`.
 
-**Step 4:** Stop propagation on the configure button click so it doesn't toggle collapse.
+**Step 2:** Make `SidebarGroupLabel` a `CollapsibleTrigger` with `asChild`, add chevron.
+
+**Step 3:** Wrap content in `<CollapsibleContent className="overflow-hidden data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">`.
+
+**Step 4:** `e.stopPropagation()` on the configure button so it doesn't toggle collapse.
 
 **Step 5:** `bun run typecheck` — fix errors.
 
@@ -523,109 +540,112 @@ function NavGroup({ group, ... }) {
 
 ```bash
 git add apps/web/src/layout/dashboard/ui/sidebar-nav.tsx
-git commit -m "feat(sidebar): collapsible nav groups with Tailwind animation"
+git commit -m "feat(sidebar): collapsible group headers for Finanças and ERP sections"
 ```
 
 ---
 
-## Task 6: Inline edit mode for nav config (replace modal)
+## Task 5: Inline edit mode for nav config (replace modal)
 
 **Files:**
 - Modify: `apps/web/src/layout/dashboard/ui/sidebar-nav.tsx`
-- Modify: `apps/web/src/layout/dashboard/ui/sidebar-nav-config-form.tsx` (may no longer be needed)
+- Modify: `apps/web/src/layout/dashboard/hooks/use-sidebar-store.ts` (if toggle missing)
 
-Currently: clicking the `Settings2` icon on the finance group opens a `SidebarNavConfigForm` modal.
+Currently: `Settings2` icon on finance group opens `SidebarNavConfigForm` modal.
 
-New behavior (like PostHog image 9): clicking the pencil toggles an inline "edit mode" for that group. In edit mode:
-- Each item shows a checkbox on the left
-- Header shows a `Check` icon instead of pencil to save, and an `X` to cancel
-- Clicking `Check` saves the visibility preferences and exits edit mode
-- Animation: fade/slide transition between view and edit modes
+New behavior (PostHog image 9): click pencil → inline checkbox list. Click ✓ → save + exit. Click ✗ → cancel.
 
-**State:** Add local state to `NavGroup` — `isEditing: boolean`.
+**Step 1:** Check `use-sidebar-store.ts` — does `useSidebarVisibility` expose a `toggleVisibility(itemId)` function? If not, add:
 
-**Implementation in `NavGroup`:**
-
-```tsx
-function NavGroup({ group, slug, teamSlug, isItemActive, onSubPanelToggle, onMainItemClick, onConfigure }) {
-  const [isEditing, setIsEditing] = useState(false);
-  const { isVisible, toggleVisibility } = useSidebarVisibility(); // need toggleVisibility
-  // ...
-
-  const handleEditStart = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation(); // don't collapse group
-    setIsEditing(true);
-  }, []);
-
-  const handleEditSave = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-    setIsEditing(false);
-    // visibility already toggled on checkbox click via store
-  }, []);
-
-  const handleEditCancel = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation();
-    setIsEditing(false);
-  }, []);
-
-  // In the label area:
-  // Replace: <Settings2 onClick={onConfigure} />
-  // With:
-  {onConfigure && !isEditing && (
-    <button onClick={handleEditStart} type="button" className="...">
-      <Pencil className="size-3.5" />
-    </button>
-  )}
-  {isEditing && (
-    <>
-      <button onClick={handleEditSave} type="button" className="text-green-600 hover:text-green-700">
-        <Check className="size-3.5" />
-      </button>
-      <button onClick={handleEditCancel} type="button" className="text-muted-foreground hover:text-foreground">
-        <X className="size-3.5" />
-      </button>
-    </>
-  )}
-
-  // Items in edit mode: render all items (not just visible) with checkboxes
-  {isEditing ? (
-    <SidebarMenu>
-      {group.items.filter(...earlyAccess).map((item) => (
-        <SidebarMenuItem key={item.id}>
-          <button
-            type="button"
-            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-sidebar-accent transition-colors duration-150"
-            onClick={() => toggleVisibility(item.id)}
-          >
-            <div className={cn(
-              "flex size-4 items-center justify-center rounded-sm border transition-colors duration-150",
-              isVisible(item.id) ? "bg-primary border-primary text-primary-foreground" : "border-muted-foreground"
-            )}>
-              {isVisible(item.id) && <Check className="size-3" />}
-            </div>
-            <item.icon className="size-4 text-muted-foreground" />
-            <span>{item.label}</span>
-          </button>
-        </SidebarMenuItem>
-      ))}
-    </SidebarMenu>
-  ) : (
-    // normal items rendering
-  )}
+```typescript
+// in use-sidebar-store.ts
+export function toggleVisibility(itemId: string) {
+  // look at how isVisible/setVisible works and implement toggle
+  // likely: store.setState(s => ({ ...s, hiddenItems: s.hiddenItems.includes(itemId) ? s.hiddenItems.filter(id => id !== itemId) : [...s.hiddenItems, itemId] }))
 }
 ```
 
-**Note:** Check if `useSidebarVisibility` already exposes a toggle function. If not, add `toggleVisibility(itemId: string)` to `use-sidebar-store.ts`.
+**Step 2:** Add `isEditing` state to `NavGroup`, `handleEditStart/Save/Cancel` callbacks:
 
-**Step 1:** Check `apps/web/src/layout/dashboard/hooks/use-sidebar-store.ts` — does `useSidebarVisibility` expose a toggle? If not, add one.
+```tsx
+const [isEditing, setIsEditing] = useState(false);
+const { isVisible } = useSidebarVisibility();
 
-**Step 2:** Add `isEditing` state + `handleEditStart/Save/Cancel` to `NavGroup`.
+const handleEditStart = useCallback((e: React.MouseEvent) => {
+  e.stopPropagation();
+  setIsEditing(true);
+}, []);
 
-**Step 3:** Replace `Settings2` configure button with `Pencil` that triggers inline edit.
+const handleEditSave = useCallback((e: React.MouseEvent) => {
+  e.stopPropagation();
+  setIsEditing(false);
+}, []);
 
-**Step 4:** Render checkbox list when `isEditing === true`.
+const handleEditCancel = useCallback((e: React.MouseEvent) => {
+  e.stopPropagation();
+  setIsEditing(false);
+}, []);
+```
 
-**Step 5:** Remove `onConfigure` prop from `NavGroup` and `SidebarNav`. Remove `SidebarNavConfigForm` modal call from `SidebarNav`.
+**Step 3:** Replace `Settings2` button with `Pencil` → `handleEditStart`. When `isEditing`, show `Check` (save) + `X` (cancel) instead:
+
+```tsx
+{onConfigure && !isEditing && (
+  <button onClick={handleEditStart} type="button"
+    className="text-muted-foreground hover:text-foreground group-data-[collapsible=icon]:hidden">
+    <Pencil className="size-3.5" />
+  </button>
+)}
+{isEditing && (
+  <>
+    <button onClick={handleEditSave} type="button" className="text-emerald-600 hover:text-emerald-700">
+      <Check className="size-3.5" />
+    </button>
+    <button onClick={handleEditCancel} type="button" className="text-muted-foreground hover:text-foreground">
+      <X className="size-3.5" />
+    </button>
+  </>
+)}
+```
+
+**Step 4:** Render checkbox list when `isEditing`. Show ALL group items (not just visible), filtered by early access only:
+
+```tsx
+{isEditing ? (
+  <SidebarGroupContent>
+    <SidebarMenu>
+      {group.items
+        .filter((item) => !item.earlyAccessFlag || isEnrolled(item.earlyAccessFlag))
+        .map((item) => {
+          const Icon = item.icon;
+          const visible = isVisible(item.id);
+          return (
+            <SidebarMenuItem key={item.id}>
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-sidebar-accent transition-colors duration-150"
+                onClick={() => toggleVisibility(item.id)}
+              >
+                <div className={cn(
+                  "flex size-4 shrink-0 items-center justify-center rounded-sm border transition-colors duration-150",
+                  visible ? "bg-primary border-primary text-primary-foreground" : "border-muted-foreground",
+                )}>
+                  {visible && <Check className="size-3" />}
+                </div>
+                <Icon className="size-4 shrink-0 text-muted-foreground" />
+                <span className="truncate">{item.label}</span>
+              </button>
+            </SidebarMenuItem>
+          );
+        })}
+    </SidebarMenu>
+  </SidebarGroupContent>
+) : (
+  // existing items render
+)}
+```
+
+**Step 5:** Remove `onConfigure` prop from `NavGroup` signature and from `SidebarNav`. Remove `handleConfigure` + `SidebarNavConfigForm` call from `SidebarNav`.
 
 **Step 6:** `bun run typecheck`.
 
@@ -634,37 +654,36 @@ function NavGroup({ group, slug, teamSlug, isItemActive, onSubPanelToggle, onMai
 ```bash
 git add apps/web/src/layout/dashboard/ui/sidebar-nav.tsx
 git add apps/web/src/layout/dashboard/hooks/use-sidebar-store.ts
-git commit -m "feat(sidebar): inline edit mode for nav config, replace modal"
+git commit -m "feat(sidebar): inline checkbox edit mode, remove modal config"
 ```
 
 ---
 
-## Task 7: Cleanup
+## Task 6: Cleanup
 
 **Files:**
-- Check: `apps/web/src/layout/dashboard/ui/sidebar-nav-config-form.tsx` — delete if no longer referenced
-- Check: `apps/web/src/layout/dashboard/ui/sidebar-scope-switcher.tsx` — delete if not done in Task 3
+- Delete: `apps/web/src/layout/dashboard/ui/sidebar-nav-config-form.tsx` (if unreferenced)
 
-**Step 1:** `grep -r "SidebarNavConfigForm" apps/web/src` — confirm no references remain.
+**Step 1:** `grep -r "SidebarNavConfigForm" apps/web/src` — confirm zero references.
 
-**Step 2:** Delete `sidebar-nav-config-form.tsx` if unreferenced.
+**Step 2:** Delete if clean.
 
 **Step 3:** `bun run typecheck && bun run check` — all clean.
 
-**Step 4:** Final commit.
+**Step 4:** Commit.
 
 ```bash
 git rm apps/web/src/layout/dashboard/ui/sidebar-nav-config-form.tsx
-git commit -m "chore(sidebar): remove unused SidebarNavConfigForm after inline edit migration"
+git commit -m "chore(sidebar): remove SidebarNavConfigForm after inline edit migration"
 ```
 
 ---
 
 ## Notes & Gotchas
 
-- **`SidebarGroupLabel` as CollapsibleTrigger**: shadcn's `SidebarGroupLabel` renders a `div`, not a `button`. Pass `asChild` to `SidebarGroupLabel` and make `CollapsibleTrigger` the child — not the other way around. Check if this causes styling issues; might need to `asChild` chain carefully.
-- **`group-data-[state=open]/nav-group` Tailwind variant**: Requires the `Collapsible` to have `className="group/nav-group"` — already done in the code above. The chevron rotation uses this.
-- **Animation classes**: `animate-accordion-up` / `animate-accordion-down` are defined by shadcn in `tailwind.config.ts` via `tailwindcss-animate`. Verify they exist: `grep -r "accordion" apps/web/tailwind.config.ts`. If missing, use `data-[state=closed]:h-0 data-[state=open]:h-auto transition-all duration-200` with `overflow-hidden` instead (less smooth but works).
-- **`OrgAvatar` extraction**: Both `SidebarOrgSelector` and any org-related display in `SidebarAccountMenu` need it. Keep it in `sidebar-org-avatar.tsx` as a named export only — no barrel.
-- **Mobile sidebar**: `isMobile` from `useSidebar()` — existing pattern already handles this. Keep `side={isMobile ? "bottom" : "right"}` on project/org dropdowns.
-- **`SidebarHeader` padding**: Current sidebar uses `px-0` on `<Sidebar>`. Add `px-2 pt-2` on `SidebarHeader` or use individual `px-2` on each selector to match the existing item padding.
+- **`SidebarGroupLabel` + `asChild` + `CollapsibleTrigger`**: `SidebarGroupLabel` renders a `div`. Pass `asChild` on it and use `CollapsibleTrigger` as the direct child. Do NOT put `asChild` on `CollapsibleTrigger` here — it's the trigger itself. If styling breaks, fall back to a plain `button` styled to match `SidebarGroupLabel` classes.
+- **`group/nav-group` shared name**: All `NavGroup` collapsibles can share `className="group/nav-group"` — each `Collapsible` scopes its `data-[state]` to its own subtree. No name conflicts.
+- **Animation classes**: `animate-accordion-up`/`animate-accordion-down` from `tailwindcss-animate`. Verify: `grep accordion apps/web/tailwind.config.ts`. Fallback: `data-[state=closed]:grid-rows-[0fr] data-[state=open]:grid-rows-[1fr] transition-[grid-template-rows] duration-200` with inner `div className="overflow-hidden"`.
+- **`SidebarScopeSwitcher` size in header**: The existing trigger uses `size="lg"`. In a header context this may feel large — consider `size="sm"` or default. Adjust if needed.
+- **Mobile**: `SidebarScopeSwitcher` already handles `isMobile`. No changes needed there.
+- **`SidebarHeader` padding**: `Sidebar` has `px-0`. `SidebarHeader` will need `px-2` or the child `SidebarMenu` will handle it. Check visually.

--- a/docs/plans/2026-04-19-sidebar-posthog-redesign.md
+++ b/docs/plans/2026-04-19-sidebar-posthog-redesign.md
@@ -1,0 +1,670 @@
+# Sidebar PostHog-Inspired Redesign Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Redesign AppSidebar to match PostHog layout — org selector + project selector at top, account at bottom, nav groups collapsible at group level with Tailwind animation, inline edit mode for nav config (no modal).
+
+**Architecture:** Split the single `SidebarScopeSwitcher` (537 lines, does too much) into three focused components: `SidebarOrgSelector`, `SidebarProjectSelector`, `SidebarAccountMenu`. Move selectors to `SidebarHeader`. Add a `ChatButton` stub. Make `NavGroup` headers into collapsible triggers at the group level. Replace the modal-based nav config with an inline toggle mode triggered by the pencil icon.
+
+**Tech Stack:** shadcn/ui Sidebar primitives, Radix Collapsible, TanStack Query, Better Auth authClient, Tailwind CSS transitions, Lucide icons.
+
+---
+
+## Layout Target
+
+```
+<Sidebar>
+  <SidebarHeader>
+    <SidebarOrgSelector />      ← org dropdown (top)
+    <SidebarProjectSelector />  ← team/project dropdown
+    <ChatButton />              ← chat stub (disabled, tooltip)
+  </SidebarHeader>
+  <SidebarContent>
+    <SidebarDefaultItems />     ← unchanged
+    <SidebarNav />              ← groups now collapsible at group level
+  </SidebarContent>
+  <SidebarFooter>
+    <EarlyAccessSidebarBanner />
+    <Separator />
+    <SidebarAccountMenu />      ← user avatar, theme, logout
+    <SidebarFooterContent />    ← hide/settings buttons
+  </SidebarFooter>
+</Sidebar>
+```
+
+---
+
+## Task 1: Split SidebarScopeSwitcher → OrgSelector
+
+**Files:**
+- Create: `apps/web/src/layout/dashboard/ui/sidebar-org-selector.tsx`
+- Modify: `apps/web/src/layout/dashboard/ui/sidebar-scope-switcher.tsx` (keep only what task 2 and 3 need)
+
+**What to build:**
+
+`SidebarOrgSelector` renders a `DropdownMenu` triggered by a `SidebarMenuButton` that shows:
+- Active org avatar + name
+- `ChevronsUpDown` chevron on the right
+- Dropdown content: list of orgs with check mark on active, "Nova organização" at bottom
+- Links to org settings + billing
+
+Copy the org-related logic from `SidebarScopeSwitcherContent` (lines 159–186, 272–278, 460–479 in current file).
+
+```tsx
+// sidebar-org-selector.tsx
+import { ... } from "@packages/ui/components/dropdown-menu";
+import { SidebarMenu, SidebarMenuButton, SidebarMenuItem, useSidebar } from "@packages/ui/components/sidebar";
+import { useActiveOrganization } from "@/hooks/use-active-organization";
+import { useSetActiveOrganization } from "./-sidebar-scope-switcher/use-set-active-organization";
+import { orpc } from "@/integrations/orpc/client";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { ManageOrganizationForm } from "./-sidebar-scope-switcher/manage-organization-form";
+import { useCredenza } from "@/hooks/use-credenza";
+import { QueryBoundary } from "@/components/query-boundary";
+import { OrgAvatar } from "./sidebar-org-avatar"; // see Task 0
+
+export function SidebarOrgSelector() {
+  return (
+    <QueryBoundary fallback={<SidebarOrgSelectorSkeleton />} errorTitle="Erro ao carregar organização">
+      <SidebarOrgSelectorContent />
+    </QueryBoundary>
+  );
+}
+
+function SidebarOrgSelectorContent() {
+  const { activeOrganization } = useActiveOrganization();
+  const { isMobile } = useSidebar();
+  const { openCredenza } = useCredenza();
+  const { setActiveOrganization } = useSetActiveOrganization();
+  const [isPending, startTransition] = useTransition();
+  const { pathname } = useLocation();
+  const { slug, teamSlug } = useDashboardSlugs();
+  const router = useRouter();
+  const { data: organizations } = useSuspenseQuery(orpc.organization.getOrganizations.queryOptions({}));
+
+  // handleOrganizationSwitch — same logic as current SidebarScopeSwitcherContent
+  // handleNewOrganization — same as current
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <SidebarMenuButton
+              size="sm"
+              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+            >
+              <OrgAvatar name={activeOrganization.name} logo={activeOrganization.logo} size="sm" />
+              <span className="truncate text-xs font-medium">{activeOrganization.name}</span>
+              <ChevronsUpDown className="ml-auto size-3.5 shrink-0" />
+            </SidebarMenuButton>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="start"
+            side={isMobile ? "bottom" : "right"}
+            sideOffset={4}
+            className="min-w-56 rounded-lg"
+          >
+            <DropdownMenuLabel className="py-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Organizações
+            </DropdownMenuLabel>
+            {organizations?.map((org, i) => (
+              <DropdownMenuItem key={`org-${i + 1}`} onSelect={() => handleOrganizationSwitch(org)}>
+                {org.id === activeOrganization.id ? <Check className="size-4 shrink-0" /> : <span className="size-4 shrink-0" />}
+                <OrgAvatar name={org.name} logo={org.logo} size="md" />
+                <span className="truncate">{org.name}</span>
+                {org.role && <span className="ml-auto text-[10px] text-muted-foreground">{org.role}</span>}
+              </DropdownMenuItem>
+            ))}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={() => handleNewOrganization()}>
+              <Plus className="size-4" />
+              Nova organização
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem asChild>
+              <Link params={{ slug, teamSlug }} to="/$slug/$teamSlug/settings/organization/general">
+                <Settings className="size-4" /> Configurações da organização
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link params={{ slug, teamSlug }} to="/$slug/$teamSlug/billing">
+                <CreditCard className="size-4" /> Cobrança & uso
+              </Link>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  );
+}
+```
+
+**Step 1:** Extract `OrgAvatar`, `getInitials`, `getOrgColor`, `ORG_AVATAR_COLORS` to a new shared file `sidebar-org-avatar.tsx` — these are needed by multiple components.
+
+**Step 2:** Create `sidebar-org-selector.tsx` with `SidebarOrgSelectorContent` + `SidebarOrgSelectorSkeleton` + `SidebarOrgSelector` (boundary wrapper).
+
+**Step 3:** Run `bun run typecheck` — fix any errors.
+
+**Step 4:** Commit.
+
+```bash
+git add apps/web/src/layout/dashboard/ui/sidebar-org-avatar.tsx
+git add apps/web/src/layout/dashboard/ui/sidebar-org-selector.tsx
+git commit -m "feat(sidebar): extract OrgAvatar + SidebarOrgSelector component"
+```
+
+---
+
+## Task 2: Split SidebarScopeSwitcher → ProjectSelector
+
+**Files:**
+- Create: `apps/web/src/layout/dashboard/ui/-sidebar-scope-switcher/sidebar-project-selector.tsx`
+
+**What to build:**
+
+`SidebarProjectSelector` shows active team/project with a dropdown to switch between teams or create new one. Smaller than org selector since projects are within an org.
+
+```tsx
+function SidebarProjectSelectorContent() {
+  const { activeTeam, teams } = useActiveTeam();
+  const { projectLimit, projectCount } = useActiveOrganization();
+  const { isMobile } = useSidebar();
+  const { openCredenza, closeCredenza } = useCredenza();
+  // handleTeamSwitch, handleNewProject — same logic as current
+  const { slug, teamSlug } = useDashboardSlugs();
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <SidebarMenuButton
+              size="sm"
+              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+            >
+              <LayoutGrid className="size-4 shrink-0 text-muted-foreground" />
+              <span className="truncate text-sm font-medium">{activeTeam?.name ?? "Sem espaço"}</span>
+              <ChevronsUpDown className="ml-auto size-3.5 shrink-0" />
+            </SidebarMenuButton>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" side={isMobile ? "bottom" : "right"} sideOffset={4} className="min-w-56 rounded-lg">
+            <DropdownMenuLabel className="py-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Espaços
+            </DropdownMenuLabel>
+            {teams.map((team, i) => (
+              <DropdownMenuItem key={`team-${i + 1}`} onSelect={() => handleTeamSwitch(team)}>
+                {team.id === activeTeam?.id ? <Check className="size-4 shrink-0" /> : <span className="size-4 shrink-0" />}
+                <span className="truncate">{team.name}</span>
+              </DropdownMenuItem>
+            ))}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={() => handleNewProject()}>
+              <Plus className="size-4" />
+              {projectLimit !== null && projectLimit !== Number.POSITIVE_INFINITY
+                ? `Novo espaço (${projectCount}/${projectLimit})`
+                : "Novo espaço"}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem asChild>
+              <Link params={{ slug, teamSlug }} to="/$slug/$teamSlug/settings/project/general">
+                <Settings className="size-4" /> Configurações do espaço
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link params={{ slug, teamSlug }} to="/$slug/$teamSlug/settings/organization/members">
+                <UserPlus className="size-4" /> Convidar membros
+              </Link>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  );
+}
+```
+
+**Step 1:** Create `sidebar-project-selector.tsx` — copy team/project logic from `SidebarScopeSwitcherContent`.
+
+**Step 2:** `bun run typecheck` — fix errors.
+
+**Step 3:** Commit.
+
+```bash
+git add apps/web/src/layout/dashboard/ui/sidebar-project-selector.tsx
+git commit -m "feat(sidebar): extract SidebarProjectSelector component"
+```
+
+---
+
+## Task 3: Split SidebarScopeSwitcher → AccountMenu
+
+**Files:**
+- Create: `apps/web/src/layout/dashboard/ui/sidebar-account-menu.tsx`
+- Delete or gut: `apps/web/src/layout/dashboard/ui/sidebar-scope-switcher.tsx` (replace with thin re-exports or delete)
+
+**What to build:**
+
+`SidebarAccountMenu` at the bottom — user avatar, name, email, theme switcher, logout.
+
+```tsx
+function SidebarAccountMenuContent() {
+  const { data: session } = useSuspenseQuery(orpc.session.getSession.queryOptions({}));
+  const { slug, teamSlug } = useDashboardSlugs();
+  const { openAlertDialog } = useAlertDialog();
+  const { isMobile, setOpenMobile } = useSidebar();
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  // handleLogout, handleLogoutClick — same as current
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <SidebarMenuButton
+              size="lg"
+              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+            >
+              <Avatar className="size-8 shrink-0 rounded-full">
+                <AvatarImage src={session?.user.image ?? undefined} alt={session?.user.name ?? ""} />
+                <AvatarFallback className="rounded-full text-[10px]">
+                  {session?.user.name?.charAt(0) ?? "?"}
+                </AvatarFallback>
+              </Avatar>
+              <div className="grid min-w-0 flex-1 leading-tight text-left">
+                <span className="truncate text-sm font-medium">{session?.user.name}</span>
+                <span className="truncate text-xs text-muted-foreground">{session?.user.email}</span>
+              </div>
+              <ChevronsUpDown className="ml-auto size-4 shrink-0" />
+            </SidebarMenuButton>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="end"
+            side={isMobile ? "bottom" : "top"}
+            sideOffset={4}
+            className="w-(--radix-dropdown-menu-trigger-width) min-w-64 rounded-lg"
+          >
+            <DropdownMenuLabel className="py-2">
+              <div className="flex items-center gap-2">
+                <Avatar className="size-8 rounded-full">
+                  <AvatarImage src={session?.user.image ?? undefined} />
+                  <AvatarFallback>{session?.user.name?.charAt(0) ?? "?"}</AvatarFallback>
+                </Avatar>
+                <div className="grid min-w-0 flex-1 leading-tight">
+                  <span className="truncate font-medium">{session?.user.name}</span>
+                  <span className="truncate text-xs text-muted-foreground">{session?.user.email}</span>
+                </div>
+              </div>
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <div className="flex items-center justify-between px-2 py-1.5">
+              <span className="text-sm text-muted-foreground">Tema</span>
+              <ThemeSwitcher />
+            </div>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem asChild>
+              <Link params={{ slug, teamSlug }} to="/$slug/$teamSlug/settings/profile">
+                <Settings className="size-4" /> Meu perfil
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={handleLogoutClick} className="text-destructive focus:text-destructive">
+              <LogOut className="size-4" />
+              Sair
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  );
+}
+```
+
+**Step 1:** Create `sidebar-account-menu.tsx` with `SidebarAccountMenuContent` + skeleton + `SidebarAccountMenu` (QueryBoundary wrapper).
+
+**Step 2:** Delete `sidebar-scope-switcher.tsx` (all its consumers will be replaced in Task 4).
+
+**Step 3:** `bun run typecheck` — fix broken imports.
+
+**Step 4:** Commit.
+
+```bash
+git add apps/web/src/layout/dashboard/ui/sidebar-account-menu.tsx
+git rm apps/web/src/layout/dashboard/ui/sidebar-scope-switcher.tsx
+git commit -m "feat(sidebar): extract SidebarAccountMenu, remove old scope switcher"
+```
+
+---
+
+## Task 4: Rewire app-sidebar.tsx + add ChatButton
+
+**Files:**
+- Modify: `apps/web/src/layout/dashboard/ui/app-sidebar.tsx`
+- Create: `apps/web/src/layout/dashboard/ui/sidebar-chat-button.tsx`
+
+**ChatButton** — just a button that shows a "em breve" tooltip. No infra needed.
+
+```tsx
+// sidebar-chat-button.tsx
+import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from "@packages/ui/components/sidebar";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@packages/ui/components/tooltip";
+import { MessageSquare } from "lucide-react";
+
+export function SidebarChatButton() {
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <SidebarMenuButton className="cursor-not-allowed opacity-60" size="sm">
+              <MessageSquare className="size-4" />
+              <span>Chat</span>
+              <span className="ml-auto rounded-sm bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                Em breve
+              </span>
+            </SidebarMenuButton>
+          </TooltipTrigger>
+          <TooltipContent side="right">Chat com Rubi — em breve</TooltipContent>
+        </Tooltip>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  );
+}
+```
+
+**New app-sidebar.tsx:**
+
+```tsx
+import { Separator } from "@packages/ui/components/separator";
+import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem, useSidebar } from "@packages/ui/components/sidebar";
+import { Link } from "@tanstack/react-router";
+import { PanelLeftClose, Settings } from "lucide-react";
+import type * as React from "react";
+import { useDashboardSlugs } from "@/hooks/use-dashboard-slugs";
+import { EarlyAccessSidebarBanner } from "./early-access-sidebar-banner";
+import { SidebarDefaultItems, SidebarNav } from "./sidebar-nav";
+import { SidebarOrgSelector } from "./sidebar-org-selector";
+import { SidebarProjectSelector } from "./sidebar-project-selector";
+import { SidebarChatButton } from "./sidebar-chat-button";
+import { SidebarAccountMenu } from "./sidebar-account-menu";
+
+export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
+  return (
+    <Sidebar className="px-0" collapsible="icon" variant="inset" {...props}>
+      <SidebarHeader className="gap-1 pb-2">
+        <SidebarOrgSelector />
+        <SidebarProjectSelector />
+        <Separator className="my-1" />
+        <SidebarChatButton />
+      </SidebarHeader>
+
+      <SidebarContent>
+        <SidebarDefaultItems />
+        <div className="px-2">
+          <Separator />
+        </div>
+        <SidebarNav />
+      </SidebarContent>
+
+      <SidebarFooter>
+        <EarlyAccessSidebarBanner />
+        <Separator />
+        <SidebarAccountMenu />
+        <Separator />
+        <SidebarFooterContent />
+      </SidebarFooter>
+    </Sidebar>
+  );
+}
+
+function SidebarFooterContent() {
+  const { slug, teamSlug } = useDashboardSlugs();
+  const { toggleSidebar, state } = useSidebar();
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <SidebarMenuButton onClick={toggleSidebar} tooltip={state === "expanded" ? "Ocultar" : "Abrir"}>
+          <PanelLeftClose className={state === "collapsed" ? "rotate-180" : ""} />
+          <span>Ocultar</span>
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+      <SidebarMenuItem>
+        <SidebarMenuButton asChild tooltip="Configurações">
+          <Link params={{ slug, teamSlug }} to="/$slug/$teamSlug/settings">
+            <Settings />
+            <span>Configurações</span>
+          </Link>
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  );
+}
+```
+
+**Step 1:** Create `sidebar-chat-button.tsx`.
+
+**Step 2:** Rewrite `app-sidebar.tsx` with new structure above.
+
+**Step 3:** `bun run typecheck` — fix errors.
+
+**Step 4:** Commit.
+
+```bash
+git add apps/web/src/layout/dashboard/ui/sidebar-chat-button.tsx
+git add apps/web/src/layout/dashboard/ui/app-sidebar.tsx
+git commit -m "feat(sidebar): new PostHog-style layout — org+project header, account footer, chat button stub"
+```
+
+---
+
+## Task 5: Collapsible NavGroups at group level with Tailwind animation
+
+**Files:**
+- Modify: `apps/web/src/layout/dashboard/ui/sidebar-nav.tsx`
+
+Currently `NavGroup` has a static `SidebarGroupLabel` header. Make each group with a `label` collapsible — clicking the label toggles the whole group.
+
+**Key change in `NavGroup`:**
+
+```tsx
+function NavGroup({ group, ... }) {
+  // ...existing logic...
+
+  // Groups are open by default; state stored in component (no persistence needed)
+  return (
+    <Collapsible asChild defaultOpen className="group/nav-group pt-0">
+      <SidebarGroup className="pt-0">
+        {group.label && (
+          <SidebarGroupLabel asChild className="justify-between pr-1">
+            <CollapsibleTrigger className="w-full cursor-pointer hover:text-foreground transition-colors duration-150">
+              <span>{group.label}</span>
+              <div className="flex items-center gap-1">
+                {onConfigure && (
+                  <button
+                    className="text-muted-foreground hover:text-foreground group-data-[collapsible=icon]:hidden"
+                    onClick={(e) => { e.stopPropagation(); onConfigure(); }}
+                    type="button"
+                  >
+                    <Settings2 className="size-3.5" />
+                  </button>
+                )}
+                <ChevronRight className="size-3 text-muted-foreground transition-transform duration-200 group-data-[state=open]/nav-group:rotate-90 group-data-[collapsible=icon]:hidden" />
+              </div>
+            </CollapsibleTrigger>
+          </SidebarGroupLabel>
+        )}
+        <CollapsibleContent className="overflow-hidden transition-all duration-200 data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {visibleItems.map((item) => ...)}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </CollapsibleContent>
+      </SidebarGroup>
+    </Collapsible>
+  );
+}
+```
+
+**Note on Tailwind animation classes:** shadcn/ui already ships `animate-accordion-up` and `animate-accordion-down` via `tailwindcss-animate` in `globals.css`. These work on `CollapsibleContent`. No extra config needed.
+
+**Step 1:** Wrap `NavGroup` body in `<Collapsible asChild defaultOpen>`.
+
+**Step 2:** Make `SidebarGroupLabel` a `CollapsibleTrigger` — add chevron to right side.
+
+**Step 3:** Wrap `SidebarGroupContent` in `<CollapsibleContent className="overflow-hidden transition-all duration-200 data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">`.
+
+**Step 4:** Stop propagation on the configure button click so it doesn't toggle collapse.
+
+**Step 5:** `bun run typecheck` — fix errors.
+
+**Step 6:** Commit.
+
+```bash
+git add apps/web/src/layout/dashboard/ui/sidebar-nav.tsx
+git commit -m "feat(sidebar): collapsible nav groups with Tailwind animation"
+```
+
+---
+
+## Task 6: Inline edit mode for nav config (replace modal)
+
+**Files:**
+- Modify: `apps/web/src/layout/dashboard/ui/sidebar-nav.tsx`
+- Modify: `apps/web/src/layout/dashboard/ui/sidebar-nav-config-form.tsx` (may no longer be needed)
+
+Currently: clicking the `Settings2` icon on the finance group opens a `SidebarNavConfigForm` modal.
+
+New behavior (like PostHog image 9): clicking the pencil toggles an inline "edit mode" for that group. In edit mode:
+- Each item shows a checkbox on the left
+- Header shows a `Check` icon instead of pencil to save, and an `X` to cancel
+- Clicking `Check` saves the visibility preferences and exits edit mode
+- Animation: fade/slide transition between view and edit modes
+
+**State:** Add local state to `NavGroup` — `isEditing: boolean`.
+
+**Implementation in `NavGroup`:**
+
+```tsx
+function NavGroup({ group, slug, teamSlug, isItemActive, onSubPanelToggle, onMainItemClick, onConfigure }) {
+  const [isEditing, setIsEditing] = useState(false);
+  const { isVisible, toggleVisibility } = useSidebarVisibility(); // need toggleVisibility
+  // ...
+
+  const handleEditStart = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation(); // don't collapse group
+    setIsEditing(true);
+  }, []);
+
+  const handleEditSave = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    setIsEditing(false);
+    // visibility already toggled on checkbox click via store
+  }, []);
+
+  const handleEditCancel = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    setIsEditing(false);
+  }, []);
+
+  // In the label area:
+  // Replace: <Settings2 onClick={onConfigure} />
+  // With:
+  {onConfigure && !isEditing && (
+    <button onClick={handleEditStart} type="button" className="...">
+      <Pencil className="size-3.5" />
+    </button>
+  )}
+  {isEditing && (
+    <>
+      <button onClick={handleEditSave} type="button" className="text-green-600 hover:text-green-700">
+        <Check className="size-3.5" />
+      </button>
+      <button onClick={handleEditCancel} type="button" className="text-muted-foreground hover:text-foreground">
+        <X className="size-3.5" />
+      </button>
+    </>
+  )}
+
+  // Items in edit mode: render all items (not just visible) with checkboxes
+  {isEditing ? (
+    <SidebarMenu>
+      {group.items.filter(...earlyAccess).map((item) => (
+        <SidebarMenuItem key={item.id}>
+          <button
+            type="button"
+            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-sidebar-accent transition-colors duration-150"
+            onClick={() => toggleVisibility(item.id)}
+          >
+            <div className={cn(
+              "flex size-4 items-center justify-center rounded-sm border transition-colors duration-150",
+              isVisible(item.id) ? "bg-primary border-primary text-primary-foreground" : "border-muted-foreground"
+            )}>
+              {isVisible(item.id) && <Check className="size-3" />}
+            </div>
+            <item.icon className="size-4 text-muted-foreground" />
+            <span>{item.label}</span>
+          </button>
+        </SidebarMenuItem>
+      ))}
+    </SidebarMenu>
+  ) : (
+    // normal items rendering
+  )}
+}
+```
+
+**Note:** Check if `useSidebarVisibility` already exposes a toggle function. If not, add `toggleVisibility(itemId: string)` to `use-sidebar-store.ts`.
+
+**Step 1:** Check `apps/web/src/layout/dashboard/hooks/use-sidebar-store.ts` — does `useSidebarVisibility` expose a toggle? If not, add one.
+
+**Step 2:** Add `isEditing` state + `handleEditStart/Save/Cancel` to `NavGroup`.
+
+**Step 3:** Replace `Settings2` configure button with `Pencil` that triggers inline edit.
+
+**Step 4:** Render checkbox list when `isEditing === true`.
+
+**Step 5:** Remove `onConfigure` prop from `NavGroup` and `SidebarNav`. Remove `SidebarNavConfigForm` modal call from `SidebarNav`.
+
+**Step 6:** `bun run typecheck`.
+
+**Step 7:** Commit.
+
+```bash
+git add apps/web/src/layout/dashboard/ui/sidebar-nav.tsx
+git add apps/web/src/layout/dashboard/hooks/use-sidebar-store.ts
+git commit -m "feat(sidebar): inline edit mode for nav config, replace modal"
+```
+
+---
+
+## Task 7: Cleanup
+
+**Files:**
+- Check: `apps/web/src/layout/dashboard/ui/sidebar-nav-config-form.tsx` — delete if no longer referenced
+- Check: `apps/web/src/layout/dashboard/ui/sidebar-scope-switcher.tsx` — delete if not done in Task 3
+
+**Step 1:** `grep -r "SidebarNavConfigForm" apps/web/src` — confirm no references remain.
+
+**Step 2:** Delete `sidebar-nav-config-form.tsx` if unreferenced.
+
+**Step 3:** `bun run typecheck && bun run check` — all clean.
+
+**Step 4:** Final commit.
+
+```bash
+git rm apps/web/src/layout/dashboard/ui/sidebar-nav-config-form.tsx
+git commit -m "chore(sidebar): remove unused SidebarNavConfigForm after inline edit migration"
+```
+
+---
+
+## Notes & Gotchas
+
+- **`SidebarGroupLabel` as CollapsibleTrigger**: shadcn's `SidebarGroupLabel` renders a `div`, not a `button`. Pass `asChild` to `SidebarGroupLabel` and make `CollapsibleTrigger` the child — not the other way around. Check if this causes styling issues; might need to `asChild` chain carefully.
+- **`group-data-[state=open]/nav-group` Tailwind variant**: Requires the `Collapsible` to have `className="group/nav-group"` — already done in the code above. The chevron rotation uses this.
+- **Animation classes**: `animate-accordion-up` / `animate-accordion-down` are defined by shadcn in `tailwind.config.ts` via `tailwindcss-animate`. Verify they exist: `grep -r "accordion" apps/web/tailwind.config.ts`. If missing, use `data-[state=closed]:h-0 data-[state=open]:h-auto transition-all duration-200` with `overflow-hidden` instead (less smooth but works).
+- **`OrgAvatar` extraction**: Both `SidebarOrgSelector` and any org-related display in `SidebarAccountMenu` need it. Keep it in `sidebar-org-avatar.tsx` as a named export only — no barrel.
+- **Mobile sidebar**: `isMobile` from `useSidebar()` — existing pattern already handles this. Keep `side={isMobile ? "bottom" : "right"}` on project/org dropdowns.
+- **`SidebarHeader` padding**: Current sidebar uses `px-0` on `<Sidebar>`. Add `px-2 pt-2` on `SidebarHeader` or use individual `px-2` on each selector to match the existing item padding.

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -39,7 +39,7 @@ function TooltipContent({
       <TooltipPrimitive.Portal>
          <TooltipPrimitive.Content
             className={cn(
-               "bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+               "bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[200] w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
                className,
             )}
             data-slot="tooltip-content"
@@ -47,7 +47,7 @@ function TooltipContent({
             {...props}
          >
             {children}
-            <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+            <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-[200] size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
          </TooltipPrimitive.Content>
       </TooltipPrimitive.Portal>
    );

--- a/packages/workflows/src/workflows/derive-keywords-workflow.ts
+++ b/packages/workflows/src/workflows/derive-keywords-workflow.ts
@@ -2,7 +2,7 @@ import type { DBOSClient } from "@dbos-inc/dbos-sdk";
 import { fromPromise } from "neverthrow";
 import dayjs from "dayjs";
 import { DBOS, WorkflowQueue } from "@dbos-inc/dbos-sdk";
-import { updateCategory } from "@core/database/repositories/categories-repository";
+import { updateCategoryKeywords } from "@core/database/repositories/categories-repository";
 import { emitAiKeywordDerived } from "@packages/events/ai";
 import { createEmitFn } from "@packages/events/emit";
 import { enforceCreditBudget } from "@packages/events/credits";
@@ -135,7 +135,9 @@ async function deriveKeywordsWorkflowFn(input: DeriveKeywordsInput) {
    const saveResult = await fromPromise(
       DBOS.runStep(
          async () =>
-            (await updateCategory(db, input.categoryId, { keywords })).match(
+            (
+               await updateCategoryKeywords(db, input.categoryId, keywords)
+            ).match(
                () => null,
                (e) => {
                   throw e;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Redesenhei o painel de contexto movendo as abas para um rail vertical fixo à direita e transformei a geração de palavras‑chave de categorias numa ação explícita com indicador de desatualização; adicione filtros externos reutilizáveis na toolbar das tabelas. Atende ao MON‑495.

- **Impacto por camadas**
  - Router: adiciona `orpc.categories.regenerateKeywords`; `orpc.categories.update` não enfileira mais derivação.
  - Repositório: novo `updateCategoryKeywords`; adiciona `keywordsUpdatedAt` ao schema `categories`.
  - Componentes:
    - Context panel: novo `ContextPanelRail` no `SidebarInset` (oculto no mobile; menu “…” com “Dar feedback” e “Documentação”); `ContextPanel` remove as abas do header e mostra apenas ícone+título da aba ativa.
    - Layout: `DashboardLayout` posiciona o `ContextPanelRail` à direita do `main`; `PageHeader` remove ações do painel no desktop (acesso pelo rail).
    - Sidebar: remove popover de Feedback (acesso via menu do rail).
    - Data Table: `DataTableExternalFilter`/`useRegisterDataTableFilter` para registrar filtros externos por tabela; toolbar ganha dropdown de filtros (ícone `ListFilter` com badge de ativos) e “Limpar” passa a desligar filtros externos; `tags.tsx` usa filtro “Mostrar arquivados”.
    - Categorias: coluna “Palavras‑chave” mostra contagem, alerta de desatualização/“Não geradas” e “—” para subcategorias; ação de linha “Regerar palavras‑chave” (raiz).
    - Ajustes: botão “Exportar” sem tooltip; `Tooltip` com `z-index` maior; DevTools no canto inferior direito.
  - Store: `contextPanelStore` sem mudanças; `DataTableStore` ganha registro de `externalFilters`.
  - Workflows: `derive-keywords-workflow` salva via `updateCategoryKeywords` e persiste `keywordsUpdatedAt`.

- **Checklist de teste**
  - Rail (desktop): visível com painel fechado; clicar em aba abre; clicar na aba ativa com painel aberto fecha; trocar de aba não fecha; menu “…” abre; docs em nova aba; modal de feedback abre.
  - Painel: header sem abas; exibe ícone+título e “Fechar”; no mobile, rail oculto e ações de abrir painel no header permanecem.
  - Data Table: dropdown de filtros aparece quando há filtros externos; badge com total de ativos; toggles funcionam; “Limpar” zera busca, filtros de coluna e externos; em Tags, “Mostrar arquivados” alterna corretamente.
  - Categorias: alerta quando `updatedAt > keywordsUpdatedAt` ou sem geração; “Regerar” dispara `orpc.categories.regenerateKeywords`, toasts de sucesso/erro; ao concluir, `keywords`/`keywordsUpdatedAt` atualizam; subcategorias mostram “—”.
  - Regressões: `orpc.categories.update` não dispara derivação; tooltips acima de overlays; DevTools no canto inferior direito; Sidebar sem Feedback (acesso pelo rail).

<sup>Written for commit 66cbc84515be640dbdeb57cdb52f67b1279cf90e. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/796">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

