### PR TITLE
poc(nfse): NFS-e emission via steel.dev cloud browser (DBOS workflow)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -527,6 +527,8 @@
         "@tanstack/store": "catalog:tanstack",
         "dayjs": "catalog:ui",
         "neverthrow": "catalog:validation",
+        "playwright": "^1.59.1",
+        "steel-sdk": "^0.18.0",
         "zod": "catalog:validation",
       },
       "devDependencies": {
@@ -2119,6 +2121,8 @@
 
     "@types/node": ["@types/node@20.19.37", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw=="],
 
+    "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
+
     "@types/parse-json": ["@types/parse-json@4.0.2", "", {}, "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="],
 
     "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
@@ -2215,6 +2219,8 @@
 
     "@zkochan/js-yaml": ["@zkochan/js-yaml@0.0.7", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ=="],
 
+    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
+
     "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
@@ -2226,6 +2232,8 @@
     "adler-32": ["adler-32@1.3.1", "", {}, "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
 
     "ai": ["ai@6.0.97", "", { "dependencies": { "@ai-sdk/gateway": "3.0.53", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-eZIAcBymwGhBwncRH/v9pillZNMeRCDkc4BwcvwXerXd7sxjVxRis3ZNCNCpP02pVH4NLs81ljm4cElC4vbNcQ=="],
 
@@ -2683,6 +2691,8 @@
 
     "event-target-bus": ["event-target-bus@1.0.0", "", {}, "sha512-uPcWKbj/BJU3Tbw9XqhHqET4/LBOhvv3/SJWr7NksxA6TC5YqBpaZgawE9R+WpYFCBFSAE4Vun+xQS6w4ABdlA=="],
 
+    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
@@ -2730,6 +2740,10 @@
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "form-data-encoder": ["form-data-encoder@1.7.2", "", {}, "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="],
+
+    "formdata-node": ["formdata-node@4.4.1", "", { "dependencies": { "node-domexception": "1.0.0", "web-streams-polyfill": "4.0.0-beta.3" } }, "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ=="],
 
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
 
@@ -2842,6 +2856,8 @@
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "httpxy": ["httpxy@0.5.0", "", {}, "sha512-qwX7QX/rK2visT10/b7bSeZWQOMlSm3svTD0pZpU+vJjNUP0YHtNv4c3z+MO+MSnGuRFWJFdCZiV+7F7dXIOzg=="],
+
+    "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
@@ -3241,7 +3257,7 @@
 
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
-    "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
 
@@ -3372,6 +3388,10 @@
     "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
 
     "player.style": ["player.style@0.3.1", "", { "dependencies": { "media-chrome": "~4.16.1" } }, "sha512-z/T8hJGaTkHT9vdXgWdOgF37eB1FV7/j52VXQZ2lgEhpru9oT8TaUWIxp6GoxTnhPBM4X6nSbpkAHrT7UTjUKg=="],
+
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
 
     "postal-mime": ["postal-mime@2.7.4", "", {}, "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g=="],
 
@@ -3637,6 +3657,8 @@
 
     "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
 
+    "steel-sdk": ["steel-sdk@0.18.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-OdW4OIakOooeqgLdn+BRf3yyfeFx4HJ713/7pSa3g82t8NmlURs9xPg4oBLWUttRzaY6oMGNTQtq0DEYg2nOJA=="],
+
     "stream-chain": ["stream-chain@2.2.5", "", {}, "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA=="],
 
     "stream-json": ["stream-json@1.9.1", "", { "dependencies": { "stream-chain": "^2.2.5" } }, "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw=="],
@@ -3845,7 +3867,7 @@
 
     "web": ["web@workspace:apps/web"],
 
-    "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+    "web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
 
     "web-vitals": ["web-vitals@5.2.0", "", {}, "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA=="],
 
@@ -4201,6 +4223,8 @@
 
     "@types/cors/@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
 
+    "@types/node-fetch/@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
+
     "@types/pg/@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
 
     "@udecode/react-utils/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
@@ -4269,6 +4293,8 @@
 
     "engine.io/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
+    "fetch-blob/web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
     "figures/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
@@ -4276,6 +4302,8 @@
     "fs-extra/jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
     "fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
+
+    "gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "giget/defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
 
@@ -4300,6 +4328,8 @@
     "mlly/pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
     "mongodb-connection-string-url/whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
+
+    "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "nx/dotenv": ["dotenv@16.4.7", "", {}, "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="],
 
@@ -4334,6 +4364,8 @@
     "path-scurry/lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
 
     "player.style/media-chrome": ["media-chrome@4.16.1", "", { "dependencies": { "ce-la-react": "^0.3.2" } }, "sha512-qtFlsy0lNDVCyVo//ZCAfRPKwgehfOYp6rThZzDUuZ5ypv41yqUfAxK+P9TOs+XSVWXATPTT2WRV0fbW0BH4vQ=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "posthog-js/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.208.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg=="],
 
@@ -4372,6 +4404,8 @@
     "serialize-error/type-fest": ["type-fest@0.20.2", "", {}, "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="],
 
     "socket.io-adapter/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
+
+    "steel-sdk/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
     "svix/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
@@ -4529,6 +4563,10 @@
 
     "mongodb-connection-string-url/whatwg-url/webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
 
+    "node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
     "ora/log-symbols/is-unicode-supported": ["is-unicode-supported@0.1.0", "", {}, "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="],
 
     "otlp-logger/@opentelemetry/exporter-logs-otlp-grpc/@opentelemetry/core": ["@opentelemetry/core@2.5.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-Dwlc+3HAZqpgTYq0MUyZABjFkcrKTePwuiFVLjahGD8cx3enqihmpAmdgNFO1R4m/sIe5afjJrA25Prqy4NXlA=="],
@@ -4638,6 +4676,8 @@
     "react-email/ora/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "react-email/ora/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "steel-sdk/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 

--- a/packages/notifications/src/types.ts
+++ b/packages/notifications/src/types.ts
@@ -4,6 +4,7 @@ export const NOTIFICATION_TYPES = {
    AI_TAG_KEYWORD_DERIVED: "ai.tag_keyword_derived",
    AI_TAG_SUGGESTED: "ai.tag_suggested",
    CRON_KEYWORDS_BACKFILL: "cron.keywords_backfill",
+   NFSE_EMISSION_COMPLETED: "nfse.emission_completed",
 } as const;
 
 export type NotificationType =
@@ -28,6 +29,9 @@ export type NotificationPayloadMap = {
    };
    "cron.keywords_backfill": {
       count: number;
+   };
+   "nfse.emission_completed": {
+      numeroNota: string;
    };
 };
 

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -37,6 +37,8 @@
       "@tanstack/store": "catalog:tanstack",
       "dayjs": "catalog:ui",
       "neverthrow": "catalog:validation",
+      "playwright": "^1.59.1",
+      "steel-sdk": "^0.18.0",
       "zod": "catalog:validation"
    },
    "devDependencies": {

--- a/packages/workflows/src/setup.ts
+++ b/packages/workflows/src/setup.ts
@@ -6,6 +6,7 @@ import { backfillKeywordsWorkflow } from "./workflows/backfill-keywords-workflow
 import "./workflows/categorization-workflow";
 import "./workflows/derive-keywords-workflow";
 import "./workflows/derive-tag-keywords-workflow";
+import "./workflows/nfse-emission-workflow";
 import "./workflows/suggest-tag-workflow";
 import { createAllQueues } from "./workflow-factory";
 

--- a/packages/workflows/src/workflow-factory.ts
+++ b/packages/workflows/src/workflow-factory.ts
@@ -6,6 +6,7 @@ export const QUEUES = {
    suggestTag: "suggest-tag",
    deriveKeywords: "derive-keywords",
    deriveTagKeywords: "derive-tag-keywords",
+   nfseEmission: "nfse-emission",
 } as const;
 
 export type QueueName = (typeof QUEUES)[keyof typeof QUEUES];

--- a/packages/workflows/src/workflows/nfse-emission-workflow.ts
+++ b/packages/workflows/src/workflows/nfse-emission-workflow.ts
@@ -1,0 +1,296 @@
+import dayjs from "dayjs";
+import { fromPromise } from "neverthrow";
+import { DBOS } from "@dbos-inc/dbos-sdk";
+import Steel from "steel-sdk";
+import { chromium } from "playwright";
+import { createEnqueuer, QUEUES } from "../workflow-factory";
+import { NOTIFICATION_TYPES } from "@packages/notifications/types";
+import type { JobNotification } from "@packages/notifications/schema";
+import { getPublisher } from "../context";
+
+export type NfseEmissionInput = {
+   teamId: string;
+   steelApiKey: string;
+   prestador: {
+      cnpj: string;
+      inscricaoMunicipal: string;
+   };
+   tomador: {
+      cnpjCpf: string;
+      razaoSocial: string;
+      email?: string;
+   };
+   servico: {
+      discriminacao: string;
+      valorServicos: number;
+      codigoAtividade: string;
+      competencia: string;
+   };
+   rps: {
+      serie: string;
+      numero: number;
+   };
+};
+
+export type NfseEmissionResult =
+   | { success: true; numeroNota: string; sessionViewerUrl: string }
+   | { success: false; error: string; sessionViewerUrl: string };
+
+async function publishFailed(
+   publisher: ReturnType<typeof getPublisher>,
+   teamId: string,
+   msg: string,
+   stepName: string,
+) {
+   await DBOS.runStep(
+      () =>
+         publisher.publish("job.notification", {
+            jobId: crypto.randomUUID(),
+            type: NOTIFICATION_TYPES.NFSE_EMISSION_COMPLETED,
+            status: "failed",
+            message: msg,
+            teamId,
+            timestamp: dayjs().toISOString(),
+         } satisfies JobNotification),
+      { name: stepName },
+   );
+}
+
+async function nfseEmissionWorkflowFn(
+   input: NfseEmissionInput,
+): Promise<NfseEmissionResult> {
+   const publisher = getPublisher();
+   const ctx = `[nfse-emission] team=${input.teamId} rps=${input.rps.serie}-${input.rps.numero}`;
+
+   DBOS.logger.info(`${ctx} started prestador=${input.prestador.cnpj}`);
+
+   await DBOS.runStep(
+      () =>
+         publisher.publish("job.notification", {
+            jobId: crypto.randomUUID(),
+            type: NOTIFICATION_TYPES.NFSE_EMISSION_COMPLETED,
+            status: "started",
+            message: `Emitindo NFS-e RPS ${input.rps.serie}-${input.rps.numero}...`,
+            teamId: input.teamId,
+            timestamp: dayjs().toISOString(),
+         } satisfies JobNotification),
+      { name: "publishStarted" },
+   );
+
+   // Step 1: Create steel.dev cloud browser session
+   const sessionResult = await fromPromise(
+      DBOS.runStep(
+         async () => {
+            const client = new Steel({ steelAPIKey: input.steelApiKey });
+            const session = await client.sessions.create({
+               // TODO: configure proxy and stealth settings for production
+               timeout: 300000,
+            });
+            DBOS.logger.info(
+               `${ctx} steel session created id=${session.id} viewerUrl=${session.sessionViewerUrl}`,
+            );
+            return {
+               sessionId: session.id,
+               sessionViewerUrl: session.sessionViewerUrl ?? "",
+               websocketUrl: session.websocketUrl ?? "",
+            };
+         },
+         { name: "createSteelSession" },
+      ),
+      (e) => (e instanceof Error ? e.message : String(e)),
+   );
+
+   if (sessionResult.isErr()) {
+      DBOS.logger.error(
+         `${ctx} failed to create steel session: ${sessionResult.error}`,
+      );
+      await publishFailed(
+         publisher,
+         input.teamId,
+         `Falha ao criar sessão de navegador: ${sessionResult.error}`,
+         "publishFailed",
+      );
+      return {
+         success: false,
+         error: `Falha ao criar sessão de navegador: ${sessionResult.error}`,
+         sessionViewerUrl: "",
+      };
+   }
+
+   const { sessionId, sessionViewerUrl, websocketUrl } = sessionResult.value;
+
+   // Step 2: Navigate nfse.gov.br and fill NFS-e form
+   // Always release session in a cleanup step — even on failure
+   const emissionResult = await fromPromise(
+      DBOS.runStep(
+         async () => {
+            const browser = await chromium.connectOverCDP(websocketUrl);
+            const context =
+               browser.contexts()[0] ?? (await browser.newContext());
+            const page = context.pages()[0] ?? (await context.newPage());
+
+            // TODO: Replace with the actual municipality-specific nfse.gov.br URL
+            // The portal URL varies by municipality — this is the federal gateway
+            await page.goto("https://www.nfse.gov.br/EmissorNacional/Login", {
+               waitUntil: "networkidle",
+               timeout: 60000,
+            });
+
+            DBOS.logger.info(`${ctx} navigated to nfse.gov.br login`);
+
+            // TODO: Implement actual login flow
+            // Production flow requires gov.br OAuth / certificate-based auth (A1/A3)
+            // For POC: assume user is pre-authenticated or use session cookies
+            // await page.fill("#cpf-cnpj", input.prestador.cnpj);
+            // await page.click("#btn-login");
+            // await page.waitForNavigation({ waitUntil: "networkidle" });
+
+            // Navigate to RPS emission form
+            // TODO: Actual navigation depends on municipality portal structure
+            // Most ABRASF-compliant portals follow this pattern:
+            await page.goto(
+               "https://www.nfse.gov.br/EmissorNacional/NotaFiscal/Emitir",
+               { waitUntil: "networkidle", timeout: 60000 },
+            );
+
+            DBOS.logger.info(`${ctx} navigated to RPS emission form`);
+
+            // Fill RPS fields (ABRASF standard)
+            // TODO: Selectors must be validated against the live portal DOM
+            await page.selectOption("#tipo-rps", "RPS");
+            await page.fill("#serie-rps", input.rps.serie);
+            await page.fill("#numero-rps", String(input.rps.numero));
+
+            // Competência: YYYY-MM → MM/YYYY for display
+            const [year, month] = input.servico.competencia.split("-");
+            await page.fill("#competencia", `${month}/${year}`);
+
+            // Natureza da operação: 1 = Tributada no município (most common)
+            await page.selectOption("#natureza-operacao", "1");
+
+            // ISS Retido: Não (default for most cases)
+            await page.selectOption("#iss-retido", "0");
+
+            // Prestador fields — usually pre-filled after auth, but set defensively
+            await page.fill("#cnpj-prestador", input.prestador.cnpj);
+            await page.fill(
+               "#inscricao-municipal",
+               input.prestador.inscricaoMunicipal,
+            );
+
+            // Tomador fields
+            await page.fill("#cnpj-cpf-tomador", input.tomador.cnpjCpf);
+            await page.fill("#razao-social-tomador", input.tomador.razaoSocial);
+            if (input.tomador.email) {
+               await page.fill("#email-tomador", input.tomador.email);
+            }
+
+            // Serviço fields
+            await page.fill("#discriminacao", input.servico.discriminacao);
+
+            // Valor em reais (centavos → reais)
+            const valorReais = (input.servico.valorServicos / 100).toFixed(2);
+            await page.fill("#valor-servicos", valorReais);
+
+            await page.fill("#codigo-atividade", input.servico.codigoAtividade);
+
+            DBOS.logger.info(`${ctx} form filled, submitting`);
+
+            // Submit form
+            // TODO: Confirm submit button selector and any confirmation modal
+            await page.click("#btn-emitir");
+            await page.waitForNavigation({
+               waitUntil: "networkidle",
+               timeout: 60000,
+            });
+
+            // Extract nota number from success page
+            // TODO: Adjust selector to match actual portal response DOM
+            const numeroNota = await page
+               .locator("#numero-nota-emitida")
+               .textContent({ timeout: 15000 });
+
+            if (!numeroNota) {
+               throw new Error(
+                  "Número da nota não encontrado na página de confirmação",
+               );
+            }
+
+            DBOS.logger.info(
+               `${ctx} NFS-e emitida com sucesso numero=${numeroNota.trim()}`,
+            );
+
+            await browser.close();
+
+            return numeroNota.trim();
+         },
+         { name: "fillAndSubmitNfse" },
+      ),
+      (e) => (e instanceof Error ? e.message : String(e)),
+   );
+
+   // Step 3: Always release steel session — equivalent to finally block
+   await fromPromise(
+      DBOS.runStep(
+         async () => {
+            const client = new Steel({ steelAPIKey: input.steelApiKey });
+            await client.sessions.release(sessionId);
+            DBOS.logger.info(`${ctx} steel session released id=${sessionId}`);
+         },
+         { name: "releaseSteelSession" },
+      ),
+      (e) => {
+         DBOS.logger.warn(
+            `${ctx} failed to release steel session: ${e instanceof Error ? e.message : String(e)}`,
+         );
+         return e instanceof Error ? e.message : String(e);
+      },
+   );
+
+   if (emissionResult.isErr()) {
+      DBOS.logger.error(
+         `${ctx} NFS-e emission failed: ${emissionResult.error}`,
+      );
+      await publishFailed(
+         publisher,
+         input.teamId,
+         `Falha ao emitir NFS-e: ${emissionResult.error}`,
+         "publishFailed",
+      );
+      return {
+         success: false,
+         error: `Falha ao emitir NFS-e: ${emissionResult.error}`,
+         sessionViewerUrl,
+      };
+   }
+
+   const numeroNota = emissionResult.value;
+
+   await DBOS.runStep(
+      () =>
+         publisher.publish("job.notification", {
+            jobId: crypto.randomUUID(),
+            type: NOTIFICATION_TYPES.NFSE_EMISSION_COMPLETED,
+            status: "completed",
+            message: `NFS-e emitida com sucesso. Nota nº ${numeroNota}.`,
+            payload: { numeroNota },
+            teamId: input.teamId,
+            timestamp: dayjs().toISOString(),
+         } satisfies JobNotification),
+      { name: "publishCompleted" },
+   );
+
+   DBOS.logger.info(`${ctx} completed numeroNota=${numeroNota}`);
+
+   return { success: true, numeroNota, sessionViewerUrl };
+}
+
+export const nfseEmissionWorkflow = DBOS.registerWorkflow(
+   nfseEmissionWorkflowFn,
+);
+
+export const enqueueNfseEmissionWorkflow = createEnqueuer<NfseEmissionInput>(
+   nfseEmissionWorkflowFn.name,
+   QUEUES.nfseEmission,
+   (i) => `nfse-emission-${i.teamId}-${i.rps.serie}-${i.rps.numero}`,
+);


### PR DESCRIPTION
## Contexto

POC para MON-328 / MON-329 — automação server-side de emissão de NFS-e via steel.dev (browser em nuvem), sem precisar de extensão de browser instalada pelo usuário.

## O que foi feito

- **`nfse-emission-workflow.ts`** — workflow DBOS com 3 steps:
  1. `createSteelSession` — cria sessão de browser remoto no steel.dev
  2. `fillAndSubmitNfse` — Playwright via CDP → navega nfse.gov.br, preenche campos ABRASF (tipo RPS, série, número, competência, natureza da operação, ISS retido, CNPJ prestador, inscrição municipal, CNPJ/CPF tomador, razão social, discriminação, valor, código de atividade), submete e extrai número da nota
  3. `releaseSteelSession` — sempre executa (sucesso ou falha, equivalente a `finally`)
- Adicionado `nfseEmission` queue no `workflow-factory.ts`
- Registrado import no `setup.ts`
- `NFSE_EMISSION_COMPLETED` adicionado aos tipos de notificação
- Dependências: `steel-sdk` + `playwright`

## TODOs para produção

- [ ] Login gov.br OAuth / certificado A1 (maior gap)
- [ ] Validar seletores DOM contra o portal real
- [ ] Mover `steelApiKey` para `@core/environment/worker`
- [ ] Roteamento por município (portal federal vs. portais próprios)

## Issues relacionadas

Closes MON-328, MON-329

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
POC de emissão de NFS-e server-side via `steel.dev` com Playwright remoto em workflow DBOS. Atende MON-328 e MON-329 e elimina a dependência de extensão de navegador.

- **New Features - Novidades**
  - Workflow NFS-e: `nfseEmissionWorkflow` com steps criar sessão (`steel-sdk`) → navegar/preencher/submeter RPS no `nfse.gov.br` (Playwright/CDP) → liberar sessão; enfileirado em `nfse-emission` via `enqueueNfseEmissionWorkflow`; registrado em `setup.ts`.
  - Notificações: novo tipo `nfse.emission_completed`; publica `started`/`failed`/`completed` com payload `{ numeroNota }`.
  - Erros e logging: `fromPromise` para captura de falhas por step; release de sessão sempre executado.
  - Dependências: adicionados `steel-sdk` e `playwright` em `packages/workflows`; lockfile atualizado.
  - Impacto por camada
    - Router: sem mudanças.
    - Repositório: sem mudanças.
    - Componente/Store: sem mudanças.
    - Workflows/Notifications: nova fila/workflow e novo tipo de notificação.

- **Checklist de teste**
  - Configurar `steelApiKey` válida; enfileirar item em `nfse-emission`.
  - Verificar publicação de notificações: `started` ao iniciar, `completed` com `payload.numeroNota` em sucesso, `failed` com mensagem em erro.
  - Confirmar criação/liberação de sessão Steel (URL de viewer no resultado).
  - Validar que o step de release roda mesmo em falha.

<sup>Written for commit de6d9a27427d49ef7aaacc25f4852ccb1a22c854. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/802">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

