### PR TITLE
poc(rubi): ComputeSDK E2B sandbox + Montte CLI integration

### DIFF
--- a/apps/web/src/integrations/orpc/router/contacts.ts
+++ b/apps/web/src/integrations/orpc/router/contacts.ts
@@ -3,6 +3,8 @@ import {
    createContact,
    deleteContact,
    ensureContactOwnership,
+   getContactTransactionStats,
+   getContactTransactions,
    listContacts,
    updateContact,
 } from "@core/database/repositories/contacts-repository";
@@ -10,6 +12,7 @@ import {
    createContactSchema,
    updateContactSchema,
 } from "@core/database/schemas/contacts";
+import { WebAppError } from "@core/logging/errors";
 import { z } from "zod";
 import { protectedProcedure } from "../server";
 
@@ -18,7 +21,12 @@ const idSchema = z.object({ id: z.string().uuid() });
 export const create = protectedProcedure
    .input(createContactSchema)
    .handler(async ({ context, input }) => {
-      return createContact(context.db, context.teamId, input);
+      return (await createContact(context.db, context.teamId, input)).match(
+         (contact) => contact,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
    });
 
 export const getAll = protectedProcedure
@@ -30,28 +38,120 @@ export const getAll = protectedProcedure
          .optional(),
    )
    .handler(async ({ context, input }) => {
-      return listContacts(context.db, context.teamId, input?.type);
+      return (
+         await listContacts(context.db, context.teamId, input?.type)
+      ).match(
+         (contacts) => contacts,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+   });
+
+export const getById = protectedProcedure
+   .input(idSchema)
+   .handler(async ({ context, input }) => {
+      return (
+         await ensureContactOwnership(context.db, input.id, context.teamId)
+      ).match(
+         (contact) => contact,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+   });
+
+export const getStats = protectedProcedure
+   .input(idSchema)
+   .handler(async ({ context, input }) => {
+      const ownership = await ensureContactOwnership(
+         context.db,
+         input.id,
+         context.teamId,
+      );
+      if (ownership.isErr()) throw WebAppError.fromAppError(ownership.error);
+      return (
+         await getContactTransactionStats(context.db, input.id, context.teamId)
+      ).match(
+         (stats) => stats,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+   });
+
+export const getTransactions = protectedProcedure
+   .input(
+      z.object({
+         id: z.string().uuid(),
+         page: z.number().int().min(1).default(1),
+         pageSize: z.number().int().min(1).max(100).default(20),
+      }),
+   )
+   .handler(async ({ context, input }) => {
+      const ownership = await ensureContactOwnership(
+         context.db,
+         input.id,
+         context.teamId,
+      );
+      if (ownership.isErr()) throw WebAppError.fromAppError(ownership.error);
+      return (
+         await getContactTransactions(context.db, input.id, context.teamId, {
+            page: input.page,
+            limit: input.pageSize,
+         })
+      ).match(
+         (result) => result,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
    });
 
 export const update = protectedProcedure
    .input(idSchema.merge(updateContactSchema))
    .handler(async ({ context, input }) => {
-      await ensureContactOwnership(context.db, input.id, context.teamId);
+      const ownership = await ensureContactOwnership(
+         context.db,
+         input.id,
+         context.teamId,
+      );
+      if (ownership.isErr()) throw WebAppError.fromAppError(ownership.error);
       const { id, ...data } = input;
-      return updateContact(context.db, id, data);
+      return (await updateContact(context.db, id, data)).match(
+         (contact) => contact,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
    });
 
 export const remove = protectedProcedure
    .input(idSchema)
    .handler(async ({ context, input }) => {
-      await ensureContactOwnership(context.db, input.id, context.teamId);
-      await deleteContact(context.db, input.id);
-      return { success: true };
+      const ownership = await ensureContactOwnership(
+         context.db,
+         input.id,
+         context.teamId,
+      );
+      if (ownership.isErr()) throw WebAppError.fromAppError(ownership.error);
+      return (await deleteContact(context.db, input.id)).match(
+         () => ({ success: true }),
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
    });
 
 export const bulkRemove = protectedProcedure
    .input(z.object({ ids: z.array(z.string().uuid()).min(1) }))
    .handler(async ({ context, input }) => {
-      await bulkDeleteContacts(context.db, input.ids, context.teamId);
-      return { deleted: input.ids.length };
+      return (
+         await bulkDeleteContacts(context.db, input.ids, context.teamId)
+      ).match(
+         () => ({ deleted: input.ids.length }),
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
    });

--- a/apps/web/src/integrations/orpc/router/services.ts
+++ b/apps/web/src/integrations/orpc/router/services.ts
@@ -137,14 +137,32 @@ export const getAllSubscriptions = protectedProcedure
          .optional(),
    )
    .handler(async ({ context, input }) => {
-      return listSubscriptionsByTeam(context.db, context.teamId, input?.status);
+      return (
+         await listSubscriptionsByTeam(
+            context.db,
+            context.teamId,
+            input?.status,
+         )
+      ).match(
+         (rows) => rows,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
    });
 
 export const getContactSubscriptions = protectedProcedure
    .input(z.object({ contactId: z.string().uuid() }))
    .handler(async ({ context, input }) => {
       await ensureContactOwnership(context.db, input.contactId, context.teamId);
-      return listSubscriptionsByContact(context.db, input.contactId);
+      return (
+         await listSubscriptionsByContact(context.db, input.contactId)
+      ).match(
+         (rows) => rows,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
    });
 
 export const createSubscription = protectedProcedure
@@ -162,13 +180,18 @@ export const createSubscription = protectedProcedure
       await ensureContactOwnership(context.db, input.contactId, context.teamId);
       await ensureVariantOwnership(context.db, input.variantId, context.teamId);
 
-      const sub = await createSubscriptionRepo(context.db, context.teamId, {
-         ...input,
-         source: "manual",
-         cancelAtPeriodEnd: false,
-      });
-
-      return sub;
+      return (
+         await createSubscriptionRepo(context.db, context.teamId, {
+            ...input,
+            source: "manual",
+            cancelAtPeriodEnd: false,
+         })
+      ).match(
+         (sub) => sub,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
    });
 
 export const cancelSubscription = protectedProcedure
@@ -178,6 +201,11 @@ export const cancelSubscription = protectedProcedure
          context.db,
          input.id,
          context.teamId,
+      ).match(
+         (sub) => sub,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
       );
 
       if (subscription.status !== "active") {
@@ -192,21 +220,38 @@ export const cancelSubscription = protectedProcedure
          );
       }
 
-      const cancelled = await updateSubscription(context.db, input.id, {
-         status: "cancelled",
-      });
-
-      return cancelled;
+      return (
+         await updateSubscription(context.db, input.id, {
+            status: "cancelled",
+         })
+      ).match(
+         (cancelled) => cancelled,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
    });
 
 export const getExpiringSoon = protectedProcedure.handler(
    async ({ context }) => {
-      return listExpiringSoon(context.db, context.teamId);
+      return (await listExpiringSoon(context.db, context.teamId)).match(
+         (rows) => rows,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
    },
 );
 
 export const getActiveCountByVariant = protectedProcedure.handler(
    async ({ context }) => {
-      return countActiveSubscriptionsByVariant(context.db, context.teamId);
+      return (
+         await countActiveSubscriptionsByVariant(context.db, context.teamId)
+      ).match(
+         (rows) => rows,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
    },
 );

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -50,6 +50,7 @@ import { Route as AuthenticatedSlugTeamSlugDashboardSettingsFeaturePreviewsRoute
 import { Route as AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/settings/danger-zone";
 import { Route as AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/settings/customization";
 import { Route as AuthenticatedSlugTeamSlugDashboardErpServicesRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/erp/services";
+import { Route as AuthenticatedSlugTeamSlugDashboardContactsContactIdRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/contacts/$contactId";
 import { Route as AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management";
 import { Route as AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsIndexRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/index";
 import { Route as AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementIndexRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/index";
@@ -294,6 +295,12 @@ const AuthenticatedSlugTeamSlugDashboardErpServicesRoute =
       path: "/erp/services",
       getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
    } as any);
+const AuthenticatedSlugTeamSlugDashboardContactsContactIdRoute =
+   AuthenticatedSlugTeamSlugDashboardContactsContactIdRouteImport.update({
+      id: "/$contactId",
+      path: "/$contactId",
+      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardContactsRoute,
+   } as any);
 const AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRoute =
    AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRouteImport.update({
       id: "/analytics/data-management",
@@ -468,12 +475,13 @@ export interface FileRoutesByFullPath {
    "/$slug/$teamSlug/billing": typeof AuthenticatedSlugTeamSlugDashboardBillingRoute;
    "/$slug/$teamSlug/categories": typeof AuthenticatedSlugTeamSlugDashboardCategoriesRoute;
    "/$slug/$teamSlug/chat": typeof AuthenticatedSlugTeamSlugDashboardChatRoute;
-   "/$slug/$teamSlug/contacts": typeof AuthenticatedSlugTeamSlugDashboardContactsRoute;
+   "/$slug/$teamSlug/contacts": typeof AuthenticatedSlugTeamSlugDashboardContactsRouteWithChildren;
    "/$slug/$teamSlug/credit-cards": typeof AuthenticatedSlugTeamSlugDashboardCreditCardsRoute;
    "/$slug/$teamSlug/settings": typeof AuthenticatedSlugTeamSlugDashboardSettingsRouteWithChildren;
    "/$slug/$teamSlug/tags": typeof AuthenticatedSlugTeamSlugDashboardTagsRoute;
    "/$slug/$teamSlug/transactions": typeof AuthenticatedSlugTeamSlugDashboardTransactionsRoute;
    "/$slug/$teamSlug/analytics/data-management": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRouteWithChildren;
+   "/$slug/$teamSlug/contacts/$contactId": typeof AuthenticatedSlugTeamSlugDashboardContactsContactIdRoute;
    "/$slug/$teamSlug/erp/services": typeof AuthenticatedSlugTeamSlugDashboardErpServicesRoute;
    "/$slug/$teamSlug/settings/customization": typeof AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRoute;
    "/$slug/$teamSlug/settings/danger-zone": typeof AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRoute;
@@ -527,10 +535,11 @@ export interface FileRoutesByTo {
    "/$slug/$teamSlug/billing": typeof AuthenticatedSlugTeamSlugDashboardBillingRoute;
    "/$slug/$teamSlug/categories": typeof AuthenticatedSlugTeamSlugDashboardCategoriesRoute;
    "/$slug/$teamSlug/chat": typeof AuthenticatedSlugTeamSlugDashboardChatRoute;
-   "/$slug/$teamSlug/contacts": typeof AuthenticatedSlugTeamSlugDashboardContactsRoute;
+   "/$slug/$teamSlug/contacts": typeof AuthenticatedSlugTeamSlugDashboardContactsRouteWithChildren;
    "/$slug/$teamSlug/credit-cards": typeof AuthenticatedSlugTeamSlugDashboardCreditCardsRoute;
    "/$slug/$teamSlug/tags": typeof AuthenticatedSlugTeamSlugDashboardTagsRoute;
    "/$slug/$teamSlug/transactions": typeof AuthenticatedSlugTeamSlugDashboardTransactionsRoute;
+   "/$slug/$teamSlug/contacts/$contactId": typeof AuthenticatedSlugTeamSlugDashboardContactsContactIdRoute;
    "/$slug/$teamSlug/erp/services": typeof AuthenticatedSlugTeamSlugDashboardErpServicesRoute;
    "/$slug/$teamSlug/settings/customization": typeof AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRoute;
    "/$slug/$teamSlug/settings/danger-zone": typeof AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRoute;
@@ -588,12 +597,13 @@ export interface FileRoutesById {
    "/_authenticated/$slug/$teamSlug/_dashboard/billing": typeof AuthenticatedSlugTeamSlugDashboardBillingRoute;
    "/_authenticated/$slug/$teamSlug/_dashboard/categories": typeof AuthenticatedSlugTeamSlugDashboardCategoriesRoute;
    "/_authenticated/$slug/$teamSlug/_dashboard/chat": typeof AuthenticatedSlugTeamSlugDashboardChatRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/contacts": typeof AuthenticatedSlugTeamSlugDashboardContactsRoute;
+   "/_authenticated/$slug/$teamSlug/_dashboard/contacts": typeof AuthenticatedSlugTeamSlugDashboardContactsRouteWithChildren;
    "/_authenticated/$slug/$teamSlug/_dashboard/credit-cards": typeof AuthenticatedSlugTeamSlugDashboardCreditCardsRoute;
    "/_authenticated/$slug/$teamSlug/_dashboard/settings": typeof AuthenticatedSlugTeamSlugDashboardSettingsRouteWithChildren;
    "/_authenticated/$slug/$teamSlug/_dashboard/tags": typeof AuthenticatedSlugTeamSlugDashboardTagsRoute;
    "/_authenticated/$slug/$teamSlug/_dashboard/transactions": typeof AuthenticatedSlugTeamSlugDashboardTransactionsRoute;
    "/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRouteWithChildren;
+   "/_authenticated/$slug/$teamSlug/_dashboard/contacts/$contactId": typeof AuthenticatedSlugTeamSlugDashboardContactsContactIdRoute;
    "/_authenticated/$slug/$teamSlug/_dashboard/erp/services": typeof AuthenticatedSlugTeamSlugDashboardErpServicesRoute;
    "/_authenticated/$slug/$teamSlug/_dashboard/settings/customization": typeof AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRoute;
    "/_authenticated/$slug/$teamSlug/_dashboard/settings/danger-zone": typeof AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRoute;
@@ -656,6 +666,7 @@ export interface FileRouteTypes {
       | "/$slug/$teamSlug/tags"
       | "/$slug/$teamSlug/transactions"
       | "/$slug/$teamSlug/analytics/data-management"
+      | "/$slug/$teamSlug/contacts/$contactId"
       | "/$slug/$teamSlug/erp/services"
       | "/$slug/$teamSlug/settings/customization"
       | "/$slug/$teamSlug/settings/danger-zone"
@@ -713,6 +724,7 @@ export interface FileRouteTypes {
       | "/$slug/$teamSlug/credit-cards"
       | "/$slug/$teamSlug/tags"
       | "/$slug/$teamSlug/transactions"
+      | "/$slug/$teamSlug/contacts/$contactId"
       | "/$slug/$teamSlug/erp/services"
       | "/$slug/$teamSlug/settings/customization"
       | "/$slug/$teamSlug/settings/danger-zone"
@@ -775,6 +787,7 @@ export interface FileRouteTypes {
       | "/_authenticated/$slug/$teamSlug/_dashboard/tags"
       | "/_authenticated/$slug/$teamSlug/_dashboard/transactions"
       | "/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management"
+      | "/_authenticated/$slug/$teamSlug/_dashboard/contacts/$contactId"
       | "/_authenticated/$slug/$teamSlug/_dashboard/erp/services"
       | "/_authenticated/$slug/$teamSlug/_dashboard/settings/customization"
       | "/_authenticated/$slug/$teamSlug/_dashboard/settings/danger-zone"
@@ -1107,6 +1120,13 @@ declare module "@tanstack/react-router" {
          preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardErpServicesRouteImport;
          parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute;
       };
+      "/_authenticated/$slug/$teamSlug/_dashboard/contacts/$contactId": {
+         id: "/_authenticated/$slug/$teamSlug/_dashboard/contacts/$contactId";
+         path: "/$contactId";
+         fullPath: "/$slug/$teamSlug/contacts/$contactId";
+         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardContactsContactIdRouteImport;
+         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardContactsRoute;
+      };
       "/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management": {
          id: "/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management";
          path: "/analytics/data-management";
@@ -1243,6 +1263,21 @@ declare module "@tanstack/react-router" {
    }
 }
 
+interface AuthenticatedSlugTeamSlugDashboardContactsRouteChildren {
+   AuthenticatedSlugTeamSlugDashboardContactsContactIdRoute: typeof AuthenticatedSlugTeamSlugDashboardContactsContactIdRoute;
+}
+
+const AuthenticatedSlugTeamSlugDashboardContactsRouteChildren: AuthenticatedSlugTeamSlugDashboardContactsRouteChildren =
+   {
+      AuthenticatedSlugTeamSlugDashboardContactsContactIdRoute:
+         AuthenticatedSlugTeamSlugDashboardContactsContactIdRoute,
+   };
+
+const AuthenticatedSlugTeamSlugDashboardContactsRouteWithChildren =
+   AuthenticatedSlugTeamSlugDashboardContactsRoute._addFileChildren(
+      AuthenticatedSlugTeamSlugDashboardContactsRouteChildren,
+   );
+
 interface AuthenticatedSlugTeamSlugDashboardSettingsRouteChildren {
    AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRoute;
    AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRoute;
@@ -1332,7 +1367,7 @@ interface AuthenticatedSlugTeamSlugDashboardRouteChildren {
    AuthenticatedSlugTeamSlugDashboardBillingRoute: typeof AuthenticatedSlugTeamSlugDashboardBillingRoute;
    AuthenticatedSlugTeamSlugDashboardCategoriesRoute: typeof AuthenticatedSlugTeamSlugDashboardCategoriesRoute;
    AuthenticatedSlugTeamSlugDashboardChatRoute: typeof AuthenticatedSlugTeamSlugDashboardChatRoute;
-   AuthenticatedSlugTeamSlugDashboardContactsRoute: typeof AuthenticatedSlugTeamSlugDashboardContactsRoute;
+   AuthenticatedSlugTeamSlugDashboardContactsRoute: typeof AuthenticatedSlugTeamSlugDashboardContactsRouteWithChildren;
    AuthenticatedSlugTeamSlugDashboardCreditCardsRoute: typeof AuthenticatedSlugTeamSlugDashboardCreditCardsRoute;
    AuthenticatedSlugTeamSlugDashboardSettingsRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRouteWithChildren;
    AuthenticatedSlugTeamSlugDashboardTagsRoute: typeof AuthenticatedSlugTeamSlugDashboardTagsRoute;
@@ -1358,7 +1393,7 @@ const AuthenticatedSlugTeamSlugDashboardRouteChildren: AuthenticatedSlugTeamSlug
       AuthenticatedSlugTeamSlugDashboardChatRoute:
          AuthenticatedSlugTeamSlugDashboardChatRoute,
       AuthenticatedSlugTeamSlugDashboardContactsRoute:
-         AuthenticatedSlugTeamSlugDashboardContactsRoute,
+         AuthenticatedSlugTeamSlugDashboardContactsRouteWithChildren,
       AuthenticatedSlugTeamSlugDashboardCreditCardsRoute:
          AuthenticatedSlugTeamSlugDashboardCreditCardsRoute,
       AuthenticatedSlugTeamSlugDashboardSettingsRoute:

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-contacts/add-subscription-form.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-contacts/add-subscription-form.tsx
@@ -1,0 +1,203 @@
+import { Button } from "@packages/ui/components/button";
+import {
+   CredenzaBody,
+   CredenzaFooter,
+   CredenzaHeader,
+   CredenzaTitle,
+} from "@packages/ui/components/credenza";
+import { Label } from "@packages/ui/components/label";
+import {
+   Select,
+   SelectContent,
+   SelectItem,
+   SelectTrigger,
+   SelectValue,
+} from "@packages/ui/components/select";
+import { Skeleton } from "@packages/ui/components/skeleton";
+import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
+import { Suspense, useState } from "react";
+import { toast } from "sonner";
+import type { Outputs } from "@/integrations/orpc/client";
+import { orpc } from "@/integrations/orpc/client";
+import { useCredenza } from "@/hooks/use-credenza";
+
+type Variant = Outputs["services"]["getVariants"][number];
+
+const BILLING_CYCLE_LABELS: Record<string, string> = {
+   hourly: "Por hora",
+   monthly: "Mensal",
+   annual: "Anual",
+   one_time: "Único",
+};
+
+function VariantSelector({
+   serviceId,
+   selectedVariantId,
+   onSelect,
+   onPriceChange,
+}: {
+   serviceId: string;
+   selectedVariantId: string;
+   onSelect: (variantId: string) => void;
+   onPriceChange: (price: string) => void;
+}) {
+   const { data: variants } = useSuspenseQuery(
+      orpc.services.getVariants.queryOptions({ input: { serviceId } }),
+   );
+
+   function handleVariantChange(variantId: string) {
+      onSelect(variantId);
+      const variant = variants.find((v) => v.id === variantId);
+      if (variant) {
+         onPriceChange(variant.basePrice);
+      }
+   }
+
+   return (
+      <div className="flex flex-col gap-2">
+         <Label htmlFor="variantId">Variante</Label>
+         <Select value={selectedVariantId} onValueChange={handleVariantChange}>
+            <SelectTrigger id="variantId">
+               <SelectValue placeholder="Selecione uma variante" />
+            </SelectTrigger>
+            <SelectContent>
+               {variants.map((v: Variant) => (
+                  <SelectItem key={v.id} value={v.id}>
+                     {v.name} —{" "}
+                     {BILLING_CYCLE_LABELS[v.billingCycle] ?? v.billingCycle}
+                  </SelectItem>
+               ))}
+            </SelectContent>
+         </Select>
+      </div>
+   );
+}
+
+export function AddSubscriptionForm({
+   contactId,
+   onSuccess,
+}: {
+   contactId: string;
+   onSuccess: () => void;
+}) {
+   const { data: services } = useSuspenseQuery(
+      orpc.services.getAll.queryOptions({ input: {} }),
+   );
+   const queryClient = useQueryClient();
+   const { closeCredenza } = useCredenza();
+
+   const [serviceId, setServiceId] = useState("");
+   const [variantId, setVariantId] = useState("");
+   const [startDate, setStartDate] = useState("");
+   const [negotiatedPrice, setNegotiatedPrice] = useState("");
+
+   const createMutation = useMutation(
+      orpc.services.createSubscription.mutationOptions({
+         onSuccess: () => {
+            toast.success("Assinatura criada.");
+            queryClient.invalidateQueries({
+               queryKey: orpc.services.getContactSubscriptions.queryKey({
+                  input: { contactId },
+               }),
+            });
+            onSuccess();
+            closeCredenza();
+         },
+         onError: (e) => toast.error(e.message),
+      }),
+   );
+
+   function handleServiceChange(id: string) {
+      setServiceId(id);
+      setVariantId("");
+      setNegotiatedPrice("");
+   }
+
+   function handleSubmit(e: React.FormEvent) {
+      e.preventDefault();
+      if (!variantId || !startDate || !negotiatedPrice) return;
+      createMutation.mutate({
+         contactId,
+         variantId,
+         startDate,
+         negotiatedPrice,
+      });
+   }
+
+   return (
+      <form onSubmit={handleSubmit}>
+         <CredenzaHeader>
+            <CredenzaTitle>Nova assinatura</CredenzaTitle>
+         </CredenzaHeader>
+         <CredenzaBody>
+            <div className="flex flex-col gap-4">
+               <div className="flex flex-col gap-2">
+                  <Label htmlFor="serviceId">Serviço</Label>
+                  <Select value={serviceId} onValueChange={handleServiceChange}>
+                     <SelectTrigger id="serviceId">
+                        <SelectValue placeholder="Selecione um serviço" />
+                     </SelectTrigger>
+                     <SelectContent>
+                        {services.map((s) => (
+                           <SelectItem key={s.id} value={s.id}>
+                              {s.name}
+                           </SelectItem>
+                        ))}
+                     </SelectContent>
+                  </Select>
+               </div>
+
+               {serviceId && (
+                  <Suspense fallback={<Skeleton className="h-10 w-full" />}>
+                     <VariantSelector
+                        serviceId={serviceId}
+                        selectedVariantId={variantId}
+                        onPriceChange={setNegotiatedPrice}
+                        onSelect={setVariantId}
+                     />
+                  </Suspense>
+               )}
+
+               <div className="flex flex-col gap-2">
+                  <Label htmlFor="startDate">Data de início</Label>
+                  <input
+                     className="rounded-md border px-3 py-2 text-sm outline-none focus:ring-1"
+                     id="startDate"
+                     placeholder="AAAA-MM-DD"
+                     type="date"
+                     value={startDate}
+                     onChange={(e) => setStartDate(e.target.value)}
+                  />
+               </div>
+
+               <div className="flex flex-col gap-2">
+                  <Label htmlFor="negotiatedPrice">Preço negociado (R$)</Label>
+                  <input
+                     className="rounded-md border px-3 py-2 text-sm outline-none focus:ring-1"
+                     id="negotiatedPrice"
+                     placeholder="0.00"
+                     step="0.01"
+                     type="number"
+                     value={negotiatedPrice}
+                     onChange={(e) => setNegotiatedPrice(e.target.value)}
+                  />
+               </div>
+            </div>
+         </CredenzaBody>
+         <CredenzaFooter>
+            <Button
+               disabled={
+                  !variantId ||
+                  !startDate ||
+                  !negotiatedPrice ||
+                  createMutation.isPending
+               }
+               type="submit"
+            >
+               {createMutation.isPending ? "Salvando..." : "Salvar"}
+            </Button>
+         </CredenzaFooter>
+      </form>
+   );
+}

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-contacts/contact-assinaturas-tab.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-contacts/contact-assinaturas-tab.tsx
@@ -1,0 +1,153 @@
+import { Badge } from "@packages/ui/components/badge";
+import { Button } from "@packages/ui/components/button";
+import {
+   Card,
+   CardContent,
+   CardHeader,
+   CardTitle,
+} from "@packages/ui/components/card";
+import {
+   Empty,
+   EmptyDescription,
+   EmptyHeader,
+   EmptyMedia,
+   EmptyTitle,
+} from "@packages/ui/components/empty";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { format, of } from "@f-o-t/money";
+import dayjs from "dayjs";
+import { Plus, RefreshCw } from "lucide-react";
+import type { Outputs } from "@/integrations/orpc/client";
+import { orpc } from "@/integrations/orpc/client";
+import { useCredenza } from "@/hooks/use-credenza";
+import { AddSubscriptionForm } from "./add-subscription-form";
+
+type Subscription = Outputs["services"]["getContactSubscriptions"][number];
+
+const STATUS_LABELS: Record<Subscription["status"], string> = {
+   active: "Ativa",
+   completed: "Concluída",
+   cancelled: "Cancelada",
+};
+
+const STATUS_VARIANTS: Record<
+   Subscription["status"],
+   "default" | "secondary" | "outline"
+> = {
+   active: "default",
+   completed: "secondary",
+   cancelled: "outline",
+};
+
+const BILLING_CYCLE_LABELS: Record<string, string> = {
+   hourly: "Por hora",
+   monthly: "Mensal",
+   annual: "Anual",
+   one_time: "Único",
+};
+
+function SubscriptionCard({ sub }: { sub: Subscription }) {
+   return (
+      <Card>
+         <CardHeader>
+            <div className="flex items-center gap-2">
+               <CardTitle className="flex-1 text-sm">
+                  {sub.serviceName ?? "Serviço removido"}
+               </CardTitle>
+               <Badge variant={STATUS_VARIANTS[sub.status]}>
+                  {STATUS_LABELS[sub.status]}
+               </Badge>
+            </div>
+            {sub.variantName && sub.billingCycle && (
+               <span className="text-xs text-muted-foreground">
+                  {sub.variantName} —{" "}
+                  {BILLING_CYCLE_LABELS[sub.billingCycle] ?? sub.billingCycle}
+               </span>
+            )}
+         </CardHeader>
+         <CardContent>
+            <div className="flex flex-col gap-2 text-sm">
+               <div className="flex items-center gap-2">
+                  <span className="text-muted-foreground">Valor:</span>
+                  <span className="font-medium">
+                     {format(of(sub.negotiatedPrice, "BRL"), "pt-BR")}
+                  </span>
+               </div>
+               <div className="flex items-center gap-2">
+                  <span className="text-muted-foreground">Início:</span>
+                  <span>{dayjs(sub.startDate).format("DD/MM/YYYY")}</span>
+               </div>
+               {sub.endDate && (
+                  <div className="flex items-center gap-2">
+                     <span className="text-muted-foreground">Término:</span>
+                     <span>{dayjs(sub.endDate).format("DD/MM/YYYY")}</span>
+                  </div>
+               )}
+               {sub.currentPeriodEnd && (
+                  <div className="flex items-center gap-2">
+                     <span className="text-muted-foreground">
+                        Período atual até:
+                     </span>
+                     <span>
+                        {dayjs(sub.currentPeriodEnd).format("DD/MM/YYYY")}
+                     </span>
+                  </div>
+               )}
+            </div>
+         </CardContent>
+      </Card>
+   );
+}
+
+export function ContactAssinaturasTab({ contactId }: { contactId: string }) {
+   const { data: subscriptions } = useSuspenseQuery(
+      orpc.services.getContactSubscriptions.queryOptions({
+         input: { contactId },
+      }),
+   );
+   const { openCredenza } = useCredenza();
+
+   function handleAdd() {
+      openCredenza({
+         renderChildren: () => (
+            <AddSubscriptionForm contactId={contactId} onSuccess={() => {}} />
+         ),
+      });
+   }
+
+   return (
+      <div className="flex flex-col gap-4">
+         <div className="flex items-center gap-4">
+            <h2 className="flex-1 text-sm font-medium text-muted-foreground">
+               {subscriptions.length} assinatura
+               {subscriptions.length !== 1 ? "s" : ""}
+            </h2>
+            <Button size="sm" variant="outline" onClick={handleAdd}>
+               <Plus className="size-4" />
+               Adicionar
+            </Button>
+         </div>
+
+         {subscriptions.length === 0 ? (
+            <Empty>
+               <EmptyHeader>
+                  <EmptyMedia variant="icon">
+                     <RefreshCw className="size-6" />
+                  </EmptyMedia>
+                  <EmptyTitle>Nenhuma assinatura</EmptyTitle>
+                  <EmptyDescription>
+                     Vincule este contato a um serviço para acompanhar
+                     assinaturas e cobranças.
+                  </EmptyDescription>
+               </EmptyHeader>
+            </Empty>
+         ) : (
+            <div className="flex flex-col gap-4">
+               {subscriptions.map((sub) => (
+                  <SubscriptionCard key={sub.id} sub={sub} />
+               ))}
+            </div>
+         )}
+      </div>
+   );
+}

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-contacts/contact-dados-tab.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-contacts/contact-dados-tab.tsx
@@ -1,0 +1,283 @@
+import { Button } from "@packages/ui/components/button";
+import {
+   Card,
+   CardContent,
+   CardHeader,
+   CardTitle,
+} from "@packages/ui/components/card";
+import {
+   Select,
+   SelectContent,
+   SelectItem,
+   SelectTrigger,
+   SelectValue,
+} from "@packages/ui/components/select";
+import { Textarea } from "@packages/ui/components/textarea";
+import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { format, of } from "@f-o-t/money";
+import { Pencil, TrendingDown, TrendingUp } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import type { Outputs } from "@/integrations/orpc/client";
+import { orpc } from "@/integrations/orpc/client";
+
+type Contact = Outputs["contacts"]["getById"];
+
+type EditRowProps = {
+   label: string;
+   isLast?: boolean;
+   onEdit: () => void;
+   children: React.ReactNode;
+};
+
+function EditRow({ label, isLast, onEdit, children }: EditRowProps) {
+   return (
+      <div
+         className={`group flex items-start gap-4 px-4 py-3${isLast ? "" : " border-b"}`}
+      >
+         <span className="w-28 shrink-0 text-xs text-muted-foreground">
+            {label}
+         </span>
+         <div className="flex flex-1 items-center gap-2">
+            <div className="flex-1 text-sm">{children}</div>
+            <Button
+               className="size-6 opacity-0 transition-opacity group-hover:opacity-100 hover:opacity-100"
+               size="icon"
+               variant="ghost"
+               onClick={onEdit}
+            >
+               <Pencil className="size-3" />
+               <span className="sr-only">Editar</span>
+            </Button>
+         </div>
+      </div>
+   );
+}
+
+type FieldKey = "name" | "type" | "email" | "phone" | "document" | "notes";
+
+export function ContactDadosTab({ contact }: { contact: Contact }) {
+   const [editingField, setEditingField] = useState<FieldKey | null>(null);
+   const [editValue, setEditValue] = useState<string>("");
+
+   const { data: stats } = useSuspenseQuery(
+      orpc.contacts.getStats.queryOptions({ input: { id: contact.id } }),
+   );
+
+   const updateMutation = useMutation(
+      orpc.contacts.update.mutationOptions({
+         onSuccess: () => {
+            toast.success("Contato atualizado.");
+            setEditingField(null);
+         },
+         onError: (e) => toast.error(e.message),
+      }),
+   );
+
+   function startEdit(field: FieldKey, current: string | null | undefined) {
+      setEditingField(field);
+      setEditValue(current ?? "");
+   }
+
+   function cancelEdit() {
+      setEditingField(null);
+      setEditValue("");
+   }
+
+   function commitEdit(field: FieldKey) {
+      const value = editValue.trim() === "" ? null : editValue.trim();
+      updateMutation.mutate({ id: contact.id, [field]: value });
+   }
+
+   function handleKeyDown(e: React.KeyboardEvent, field: FieldKey) {
+      if (e.key === "Enter" && field !== "notes") {
+         commitEdit(field);
+      }
+      if (e.key === "Escape") {
+         cancelEdit();
+      }
+   }
+
+   const typeLabels: Record<Contact["type"], string> = {
+      cliente: "Cliente",
+      fornecedor: "Fornecedor",
+      ambos: "Ambos",
+   };
+
+   return (
+      <div className="flex flex-col gap-4">
+         <div className="group rounded-lg border">
+            <EditRow
+               label="Nome"
+               onEdit={() => startEdit("name", contact.name)}
+            >
+               {editingField === "name" ? (
+                  <input
+                     autoFocus
+                     className="w-full rounded border px-2 py-1 text-sm outline-none focus:ring-1"
+                     value={editValue}
+                     onBlur={() => commitEdit("name")}
+                     onChange={(e) => setEditValue(e.target.value)}
+                     onKeyDown={(e) => handleKeyDown(e, "name")}
+                  />
+               ) : (
+                  <span>{contact.name}</span>
+               )}
+            </EditRow>
+
+            <EditRow
+               label="Tipo"
+               onEdit={() => startEdit("type", contact.type)}
+            >
+               {editingField === "type" ? (
+                  <Select
+                     defaultOpen
+                     value={editValue || contact.type}
+                     onValueChange={(val) => {
+                        setEditValue(val);
+                        updateMutation.mutate({
+                           id: contact.id,
+                           type: val as Contact["type"],
+                        });
+                     }}
+                  >
+                     <SelectTrigger className="h-8 text-sm">
+                        <SelectValue />
+                     </SelectTrigger>
+                     <SelectContent>
+                        <SelectItem value="cliente">Cliente</SelectItem>
+                        <SelectItem value="fornecedor">Fornecedor</SelectItem>
+                        <SelectItem value="ambos">Ambos</SelectItem>
+                     </SelectContent>
+                  </Select>
+               ) : (
+                  <span>{typeLabels[contact.type]}</span>
+               )}
+            </EditRow>
+
+            <EditRow
+               label="Email"
+               onEdit={() => startEdit("email", contact.email)}
+            >
+               {editingField === "email" ? (
+                  <input
+                     autoFocus
+                     className="w-full rounded border px-2 py-1 text-sm outline-none focus:ring-1"
+                     type="email"
+                     value={editValue}
+                     onBlur={() => commitEdit("email")}
+                     onChange={(e) => setEditValue(e.target.value)}
+                     onKeyDown={(e) => handleKeyDown(e, "email")}
+                  />
+               ) : (
+                  <span
+                     className={contact.email ? "" : "text-muted-foreground"}
+                  >
+                     {contact.email ?? "—"}
+                  </span>
+               )}
+            </EditRow>
+
+            <EditRow
+               label="Telefone"
+               onEdit={() => startEdit("phone", contact.phone)}
+            >
+               {editingField === "phone" ? (
+                  <input
+                     autoFocus
+                     className="w-full rounded border px-2 py-1 text-sm outline-none focus:ring-1"
+                     value={editValue}
+                     onBlur={() => commitEdit("phone")}
+                     onChange={(e) => setEditValue(e.target.value)}
+                     onKeyDown={(e) => handleKeyDown(e, "phone")}
+                  />
+               ) : (
+                  <span
+                     className={contact.phone ? "" : "text-muted-foreground"}
+                  >
+                     {contact.phone ?? "—"}
+                  </span>
+               )}
+            </EditRow>
+
+            <EditRow
+               label="Documento"
+               onEdit={() => startEdit("document", contact.document)}
+            >
+               {editingField === "document" ? (
+                  <input
+                     autoFocus
+                     className="w-full rounded border px-2 py-1 text-sm outline-none focus:ring-1"
+                     placeholder="CPF ou CNPJ"
+                     value={editValue}
+                     onBlur={() => commitEdit("document")}
+                     onChange={(e) => setEditValue(e.target.value)}
+                     onKeyDown={(e) => handleKeyDown(e, "document")}
+                  />
+               ) : (
+                  <span
+                     className={contact.document ? "" : "text-muted-foreground"}
+                  >
+                     {contact.document ?? "—"}
+                  </span>
+               )}
+            </EditRow>
+
+            <EditRow
+               isLast
+               label="Observações"
+               onEdit={() => startEdit("notes", contact.notes)}
+            >
+               {editingField === "notes" ? (
+                  <Textarea
+                     autoFocus
+                     className="text-sm"
+                     value={editValue}
+                     onBlur={() => commitEdit("notes")}
+                     onChange={(e) => setEditValue(e.target.value)}
+                     onKeyDown={(e) => handleKeyDown(e, "notes")}
+                  />
+               ) : (
+                  <span
+                     className={contact.notes ? "" : "text-muted-foreground"}
+                  >
+                     {contact.notes ?? "—"}
+                  </span>
+               )}
+            </EditRow>
+         </div>
+
+         <Card>
+            <CardHeader>
+               <CardTitle>Resumo financeiro</CardTitle>
+            </CardHeader>
+            <CardContent>
+               <div className="flex gap-4">
+                  <div className="flex flex-1 flex-col gap-2 rounded-lg border border-emerald-200 bg-emerald-50 p-4 dark:border-emerald-900 dark:bg-emerald-950">
+                     <div className="flex items-center gap-2">
+                        <TrendingUp className="size-4 text-emerald-600" />
+                        <span className="text-xs text-muted-foreground">
+                           Receitas
+                        </span>
+                     </div>
+                     <span className="text-lg font-semibold text-emerald-700 dark:text-emerald-400">
+                        {format(of(stats.totalIncome, "BRL"), "pt-BR")}
+                     </span>
+                  </div>
+                  <div className="flex flex-1 flex-col gap-2 rounded-lg border border-rose-200 bg-rose-50 p-4 dark:border-rose-900 dark:bg-rose-950">
+                     <div className="flex items-center gap-2">
+                        <TrendingDown className="size-4 text-rose-600" />
+                        <span className="text-xs text-muted-foreground">
+                           Despesas
+                        </span>
+                     </div>
+                     <span className="text-lg font-semibold text-rose-700 dark:text-rose-400">
+                        {format(of(stats.totalExpense, "BRL"), "pt-BR")}
+                     </span>
+                  </div>
+               </div>
+            </CardContent>
+         </Card>
+      </div>
+   );
+}

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-contacts/contact-detail-header.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-contacts/contact-detail-header.tsx
@@ -1,0 +1,107 @@
+import { Badge } from "@packages/ui/components/badge";
+import { Button } from "@packages/ui/components/button";
+import {
+   DropdownMenu,
+   DropdownMenuContent,
+   DropdownMenuItem,
+   DropdownMenuTrigger,
+} from "@packages/ui/components/dropdown-menu";
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { ArrowLeft, MoreHorizontal, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import type { Outputs } from "@/integrations/orpc/client";
+import { orpc } from "@/integrations/orpc/client";
+import { useAlertDialog } from "@/hooks/use-alert-dialog";
+import { useOrgSlug, useTeamSlug } from "@/hooks/use-dashboard-slugs";
+
+type Contact = Outputs["contacts"]["getById"];
+
+const TYPE_LABELS: Record<Contact["type"], string> = {
+   cliente: "Cliente",
+   fornecedor: "Fornecedor",
+   ambos: "Ambos",
+};
+
+const TYPE_VARIANTS: Record<
+   Contact["type"],
+   "default" | "secondary" | "outline"
+> = {
+   cliente: "default",
+   fornecedor: "secondary",
+   ambos: "outline",
+};
+
+export function ContactDetailHeader({ contact }: { contact: Contact }) {
+   const navigate = useNavigate();
+   const { openAlertDialog } = useAlertDialog();
+   const slug = useOrgSlug();
+   const teamSlug = useTeamSlug();
+
+   const deleteMutation = useMutation(
+      orpc.contacts.remove.mutationOptions({
+         onSuccess: () => {
+            toast.success("Contato excluído.");
+            navigate({
+               to: "/$slug/$teamSlug/contacts",
+               params: { slug, teamSlug },
+            });
+         },
+         onError: (e) => toast.error(e.message),
+      }),
+   );
+
+   function handleDelete() {
+      openAlertDialog({
+         title: "Excluir contato",
+         description: `Excluir "${contact.name}"? Lançamentos vinculados impedirão a exclusão.`,
+         actionLabel: "Excluir",
+         cancelLabel: "Cancelar",
+         variant: "destructive",
+         onAction: async () => {
+            await deleteMutation.mutateAsync({ id: contact.id });
+         },
+      });
+   }
+
+   return (
+      <div className="flex items-center gap-4">
+         <Button
+            size="icon"
+            variant="ghost"
+            onClick={() =>
+               navigate({
+                  to: "/$slug/$teamSlug/contacts",
+                  params: { slug, teamSlug },
+               })
+            }
+         >
+            <ArrowLeft className="size-4" />
+            <span className="sr-only">Voltar</span>
+         </Button>
+         <div className="flex flex-1 items-center gap-2">
+            <h1 className="text-xl font-semibold">{contact.name}</h1>
+            <Badge variant={TYPE_VARIANTS[contact.type]}>
+               {TYPE_LABELS[contact.type]}
+            </Badge>
+            {contact.isArchived && <Badge variant="outline">Arquivado</Badge>}
+         </div>
+         <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+               <Button size="icon" variant="outline">
+                  <MoreHorizontal className="size-4" />
+               </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+               <DropdownMenuItem
+                  className="text-destructive"
+                  onClick={handleDelete}
+               >
+                  <Trash2 className="size-4" />
+                  Excluir
+               </DropdownMenuItem>
+            </DropdownMenuContent>
+         </DropdownMenu>
+      </div>
+   );
+}

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-contacts/contact-info-sidebar.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-contacts/contact-info-sidebar.tsx
@@ -1,0 +1,86 @@
+import { Badge } from "@packages/ui/components/badge";
+import {
+   Card,
+   CardContent,
+   CardHeader,
+   CardTitle,
+} from "@packages/ui/components/card";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import dayjs from "dayjs";
+import type { Outputs } from "@/integrations/orpc/client";
+import { orpc } from "@/integrations/orpc/client";
+
+type Contact = Outputs["contacts"]["getById"];
+
+const TYPE_LABELS: Record<Contact["type"], string> = {
+   cliente: "Cliente",
+   fornecedor: "Fornecedor",
+   ambos: "Ambos",
+};
+
+function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
+   return (
+      <div className="flex items-center gap-2">
+         <span className="flex-1 text-xs text-muted-foreground">{label}</span>
+         <span className="text-xs">{value}</span>
+      </div>
+   );
+}
+
+export function ContactInfoSidebar({ contact }: { contact: Contact }) {
+   const { data: subscriptions } = useSuspenseQuery(
+      orpc.services.getContactSubscriptions.queryOptions({
+         input: { contactId: contact.id },
+      }),
+   );
+
+   const activeCount = subscriptions.filter(
+      (s) => s.status === "active",
+   ).length;
+
+   return (
+      <aside className="flex w-64 shrink-0 flex-col gap-4">
+         <Card>
+            <CardHeader>
+               <CardTitle>Info</CardTitle>
+            </CardHeader>
+            <CardContent>
+               <div className="flex flex-col gap-2">
+                  <InfoRow
+                     label="Tipo"
+                     value={
+                        <Badge variant="outline">
+                           {TYPE_LABELS[contact.type]}
+                        </Badge>
+                     }
+                  />
+                  <InfoRow
+                     label="Criado em"
+                     value={dayjs(contact.createdAt).format("DD/MM/YYYY")}
+                  />
+                  <InfoRow
+                     label="Atualizado"
+                     value={dayjs(contact.updatedAt).format("DD/MM/YYYY")}
+                  />
+               </div>
+            </CardContent>
+         </Card>
+
+         {activeCount > 0 && (
+            <Card>
+               <CardHeader>
+                  <CardTitle>Assinaturas</CardTitle>
+               </CardHeader>
+               <CardContent>
+                  <div className="flex items-baseline gap-2">
+                     <span className="text-3xl font-bold">{activeCount}</span>
+                     <span className="text-xs text-muted-foreground">
+                        ativa{activeCount !== 1 ? "s" : ""}
+                     </span>
+                  </div>
+               </CardContent>
+            </Card>
+         )}
+      </aside>
+   );
+}

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-contacts/contact-transacoes-tab.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-contacts/contact-transacoes-tab.tsx
@@ -1,0 +1,144 @@
+import { Badge } from "@packages/ui/components/badge";
+import { Button } from "@packages/ui/components/button";
+import {
+   Empty,
+   EmptyDescription,
+   EmptyHeader,
+   EmptyMedia,
+   EmptyTitle,
+} from "@packages/ui/components/empty";
+import {
+   Table,
+   TableBody,
+   TableCell,
+   TableHead,
+   TableHeader,
+   TableRow,
+} from "@packages/ui/components/table";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { format, of } from "@f-o-t/money";
+import dayjs from "dayjs";
+import { ChevronLeft, ChevronRight, Receipt } from "lucide-react";
+import type { Outputs } from "@/integrations/orpc/client";
+import { orpc } from "@/integrations/orpc/client";
+import { Route } from "../contacts/$contactId";
+
+type Transaction = Outputs["contacts"]["getTransactions"]["items"][number];
+
+const TYPE_LABELS: Record<Transaction["type"], string> = {
+   income: "Receita",
+   expense: "Despesa",
+   transfer: "Transferência",
+};
+
+const STATUS_LABELS: Record<Transaction["status"], string> = {
+   paid: "Pago",
+   pending: "Pendente",
+   cancelled: "Cancelado",
+};
+
+const STATUS_VARIANTS: Record<
+   Transaction["status"],
+   "default" | "secondary" | "outline"
+> = {
+   paid: "default",
+   pending: "secondary",
+   cancelled: "outline",
+};
+
+export function ContactTransacoesTab({ contactId }: { contactId: string }) {
+   const { page, pageSize } = Route.useSearch();
+   const navigate = Route.useNavigate();
+
+   const { data } = useSuspenseQuery(
+      orpc.contacts.getTransactions.queryOptions({
+         input: { id: contactId, page, pageSize },
+      }),
+   );
+
+   const totalPages = Math.max(1, Math.ceil(data.total / pageSize));
+
+   function goToPage(next: number) {
+      navigate({
+         search: (prev) => ({ ...prev, page: next }),
+         replace: true,
+      });
+   }
+
+   if (page === 1 && data.items.length === 0) {
+      return (
+         <Empty>
+            <EmptyHeader>
+               <EmptyMedia variant="icon">
+                  <Receipt className="size-6" />
+               </EmptyMedia>
+               <EmptyTitle>Nenhuma transação</EmptyTitle>
+               <EmptyDescription>
+                  Este contato ainda não possui transações vinculadas.
+               </EmptyDescription>
+            </EmptyHeader>
+         </Empty>
+      );
+   }
+
+   return (
+      <div className="flex flex-col gap-4">
+         <Table>
+            <TableHeader>
+               <TableRow>
+                  <TableHead>Descrição</TableHead>
+                  <TableHead>Data</TableHead>
+                  <TableHead>Tipo</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Valor</TableHead>
+               </TableRow>
+            </TableHeader>
+            <TableBody>
+               {data.items.map((tx) => (
+                  <TableRow key={tx.id}>
+                     <TableCell className="font-medium">
+                        {tx.description}
+                     </TableCell>
+                     <TableCell>
+                        {dayjs(tx.date).format("DD/MM/YYYY")}
+                     </TableCell>
+                     <TableCell>{TYPE_LABELS[tx.type]}</TableCell>
+                     <TableCell>
+                        <Badge variant={STATUS_VARIANTS[tx.status]}>
+                           {STATUS_LABELS[tx.status]}
+                        </Badge>
+                     </TableCell>
+                     <TableCell className="text-right">
+                        {format(of(tx.amount, "BRL"), "pt-BR")}
+                     </TableCell>
+                  </TableRow>
+               ))}
+            </TableBody>
+         </Table>
+
+         <div className="flex items-center gap-4">
+            <span className="flex-1 text-xs text-muted-foreground">
+               {data.total} transações · página {page} de {totalPages}
+            </span>
+            <Button
+               disabled={page <= 1}
+               size="sm"
+               variant="outline"
+               onClick={() => goToPage(page - 1)}
+            >
+               <ChevronLeft className="size-4" />
+               Anterior
+            </Button>
+            <Button
+               disabled={page >= totalPages}
+               size="sm"
+               variant="outline"
+               onClick={() => goToPage(page + 1)}
+            >
+               Próxima
+               <ChevronRight className="size-4" />
+            </Button>
+         </div>
+      </div>
+   );
+}

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/contacts/$contactId.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/contacts/$contactId.tsx
@@ -1,0 +1,78 @@
+import { Skeleton } from "@packages/ui/components/skeleton";
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+import { QueryBoundary } from "@/components/query-boundary";
+import { orpc } from "@/integrations/orpc/client";
+
+const searchSchema = z.object({
+   tab: z
+      .enum(["dados", "assinaturas", "transacoes"])
+      .catch("dados")
+      .default("dados"),
+   page: z.number().int().min(1).catch(1).default(1),
+   pageSize: z.number().int().catch(20).default(20),
+});
+
+export const Route = createFileRoute(
+   "/_authenticated/$slug/$teamSlug/_dashboard/contacts/$contactId",
+)({
+   validateSearch: searchSchema,
+   loaderDeps: ({ search: { page, pageSize } }) => ({ page, pageSize }),
+   loader: ({ context, params, deps }) => {
+      context.queryClient.prefetchQuery(
+         orpc.contacts.getById.queryOptions({
+            input: { id: params.contactId },
+         }),
+      );
+      context.queryClient.prefetchQuery(
+         orpc.contacts.getStats.queryOptions({
+            input: { id: params.contactId },
+         }),
+      );
+      context.queryClient.prefetchQuery(
+         orpc.contacts.getTransactions.queryOptions({
+            input: {
+               id: params.contactId,
+               page: deps.page,
+               pageSize: deps.pageSize,
+            },
+         }),
+      );
+      context.queryClient.prefetchQuery(
+         orpc.services.getContactSubscriptions.queryOptions({
+            input: { contactId: params.contactId },
+         }),
+      );
+   },
+   pendingMs: 300,
+   pendingComponent: ContactDetailSkeleton,
+   head: () => ({ meta: [{ title: "Contato — Montte" }] }),
+   component: ContactDetailPage,
+});
+
+function ContactDetailSkeleton() {
+   return (
+      <div className="flex flex-col gap-4">
+         <Skeleton className="h-10 w-64" />
+         <div className="flex gap-4">
+            <Skeleton className="h-96 flex-1" />
+            <Skeleton className="h-96 w-72" />
+         </div>
+      </div>
+   );
+}
+
+function ContactDetailPage() {
+   return (
+      <QueryBoundary
+         fallback={<ContactDetailSkeleton />}
+         errorTitle="Erro ao carregar contato"
+      >
+         <ContactDetailContent />
+      </QueryBoundary>
+   );
+}
+
+function ContactDetailContent() {
+   return <div />;
+}

--- a/core/agents/package.json
+++ b/core/agents/package.json
@@ -31,6 +31,7 @@
       "typecheck": "tsgo"
    },
    "dependencies": {
+      "@computesdk/e2b": "^1.7.44",
       "@core/database": "workspace:*",
       "@core/environment": "workspace:*",
       "@core/logging": "workspace:*",
@@ -38,6 +39,7 @@
       "@core/utils": "workspace:*",
       "@tanstack/ai": "catalog:tanstack-ai",
       "@tanstack/ai-openrouter": "catalog:tanstack-ai",
+      "computesdk": "^2.6.0",
       "neverthrow": "catalog:validation",
       "zod": "catalog:validation"
    },

--- a/core/agents/src/agent.ts
+++ b/core/agents/src/agent.ts
@@ -1,8 +1,94 @@
-export type ChatRubiOptions = {
-   modelId?: string;
-   language?: string;
+import { chat, toolDefinition, toServerSentEventsStream } from "@tanstack/ai";
+import { createOpenRouterText } from "@tanstack/ai-openrouter";
+import { z } from "zod";
+import { e2b } from "@computesdk/e2b";
+import { compute } from "computesdk";
+import { buildLanguageInstruction } from "./utils";
+
+type OpenRouterModelId = Parameters<typeof createOpenRouterText>[0];
+
+const DEFAULT_MODEL: OpenRouterModelId = "moonshotai/kimi-k2.5";
+
+export type ChatMessage = {
+   role: "user" | "assistant";
+   content: string;
 };
 
-export function chatRubi(_options: ChatRubiOptions): never {
-   throw new Error("Not implemented — Rubi chat agent coming soon");
+export type ChatRubiOptions = {
+   messages: ChatMessage[];
+   montteApiKey: string;
+   openRouterApiKey: string;
+   e2bApiKey: string;
+   modelId?: OpenRouterModelId;
+   language?: string;
+   montteHost?: string;
+};
+
+const SYSTEM_PROMPT = `Você é a Rubi, assistente de inteligência artificial do Montte ERP.
+Você tem acesso ao CLI do Montte autenticado como o próprio usuário.
+Use as ferramentas disponíveis para consultar e gerenciar dados financeiros: transações, contas bancárias, categorias, orçamentos e mais.
+Sempre responda de forma clara, objetiva e em português brasileiro.
+Ao apresentar valores monetários, use o formato brasileiro (R$ 1.234,56).
+Ao apresentar datas, use o formato DD/MM/AAAA.
+Quando executar comandos, interprete e resuma os resultados de forma amigável — nunca exiba JSON bruto ao usuário.`;
+
+export function chatRubi(options: ChatRubiOptions) {
+   const {
+      messages,
+      montteApiKey,
+      openRouterApiKey,
+      e2bApiKey,
+      modelId = DEFAULT_MODEL,
+      language = "pt-BR",
+      montteHost,
+   } = options;
+
+   const scopedCompute = compute({
+      provider: e2b({ apiKey: e2bApiKey }),
+   });
+
+   const runMontteCommand = toolDefinition({
+      name: "run_montte_command",
+      description:
+         "Executa um comando do Montte CLI autenticado como o usuário. " +
+         "Use para consultar transações, contas bancárias, categorias, orçamentos e outros dados do ERP. " +
+         "Exemplos: args='transactions list --from 2025-01-01', args='accounts list', args='categories list'",
+      inputSchema: z.object({
+         args: z
+            .string()
+            .describe(
+               "Argumentos do comando montte (sem o prefixo 'montte'). Ex: 'transactions list --from 2025-01-01 --to 2025-03-31'",
+            ),
+      }),
+   }).server(async ({ args }) => {
+      const sandbox = await scopedCompute.sandbox.create();
+
+      const env: Record<string, string> = {
+         MONTTE_API_KEY: montteApiKey,
+         ...(montteHost ? { MONTTE_HOST: montteHost } : {}),
+      };
+
+      const result = await sandbox.runCommand(
+         `npx --yes @montte/cli@latest ${args} --json`,
+         { env },
+      );
+
+      await sandbox.destroy();
+
+      if (result.exitCode !== 0) {
+         return { success: false, error: result.stderr };
+      }
+
+      return { success: true, output: result.stdout };
+   });
+
+   const stream = chat({
+      adapter: createOpenRouterText(modelId, openRouterApiKey),
+      messages: messages.map((m) => ({ role: m.role, content: m.content })),
+      systemPrompts: [SYSTEM_PROMPT, buildLanguageInstruction(language)],
+      tools: [runMontteCommand],
+      stream: true,
+   });
+
+   return toServerSentEventsStream(stream);
 }

--- a/core/database/__tests__/repositories/subscriptions-repository.test.ts
+++ b/core/database/__tests__/repositories/subscriptions-repository.test.ts
@@ -68,6 +68,14 @@ function validCreateInput(
    };
 }
 
+async function unwrap<T>(
+   result: Awaited<ReturnType<typeof repo.createSubscription>>,
+): Promise<T> {
+   const r = result as { isOk(): boolean; value: T; error: unknown };
+   if (!r.isOk()) throw r.error;
+   return r.value;
+}
+
 describe("subscriptions-repository", () => {
    describe("createSubscription", () => {
       it("creates with lifecycle fields", async () => {
@@ -75,11 +83,14 @@ describe("subscriptions-repository", () => {
          const variant = await createTestVariant(teamId);
          const contact = await createTestContact(teamId);
 
-         const sub = await repo.createSubscription(
+         const result = await repo.createSubscription(
             testDb.db,
             teamId,
             validCreateInput(contact.id, variant.id),
          );
+
+         expect(result.isOk()).toBe(true);
+         const sub = result._unsafeUnwrap();
 
          expect(sub).toMatchObject({
             teamId,
@@ -101,22 +112,26 @@ describe("subscriptions-repository", () => {
          const teamId = randomTeamId();
          const variant = await createTestVariant(teamId);
          const contact = await createTestContact(teamId);
-         const created = await repo.createSubscription(
+         const createResult = await repo.createSubscription(
             testDb.db,
             teamId,
             validCreateInput(contact.id, variant.id),
          );
+         const created = createResult._unsafeUnwrap();
 
-         const found = await repo.getSubscription(testDb.db, created.id);
+         const result = await repo.getSubscription(testDb.db, created.id);
+         expect(result.isOk()).toBe(true);
+         const found = result._unsafeUnwrap();
          expect(found).toMatchObject({ id: created.id });
       });
 
       it("returns null for non-existent id", async () => {
-         const found = await repo.getSubscription(
+         const result = await repo.getSubscription(
             testDb.db,
             crypto.randomUUID(),
          );
-         expect(found).toBeNull();
+         expect(result.isOk()).toBe(true);
+         expect(result._unsafeUnwrap()).toBeNull();
       });
    });
 
@@ -125,17 +140,21 @@ describe("subscriptions-repository", () => {
          const teamId = randomTeamId();
          const variant = await createTestVariant(teamId);
          const contact = await createTestContact(teamId);
-         const created = await repo.createSubscription(
-            testDb.db,
-            teamId,
-            validCreateInput(contact.id, variant.id),
-         );
+         const created = (
+            await repo.createSubscription(
+               testDb.db,
+               teamId,
+               validCreateInput(contact.id, variant.id),
+            )
+         )._unsafeUnwrap();
 
-         const updated = await repo.updateSubscription(testDb.db, created.id, {
+         const result = await repo.updateSubscription(testDb.db, created.id, {
             cancelAtPeriodEnd: true,
             status: "cancelled",
          });
 
+         expect(result.isOk()).toBe(true);
+         const updated = result._unsafeUnwrap();
          expect(updated.cancelAtPeriodEnd).toBe(true);
          expect(updated.status).toBe("cancelled");
          expect(updated.id).toBe(created.id);
@@ -147,56 +166,67 @@ describe("subscriptions-repository", () => {
          const teamId = randomTeamId();
          const variant = await createTestVariant(teamId);
          const contact = await createTestContact(teamId);
-         await repo.createSubscription(
-            testDb.db,
-            teamId,
-            validCreateInput(contact.id, variant.id),
-         );
-         await repo.createSubscription(
-            testDb.db,
-            teamId,
-            validCreateInput(contact.id, variant.id, {
-               startDate: "2026-02-01",
-            }),
-         );
+         await (
+            await repo.createSubscription(
+               testDb.db,
+               teamId,
+               validCreateInput(contact.id, variant.id),
+            )
+         )._unsafeUnwrap();
+         await (
+            await repo.createSubscription(
+               testDb.db,
+               teamId,
+               validCreateInput(contact.id, variant.id, {
+                  startDate: "2026-02-01",
+               }),
+            )
+         )._unsafeUnwrap();
 
-         const list = await repo.listSubscriptionsByTeam(testDb.db, teamId);
-         expect(list).toHaveLength(2);
+         const result = await repo.listSubscriptionsByTeam(testDb.db, teamId);
+         expect(result.isOk()).toBe(true);
+         expect(result._unsafeUnwrap()).toHaveLength(2);
       });
 
       it("filters by status", async () => {
          const teamId = randomTeamId();
          const variant = await createTestVariant(teamId);
          const contact = await createTestContact(teamId);
-         await repo.createSubscription(
-            testDb.db,
-            teamId,
-            validCreateInput(contact.id, variant.id),
-         );
-         const canceled = await repo.createSubscription(
-            testDb.db,
-            teamId,
-            validCreateInput(contact.id, variant.id, {
-               startDate: "2026-02-01",
-            }),
-         );
-         await repo.updateSubscription(testDb.db, canceled.id, {
-            status: "cancelled",
-         });
+         await (
+            await repo.createSubscription(
+               testDb.db,
+               teamId,
+               validCreateInput(contact.id, variant.id),
+            )
+         )._unsafeUnwrap();
+         const canceled = (
+            await repo.createSubscription(
+               testDb.db,
+               teamId,
+               validCreateInput(contact.id, variant.id, {
+                  startDate: "2026-02-01",
+               }),
+            )
+         )._unsafeUnwrap();
+         await (
+            await repo.updateSubscription(testDb.db, canceled.id, {
+               status: "cancelled",
+            })
+         )._unsafeUnwrap();
 
-         const activeList = await repo.listSubscriptionsByTeam(
+         const activeResult = await repo.listSubscriptionsByTeam(
             testDb.db,
             teamId,
             "active",
          );
-         expect(activeList).toHaveLength(1);
+         expect(activeResult._unsafeUnwrap()).toHaveLength(1);
 
-         const canceledList = await repo.listSubscriptionsByTeam(
+         const canceledResult = await repo.listSubscriptionsByTeam(
             testDb.db,
             teamId,
             "cancelled",
          );
-         expect(canceledList).toHaveLength(1);
+         expect(canceledResult._unsafeUnwrap()).toHaveLength(1);
       });
    });
 
@@ -205,16 +235,20 @@ describe("subscriptions-repository", () => {
          const teamId = randomTeamId();
          const variant = await createTestVariant(teamId);
          const contact = await createTestContact(teamId);
-         await repo.createSubscription(
-            testDb.db,
-            teamId,
-            validCreateInput(contact.id, variant.id),
-         );
+         await (
+            await repo.createSubscription(
+               testDb.db,
+               teamId,
+               validCreateInput(contact.id, variant.id),
+            )
+         )._unsafeUnwrap();
 
-         const list = await repo.listSubscriptionsByContact(
+         const result = await repo.listSubscriptionsByContact(
             testDb.db,
             contact.id,
          );
+         expect(result.isOk()).toBe(true);
+         const list = result._unsafeUnwrap();
          expect(list).toHaveLength(1);
          expect(list[0]!.contactId).toBe(contact.id);
       });
@@ -238,8 +272,10 @@ describe("subscriptions-repository", () => {
             },
          );
 
-         expect(result.externalId).toBe(extId);
-         expect(result.negotiatedPrice).toBe("399.00");
+         expect(result.isOk()).toBe(true);
+         const sub = result._unsafeUnwrap();
+         expect(sub.externalId).toBe(extId);
+         expect(sub.negotiatedPrice).toBe("399.00");
       });
 
       it("updates when externalId already exists", async () => {
@@ -248,12 +284,16 @@ describe("subscriptions-repository", () => {
          const contact = await createTestContact(teamId);
          const extId = `ext-${crypto.randomUUID().slice(0, 8)}`;
 
-         await repo.upsertSubscriptionByExternalId(testDb.db, extId, {
-            teamId,
-            ...validCreateInput(contact.id, variant.id, { externalId: extId }),
-         });
+         await (
+            await repo.upsertSubscriptionByExternalId(testDb.db, extId, {
+               teamId,
+               ...validCreateInput(contact.id, variant.id, {
+                  externalId: extId,
+               }),
+            })
+         )._unsafeUnwrap();
 
-         const updated = await repo.upsertSubscriptionByExternalId(
+         const result = await repo.upsertSubscriptionByExternalId(
             testDb.db,
             extId,
             {
@@ -266,6 +306,8 @@ describe("subscriptions-repository", () => {
             },
          );
 
+         expect(result.isOk()).toBe(true);
+         const updated = result._unsafeUnwrap();
          expect(updated.negotiatedPrice).toBe("499.00");
          expect(updated.status).toBe("completed");
       });
@@ -278,34 +320,46 @@ describe("subscriptions-repository", () => {
          const variant2 = await createTestVariant(teamId);
          const contact = await createTestContact(teamId);
 
-         await repo.createSubscription(
-            testDb.db,
-            teamId,
-            validCreateInput(contact.id, variant1.id),
-         );
-         await repo.createSubscription(
-            testDb.db,
-            teamId,
-            validCreateInput(contact.id, variant1.id),
-         );
-         await repo.createSubscription(
-            testDb.db,
-            teamId,
-            validCreateInput(contact.id, variant2.id),
-         );
-         const canceled = await repo.createSubscription(
-            testDb.db,
-            teamId,
-            validCreateInput(contact.id, variant2.id),
-         );
-         await repo.updateSubscription(testDb.db, canceled.id, {
-            status: "cancelled",
-         });
+         await (
+            await repo.createSubscription(
+               testDb.db,
+               teamId,
+               validCreateInput(contact.id, variant1.id),
+            )
+         )._unsafeUnwrap();
+         await (
+            await repo.createSubscription(
+               testDb.db,
+               teamId,
+               validCreateInput(contact.id, variant1.id),
+            )
+         )._unsafeUnwrap();
+         await (
+            await repo.createSubscription(
+               testDb.db,
+               teamId,
+               validCreateInput(contact.id, variant2.id),
+            )
+         )._unsafeUnwrap();
+         const canceled = (
+            await repo.createSubscription(
+               testDb.db,
+               teamId,
+               validCreateInput(contact.id, variant2.id),
+            )
+         )._unsafeUnwrap();
+         await (
+            await repo.updateSubscription(testDb.db, canceled.id, {
+               status: "cancelled",
+            })
+         )._unsafeUnwrap();
 
-         const counts = await repo.countActiveSubscriptionsByVariant(
+         const result = await repo.countActiveSubscriptionsByVariant(
             testDb.db,
             teamId,
          );
+         expect(result.isOk()).toBe(true);
+         const counts = result._unsafeUnwrap();
          const v1Count = counts.find((c) => c.variantId === variant1.id);
          const v2Count = counts.find((c) => c.variantId === variant2.id);
 
@@ -328,18 +382,24 @@ describe("subscriptions-repository", () => {
             .toISOString()
             .split("T")[0]!;
 
-         await repo.createSubscription(
-            testDb.db,
-            teamId,
-            validCreateInput(contact.id, variant.id, { endDate: in7Days }),
-         );
-         await repo.createSubscription(
-            testDb.db,
-            teamId,
-            validCreateInput(contact.id, variant.id, { endDate: in90Days }),
-         );
+         await (
+            await repo.createSubscription(
+               testDb.db,
+               teamId,
+               validCreateInput(contact.id, variant.id, { endDate: in7Days }),
+            )
+         )._unsafeUnwrap();
+         await (
+            await repo.createSubscription(
+               testDb.db,
+               teamId,
+               validCreateInput(contact.id, variant.id, { endDate: in90Days }),
+            )
+         )._unsafeUnwrap();
 
-         const expiring = await repo.listExpiringSoon(testDb.db, teamId, 30);
+         const result = await repo.listExpiringSoon(testDb.db, teamId, 30);
+         expect(result.isOk()).toBe(true);
+         const expiring = result._unsafeUnwrap();
          expect(expiring).toHaveLength(1);
          expect(expiring[0]!.endDate).toBe(in7Days);
       });

--- a/core/database/src/repositories/contacts-repository.ts
+++ b/core/database/src/repositories/contacts-repository.ts
@@ -1,6 +1,7 @@
 import dayjs from "dayjs";
-import { AppError, propagateError, validateInput } from "@core/logging/errors";
-import { and, asc, count, eq, inArray } from "drizzle-orm";
+import { AppError, validateInput } from "@core/logging/errors";
+import { and, asc, count, desc, eq, inArray, sum } from "drizzle-orm";
+import { fromPromise, fromThrowable, ok, err } from "neverthrow";
 import type { DatabaseInstance } from "@core/database/client";
 import {
    type CreateContactInput,
@@ -12,196 +13,243 @@ import {
 } from "@core/database/schemas/contacts";
 import { transactions } from "@core/database/schemas/transactions";
 
-export async function createContact(
+const safeValidateCreate = fromThrowable(
+   (data: CreateContactInput) => validateInput(createContactSchema, data),
+   (e) =>
+      e instanceof AppError
+         ? e
+         : AppError.validation("Dados inválidos.", { cause: e }),
+);
+
+const safeValidateUpdate = fromThrowable(
+   (data: UpdateContactInput) => validateInput(updateContactSchema, data),
+   (e) =>
+      e instanceof AppError
+         ? e
+         : AppError.validation("Dados inválidos.", { cause: e }),
+);
+
+export function createContact(
    db: DatabaseInstance,
    teamId: string,
    data: CreateContactInput,
 ) {
-   const validated = validateInput(createContactSchema, data);
-   try {
-      const [contact] = await db
-         .insert(contacts)
-         .values({ ...validated, teamId })
-         .returning();
-      if (!contact) throw AppError.database("Failed to create contact");
-      return contact;
-   } catch (err) {
-      propagateError(err);
-      throw AppError.database("Failed to create contact");
-   }
+   return safeValidateCreate(data).asyncAndThen((validated) =>
+      fromPromise(
+         db
+            .insert(contacts)
+            .values({ ...validated, teamId })
+            .returning(),
+         (e) => AppError.database("Falha ao criar contato.", { cause: e }),
+      ).andThen(([contact]) =>
+         contact
+            ? ok(contact)
+            : err(AppError.database("Falha ao criar contato.")),
+      ),
+   );
 }
 
-export async function listContacts(
+export function listContacts(
    db: DatabaseInstance,
    teamId: string,
    type?: ContactType,
    includeArchived = false,
 ) {
-   try {
-      const conditions = [eq(contacts.teamId, teamId)];
-      if (type) conditions.push(eq(contacts.type, type));
-      if (!includeArchived) conditions.push(eq(contacts.isArchived, false));
-      return await db
+   const conditions = [eq(contacts.teamId, teamId)];
+   if (type) conditions.push(eq(contacts.type, type));
+   if (!includeArchived) conditions.push(eq(contacts.isArchived, false));
+   return fromPromise(
+      db
          .select()
          .from(contacts)
          .where(and(...conditions))
-         .orderBy(contacts.name);
-   } catch (err) {
-      propagateError(err);
-      throw AppError.database("Failed to list contacts");
-   }
+         .orderBy(contacts.name),
+      (e) => AppError.database("Falha ao listar contatos.", { cause: e }),
+   );
 }
 
-export async function getContact(db: DatabaseInstance, id: string) {
-   try {
-      const [contact] = await db
-         .select()
-         .from(contacts)
-         .where(eq(contacts.id, id));
-      return contact ?? null;
-   } catch (err) {
-      propagateError(err);
-      throw AppError.database("Failed to get contact");
-   }
+export function getContact(db: DatabaseInstance, id: string) {
+   return fromPromise(
+      db.select().from(contacts).where(eq(contacts.id, id)),
+      (e) => AppError.database("Falha ao buscar contato.", { cause: e }),
+   ).map(([contact]) => contact ?? null);
 }
 
-export async function updateContact(
+export function updateContact(
    db: DatabaseInstance,
    id: string,
    data: UpdateContactInput,
 ) {
-   const validated = validateInput(updateContactSchema, data);
-   try {
-      const [updated] = await db
-         .update(contacts)
-         .set({ ...validated, updatedAt: dayjs().toDate() })
-         .where(eq(contacts.id, id))
-         .returning();
-      if (!updated) throw AppError.notFound("Contato não encontrado.");
-      return updated;
-   } catch (err) {
-      propagateError(err);
-      throw AppError.database("Failed to update contact");
-   }
+   return safeValidateUpdate(data).asyncAndThen((validated) =>
+      fromPromise(
+         db
+            .update(contacts)
+            .set({ ...validated, updatedAt: dayjs().toDate() })
+            .where(eq(contacts.id, id))
+            .returning(),
+         (e) => AppError.database("Falha ao atualizar contato.", { cause: e }),
+      ).andThen(([updated]) =>
+         updated
+            ? ok(updated)
+            : err(AppError.notFound("Contato não encontrado.")),
+      ),
+   );
 }
 
-export async function archiveContact(db: DatabaseInstance, id: string) {
-   try {
-      const [updated] = await db
+export function archiveContact(db: DatabaseInstance, id: string) {
+   return fromPromise(
+      db
          .update(contacts)
          .set({ isArchived: true, updatedAt: dayjs().toDate() })
          .where(eq(contacts.id, id))
-         .returning();
-      if (!updated) throw AppError.notFound("Contato não encontrado.");
-      return updated;
-   } catch (err) {
-      propagateError(err);
-      throw AppError.database("Failed to archive contact");
-   }
+         .returning(),
+      (e) => AppError.database("Falha ao arquivar contato.", { cause: e }),
+   ).andThen(([updated]) =>
+      updated ? ok(updated) : err(AppError.notFound("Contato não encontrado.")),
+   );
 }
 
-export async function reactivateContact(db: DatabaseInstance, id: string) {
-   try {
-      const [updated] = await db
+export function reactivateContact(db: DatabaseInstance, id: string) {
+   return fromPromise(
+      db
          .update(contacts)
          .set({ isArchived: false, updatedAt: dayjs().toDate() })
          .where(eq(contacts.id, id))
-         .returning();
-      if (!updated) throw AppError.notFound("Contato não encontrado.");
-      return updated;
-   } catch (err) {
-      propagateError(err);
-      throw AppError.database("Failed to reactivate contact");
-   }
+         .returning(),
+      (e) => AppError.database("Falha ao reativar contato.", { cause: e }),
+   ).andThen(([updated]) =>
+      updated ? ok(updated) : err(AppError.notFound("Contato não encontrado.")),
+   );
 }
 
-export async function deleteContact(db: DatabaseInstance, id: string) {
-   try {
-      const hasLinks = await contactHasLinks(db, id);
-      if (hasLinks) {
-         throw AppError.conflict(
-            "Contato possui lançamentos vinculados. Arquive em vez de excluir.",
-         );
-      }
-      await db.delete(contacts).where(eq(contacts.id, id));
-   } catch (err) {
-      propagateError(err);
-      throw AppError.database("Failed to delete contact");
-   }
+export function contactHasLinks(db: DatabaseInstance, id: string) {
+   return fromPromise(
+      db
+         .select({ total: count() })
+         .from(transactions)
+         .where(eq(transactions.contactId, id)),
+      (e) =>
+         AppError.database("Falha ao verificar vínculos do contato.", {
+            cause: e,
+         }),
+   ).map(([result]) => (result?.total ?? 0) > 0);
 }
 
-export async function bulkDeleteContacts(
+export function deleteContact(db: DatabaseInstance, id: string) {
+   return fromPromise(
+      db.select().from(contacts).where(eq(contacts.id, id)),
+      (e) => AppError.database("Falha ao excluir contato.", { cause: e }),
+   )
+      .andThen(([contact]) =>
+         contact
+            ? ok(contact)
+            : err(AppError.notFound("Contato não encontrado.")),
+      )
+      .andThen(() => contactHasLinks(db, id))
+      .andThen((hasLinks) =>
+         hasLinks
+            ? err(
+                 AppError.conflict(
+                    "Contato possui lançamentos vinculados. Arquive em vez de excluir.",
+                 ),
+              )
+            : ok(undefined),
+      )
+      .andThen(() =>
+         fromPromise(db.delete(contacts).where(eq(contacts.id, id)), (e) =>
+            AppError.database("Falha ao excluir contato.", { cause: e }),
+         ),
+      );
+}
+
+export function bulkDeleteContacts(
    db: DatabaseInstance,
    ids: string[],
    teamId: string,
 ) {
-   try {
-      const existing = await db
+   return fromPromise(
+      db
          .select({ id: contacts.id })
          .from(contacts)
-         .where(and(inArray(contacts.id, ids), eq(contacts.teamId, teamId)));
-      if (existing.length !== ids.length) {
-         throw AppError.notFound("Um ou mais contatos não foram encontrados.");
-      }
-      const results = await Promise.allSettled(
-         ids.map(async (id) => {
-            const hasLinks = await contactHasLinks(db, id);
-            if (hasLinks) {
-               throw AppError.conflict(
-                  "Contato possui lançamentos vinculados. Arquive em vez de excluir.",
+         .where(and(inArray(contacts.id, ids), eq(contacts.teamId, teamId))),
+      (e) => AppError.database("Falha ao excluir contatos.", { cause: e }),
+   )
+      .andThen((existing) =>
+         existing.length !== ids.length
+            ? err(
+                 AppError.notFound(
+                    "Um ou mais contatos não foram encontrados.",
+                 ),
+              )
+            : ok(undefined),
+      )
+      .andThen(() =>
+         fromPromise(
+            (async () => {
+               const results = await Promise.allSettled(
+                  ids.map(async (id) => {
+                     const [result] = await db
+                        .select({ total: count() })
+                        .from(transactions)
+                        .where(eq(transactions.contactId, id));
+                     if ((result?.total ?? 0) > 0)
+                        throw AppError.conflict(
+                           "Contato possui lançamentos vinculados. Arquive em vez de excluir.",
+                        );
+                     await db.delete(contacts).where(eq(contacts.id, id));
+                  }),
                );
-            }
-            await db.delete(contacts).where(eq(contacts.id, id));
-         }),
+               const failed = results.filter(
+                  (r) => r.status === "rejected",
+               ).length;
+               if (failed > 0)
+                  throw AppError.database(
+                     `${failed} contato(s) não puderam ser excluídos.`,
+                  );
+            })(),
+            (e) =>
+               e instanceof AppError
+                  ? e
+                  : AppError.database("Falha ao excluir contatos.", {
+                       cause: e,
+                    }),
+         ),
       );
-      const failed = results.filter((r) => r.status === "rejected").length;
-      if (failed > 0) {
-         throw AppError.database(
-            `${failed} contato(s) não puderam ser excluídos.`,
-         );
-      }
-   } catch (err) {
-      propagateError(err);
-      throw AppError.database("Failed to bulk delete contacts");
-   }
 }
 
-export async function ensureContactOwnership(
+export function ensureContactOwnership(
    db: DatabaseInstance,
    id: string,
    teamId: string,
 ) {
-   const contact = await getContact(db, id);
-   if (!contact || contact.teamId !== teamId) {
-      throw AppError.notFound("Contato não encontrado.");
-   }
-   return contact;
+   return getContact(db, id).andThen((contact) => {
+      if (!contact || contact.teamId !== teamId)
+         return err(AppError.notFound("Contato não encontrado."));
+      return ok(contact);
+   });
 }
 
-export async function getContactByExternalId(
+export function getContactByExternalId(
    db: DatabaseInstance,
    externalId: string,
    teamId: string,
    type?: ContactType,
 ) {
-   try {
-      const conditions = [
-         eq(contacts.externalId, externalId),
-         eq(contacts.teamId, teamId),
-      ];
-      if (type) conditions.push(eq(contacts.type, type));
-      const [contact] = await db
+   const conditions = [
+      eq(contacts.externalId, externalId),
+      eq(contacts.teamId, teamId),
+   ];
+   if (type) conditions.push(eq(contacts.type, type));
+   return fromPromise(
+      db
          .select()
          .from(contacts)
-         .where(and(...conditions));
-      return contact ?? null;
-   } catch (err) {
-      propagateError(err);
-      throw AppError.database("Failed to get contact by external id");
-   }
+         .where(and(...conditions)),
+      (e) => AppError.database("Falha ao buscar contato.", { cause: e }),
+   ).map(([contact]) => contact ?? null);
 }
 
-export async function listContactsPaginated(
+export function listContactsPaginated(
    db: DatabaseInstance,
    teamId: string,
    options: {
@@ -211,44 +259,92 @@ export async function listContactsPaginated(
       includeArchived?: boolean;
    },
 ) {
-   try {
-      const { page, limit, type, includeArchived = false } = options;
-      const conditions = [eq(contacts.teamId, teamId)];
-      if (type) conditions.push(eq(contacts.type, type));
-      if (!includeArchived) conditions.push(eq(contacts.isArchived, false));
-      const where = and(...conditions);
-      const [totalResult] = await db
-         .select({ value: count() })
-         .from(contacts)
-         .where(where);
-      const total = totalResult?.value ?? 0;
-      const items = await db
-         .select()
-         .from(contacts)
-         .where(where)
-         .orderBy(asc(contacts.name))
-         .limit(limit)
-         .offset((page - 1) * limit);
-      return { items, total };
-   } catch (err) {
-      propagateError(err);
-      throw AppError.database("Failed to list contacts");
-   }
+   const { page, limit, type, includeArchived = false } = options;
+   const conditions = [eq(contacts.teamId, teamId)];
+   if (type) conditions.push(eq(contacts.type, type));
+   if (!includeArchived) conditions.push(eq(contacts.isArchived, false));
+   const where = and(...conditions);
+   return fromPromise(
+      (async () => {
+         const [totalResult] = await db
+            .select({ value: count() })
+            .from(contacts)
+            .where(where);
+         const total = totalResult?.value ?? 0;
+         const items = await db
+            .select()
+            .from(contacts)
+            .where(where)
+            .orderBy(asc(contacts.name))
+            .limit(limit)
+            .offset((page - 1) * limit);
+         return { items, total };
+      })(),
+      (e) => AppError.database("Falha ao listar contatos.", { cause: e }),
+   );
 }
 
-export async function contactHasLinks(
+export function getContactTransactions(
    db: DatabaseInstance,
-   id: string,
-): Promise<boolean> {
-   try {
-      const [txResult] = await db
-         .select({ total: count() })
-         .from(transactions)
-         .where(eq(transactions.contactId, id));
+   contactId: string,
+   teamId: string,
+   options: { page: number; limit: number },
+) {
+   const { page, limit } = options;
+   return fromPromise(
+      (async () => {
+         const where = and(
+            eq(transactions.contactId, contactId),
+            eq(transactions.teamId, teamId),
+         );
+         const [totalResult] = await db
+            .select({ value: count() })
+            .from(transactions)
+            .where(where);
+         const total = totalResult?.value ?? 0;
+         const items = await db
+            .select()
+            .from(transactions)
+            .where(where)
+            .orderBy(desc(transactions.date))
+            .limit(limit)
+            .offset((page - 1) * limit);
+         return { items, total };
+      })(),
+      (e) =>
+         AppError.database("Falha ao listar transações do contato.", {
+            cause: e,
+         }),
+   );
+}
 
-      return (txResult?.total ?? 0) > 0;
-   } catch (err) {
-      propagateError(err);
-      throw AppError.database("Failed to check contact links");
-   }
+export function getContactTransactionStats(
+   db: DatabaseInstance,
+   contactId: string,
+   teamId: string,
+) {
+   return fromPromise(
+      (async () => {
+         const where = and(
+            eq(transactions.contactId, contactId),
+            eq(transactions.teamId, teamId),
+         );
+         const [incomeResult] = await db
+            .select({ total: sum(transactions.amount) })
+            .from(transactions)
+            .where(and(where, eq(transactions.type, "income")));
+         const [expenseResult] = await db
+            .select({ total: sum(transactions.amount) })
+            .from(transactions)
+            .where(and(where, eq(transactions.type, "expense")));
+         return {
+            totalIncome: incomeResult?.total ?? "0",
+            totalExpense: expenseResult?.total ?? "0",
+         };
+      })(),
+      (e) =>
+         AppError.database("Falha ao buscar estatísticas do contato.", {
+            cause: e,
+         }),
+   );
 }

--- a/core/database/src/repositories/subscriptions-repository.ts
+++ b/core/database/src/repositories/subscriptions-repository.ts
@@ -1,6 +1,7 @@
 import dayjs from "dayjs";
-import { AppError, propagateError, validateInput } from "@core/logging/errors";
-import { and, count, eq, gte, lte } from "drizzle-orm";
+import { AppError, validateInput } from "@core/logging/errors";
+import { and, count, desc, eq, gte, lte } from "drizzle-orm";
+import { fromPromise, fromThrowable, ok, err } from "neverthrow";
 import type { DatabaseInstance } from "@core/database/client";
 import {
    type CreateSubscriptionInput,
@@ -10,141 +11,194 @@ import {
    createSubscriptionSchema,
    updateSubscriptionSchema,
 } from "@core/database/schemas/subscriptions";
+import { services, serviceVariants } from "@core/database/schemas/services";
 
-export async function createSubscription(
+const safeValidateCreate = fromThrowable(
+   (data: CreateSubscriptionInput) =>
+      validateInput(createSubscriptionSchema, data),
+   (e) =>
+      e instanceof AppError
+         ? e
+         : AppError.validation("Dados inválidos.", { cause: e }),
+);
+
+const safeValidateUpdate = fromThrowable(
+   (data: UpdateSubscriptionInput) =>
+      validateInput(updateSubscriptionSchema, data),
+   (e) =>
+      e instanceof AppError
+         ? e
+         : AppError.validation("Dados inválidos.", { cause: e }),
+);
+
+export function createSubscription(
    db: DatabaseInstance,
    teamId: string,
    data: CreateSubscriptionInput,
 ) {
-   const validated = validateInput(createSubscriptionSchema, data);
-   try {
-      const [subscription] = await db
-         .insert(contactSubscriptions)
-         .values({ ...validated, teamId })
-         .returning();
-      if (!subscription)
-         throw AppError.database("Failed to create subscription");
-      return subscription;
-   } catch (err) {
-      propagateError(err);
-      throw AppError.database("Failed to create subscription");
-   }
+   return safeValidateCreate(data).asyncAndThen((validated) =>
+      fromPromise(
+         db
+            .insert(contactSubscriptions)
+            .values({ ...validated, teamId })
+            .returning(),
+         (e) => AppError.database("Falha ao criar assinatura.", { cause: e }),
+      ).andThen(([subscription]) =>
+         subscription
+            ? ok(subscription)
+            : err(AppError.database("Falha ao criar assinatura.")),
+      ),
+   );
 }
 
-export async function getSubscription(db: DatabaseInstance, id: string) {
-   try {
-      const subscription = await db.query.contactSubscriptions.findFirst({
+export function getSubscription(db: DatabaseInstance, id: string) {
+   return fromPromise(
+      db.query.contactSubscriptions.findFirst({
          where: (fields, { eq }) => eq(fields.id, id),
-      });
-      return subscription ?? null;
-   } catch (err) {
-      propagateError(err);
-      throw AppError.database("Failed to get subscription");
-   }
+      }),
+      (e) => AppError.database("Falha ao buscar assinatura.", { cause: e }),
+   ).map((subscription) => subscription ?? null);
 }
 
-export async function updateSubscription(
+export function updateSubscription(
    db: DatabaseInstance,
    id: string,
    data: UpdateSubscriptionInput,
 ) {
-   const validated = validateInput(updateSubscriptionSchema, data);
-   try {
-      const [updated] = await db
-         .update(contactSubscriptions)
-         .set({ ...validated, updatedAt: dayjs().toDate() })
-         .where(eq(contactSubscriptions.id, id))
-         .returning();
-      if (!updated) throw AppError.notFound("Assinatura não encontrada.");
-      return updated;
-   } catch (err) {
-      propagateError(err);
-      throw AppError.database("Failed to update subscription");
-   }
+   return safeValidateUpdate(data).asyncAndThen((validated) =>
+      fromPromise(
+         db
+            .update(contactSubscriptions)
+            .set({ ...validated, updatedAt: dayjs().toDate() })
+            .where(eq(contactSubscriptions.id, id))
+            .returning(),
+         (e) =>
+            AppError.database("Falha ao atualizar assinatura.", { cause: e }),
+      ).andThen(([updated]) =>
+         updated
+            ? ok(updated)
+            : err(AppError.notFound("Assinatura não encontrada.")),
+      ),
+   );
 }
 
-export async function listSubscriptionsByTeam(
+export function listSubscriptionsByTeam(
    db: DatabaseInstance,
    teamId: string,
    status?: string,
 ) {
-   try {
-      const conditions = [eq(contactSubscriptions.teamId, teamId)];
-      if (status) {
-         const normalizedStatus = status as SubscriptionStatus;
-         conditions.push(eq(contactSubscriptions.status, normalizedStatus));
-      }
-      return await db
-         .select()
-         .from(contactSubscriptions)
-         .where(and(...conditions));
-   } catch (err) {
-      propagateError(err);
-      throw AppError.database("Failed to list subscriptions by team");
-   }
+   return fromPromise(
+      (async () => {
+         const conditions = [eq(contactSubscriptions.teamId, teamId)];
+         if (status) {
+            const normalizedStatus = status as SubscriptionStatus;
+            conditions.push(eq(contactSubscriptions.status, normalizedStatus));
+         }
+         return db
+            .select()
+            .from(contactSubscriptions)
+            .where(and(...conditions));
+      })(),
+      (e) => AppError.database("Falha ao listar assinaturas.", { cause: e }),
+   );
 }
 
-export async function listSubscriptionsByContact(
+export function listSubscriptionsByContact(
    db: DatabaseInstance,
    contactId: string,
 ) {
-   try {
-      return await db
-         .select()
+   return fromPromise(
+      db
+         .select({
+            id: contactSubscriptions.id,
+            teamId: contactSubscriptions.teamId,
+            contactId: contactSubscriptions.contactId,
+            variantId: contactSubscriptions.variantId,
+            startDate: contactSubscriptions.startDate,
+            endDate: contactSubscriptions.endDate,
+            negotiatedPrice: contactSubscriptions.negotiatedPrice,
+            notes: contactSubscriptions.notes,
+            status: contactSubscriptions.status,
+            source: contactSubscriptions.source,
+            externalId: contactSubscriptions.externalId,
+            currentPeriodStart: contactSubscriptions.currentPeriodStart,
+            currentPeriodEnd: contactSubscriptions.currentPeriodEnd,
+            cancelAtPeriodEnd: contactSubscriptions.cancelAtPeriodEnd,
+            canceledAt: contactSubscriptions.canceledAt,
+            createdAt: contactSubscriptions.createdAt,
+            updatedAt: contactSubscriptions.updatedAt,
+            serviceName: services.name,
+            variantName: serviceVariants.name,
+            billingCycle: serviceVariants.billingCycle,
+            serviceId: services.id,
+         })
          .from(contactSubscriptions)
-         .where(eq(contactSubscriptions.contactId, contactId));
-   } catch (err) {
-      propagateError(err);
-      throw AppError.database("Failed to list subscriptions by contact");
-   }
+         .leftJoin(
+            serviceVariants,
+            eq(contactSubscriptions.variantId, serviceVariants.id),
+         )
+         .leftJoin(services, eq(serviceVariants.serviceId, services.id))
+         .where(eq(contactSubscriptions.contactId, contactId))
+         .orderBy(desc(contactSubscriptions.createdAt)),
+      (e) =>
+         AppError.database("Falha ao listar assinaturas do contato.", {
+            cause: e,
+         }),
+   );
 }
 
-export async function upsertSubscriptionByExternalId(
+export function upsertSubscriptionByExternalId(
    db: DatabaseInstance,
    externalId: string,
    data: CreateSubscriptionInput & { teamId: string },
 ) {
-   const validated = validateInput(createSubscriptionSchema, data);
-   try {
-      const existing = await db.query.contactSubscriptions.findFirst({
-         where: (fields, { eq }) => eq(fields.externalId, externalId),
-      });
+   return safeValidateCreate(data).asyncAndThen((validated) =>
+      fromPromise(
+         (async () => {
+            const existing = await db.query.contactSubscriptions.findFirst({
+               where: (fields, { eq }) => eq(fields.externalId, externalId),
+            });
 
-      if (existing) {
-         const [updated] = await db
-            .update(contactSubscriptions)
-            .set({
-               status: validated.status,
-               negotiatedPrice: validated.negotiatedPrice,
-               endDate: validated.endDate,
-               currentPeriodStart: validated.currentPeriodStart,
-               currentPeriodEnd: validated.currentPeriodEnd,
-               updatedAt: dayjs().toDate(),
-            })
-            .where(eq(contactSubscriptions.id, existing.id))
-            .returning();
-         if (!updated) throw AppError.database("Failed to upsert subscription");
-         return updated;
-      }
+            if (existing) {
+               const [updated] = await db
+                  .update(contactSubscriptions)
+                  .set({
+                     status: validated.status,
+                     negotiatedPrice: validated.negotiatedPrice,
+                     endDate: validated.endDate,
+                     currentPeriodStart: validated.currentPeriodStart,
+                     currentPeriodEnd: validated.currentPeriodEnd,
+                     updatedAt: dayjs().toDate(),
+                  })
+                  .where(eq(contactSubscriptions.id, existing.id))
+                  .returning();
+               if (!updated)
+                  throw AppError.database("Falha ao salvar assinatura.");
+               return updated;
+            }
 
-      const [created] = await db
-         .insert(contactSubscriptions)
-         .values({ ...validated, teamId: data.teamId, externalId })
-         .returning();
-      if (!created) throw AppError.database("Failed to upsert subscription");
-      return created;
-   } catch (err) {
-      propagateError(err);
-      throw AppError.database("Failed to upsert subscription by external ID");
-   }
+            const [created] = await db
+               .insert(contactSubscriptions)
+               .values({ ...validated, teamId: data.teamId, externalId })
+               .returning();
+            if (!created)
+               throw AppError.database("Falha ao salvar assinatura.");
+            return created;
+         })(),
+         (e) =>
+            e instanceof AppError
+               ? e
+               : AppError.database("Falha ao salvar assinatura.", { cause: e }),
+      ),
+   );
 }
 
-export async function countActiveSubscriptionsByVariant(
+export function countActiveSubscriptionsByVariant(
    db: DatabaseInstance,
    teamId: string,
 ) {
-   try {
-      return await db
+   return fromPromise(
+      db
          .select({
             variantId: contactSubscriptions.variantId,
             count: count(),
@@ -156,49 +210,48 @@ export async function countActiveSubscriptionsByVariant(
                eq(contactSubscriptions.status, "active"),
             ),
          )
-         .groupBy(contactSubscriptions.variantId);
-   } catch (err) {
-      propagateError(err);
-      throw AppError.database(
-         "Failed to count active subscriptions by variant",
-      );
-   }
+         .groupBy(contactSubscriptions.variantId),
+      (e) =>
+         AppError.database("Falha ao contar assinaturas ativas.", { cause: e }),
+   );
 }
 
-export async function ensureSubscriptionOwnership(
+export function ensureSubscriptionOwnership(
    db: DatabaseInstance,
    id: string,
    teamId: string,
 ) {
-   const subscription = await getSubscription(db, id);
-   if (!subscription || subscription.teamId !== teamId) {
-      throw AppError.notFound("Assinatura não encontrada.");
-   }
-   return subscription;
+   return getSubscription(db, id).andThen((subscription) => {
+      if (!subscription || subscription.teamId !== teamId)
+         return err(AppError.notFound("Assinatura não encontrada."));
+      return ok(subscription);
+   });
 }
 
-export async function listExpiringSoon(
+export function listExpiringSoon(
    db: DatabaseInstance,
    teamId: string,
    withinDays = 30,
 ) {
-   try {
-      const now = dayjs().format("YYYY-MM-DD");
-      const futureDate = dayjs().add(withinDays, "day").format("YYYY-MM-DD");
-
-      return await db
-         .select()
-         .from(contactSubscriptions)
-         .where(
-            and(
-               eq(contactSubscriptions.teamId, teamId),
-               eq(contactSubscriptions.status, "active"),
-               gte(contactSubscriptions.endDate, now),
-               lte(contactSubscriptions.endDate, futureDate),
-            ),
-         );
-   } catch (err) {
-      propagateError(err);
-      throw AppError.database("Failed to list expiring subscriptions");
-   }
+   return fromPromise(
+      (async () => {
+         const now = dayjs().format("YYYY-MM-DD");
+         const futureDate = dayjs().add(withinDays, "day").format("YYYY-MM-DD");
+         return db
+            .select()
+            .from(contactSubscriptions)
+            .where(
+               and(
+                  eq(contactSubscriptions.teamId, teamId),
+                  eq(contactSubscriptions.status, "active"),
+                  gte(contactSubscriptions.endDate, now),
+                  lte(contactSubscriptions.endDate, futureDate),
+               ),
+            );
+      })(),
+      (e) =>
+         AppError.database("Falha ao listar assinaturas expirando.", {
+            cause: e,
+         }),
+   );
 }


### PR DESCRIPTION
## Summary

- Implements `chatRubi` in `core/agents` using ComputeSDK (E2B provider) + `@tanstack/ai`
- Each chat turn spins up an isolated E2B sandbox, runs `@montte/cli` authenticated as the user via `MONTTE_API_KEY`, then destroys the sandbox
- Single generic `run_montte_command` tool lets the model compose any CLI command
- Returns SSE stream via `toServerSentEventsStream` — ready to wire into an oRPC route

## Architecture

```
User message → chatRubi()
  → openRouterText(model) + @tanstack/ai agentic loop
  → tool: run_montte_command
      → E2B sandbox (computesdk)
      → npx @montte/cli@latest <args> --json  (MONTTE_API_KEY env var)
      → sandbox.destroy()
  → SSE stream → UI
```

## What's missing (next steps)

- [ ] Add `E2B_API_KEY` to `core/environment/src/server.ts`
- [ ] oRPC procedure (`router/rubi.ts`) that calls `chatRubi` and returns SSE
- [ ] Chat UI component with `useQuery` + `experimental_liveOptions`
- [ ] Persistent sandbox per session (instead of per-turn) for faster tool calls
- [ ] Swap E2B → Railway self-hosted per MON-342 architecture

## References

Closes MON-342

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Entrega o agente Rubi com ComputeSDK (E2B) executando `@montte/cli` por turno com streaming SSE e adiciona a página de Detalhe do Contato (dados, assinaturas e transações). Migra repositórios para `neverthrow` com erros em pt-BR e atualiza rotas oRPC para o novo fluxo.

- New Features
  - Agente Rubi: sandbox E2B por turno via `@computesdk/e2b`/`computesdk`, executa `npx @montte/cli@latest ... --json` autenticado por MONTTE_API_KEY; ferramenta única `run_montte_command`; streaming com `toServerSentEventsStream`; modelo via `@tanstack/ai` + `@tanstack/ai-openrouter`; pronto para expor em oRPC.
  - Componentes: nova rota de Detalhe do Contato (`/contacts/$contactId`) com cabeçalho, abas Dados/Assinaturas/Transações, formulário de nova assinatura e sidebar de info.
  - Router: `contacts` ganha `getById`, `getTransactions` (com paginação) e `getTransactionStats`; `services` expõe assinaturas por time/contato com tratamento de resultado.
  - Store: uso de `useSuspenseQuery`, `useMutation` e prefetch no loader da rota para UX suave.
  - Dependências: adiciona `@computesdk/e2b` e `computesdk` em `core/agents`.
  - Linear: atende MON-342 com POC de ComputeSDK + sandbox E2B e SSE.

- Refactors
  - Repositório: migração total para `neverthrow` (`fromPromise`/`fromThrowable`/`ok`/`err`) e erros padronizados em pt-BR; `contacts` ganha `getContactTransactions` e `getContactTransactionStats`; `subscriptions` passa a fazer join com `services`/`serviceVariants` e ordenar por criação.
  - Router: handlers atualizados para `.match(...)` e mapeamento para `WebAppError.fromAppError`, garantindo consistência de erro.
  - Checklist de teste
    - Agente: configurar `E2B_API_KEY`, `OPENROUTER_API_KEY`, `MONTTE_API_KEY`; chamar `chatRubi` com mensagens; verificar sandbox iniciar/executar/destroi e SSE contínuo.
    - UI: acessar Detalhe do Contato; trocar abas; criar assinatura e ver listas/estatísticas atualizando; validar paginação de transações.
    - oRPC/Erros: forçar falhas e confirmar mensagens em pt-BR e mapeamento via `WebAppError`.
    - Repositórios: rodar testes; garantir unwrap/Result nos cenários de sucesso e erro.

<sup>Written for commit 241557afce60d40b5145ac83ccadcbfa31c0217b. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/803">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

