### PR TITLE
feat(database): add usage_events table and repository

### DIFF
--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -8,1541 +8,1539 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from "./routes/__root";
-import { Route as AuthRouteImport } from "./routes/auth";
-import { Route as AuthenticatedRouteImport } from "./routes/_authenticated";
-import { Route as IndexRouteImport } from "./routes/index";
-import { Route as AuthSignUpRouteImport } from "./routes/auth/sign-up";
-import { Route as AuthSignInRouteImport } from "./routes/auth/sign-in";
-import { Route as AuthMagicLinkRouteImport } from "./routes/auth/magic-link";
-import { Route as AuthForgotPasswordRouteImport } from "./routes/auth/forgot-password";
-import { Route as AuthEmailVerificationRouteImport } from "./routes/auth/email-verification";
-import { Route as AuthCallbackRouteImport } from "./routes/auth/callback";
-import { Route as ApiPingRouteImport } from "./routes/api/ping";
-import { Route as ApiHealthRouteImport } from "./routes/api/health";
-import { Route as ApiSplatRouteImport } from "./routes/api/$";
-import { Route as AuthenticatedOnboardingRouteImport } from "./routes/_authenticated/onboarding";
-import { Route as AuthenticatedSlugRouteImport } from "./routes/_authenticated/$slug";
-import { Route as AuthSignInIndexRouteImport } from "./routes/auth/sign-in/index";
-import { Route as AuthSignInEmailRouteImport } from "./routes/auth/sign-in/email";
-import { Route as ApiSdkSplatRouteImport } from "./routes/api/sdk/$";
-import { Route as ApiRpcSplatRouteImport } from "./routes/api/rpc/$";
-import { Route as ApiFilesSplatRouteImport } from "./routes/api/files/$";
-import { Route as ApiAuthSplatRouteImport } from "./routes/api/auth/$";
-import { Route as AuthenticatedSlugTeamSlugRouteImport } from "./routes/_authenticated/$slug/$teamSlug";
-import { Route as CallbackOrganizationInvitationInvitationIdRouteImport } from "./routes/callback/organization/invitation/$invitationId";
-import { Route as AuthenticatedSlugTeamSlugDashboardRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard";
-import { Route as AuthenticatedSlugTeamSlugDashboardTransactionsRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/transactions";
-import { Route as AuthenticatedSlugTeamSlugDashboardTagsRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/tags";
-import { Route as AuthenticatedSlugTeamSlugDashboardSettingsRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/settings";
-import { Route as AuthenticatedSlugTeamSlugDashboardCreditCardsRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards";
-import { Route as AuthenticatedSlugTeamSlugDashboardContactsRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/contacts";
-import { Route as AuthenticatedSlugTeamSlugDashboardChatRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/chat";
-import { Route as AuthenticatedSlugTeamSlugDashboardCategoriesRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/categories";
-import { Route as AuthenticatedSlugTeamSlugDashboardBillingRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/billing";
-import { Route as AuthenticatedSlugTeamSlugDashboardBankAccountsRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/bank-accounts";
-import { Route as AuthenticatedSlugTeamSlugDashboardSettingsIndexRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/settings/index";
-import { Route as AuthenticatedSlugTeamSlugDashboardInventoryIndexRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/inventory/index";
-import { Route as AuthenticatedSlugTeamSlugDashboardHomeIndexRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/home/index";
-import { Route as AuthenticatedSlugTeamSlugDashboardContactsIndexRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/contacts/index";
-import { Route as AuthenticatedSlugTeamSlugDashboardSettingsSecurityRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/settings/security";
-import { Route as AuthenticatedSlugTeamSlugDashboardSettingsProfileRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/settings/profile";
-import { Route as AuthenticatedSlugTeamSlugDashboardSettingsFeaturePreviewsRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/settings/feature-previews";
-import { Route as AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/settings/danger-zone";
-import { Route as AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/settings/customization";
-import { Route as AuthenticatedSlugTeamSlugDashboardErpServicesRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/erp/services";
-import { Route as AuthenticatedSlugTeamSlugDashboardContactsContactIdRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/contacts/$contactId";
-import { Route as AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management";
-import { Route as AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsIndexRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/index";
-import { Route as AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementIndexRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/index";
-import { Route as AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsIndexRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/index";
-import { Route as AuthenticatedSlugTeamSlugDashboardSettingsProjectIntegrationsRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/integrations";
-import { Route as AuthenticatedSlugTeamSlugDashboardSettingsProjectGeneralRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/general";
-import { Route as AuthenticatedSlugTeamSlugDashboardSettingsProjectDangerZoneRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/danger-zone";
-import { Route as AuthenticatedSlugTeamSlugDashboardSettingsProjectApiKeysRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/api-keys";
-import { Route as AuthenticatedSlugTeamSlugDashboardSettingsOrganizationMembersRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/members";
-import { Route as AuthenticatedSlugTeamSlugDashboardSettingsOrganizationGeneralRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/general";
-import { Route as AuthenticatedSlugTeamSlugDashboardSettingsOrganizationDangerZoneRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/danger-zone";
-import { Route as AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsInsightIdRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/$insightId";
-import { Route as AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementEventDefinitionsRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/event-definitions";
-import { Route as AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementDestinationsRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/destinations";
-import { Route as AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsDashboardIdRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/$dashboardId";
-import { Route as AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsFinanceiroRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/financeiro";
-import { Route as AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsEstoqueRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/estoque";
-import { Route as AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsContatosRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/contatos";
-import { Route as AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsAiAgentsRouteImport } from "./routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/ai-agents";
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as AuthRouteImport } from './routes/auth'
+import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as AuthSignUpRouteImport } from './routes/auth/sign-up'
+import { Route as AuthSignInRouteImport } from './routes/auth/sign-in'
+import { Route as AuthMagicLinkRouteImport } from './routes/auth/magic-link'
+import { Route as AuthForgotPasswordRouteImport } from './routes/auth/forgot-password'
+import { Route as AuthEmailVerificationRouteImport } from './routes/auth/email-verification'
+import { Route as AuthCallbackRouteImport } from './routes/auth/callback'
+import { Route as ApiPingRouteImport } from './routes/api/ping'
+import { Route as ApiHealthRouteImport } from './routes/api/health'
+import { Route as ApiSplatRouteImport } from './routes/api/$'
+import { Route as AuthenticatedOnboardingRouteImport } from './routes/_authenticated/onboarding'
+import { Route as AuthenticatedSlugRouteImport } from './routes/_authenticated/$slug'
+import { Route as AuthSignInIndexRouteImport } from './routes/auth/sign-in/index'
+import { Route as AuthSignInEmailRouteImport } from './routes/auth/sign-in/email'
+import { Route as ApiSdkSplatRouteImport } from './routes/api/sdk/$'
+import { Route as ApiRpcSplatRouteImport } from './routes/api/rpc/$'
+import { Route as ApiFilesSplatRouteImport } from './routes/api/files/$'
+import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
+import { Route as AuthenticatedSlugTeamSlugRouteImport } from './routes/_authenticated/$slug/$teamSlug'
+import { Route as CallbackOrganizationInvitationInvitationIdRouteImport } from './routes/callback/organization/invitation/$invitationId'
+import { Route as AuthenticatedSlugTeamSlugDashboardRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard'
+import { Route as AuthenticatedSlugTeamSlugDashboardTransactionsRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/transactions'
+import { Route as AuthenticatedSlugTeamSlugDashboardTagsRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/tags'
+import { Route as AuthenticatedSlugTeamSlugDashboardSettingsRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/settings'
+import { Route as AuthenticatedSlugTeamSlugDashboardCreditCardsRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards'
+import { Route as AuthenticatedSlugTeamSlugDashboardContactsRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/contacts'
+import { Route as AuthenticatedSlugTeamSlugDashboardChatRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/chat'
+import { Route as AuthenticatedSlugTeamSlugDashboardCategoriesRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/categories'
+import { Route as AuthenticatedSlugTeamSlugDashboardBillingRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/billing'
+import { Route as AuthenticatedSlugTeamSlugDashboardBankAccountsRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/bank-accounts'
+import { Route as AuthenticatedSlugTeamSlugDashboardSettingsIndexRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/settings/index'
+import { Route as AuthenticatedSlugTeamSlugDashboardInventoryIndexRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/inventory/index'
+import { Route as AuthenticatedSlugTeamSlugDashboardHomeIndexRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/home/index'
+import { Route as AuthenticatedSlugTeamSlugDashboardContactsIndexRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/contacts/index'
+import { Route as AuthenticatedSlugTeamSlugDashboardSettingsSecurityRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/settings/security'
+import { Route as AuthenticatedSlugTeamSlugDashboardSettingsProfileRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/settings/profile'
+import { Route as AuthenticatedSlugTeamSlugDashboardSettingsFeaturePreviewsRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/settings/feature-previews'
+import { Route as AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/settings/danger-zone'
+import { Route as AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/settings/customization'
+import { Route as AuthenticatedSlugTeamSlugDashboardErpServicesRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/erp/services'
+import { Route as AuthenticatedSlugTeamSlugDashboardContactsContactIdRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/contacts/$contactId'
+import { Route as AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management'
+import { Route as AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsIndexRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/index'
+import { Route as AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementIndexRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/index'
+import { Route as AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsIndexRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/index'
+import { Route as AuthenticatedSlugTeamSlugDashboardSettingsProjectIntegrationsRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/integrations'
+import { Route as AuthenticatedSlugTeamSlugDashboardSettingsProjectGeneralRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/general'
+import { Route as AuthenticatedSlugTeamSlugDashboardSettingsProjectDangerZoneRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/danger-zone'
+import { Route as AuthenticatedSlugTeamSlugDashboardSettingsProjectApiKeysRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/api-keys'
+import { Route as AuthenticatedSlugTeamSlugDashboardSettingsOrganizationMembersRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/members'
+import { Route as AuthenticatedSlugTeamSlugDashboardSettingsOrganizationGeneralRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/general'
+import { Route as AuthenticatedSlugTeamSlugDashboardSettingsOrganizationDangerZoneRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/danger-zone'
+import { Route as AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsInsightIdRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/$insightId'
+import { Route as AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementEventDefinitionsRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/event-definitions'
+import { Route as AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementDestinationsRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/destinations'
+import { Route as AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsDashboardIdRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/$dashboardId'
+import { Route as AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsFinanceiroRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/financeiro'
+import { Route as AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsEstoqueRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/estoque'
+import { Route as AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsContatosRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/contatos'
+import { Route as AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsAiAgentsRouteImport } from './routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/ai-agents'
 
 const AuthRoute = AuthRouteImport.update({
-   id: "/auth",
-   path: "/auth",
-   getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/auth',
+  path: '/auth',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AuthenticatedRoute = AuthenticatedRouteImport.update({
-   id: "/_authenticated",
-   getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/_authenticated',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
-   id: "/",
-   path: "/",
-   getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AuthSignUpRoute = AuthSignUpRouteImport.update({
-   id: "/sign-up",
-   path: "/sign-up",
-   getParentRoute: () => AuthRoute,
-} as any);
+  id: '/sign-up',
+  path: '/sign-up',
+  getParentRoute: () => AuthRoute,
+} as any)
 const AuthSignInRoute = AuthSignInRouteImport.update({
-   id: "/sign-in",
-   path: "/sign-in",
-   getParentRoute: () => AuthRoute,
-} as any);
+  id: '/sign-in',
+  path: '/sign-in',
+  getParentRoute: () => AuthRoute,
+} as any)
 const AuthMagicLinkRoute = AuthMagicLinkRouteImport.update({
-   id: "/magic-link",
-   path: "/magic-link",
-   getParentRoute: () => AuthRoute,
-} as any);
+  id: '/magic-link',
+  path: '/magic-link',
+  getParentRoute: () => AuthRoute,
+} as any)
 const AuthForgotPasswordRoute = AuthForgotPasswordRouteImport.update({
-   id: "/forgot-password",
-   path: "/forgot-password",
-   getParentRoute: () => AuthRoute,
-} as any);
+  id: '/forgot-password',
+  path: '/forgot-password',
+  getParentRoute: () => AuthRoute,
+} as any)
 const AuthEmailVerificationRoute = AuthEmailVerificationRouteImport.update({
-   id: "/email-verification",
-   path: "/email-verification",
-   getParentRoute: () => AuthRoute,
-} as any);
+  id: '/email-verification',
+  path: '/email-verification',
+  getParentRoute: () => AuthRoute,
+} as any)
 const AuthCallbackRoute = AuthCallbackRouteImport.update({
-   id: "/callback",
-   path: "/callback",
-   getParentRoute: () => AuthRoute,
-} as any);
+  id: '/callback',
+  path: '/callback',
+  getParentRoute: () => AuthRoute,
+} as any)
 const ApiPingRoute = ApiPingRouteImport.update({
-   id: "/api/ping",
-   path: "/api/ping",
-   getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/api/ping',
+  path: '/api/ping',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiHealthRoute = ApiHealthRouteImport.update({
-   id: "/api/health",
-   path: "/api/health",
-   getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/api/health',
+  path: '/api/health',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiSplatRoute = ApiSplatRouteImport.update({
-   id: "/api/$",
-   path: "/api/$",
-   getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/api/$',
+  path: '/api/$',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AuthenticatedOnboardingRoute = AuthenticatedOnboardingRouteImport.update({
-   id: "/onboarding",
-   path: "/onboarding",
-   getParentRoute: () => AuthenticatedRoute,
-} as any);
+  id: '/onboarding',
+  path: '/onboarding',
+  getParentRoute: () => AuthenticatedRoute,
+} as any)
 const AuthenticatedSlugRoute = AuthenticatedSlugRouteImport.update({
-   id: "/$slug",
-   path: "/$slug",
-   getParentRoute: () => AuthenticatedRoute,
-} as any);
+  id: '/$slug',
+  path: '/$slug',
+  getParentRoute: () => AuthenticatedRoute,
+} as any)
 const AuthSignInIndexRoute = AuthSignInIndexRouteImport.update({
-   id: "/",
-   path: "/",
-   getParentRoute: () => AuthSignInRoute,
-} as any);
+  id: '/',
+  path: '/',
+  getParentRoute: () => AuthSignInRoute,
+} as any)
 const AuthSignInEmailRoute = AuthSignInEmailRouteImport.update({
-   id: "/email",
-   path: "/email",
-   getParentRoute: () => AuthSignInRoute,
-} as any);
+  id: '/email',
+  path: '/email',
+  getParentRoute: () => AuthSignInRoute,
+} as any)
 const ApiSdkSplatRoute = ApiSdkSplatRouteImport.update({
-   id: "/api/sdk/$",
-   path: "/api/sdk/$",
-   getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/api/sdk/$',
+  path: '/api/sdk/$',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiRpcSplatRoute = ApiRpcSplatRouteImport.update({
-   id: "/api/rpc/$",
-   path: "/api/rpc/$",
-   getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/api/rpc/$',
+  path: '/api/rpc/$',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiFilesSplatRoute = ApiFilesSplatRouteImport.update({
-   id: "/api/files/$",
-   path: "/api/files/$",
-   getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/api/files/$',
+  path: '/api/files/$',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
-   id: "/api/auth/$",
-   path: "/api/auth/$",
-   getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/api/auth/$',
+  path: '/api/auth/$',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AuthenticatedSlugTeamSlugRoute =
-   AuthenticatedSlugTeamSlugRouteImport.update({
-      id: "/$teamSlug",
-      path: "/$teamSlug",
-      getParentRoute: () => AuthenticatedSlugRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugRouteImport.update({
+    id: '/$teamSlug',
+    path: '/$teamSlug',
+    getParentRoute: () => AuthenticatedSlugRoute,
+  } as any)
 const CallbackOrganizationInvitationInvitationIdRoute =
-   CallbackOrganizationInvitationInvitationIdRouteImport.update({
-      id: "/callback/organization/invitation/$invitationId",
-      path: "/callback/organization/invitation/$invitationId",
-      getParentRoute: () => rootRouteImport,
-   } as any);
+  CallbackOrganizationInvitationInvitationIdRouteImport.update({
+    id: '/callback/organization/invitation/$invitationId',
+    path: '/callback/organization/invitation/$invitationId',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardRoute =
-   AuthenticatedSlugTeamSlugDashboardRouteImport.update({
-      id: "/_dashboard",
-      getParentRoute: () => AuthenticatedSlugTeamSlugRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugDashboardRouteImport.update({
+    id: '/_dashboard',
+    getParentRoute: () => AuthenticatedSlugTeamSlugRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardTransactionsRoute =
-   AuthenticatedSlugTeamSlugDashboardTransactionsRouteImport.update({
-      id: "/transactions",
-      path: "/transactions",
-      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugDashboardTransactionsRouteImport.update({
+    id: '/transactions',
+    path: '/transactions',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardTagsRoute =
-   AuthenticatedSlugTeamSlugDashboardTagsRouteImport.update({
-      id: "/tags",
-      path: "/tags",
-      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugDashboardTagsRouteImport.update({
+    id: '/tags',
+    path: '/tags',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardSettingsRoute =
-   AuthenticatedSlugTeamSlugDashboardSettingsRouteImport.update({
-      id: "/settings",
-      path: "/settings",
-      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugDashboardSettingsRouteImport.update({
+    id: '/settings',
+    path: '/settings',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardCreditCardsRoute =
-   AuthenticatedSlugTeamSlugDashboardCreditCardsRouteImport.update({
-      id: "/credit-cards",
-      path: "/credit-cards",
-      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugDashboardCreditCardsRouteImport.update({
+    id: '/credit-cards',
+    path: '/credit-cards',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardContactsRoute =
-   AuthenticatedSlugTeamSlugDashboardContactsRouteImport.update({
-      id: "/contacts",
-      path: "/contacts",
-      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugDashboardContactsRouteImport.update({
+    id: '/contacts',
+    path: '/contacts',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardChatRoute =
-   AuthenticatedSlugTeamSlugDashboardChatRouteImport.update({
-      id: "/chat",
-      path: "/chat",
-      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugDashboardChatRouteImport.update({
+    id: '/chat',
+    path: '/chat',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardCategoriesRoute =
-   AuthenticatedSlugTeamSlugDashboardCategoriesRouteImport.update({
-      id: "/categories",
-      path: "/categories",
-      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugDashboardCategoriesRouteImport.update({
+    id: '/categories',
+    path: '/categories',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardBillingRoute =
-   AuthenticatedSlugTeamSlugDashboardBillingRouteImport.update({
-      id: "/billing",
-      path: "/billing",
-      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugDashboardBillingRouteImport.update({
+    id: '/billing',
+    path: '/billing',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardBankAccountsRoute =
-   AuthenticatedSlugTeamSlugDashboardBankAccountsRouteImport.update({
-      id: "/bank-accounts",
-      path: "/bank-accounts",
-      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugDashboardBankAccountsRouteImport.update({
+    id: '/bank-accounts',
+    path: '/bank-accounts',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardSettingsIndexRoute =
-   AuthenticatedSlugTeamSlugDashboardSettingsIndexRouteImport.update({
-      id: "/",
-      path: "/",
-      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugDashboardSettingsIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardInventoryIndexRoute =
-   AuthenticatedSlugTeamSlugDashboardInventoryIndexRouteImport.update({
-      id: "/inventory/",
-      path: "/inventory/",
-      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugDashboardInventoryIndexRouteImport.update({
+    id: '/inventory/',
+    path: '/inventory/',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardHomeIndexRoute =
-   AuthenticatedSlugTeamSlugDashboardHomeIndexRouteImport.update({
-      id: "/home/",
-      path: "/home/",
-      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugDashboardHomeIndexRouteImport.update({
+    id: '/home/',
+    path: '/home/',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardContactsIndexRoute =
-   AuthenticatedSlugTeamSlugDashboardContactsIndexRouteImport.update({
-      id: "/",
-      path: "/",
-      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardContactsRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugDashboardContactsIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardContactsRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardSettingsSecurityRoute =
-   AuthenticatedSlugTeamSlugDashboardSettingsSecurityRouteImport.update({
-      id: "/security",
-      path: "/security",
-      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugDashboardSettingsSecurityRouteImport.update({
+    id: '/security',
+    path: '/security',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardSettingsProfileRoute =
-   AuthenticatedSlugTeamSlugDashboardSettingsProfileRouteImport.update({
-      id: "/profile",
-      path: "/profile",
-      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugDashboardSettingsProfileRouteImport.update({
+    id: '/profile',
+    path: '/profile',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardSettingsFeaturePreviewsRoute =
-   AuthenticatedSlugTeamSlugDashboardSettingsFeaturePreviewsRouteImport.update({
-      id: "/feature-previews",
-      path: "/feature-previews",
-      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugDashboardSettingsFeaturePreviewsRouteImport.update({
+    id: '/feature-previews',
+    path: '/feature-previews',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRoute =
-   AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRouteImport.update({
-      id: "/danger-zone",
-      path: "/danger-zone",
-      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRouteImport.update({
+    id: '/danger-zone',
+    path: '/danger-zone',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRoute =
-   AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRouteImport.update({
-      id: "/customization",
-      path: "/customization",
-      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRouteImport.update({
+    id: '/customization',
+    path: '/customization',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardErpServicesRoute =
-   AuthenticatedSlugTeamSlugDashboardErpServicesRouteImport.update({
-      id: "/erp/services",
-      path: "/erp/services",
-      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugDashboardErpServicesRouteImport.update({
+    id: '/erp/services',
+    path: '/erp/services',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardContactsContactIdRoute =
-   AuthenticatedSlugTeamSlugDashboardContactsContactIdRouteImport.update({
-      id: "/$contactId",
-      path: "/$contactId",
-      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardContactsRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugDashboardContactsContactIdRouteImport.update({
+    id: '/$contactId',
+    path: '/$contactId',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardContactsRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRoute =
-   AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRouteImport.update({
-      id: "/analytics/data-management",
-      path: "/analytics/data-management",
-      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRouteImport.update({
+    id: '/analytics/data-management',
+    path: '/analytics/data-management',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsIndexRoute =
-   AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsIndexRouteImport.update({
-      id: "/analytics/insights/",
-      path: "/analytics/insights/",
-      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsIndexRouteImport.update({
+    id: '/analytics/insights/',
+    path: '/analytics/insights/',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementIndexRoute =
-   AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementIndexRouteImport.update(
-      {
-         id: "/",
-         path: "/",
-         getParentRoute: () =>
-            AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRoute,
-      } as any,
-   );
+  AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementIndexRouteImport.update(
+    {
+      id: '/',
+      path: '/',
+      getParentRoute: () =>
+        AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRoute,
+    } as any,
+  )
 const AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsIndexRoute =
-   AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsIndexRouteImport.update(
-      {
-         id: "/analytics/dashboards/",
-         path: "/analytics/dashboards/",
-         getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
-      } as any,
-   );
+  AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsIndexRouteImport.update({
+    id: '/analytics/dashboards/',
+    path: '/analytics/dashboards/',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardSettingsProjectIntegrationsRoute =
-   AuthenticatedSlugTeamSlugDashboardSettingsProjectIntegrationsRouteImport.update(
-      {
-         id: "/project/integrations",
-         path: "/project/integrations",
-         getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
-      } as any,
-   );
+  AuthenticatedSlugTeamSlugDashboardSettingsProjectIntegrationsRouteImport.update(
+    {
+      id: '/project/integrations',
+      path: '/project/integrations',
+      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
+    } as any,
+  )
 const AuthenticatedSlugTeamSlugDashboardSettingsProjectGeneralRoute =
-   AuthenticatedSlugTeamSlugDashboardSettingsProjectGeneralRouteImport.update({
-      id: "/project/general",
-      path: "/project/general",
-      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
-   } as any);
+  AuthenticatedSlugTeamSlugDashboardSettingsProjectGeneralRouteImport.update({
+    id: '/project/general',
+    path: '/project/general',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardSettingsProjectDangerZoneRoute =
-   AuthenticatedSlugTeamSlugDashboardSettingsProjectDangerZoneRouteImport.update(
-      {
-         id: "/project/danger-zone",
-         path: "/project/danger-zone",
-         getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
-      } as any,
-   );
-const AuthenticatedSlugTeamSlugDashboardSettingsProjectApiKeysRoute =
-   AuthenticatedSlugTeamSlugDashboardSettingsProjectApiKeysRouteImport.update({
-      id: "/project/api-keys",
-      path: "/project/api-keys",
+  AuthenticatedSlugTeamSlugDashboardSettingsProjectDangerZoneRouteImport.update(
+    {
+      id: '/project/danger-zone',
+      path: '/project/danger-zone',
       getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
-   } as any);
+    } as any,
+  )
+const AuthenticatedSlugTeamSlugDashboardSettingsProjectApiKeysRoute =
+  AuthenticatedSlugTeamSlugDashboardSettingsProjectApiKeysRouteImport.update({
+    id: '/project/api-keys',
+    path: '/project/api-keys',
+    getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
+  } as any)
 const AuthenticatedSlugTeamSlugDashboardSettingsOrganizationMembersRoute =
-   AuthenticatedSlugTeamSlugDashboardSettingsOrganizationMembersRouteImport.update(
-      {
-         id: "/organization/members",
-         path: "/organization/members",
-         getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
-      } as any,
-   );
+  AuthenticatedSlugTeamSlugDashboardSettingsOrganizationMembersRouteImport.update(
+    {
+      id: '/organization/members',
+      path: '/organization/members',
+      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
+    } as any,
+  )
 const AuthenticatedSlugTeamSlugDashboardSettingsOrganizationGeneralRoute =
-   AuthenticatedSlugTeamSlugDashboardSettingsOrganizationGeneralRouteImport.update(
-      {
-         id: "/organization/general",
-         path: "/organization/general",
-         getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
-      } as any,
-   );
+  AuthenticatedSlugTeamSlugDashboardSettingsOrganizationGeneralRouteImport.update(
+    {
+      id: '/organization/general',
+      path: '/organization/general',
+      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
+    } as any,
+  )
 const AuthenticatedSlugTeamSlugDashboardSettingsOrganizationDangerZoneRoute =
-   AuthenticatedSlugTeamSlugDashboardSettingsOrganizationDangerZoneRouteImport.update(
-      {
-         id: "/organization/danger-zone",
-         path: "/organization/danger-zone",
-         getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
-      } as any,
-   );
+  AuthenticatedSlugTeamSlugDashboardSettingsOrganizationDangerZoneRouteImport.update(
+    {
+      id: '/organization/danger-zone',
+      path: '/organization/danger-zone',
+      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
+    } as any,
+  )
 const AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsInsightIdRoute =
-   AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsInsightIdRouteImport.update(
-      {
-         id: "/analytics/insights/$insightId",
-         path: "/analytics/insights/$insightId",
-         getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
-      } as any,
-   );
+  AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsInsightIdRouteImport.update(
+    {
+      id: '/analytics/insights/$insightId',
+      path: '/analytics/insights/$insightId',
+      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
+    } as any,
+  )
 const AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementEventDefinitionsRoute =
-   AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementEventDefinitionsRouteImport.update(
-      {
-         id: "/event-definitions",
-         path: "/event-definitions",
-         getParentRoute: () =>
-            AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRoute,
-      } as any,
-   );
+  AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementEventDefinitionsRouteImport.update(
+    {
+      id: '/event-definitions',
+      path: '/event-definitions',
+      getParentRoute: () =>
+        AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRoute,
+    } as any,
+  )
 const AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementDestinationsRoute =
-   AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementDestinationsRouteImport.update(
-      {
-         id: "/destinations",
-         path: "/destinations",
-         getParentRoute: () =>
-            AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRoute,
-      } as any,
-   );
+  AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementDestinationsRouteImport.update(
+    {
+      id: '/destinations',
+      path: '/destinations',
+      getParentRoute: () =>
+        AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRoute,
+    } as any,
+  )
 const AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsDashboardIdRoute =
-   AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsDashboardIdRouteImport.update(
-      {
-         id: "/analytics/dashboards/$dashboardId",
-         path: "/analytics/dashboards/$dashboardId",
-         getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
-      } as any,
-   );
+  AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsDashboardIdRouteImport.update(
+    {
+      id: '/analytics/dashboards/$dashboardId',
+      path: '/analytics/dashboards/$dashboardId',
+      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardRoute,
+    } as any,
+  )
 const AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsFinanceiroRoute =
-   AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsFinanceiroRouteImport.update(
-      {
-         id: "/project/products/financeiro",
-         path: "/project/products/financeiro",
-         getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
-      } as any,
-   );
+  AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsFinanceiroRouteImport.update(
+    {
+      id: '/project/products/financeiro',
+      path: '/project/products/financeiro',
+      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
+    } as any,
+  )
 const AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsEstoqueRoute =
-   AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsEstoqueRouteImport.update(
-      {
-         id: "/project/products/estoque",
-         path: "/project/products/estoque",
-         getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
-      } as any,
-   );
+  AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsEstoqueRouteImport.update(
+    {
+      id: '/project/products/estoque',
+      path: '/project/products/estoque',
+      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
+    } as any,
+  )
 const AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsContatosRoute =
-   AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsContatosRouteImport.update(
-      {
-         id: "/project/products/contatos",
-         path: "/project/products/contatos",
-         getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
-      } as any,
-   );
+  AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsContatosRouteImport.update(
+    {
+      id: '/project/products/contatos',
+      path: '/project/products/contatos',
+      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
+    } as any,
+  )
 const AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsAiAgentsRoute =
-   AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsAiAgentsRouteImport.update(
-      {
-         id: "/project/products/ai-agents",
-         path: "/project/products/ai-agents",
-         getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
-      } as any,
-   );
+  AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsAiAgentsRouteImport.update(
+    {
+      id: '/project/products/ai-agents',
+      path: '/project/products/ai-agents',
+      getParentRoute: () => AuthenticatedSlugTeamSlugDashboardSettingsRoute,
+    } as any,
+  )
 
 export interface FileRoutesByFullPath {
-   "/": typeof IndexRoute;
-   "/auth": typeof AuthRouteWithChildren;
-   "/$slug": typeof AuthenticatedSlugRouteWithChildren;
-   "/onboarding": typeof AuthenticatedOnboardingRoute;
-   "/api/$": typeof ApiSplatRoute;
-   "/api/health": typeof ApiHealthRoute;
-   "/api/ping": typeof ApiPingRoute;
-   "/auth/callback": typeof AuthCallbackRoute;
-   "/auth/email-verification": typeof AuthEmailVerificationRoute;
-   "/auth/forgot-password": typeof AuthForgotPasswordRoute;
-   "/auth/magic-link": typeof AuthMagicLinkRoute;
-   "/auth/sign-in": typeof AuthSignInRouteWithChildren;
-   "/auth/sign-up": typeof AuthSignUpRoute;
-   "/$slug/$teamSlug": typeof AuthenticatedSlugTeamSlugDashboardRouteWithChildren;
-   "/api/auth/$": typeof ApiAuthSplatRoute;
-   "/api/files/$": typeof ApiFilesSplatRoute;
-   "/api/rpc/$": typeof ApiRpcSplatRoute;
-   "/api/sdk/$": typeof ApiSdkSplatRoute;
-   "/auth/sign-in/email": typeof AuthSignInEmailRoute;
-   "/auth/sign-in/": typeof AuthSignInIndexRoute;
-   "/callback/organization/invitation/$invitationId": typeof CallbackOrganizationInvitationInvitationIdRoute;
-   "/$slug/$teamSlug/bank-accounts": typeof AuthenticatedSlugTeamSlugDashboardBankAccountsRoute;
-   "/$slug/$teamSlug/billing": typeof AuthenticatedSlugTeamSlugDashboardBillingRoute;
-   "/$slug/$teamSlug/categories": typeof AuthenticatedSlugTeamSlugDashboardCategoriesRoute;
-   "/$slug/$teamSlug/chat": typeof AuthenticatedSlugTeamSlugDashboardChatRoute;
-   "/$slug/$teamSlug/contacts": typeof AuthenticatedSlugTeamSlugDashboardContactsRouteWithChildren;
-   "/$slug/$teamSlug/credit-cards": typeof AuthenticatedSlugTeamSlugDashboardCreditCardsRoute;
-   "/$slug/$teamSlug/settings": typeof AuthenticatedSlugTeamSlugDashboardSettingsRouteWithChildren;
-   "/$slug/$teamSlug/tags": typeof AuthenticatedSlugTeamSlugDashboardTagsRoute;
-   "/$slug/$teamSlug/transactions": typeof AuthenticatedSlugTeamSlugDashboardTransactionsRoute;
-   "/$slug/$teamSlug/analytics/data-management": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRouteWithChildren;
-   "/$slug/$teamSlug/contacts/$contactId": typeof AuthenticatedSlugTeamSlugDashboardContactsContactIdRoute;
-   "/$slug/$teamSlug/erp/services": typeof AuthenticatedSlugTeamSlugDashboardErpServicesRoute;
-   "/$slug/$teamSlug/settings/customization": typeof AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRoute;
-   "/$slug/$teamSlug/settings/danger-zone": typeof AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRoute;
-   "/$slug/$teamSlug/settings/feature-previews": typeof AuthenticatedSlugTeamSlugDashboardSettingsFeaturePreviewsRoute;
-   "/$slug/$teamSlug/settings/profile": typeof AuthenticatedSlugTeamSlugDashboardSettingsProfileRoute;
-   "/$slug/$teamSlug/settings/security": typeof AuthenticatedSlugTeamSlugDashboardSettingsSecurityRoute;
-   "/$slug/$teamSlug/contacts/": typeof AuthenticatedSlugTeamSlugDashboardContactsIndexRoute;
-   "/$slug/$teamSlug/home/": typeof AuthenticatedSlugTeamSlugDashboardHomeIndexRoute;
-   "/$slug/$teamSlug/inventory/": typeof AuthenticatedSlugTeamSlugDashboardInventoryIndexRoute;
-   "/$slug/$teamSlug/settings/": typeof AuthenticatedSlugTeamSlugDashboardSettingsIndexRoute;
-   "/$slug/$teamSlug/analytics/dashboards/$dashboardId": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsDashboardIdRoute;
-   "/$slug/$teamSlug/analytics/data-management/destinations": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementDestinationsRoute;
-   "/$slug/$teamSlug/analytics/data-management/event-definitions": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementEventDefinitionsRoute;
-   "/$slug/$teamSlug/analytics/insights/$insightId": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsInsightIdRoute;
-   "/$slug/$teamSlug/settings/organization/danger-zone": typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationDangerZoneRoute;
-   "/$slug/$teamSlug/settings/organization/general": typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationGeneralRoute;
-   "/$slug/$teamSlug/settings/organization/members": typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationMembersRoute;
-   "/$slug/$teamSlug/settings/project/api-keys": typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectApiKeysRoute;
-   "/$slug/$teamSlug/settings/project/danger-zone": typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectDangerZoneRoute;
-   "/$slug/$teamSlug/settings/project/general": typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectGeneralRoute;
-   "/$slug/$teamSlug/settings/project/integrations": typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectIntegrationsRoute;
-   "/$slug/$teamSlug/analytics/dashboards/": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsIndexRoute;
-   "/$slug/$teamSlug/analytics/data-management/": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementIndexRoute;
-   "/$slug/$teamSlug/analytics/insights/": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsIndexRoute;
-   "/$slug/$teamSlug/settings/project/products/ai-agents": typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsAiAgentsRoute;
-   "/$slug/$teamSlug/settings/project/products/contatos": typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsContatosRoute;
-   "/$slug/$teamSlug/settings/project/products/estoque": typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsEstoqueRoute;
-   "/$slug/$teamSlug/settings/project/products/financeiro": typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsFinanceiroRoute;
+  '/': typeof IndexRoute
+  '/auth': typeof AuthRouteWithChildren
+  '/$slug': typeof AuthenticatedSlugRouteWithChildren
+  '/onboarding': typeof AuthenticatedOnboardingRoute
+  '/api/$': typeof ApiSplatRoute
+  '/api/health': typeof ApiHealthRoute
+  '/api/ping': typeof ApiPingRoute
+  '/auth/callback': typeof AuthCallbackRoute
+  '/auth/email-verification': typeof AuthEmailVerificationRoute
+  '/auth/forgot-password': typeof AuthForgotPasswordRoute
+  '/auth/magic-link': typeof AuthMagicLinkRoute
+  '/auth/sign-in': typeof AuthSignInRouteWithChildren
+  '/auth/sign-up': typeof AuthSignUpRoute
+  '/$slug/$teamSlug': typeof AuthenticatedSlugTeamSlugDashboardRouteWithChildren
+  '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/files/$': typeof ApiFilesSplatRoute
+  '/api/rpc/$': typeof ApiRpcSplatRoute
+  '/api/sdk/$': typeof ApiSdkSplatRoute
+  '/auth/sign-in/email': typeof AuthSignInEmailRoute
+  '/auth/sign-in/': typeof AuthSignInIndexRoute
+  '/callback/organization/invitation/$invitationId': typeof CallbackOrganizationInvitationInvitationIdRoute
+  '/$slug/$teamSlug/bank-accounts': typeof AuthenticatedSlugTeamSlugDashboardBankAccountsRoute
+  '/$slug/$teamSlug/billing': typeof AuthenticatedSlugTeamSlugDashboardBillingRoute
+  '/$slug/$teamSlug/categories': typeof AuthenticatedSlugTeamSlugDashboardCategoriesRoute
+  '/$slug/$teamSlug/chat': typeof AuthenticatedSlugTeamSlugDashboardChatRoute
+  '/$slug/$teamSlug/contacts': typeof AuthenticatedSlugTeamSlugDashboardContactsRouteWithChildren
+  '/$slug/$teamSlug/credit-cards': typeof AuthenticatedSlugTeamSlugDashboardCreditCardsRoute
+  '/$slug/$teamSlug/settings': typeof AuthenticatedSlugTeamSlugDashboardSettingsRouteWithChildren
+  '/$slug/$teamSlug/tags': typeof AuthenticatedSlugTeamSlugDashboardTagsRoute
+  '/$slug/$teamSlug/transactions': typeof AuthenticatedSlugTeamSlugDashboardTransactionsRoute
+  '/$slug/$teamSlug/analytics/data-management': typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRouteWithChildren
+  '/$slug/$teamSlug/contacts/$contactId': typeof AuthenticatedSlugTeamSlugDashboardContactsContactIdRoute
+  '/$slug/$teamSlug/erp/services': typeof AuthenticatedSlugTeamSlugDashboardErpServicesRoute
+  '/$slug/$teamSlug/settings/customization': typeof AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRoute
+  '/$slug/$teamSlug/settings/danger-zone': typeof AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRoute
+  '/$slug/$teamSlug/settings/feature-previews': typeof AuthenticatedSlugTeamSlugDashboardSettingsFeaturePreviewsRoute
+  '/$slug/$teamSlug/settings/profile': typeof AuthenticatedSlugTeamSlugDashboardSettingsProfileRoute
+  '/$slug/$teamSlug/settings/security': typeof AuthenticatedSlugTeamSlugDashboardSettingsSecurityRoute
+  '/$slug/$teamSlug/contacts/': typeof AuthenticatedSlugTeamSlugDashboardContactsIndexRoute
+  '/$slug/$teamSlug/home/': typeof AuthenticatedSlugTeamSlugDashboardHomeIndexRoute
+  '/$slug/$teamSlug/inventory/': typeof AuthenticatedSlugTeamSlugDashboardInventoryIndexRoute
+  '/$slug/$teamSlug/settings/': typeof AuthenticatedSlugTeamSlugDashboardSettingsIndexRoute
+  '/$slug/$teamSlug/analytics/dashboards/$dashboardId': typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsDashboardIdRoute
+  '/$slug/$teamSlug/analytics/data-management/destinations': typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementDestinationsRoute
+  '/$slug/$teamSlug/analytics/data-management/event-definitions': typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementEventDefinitionsRoute
+  '/$slug/$teamSlug/analytics/insights/$insightId': typeof AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsInsightIdRoute
+  '/$slug/$teamSlug/settings/organization/danger-zone': typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationDangerZoneRoute
+  '/$slug/$teamSlug/settings/organization/general': typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationGeneralRoute
+  '/$slug/$teamSlug/settings/organization/members': typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationMembersRoute
+  '/$slug/$teamSlug/settings/project/api-keys': typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectApiKeysRoute
+  '/$slug/$teamSlug/settings/project/danger-zone': typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectDangerZoneRoute
+  '/$slug/$teamSlug/settings/project/general': typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectGeneralRoute
+  '/$slug/$teamSlug/settings/project/integrations': typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectIntegrationsRoute
+  '/$slug/$teamSlug/analytics/dashboards/': typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsIndexRoute
+  '/$slug/$teamSlug/analytics/data-management/': typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementIndexRoute
+  '/$slug/$teamSlug/analytics/insights/': typeof AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsIndexRoute
+  '/$slug/$teamSlug/settings/project/products/ai-agents': typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsAiAgentsRoute
+  '/$slug/$teamSlug/settings/project/products/contatos': typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsContatosRoute
+  '/$slug/$teamSlug/settings/project/products/estoque': typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsEstoqueRoute
+  '/$slug/$teamSlug/settings/project/products/financeiro': typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsFinanceiroRoute
 }
 export interface FileRoutesByTo {
-   "/": typeof IndexRoute;
-   "/auth": typeof AuthRouteWithChildren;
-   "/$slug": typeof AuthenticatedSlugRouteWithChildren;
-   "/onboarding": typeof AuthenticatedOnboardingRoute;
-   "/api/$": typeof ApiSplatRoute;
-   "/api/health": typeof ApiHealthRoute;
-   "/api/ping": typeof ApiPingRoute;
-   "/auth/callback": typeof AuthCallbackRoute;
-   "/auth/email-verification": typeof AuthEmailVerificationRoute;
-   "/auth/forgot-password": typeof AuthForgotPasswordRoute;
-   "/auth/magic-link": typeof AuthMagicLinkRoute;
-   "/auth/sign-up": typeof AuthSignUpRoute;
-   "/$slug/$teamSlug": typeof AuthenticatedSlugTeamSlugDashboardRouteWithChildren;
-   "/api/auth/$": typeof ApiAuthSplatRoute;
-   "/api/files/$": typeof ApiFilesSplatRoute;
-   "/api/rpc/$": typeof ApiRpcSplatRoute;
-   "/api/sdk/$": typeof ApiSdkSplatRoute;
-   "/auth/sign-in/email": typeof AuthSignInEmailRoute;
-   "/auth/sign-in": typeof AuthSignInIndexRoute;
-   "/callback/organization/invitation/$invitationId": typeof CallbackOrganizationInvitationInvitationIdRoute;
-   "/$slug/$teamSlug/bank-accounts": typeof AuthenticatedSlugTeamSlugDashboardBankAccountsRoute;
-   "/$slug/$teamSlug/billing": typeof AuthenticatedSlugTeamSlugDashboardBillingRoute;
-   "/$slug/$teamSlug/categories": typeof AuthenticatedSlugTeamSlugDashboardCategoriesRoute;
-   "/$slug/$teamSlug/chat": typeof AuthenticatedSlugTeamSlugDashboardChatRoute;
-   "/$slug/$teamSlug/credit-cards": typeof AuthenticatedSlugTeamSlugDashboardCreditCardsRoute;
-   "/$slug/$teamSlug/tags": typeof AuthenticatedSlugTeamSlugDashboardTagsRoute;
-   "/$slug/$teamSlug/transactions": typeof AuthenticatedSlugTeamSlugDashboardTransactionsRoute;
-   "/$slug/$teamSlug/contacts/$contactId": typeof AuthenticatedSlugTeamSlugDashboardContactsContactIdRoute;
-   "/$slug/$teamSlug/erp/services": typeof AuthenticatedSlugTeamSlugDashboardErpServicesRoute;
-   "/$slug/$teamSlug/settings/customization": typeof AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRoute;
-   "/$slug/$teamSlug/settings/danger-zone": typeof AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRoute;
-   "/$slug/$teamSlug/settings/feature-previews": typeof AuthenticatedSlugTeamSlugDashboardSettingsFeaturePreviewsRoute;
-   "/$slug/$teamSlug/settings/profile": typeof AuthenticatedSlugTeamSlugDashboardSettingsProfileRoute;
-   "/$slug/$teamSlug/settings/security": typeof AuthenticatedSlugTeamSlugDashboardSettingsSecurityRoute;
-   "/$slug/$teamSlug/contacts": typeof AuthenticatedSlugTeamSlugDashboardContactsIndexRoute;
-   "/$slug/$teamSlug/home": typeof AuthenticatedSlugTeamSlugDashboardHomeIndexRoute;
-   "/$slug/$teamSlug/inventory": typeof AuthenticatedSlugTeamSlugDashboardInventoryIndexRoute;
-   "/$slug/$teamSlug/settings": typeof AuthenticatedSlugTeamSlugDashboardSettingsIndexRoute;
-   "/$slug/$teamSlug/analytics/dashboards/$dashboardId": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsDashboardIdRoute;
-   "/$slug/$teamSlug/analytics/data-management/destinations": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementDestinationsRoute;
-   "/$slug/$teamSlug/analytics/data-management/event-definitions": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementEventDefinitionsRoute;
-   "/$slug/$teamSlug/analytics/insights/$insightId": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsInsightIdRoute;
-   "/$slug/$teamSlug/settings/organization/danger-zone": typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationDangerZoneRoute;
-   "/$slug/$teamSlug/settings/organization/general": typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationGeneralRoute;
-   "/$slug/$teamSlug/settings/organization/members": typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationMembersRoute;
-   "/$slug/$teamSlug/settings/project/api-keys": typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectApiKeysRoute;
-   "/$slug/$teamSlug/settings/project/danger-zone": typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectDangerZoneRoute;
-   "/$slug/$teamSlug/settings/project/general": typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectGeneralRoute;
-   "/$slug/$teamSlug/settings/project/integrations": typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectIntegrationsRoute;
-   "/$slug/$teamSlug/analytics/dashboards": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsIndexRoute;
-   "/$slug/$teamSlug/analytics/data-management": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementIndexRoute;
-   "/$slug/$teamSlug/analytics/insights": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsIndexRoute;
-   "/$slug/$teamSlug/settings/project/products/ai-agents": typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsAiAgentsRoute;
-   "/$slug/$teamSlug/settings/project/products/contatos": typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsContatosRoute;
-   "/$slug/$teamSlug/settings/project/products/estoque": typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsEstoqueRoute;
-   "/$slug/$teamSlug/settings/project/products/financeiro": typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsFinanceiroRoute;
+  '/': typeof IndexRoute
+  '/auth': typeof AuthRouteWithChildren
+  '/$slug': typeof AuthenticatedSlugRouteWithChildren
+  '/onboarding': typeof AuthenticatedOnboardingRoute
+  '/api/$': typeof ApiSplatRoute
+  '/api/health': typeof ApiHealthRoute
+  '/api/ping': typeof ApiPingRoute
+  '/auth/callback': typeof AuthCallbackRoute
+  '/auth/email-verification': typeof AuthEmailVerificationRoute
+  '/auth/forgot-password': typeof AuthForgotPasswordRoute
+  '/auth/magic-link': typeof AuthMagicLinkRoute
+  '/auth/sign-up': typeof AuthSignUpRoute
+  '/$slug/$teamSlug': typeof AuthenticatedSlugTeamSlugDashboardRouteWithChildren
+  '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/files/$': typeof ApiFilesSplatRoute
+  '/api/rpc/$': typeof ApiRpcSplatRoute
+  '/api/sdk/$': typeof ApiSdkSplatRoute
+  '/auth/sign-in/email': typeof AuthSignInEmailRoute
+  '/auth/sign-in': typeof AuthSignInIndexRoute
+  '/callback/organization/invitation/$invitationId': typeof CallbackOrganizationInvitationInvitationIdRoute
+  '/$slug/$teamSlug/bank-accounts': typeof AuthenticatedSlugTeamSlugDashboardBankAccountsRoute
+  '/$slug/$teamSlug/billing': typeof AuthenticatedSlugTeamSlugDashboardBillingRoute
+  '/$slug/$teamSlug/categories': typeof AuthenticatedSlugTeamSlugDashboardCategoriesRoute
+  '/$slug/$teamSlug/chat': typeof AuthenticatedSlugTeamSlugDashboardChatRoute
+  '/$slug/$teamSlug/credit-cards': typeof AuthenticatedSlugTeamSlugDashboardCreditCardsRoute
+  '/$slug/$teamSlug/tags': typeof AuthenticatedSlugTeamSlugDashboardTagsRoute
+  '/$slug/$teamSlug/transactions': typeof AuthenticatedSlugTeamSlugDashboardTransactionsRoute
+  '/$slug/$teamSlug/contacts/$contactId': typeof AuthenticatedSlugTeamSlugDashboardContactsContactIdRoute
+  '/$slug/$teamSlug/erp/services': typeof AuthenticatedSlugTeamSlugDashboardErpServicesRoute
+  '/$slug/$teamSlug/settings/customization': typeof AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRoute
+  '/$slug/$teamSlug/settings/danger-zone': typeof AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRoute
+  '/$slug/$teamSlug/settings/feature-previews': typeof AuthenticatedSlugTeamSlugDashboardSettingsFeaturePreviewsRoute
+  '/$slug/$teamSlug/settings/profile': typeof AuthenticatedSlugTeamSlugDashboardSettingsProfileRoute
+  '/$slug/$teamSlug/settings/security': typeof AuthenticatedSlugTeamSlugDashboardSettingsSecurityRoute
+  '/$slug/$teamSlug/contacts': typeof AuthenticatedSlugTeamSlugDashboardContactsIndexRoute
+  '/$slug/$teamSlug/home': typeof AuthenticatedSlugTeamSlugDashboardHomeIndexRoute
+  '/$slug/$teamSlug/inventory': typeof AuthenticatedSlugTeamSlugDashboardInventoryIndexRoute
+  '/$slug/$teamSlug/settings': typeof AuthenticatedSlugTeamSlugDashboardSettingsIndexRoute
+  '/$slug/$teamSlug/analytics/dashboards/$dashboardId': typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsDashboardIdRoute
+  '/$slug/$teamSlug/analytics/data-management/destinations': typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementDestinationsRoute
+  '/$slug/$teamSlug/analytics/data-management/event-definitions': typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementEventDefinitionsRoute
+  '/$slug/$teamSlug/analytics/insights/$insightId': typeof AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsInsightIdRoute
+  '/$slug/$teamSlug/settings/organization/danger-zone': typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationDangerZoneRoute
+  '/$slug/$teamSlug/settings/organization/general': typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationGeneralRoute
+  '/$slug/$teamSlug/settings/organization/members': typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationMembersRoute
+  '/$slug/$teamSlug/settings/project/api-keys': typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectApiKeysRoute
+  '/$slug/$teamSlug/settings/project/danger-zone': typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectDangerZoneRoute
+  '/$slug/$teamSlug/settings/project/general': typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectGeneralRoute
+  '/$slug/$teamSlug/settings/project/integrations': typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectIntegrationsRoute
+  '/$slug/$teamSlug/analytics/dashboards': typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsIndexRoute
+  '/$slug/$teamSlug/analytics/data-management': typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementIndexRoute
+  '/$slug/$teamSlug/analytics/insights': typeof AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsIndexRoute
+  '/$slug/$teamSlug/settings/project/products/ai-agents': typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsAiAgentsRoute
+  '/$slug/$teamSlug/settings/project/products/contatos': typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsContatosRoute
+  '/$slug/$teamSlug/settings/project/products/estoque': typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsEstoqueRoute
+  '/$slug/$teamSlug/settings/project/products/financeiro': typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsFinanceiroRoute
 }
 export interface FileRoutesById {
-   __root__: typeof rootRouteImport;
-   "/": typeof IndexRoute;
-   "/_authenticated": typeof AuthenticatedRouteWithChildren;
-   "/auth": typeof AuthRouteWithChildren;
-   "/_authenticated/$slug": typeof AuthenticatedSlugRouteWithChildren;
-   "/_authenticated/onboarding": typeof AuthenticatedOnboardingRoute;
-   "/api/$": typeof ApiSplatRoute;
-   "/api/health": typeof ApiHealthRoute;
-   "/api/ping": typeof ApiPingRoute;
-   "/auth/callback": typeof AuthCallbackRoute;
-   "/auth/email-verification": typeof AuthEmailVerificationRoute;
-   "/auth/forgot-password": typeof AuthForgotPasswordRoute;
-   "/auth/magic-link": typeof AuthMagicLinkRoute;
-   "/auth/sign-in": typeof AuthSignInRouteWithChildren;
-   "/auth/sign-up": typeof AuthSignUpRoute;
-   "/_authenticated/$slug/$teamSlug": typeof AuthenticatedSlugTeamSlugRouteWithChildren;
-   "/api/auth/$": typeof ApiAuthSplatRoute;
-   "/api/files/$": typeof ApiFilesSplatRoute;
-   "/api/rpc/$": typeof ApiRpcSplatRoute;
-   "/api/sdk/$": typeof ApiSdkSplatRoute;
-   "/auth/sign-in/email": typeof AuthSignInEmailRoute;
-   "/auth/sign-in/": typeof AuthSignInIndexRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard": typeof AuthenticatedSlugTeamSlugDashboardRouteWithChildren;
-   "/callback/organization/invitation/$invitationId": typeof CallbackOrganizationInvitationInvitationIdRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/bank-accounts": typeof AuthenticatedSlugTeamSlugDashboardBankAccountsRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/billing": typeof AuthenticatedSlugTeamSlugDashboardBillingRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/categories": typeof AuthenticatedSlugTeamSlugDashboardCategoriesRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/chat": typeof AuthenticatedSlugTeamSlugDashboardChatRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/contacts": typeof AuthenticatedSlugTeamSlugDashboardContactsRouteWithChildren;
-   "/_authenticated/$slug/$teamSlug/_dashboard/credit-cards": typeof AuthenticatedSlugTeamSlugDashboardCreditCardsRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/settings": typeof AuthenticatedSlugTeamSlugDashboardSettingsRouteWithChildren;
-   "/_authenticated/$slug/$teamSlug/_dashboard/tags": typeof AuthenticatedSlugTeamSlugDashboardTagsRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/transactions": typeof AuthenticatedSlugTeamSlugDashboardTransactionsRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRouteWithChildren;
-   "/_authenticated/$slug/$teamSlug/_dashboard/contacts/$contactId": typeof AuthenticatedSlugTeamSlugDashboardContactsContactIdRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/erp/services": typeof AuthenticatedSlugTeamSlugDashboardErpServicesRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/settings/customization": typeof AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/settings/danger-zone": typeof AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/settings/feature-previews": typeof AuthenticatedSlugTeamSlugDashboardSettingsFeaturePreviewsRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/settings/profile": typeof AuthenticatedSlugTeamSlugDashboardSettingsProfileRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/settings/security": typeof AuthenticatedSlugTeamSlugDashboardSettingsSecurityRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/contacts/": typeof AuthenticatedSlugTeamSlugDashboardContactsIndexRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/home/": typeof AuthenticatedSlugTeamSlugDashboardHomeIndexRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/inventory/": typeof AuthenticatedSlugTeamSlugDashboardInventoryIndexRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/settings/": typeof AuthenticatedSlugTeamSlugDashboardSettingsIndexRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/$dashboardId": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsDashboardIdRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/destinations": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementDestinationsRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/event-definitions": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementEventDefinitionsRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/$insightId": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsInsightIdRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/danger-zone": typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationDangerZoneRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/general": typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationGeneralRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/members": typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationMembersRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/api-keys": typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectApiKeysRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/danger-zone": typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectDangerZoneRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/general": typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectGeneralRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/integrations": typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectIntegrationsRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsIndexRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementIndexRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/": typeof AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsIndexRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/ai-agents": typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsAiAgentsRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/contatos": typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsContatosRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/estoque": typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsEstoqueRoute;
-   "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/financeiro": typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsFinanceiroRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/_authenticated': typeof AuthenticatedRouteWithChildren
+  '/auth': typeof AuthRouteWithChildren
+  '/_authenticated/$slug': typeof AuthenticatedSlugRouteWithChildren
+  '/_authenticated/onboarding': typeof AuthenticatedOnboardingRoute
+  '/api/$': typeof ApiSplatRoute
+  '/api/health': typeof ApiHealthRoute
+  '/api/ping': typeof ApiPingRoute
+  '/auth/callback': typeof AuthCallbackRoute
+  '/auth/email-verification': typeof AuthEmailVerificationRoute
+  '/auth/forgot-password': typeof AuthForgotPasswordRoute
+  '/auth/magic-link': typeof AuthMagicLinkRoute
+  '/auth/sign-in': typeof AuthSignInRouteWithChildren
+  '/auth/sign-up': typeof AuthSignUpRoute
+  '/_authenticated/$slug/$teamSlug': typeof AuthenticatedSlugTeamSlugRouteWithChildren
+  '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/files/$': typeof ApiFilesSplatRoute
+  '/api/rpc/$': typeof ApiRpcSplatRoute
+  '/api/sdk/$': typeof ApiSdkSplatRoute
+  '/auth/sign-in/email': typeof AuthSignInEmailRoute
+  '/auth/sign-in/': typeof AuthSignInIndexRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard': typeof AuthenticatedSlugTeamSlugDashboardRouteWithChildren
+  '/callback/organization/invitation/$invitationId': typeof CallbackOrganizationInvitationInvitationIdRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/bank-accounts': typeof AuthenticatedSlugTeamSlugDashboardBankAccountsRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/billing': typeof AuthenticatedSlugTeamSlugDashboardBillingRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/categories': typeof AuthenticatedSlugTeamSlugDashboardCategoriesRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/chat': typeof AuthenticatedSlugTeamSlugDashboardChatRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/contacts': typeof AuthenticatedSlugTeamSlugDashboardContactsRouteWithChildren
+  '/_authenticated/$slug/$teamSlug/_dashboard/credit-cards': typeof AuthenticatedSlugTeamSlugDashboardCreditCardsRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/settings': typeof AuthenticatedSlugTeamSlugDashboardSettingsRouteWithChildren
+  '/_authenticated/$slug/$teamSlug/_dashboard/tags': typeof AuthenticatedSlugTeamSlugDashboardTagsRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/transactions': typeof AuthenticatedSlugTeamSlugDashboardTransactionsRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management': typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRouteWithChildren
+  '/_authenticated/$slug/$teamSlug/_dashboard/contacts/$contactId': typeof AuthenticatedSlugTeamSlugDashboardContactsContactIdRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/erp/services': typeof AuthenticatedSlugTeamSlugDashboardErpServicesRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/settings/customization': typeof AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/settings/danger-zone': typeof AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/settings/feature-previews': typeof AuthenticatedSlugTeamSlugDashboardSettingsFeaturePreviewsRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/settings/profile': typeof AuthenticatedSlugTeamSlugDashboardSettingsProfileRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/settings/security': typeof AuthenticatedSlugTeamSlugDashboardSettingsSecurityRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/contacts/': typeof AuthenticatedSlugTeamSlugDashboardContactsIndexRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/home/': typeof AuthenticatedSlugTeamSlugDashboardHomeIndexRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/inventory/': typeof AuthenticatedSlugTeamSlugDashboardInventoryIndexRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/settings/': typeof AuthenticatedSlugTeamSlugDashboardSettingsIndexRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/$dashboardId': typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsDashboardIdRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/destinations': typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementDestinationsRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/event-definitions': typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementEventDefinitionsRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/$insightId': typeof AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsInsightIdRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/danger-zone': typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationDangerZoneRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/general': typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationGeneralRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/members': typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationMembersRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/api-keys': typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectApiKeysRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/danger-zone': typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectDangerZoneRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/general': typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectGeneralRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/integrations': typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectIntegrationsRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/': typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsIndexRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/': typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementIndexRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/': typeof AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsIndexRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/ai-agents': typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsAiAgentsRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/contatos': typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsContatosRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/estoque': typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsEstoqueRoute
+  '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/financeiro': typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsFinanceiroRoute
 }
 export interface FileRouteTypes {
-   fileRoutesByFullPath: FileRoutesByFullPath;
-   fullPaths:
-      | "/"
-      | "/auth"
-      | "/$slug"
-      | "/onboarding"
-      | "/api/$"
-      | "/api/health"
-      | "/api/ping"
-      | "/auth/callback"
-      | "/auth/email-verification"
-      | "/auth/forgot-password"
-      | "/auth/magic-link"
-      | "/auth/sign-in"
-      | "/auth/sign-up"
-      | "/$slug/$teamSlug"
-      | "/api/auth/$"
-      | "/api/files/$"
-      | "/api/rpc/$"
-      | "/api/sdk/$"
-      | "/auth/sign-in/email"
-      | "/auth/sign-in/"
-      | "/callback/organization/invitation/$invitationId"
-      | "/$slug/$teamSlug/bank-accounts"
-      | "/$slug/$teamSlug/billing"
-      | "/$slug/$teamSlug/categories"
-      | "/$slug/$teamSlug/chat"
-      | "/$slug/$teamSlug/contacts"
-      | "/$slug/$teamSlug/credit-cards"
-      | "/$slug/$teamSlug/settings"
-      | "/$slug/$teamSlug/tags"
-      | "/$slug/$teamSlug/transactions"
-      | "/$slug/$teamSlug/analytics/data-management"
-      | "/$slug/$teamSlug/contacts/$contactId"
-      | "/$slug/$teamSlug/erp/services"
-      | "/$slug/$teamSlug/settings/customization"
-      | "/$slug/$teamSlug/settings/danger-zone"
-      | "/$slug/$teamSlug/settings/feature-previews"
-      | "/$slug/$teamSlug/settings/profile"
-      | "/$slug/$teamSlug/settings/security"
-      | "/$slug/$teamSlug/contacts/"
-      | "/$slug/$teamSlug/home/"
-      | "/$slug/$teamSlug/inventory/"
-      | "/$slug/$teamSlug/settings/"
-      | "/$slug/$teamSlug/analytics/dashboards/$dashboardId"
-      | "/$slug/$teamSlug/analytics/data-management/destinations"
-      | "/$slug/$teamSlug/analytics/data-management/event-definitions"
-      | "/$slug/$teamSlug/analytics/insights/$insightId"
-      | "/$slug/$teamSlug/settings/organization/danger-zone"
-      | "/$slug/$teamSlug/settings/organization/general"
-      | "/$slug/$teamSlug/settings/organization/members"
-      | "/$slug/$teamSlug/settings/project/api-keys"
-      | "/$slug/$teamSlug/settings/project/danger-zone"
-      | "/$slug/$teamSlug/settings/project/general"
-      | "/$slug/$teamSlug/settings/project/integrations"
-      | "/$slug/$teamSlug/analytics/dashboards/"
-      | "/$slug/$teamSlug/analytics/data-management/"
-      | "/$slug/$teamSlug/analytics/insights/"
-      | "/$slug/$teamSlug/settings/project/products/ai-agents"
-      | "/$slug/$teamSlug/settings/project/products/contatos"
-      | "/$slug/$teamSlug/settings/project/products/estoque"
-      | "/$slug/$teamSlug/settings/project/products/financeiro";
-   fileRoutesByTo: FileRoutesByTo;
-   to:
-      | "/"
-      | "/auth"
-      | "/$slug"
-      | "/onboarding"
-      | "/api/$"
-      | "/api/health"
-      | "/api/ping"
-      | "/auth/callback"
-      | "/auth/email-verification"
-      | "/auth/forgot-password"
-      | "/auth/magic-link"
-      | "/auth/sign-up"
-      | "/$slug/$teamSlug"
-      | "/api/auth/$"
-      | "/api/files/$"
-      | "/api/rpc/$"
-      | "/api/sdk/$"
-      | "/auth/sign-in/email"
-      | "/auth/sign-in"
-      | "/callback/organization/invitation/$invitationId"
-      | "/$slug/$teamSlug/bank-accounts"
-      | "/$slug/$teamSlug/billing"
-      | "/$slug/$teamSlug/categories"
-      | "/$slug/$teamSlug/chat"
-      | "/$slug/$teamSlug/credit-cards"
-      | "/$slug/$teamSlug/tags"
-      | "/$slug/$teamSlug/transactions"
-      | "/$slug/$teamSlug/contacts/$contactId"
-      | "/$slug/$teamSlug/erp/services"
-      | "/$slug/$teamSlug/settings/customization"
-      | "/$slug/$teamSlug/settings/danger-zone"
-      | "/$slug/$teamSlug/settings/feature-previews"
-      | "/$slug/$teamSlug/settings/profile"
-      | "/$slug/$teamSlug/settings/security"
-      | "/$slug/$teamSlug/contacts"
-      | "/$slug/$teamSlug/home"
-      | "/$slug/$teamSlug/inventory"
-      | "/$slug/$teamSlug/settings"
-      | "/$slug/$teamSlug/analytics/dashboards/$dashboardId"
-      | "/$slug/$teamSlug/analytics/data-management/destinations"
-      | "/$slug/$teamSlug/analytics/data-management/event-definitions"
-      | "/$slug/$teamSlug/analytics/insights/$insightId"
-      | "/$slug/$teamSlug/settings/organization/danger-zone"
-      | "/$slug/$teamSlug/settings/organization/general"
-      | "/$slug/$teamSlug/settings/organization/members"
-      | "/$slug/$teamSlug/settings/project/api-keys"
-      | "/$slug/$teamSlug/settings/project/danger-zone"
-      | "/$slug/$teamSlug/settings/project/general"
-      | "/$slug/$teamSlug/settings/project/integrations"
-      | "/$slug/$teamSlug/analytics/dashboards"
-      | "/$slug/$teamSlug/analytics/data-management"
-      | "/$slug/$teamSlug/analytics/insights"
-      | "/$slug/$teamSlug/settings/project/products/ai-agents"
-      | "/$slug/$teamSlug/settings/project/products/contatos"
-      | "/$slug/$teamSlug/settings/project/products/estoque"
-      | "/$slug/$teamSlug/settings/project/products/financeiro";
-   id:
-      | "__root__"
-      | "/"
-      | "/_authenticated"
-      | "/auth"
-      | "/_authenticated/$slug"
-      | "/_authenticated/onboarding"
-      | "/api/$"
-      | "/api/health"
-      | "/api/ping"
-      | "/auth/callback"
-      | "/auth/email-verification"
-      | "/auth/forgot-password"
-      | "/auth/magic-link"
-      | "/auth/sign-in"
-      | "/auth/sign-up"
-      | "/_authenticated/$slug/$teamSlug"
-      | "/api/auth/$"
-      | "/api/files/$"
-      | "/api/rpc/$"
-      | "/api/sdk/$"
-      | "/auth/sign-in/email"
-      | "/auth/sign-in/"
-      | "/_authenticated/$slug/$teamSlug/_dashboard"
-      | "/callback/organization/invitation/$invitationId"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/bank-accounts"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/billing"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/categories"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/chat"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/contacts"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/credit-cards"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/settings"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/tags"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/transactions"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/contacts/$contactId"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/erp/services"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/settings/customization"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/settings/danger-zone"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/settings/feature-previews"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/settings/profile"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/settings/security"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/contacts/"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/home/"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/inventory/"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/settings/"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/$dashboardId"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/destinations"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/event-definitions"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/$insightId"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/danger-zone"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/general"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/members"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/api-keys"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/danger-zone"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/general"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/integrations"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/ai-agents"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/contatos"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/estoque"
-      | "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/financeiro";
-   fileRoutesById: FileRoutesById;
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | '/'
+    | '/auth'
+    | '/$slug'
+    | '/onboarding'
+    | '/api/$'
+    | '/api/health'
+    | '/api/ping'
+    | '/auth/callback'
+    | '/auth/email-verification'
+    | '/auth/forgot-password'
+    | '/auth/magic-link'
+    | '/auth/sign-in'
+    | '/auth/sign-up'
+    | '/$slug/$teamSlug'
+    | '/api/auth/$'
+    | '/api/files/$'
+    | '/api/rpc/$'
+    | '/api/sdk/$'
+    | '/auth/sign-in/email'
+    | '/auth/sign-in/'
+    | '/callback/organization/invitation/$invitationId'
+    | '/$slug/$teamSlug/bank-accounts'
+    | '/$slug/$teamSlug/billing'
+    | '/$slug/$teamSlug/categories'
+    | '/$slug/$teamSlug/chat'
+    | '/$slug/$teamSlug/contacts'
+    | '/$slug/$teamSlug/credit-cards'
+    | '/$slug/$teamSlug/settings'
+    | '/$slug/$teamSlug/tags'
+    | '/$slug/$teamSlug/transactions'
+    | '/$slug/$teamSlug/analytics/data-management'
+    | '/$slug/$teamSlug/contacts/$contactId'
+    | '/$slug/$teamSlug/erp/services'
+    | '/$slug/$teamSlug/settings/customization'
+    | '/$slug/$teamSlug/settings/danger-zone'
+    | '/$slug/$teamSlug/settings/feature-previews'
+    | '/$slug/$teamSlug/settings/profile'
+    | '/$slug/$teamSlug/settings/security'
+    | '/$slug/$teamSlug/contacts/'
+    | '/$slug/$teamSlug/home/'
+    | '/$slug/$teamSlug/inventory/'
+    | '/$slug/$teamSlug/settings/'
+    | '/$slug/$teamSlug/analytics/dashboards/$dashboardId'
+    | '/$slug/$teamSlug/analytics/data-management/destinations'
+    | '/$slug/$teamSlug/analytics/data-management/event-definitions'
+    | '/$slug/$teamSlug/analytics/insights/$insightId'
+    | '/$slug/$teamSlug/settings/organization/danger-zone'
+    | '/$slug/$teamSlug/settings/organization/general'
+    | '/$slug/$teamSlug/settings/organization/members'
+    | '/$slug/$teamSlug/settings/project/api-keys'
+    | '/$slug/$teamSlug/settings/project/danger-zone'
+    | '/$slug/$teamSlug/settings/project/general'
+    | '/$slug/$teamSlug/settings/project/integrations'
+    | '/$slug/$teamSlug/analytics/dashboards/'
+    | '/$slug/$teamSlug/analytics/data-management/'
+    | '/$slug/$teamSlug/analytics/insights/'
+    | '/$slug/$teamSlug/settings/project/products/ai-agents'
+    | '/$slug/$teamSlug/settings/project/products/contatos'
+    | '/$slug/$teamSlug/settings/project/products/estoque'
+    | '/$slug/$teamSlug/settings/project/products/financeiro'
+  fileRoutesByTo: FileRoutesByTo
+  to:
+    | '/'
+    | '/auth'
+    | '/$slug'
+    | '/onboarding'
+    | '/api/$'
+    | '/api/health'
+    | '/api/ping'
+    | '/auth/callback'
+    | '/auth/email-verification'
+    | '/auth/forgot-password'
+    | '/auth/magic-link'
+    | '/auth/sign-up'
+    | '/$slug/$teamSlug'
+    | '/api/auth/$'
+    | '/api/files/$'
+    | '/api/rpc/$'
+    | '/api/sdk/$'
+    | '/auth/sign-in/email'
+    | '/auth/sign-in'
+    | '/callback/organization/invitation/$invitationId'
+    | '/$slug/$teamSlug/bank-accounts'
+    | '/$slug/$teamSlug/billing'
+    | '/$slug/$teamSlug/categories'
+    | '/$slug/$teamSlug/chat'
+    | '/$slug/$teamSlug/credit-cards'
+    | '/$slug/$teamSlug/tags'
+    | '/$slug/$teamSlug/transactions'
+    | '/$slug/$teamSlug/contacts/$contactId'
+    | '/$slug/$teamSlug/erp/services'
+    | '/$slug/$teamSlug/settings/customization'
+    | '/$slug/$teamSlug/settings/danger-zone'
+    | '/$slug/$teamSlug/settings/feature-previews'
+    | '/$slug/$teamSlug/settings/profile'
+    | '/$slug/$teamSlug/settings/security'
+    | '/$slug/$teamSlug/contacts'
+    | '/$slug/$teamSlug/home'
+    | '/$slug/$teamSlug/inventory'
+    | '/$slug/$teamSlug/settings'
+    | '/$slug/$teamSlug/analytics/dashboards/$dashboardId'
+    | '/$slug/$teamSlug/analytics/data-management/destinations'
+    | '/$slug/$teamSlug/analytics/data-management/event-definitions'
+    | '/$slug/$teamSlug/analytics/insights/$insightId'
+    | '/$slug/$teamSlug/settings/organization/danger-zone'
+    | '/$slug/$teamSlug/settings/organization/general'
+    | '/$slug/$teamSlug/settings/organization/members'
+    | '/$slug/$teamSlug/settings/project/api-keys'
+    | '/$slug/$teamSlug/settings/project/danger-zone'
+    | '/$slug/$teamSlug/settings/project/general'
+    | '/$slug/$teamSlug/settings/project/integrations'
+    | '/$slug/$teamSlug/analytics/dashboards'
+    | '/$slug/$teamSlug/analytics/data-management'
+    | '/$slug/$teamSlug/analytics/insights'
+    | '/$slug/$teamSlug/settings/project/products/ai-agents'
+    | '/$slug/$teamSlug/settings/project/products/contatos'
+    | '/$slug/$teamSlug/settings/project/products/estoque'
+    | '/$slug/$teamSlug/settings/project/products/financeiro'
+  id:
+    | '__root__'
+    | '/'
+    | '/_authenticated'
+    | '/auth'
+    | '/_authenticated/$slug'
+    | '/_authenticated/onboarding'
+    | '/api/$'
+    | '/api/health'
+    | '/api/ping'
+    | '/auth/callback'
+    | '/auth/email-verification'
+    | '/auth/forgot-password'
+    | '/auth/magic-link'
+    | '/auth/sign-in'
+    | '/auth/sign-up'
+    | '/_authenticated/$slug/$teamSlug'
+    | '/api/auth/$'
+    | '/api/files/$'
+    | '/api/rpc/$'
+    | '/api/sdk/$'
+    | '/auth/sign-in/email'
+    | '/auth/sign-in/'
+    | '/_authenticated/$slug/$teamSlug/_dashboard'
+    | '/callback/organization/invitation/$invitationId'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/bank-accounts'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/billing'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/categories'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/chat'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/contacts'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/credit-cards'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/settings'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/tags'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/transactions'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/contacts/$contactId'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/erp/services'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/settings/customization'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/settings/danger-zone'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/settings/feature-previews'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/settings/profile'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/settings/security'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/contacts/'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/home/'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/inventory/'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/settings/'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/$dashboardId'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/destinations'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/event-definitions'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/$insightId'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/danger-zone'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/general'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/members'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/api-keys'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/danger-zone'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/general'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/integrations'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/ai-agents'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/contatos'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/estoque'
+    | '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/financeiro'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-   IndexRoute: typeof IndexRoute;
-   AuthenticatedRoute: typeof AuthenticatedRouteWithChildren;
-   AuthRoute: typeof AuthRouteWithChildren;
-   ApiSplatRoute: typeof ApiSplatRoute;
-   ApiHealthRoute: typeof ApiHealthRoute;
-   ApiPingRoute: typeof ApiPingRoute;
-   ApiAuthSplatRoute: typeof ApiAuthSplatRoute;
-   ApiFilesSplatRoute: typeof ApiFilesSplatRoute;
-   ApiRpcSplatRoute: typeof ApiRpcSplatRoute;
-   ApiSdkSplatRoute: typeof ApiSdkSplatRoute;
-   CallbackOrganizationInvitationInvitationIdRoute: typeof CallbackOrganizationInvitationInvitationIdRoute;
+  IndexRoute: typeof IndexRoute
+  AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
+  AuthRoute: typeof AuthRouteWithChildren
+  ApiSplatRoute: typeof ApiSplatRoute
+  ApiHealthRoute: typeof ApiHealthRoute
+  ApiPingRoute: typeof ApiPingRoute
+  ApiAuthSplatRoute: typeof ApiAuthSplatRoute
+  ApiFilesSplatRoute: typeof ApiFilesSplatRoute
+  ApiRpcSplatRoute: typeof ApiRpcSplatRoute
+  ApiSdkSplatRoute: typeof ApiSdkSplatRoute
+  CallbackOrganizationInvitationInvitationIdRoute: typeof CallbackOrganizationInvitationInvitationIdRoute
 }
 
-declare module "@tanstack/react-router" {
-   interface FileRoutesByPath {
-      "/auth": {
-         id: "/auth";
-         path: "/auth";
-         fullPath: "/auth";
-         preLoaderRoute: typeof AuthRouteImport;
-         parentRoute: typeof rootRouteImport;
-      };
-      "/_authenticated": {
-         id: "/_authenticated";
-         path: "";
-         fullPath: "/";
-         preLoaderRoute: typeof AuthenticatedRouteImport;
-         parentRoute: typeof rootRouteImport;
-      };
-      "/": {
-         id: "/";
-         path: "/";
-         fullPath: "/";
-         preLoaderRoute: typeof IndexRouteImport;
-         parentRoute: typeof rootRouteImport;
-      };
-      "/auth/sign-up": {
-         id: "/auth/sign-up";
-         path: "/sign-up";
-         fullPath: "/auth/sign-up";
-         preLoaderRoute: typeof AuthSignUpRouteImport;
-         parentRoute: typeof AuthRoute;
-      };
-      "/auth/sign-in": {
-         id: "/auth/sign-in";
-         path: "/sign-in";
-         fullPath: "/auth/sign-in";
-         preLoaderRoute: typeof AuthSignInRouteImport;
-         parentRoute: typeof AuthRoute;
-      };
-      "/auth/magic-link": {
-         id: "/auth/magic-link";
-         path: "/magic-link";
-         fullPath: "/auth/magic-link";
-         preLoaderRoute: typeof AuthMagicLinkRouteImport;
-         parentRoute: typeof AuthRoute;
-      };
-      "/auth/forgot-password": {
-         id: "/auth/forgot-password";
-         path: "/forgot-password";
-         fullPath: "/auth/forgot-password";
-         preLoaderRoute: typeof AuthForgotPasswordRouteImport;
-         parentRoute: typeof AuthRoute;
-      };
-      "/auth/email-verification": {
-         id: "/auth/email-verification";
-         path: "/email-verification";
-         fullPath: "/auth/email-verification";
-         preLoaderRoute: typeof AuthEmailVerificationRouteImport;
-         parentRoute: typeof AuthRoute;
-      };
-      "/auth/callback": {
-         id: "/auth/callback";
-         path: "/callback";
-         fullPath: "/auth/callback";
-         preLoaderRoute: typeof AuthCallbackRouteImport;
-         parentRoute: typeof AuthRoute;
-      };
-      "/api/ping": {
-         id: "/api/ping";
-         path: "/api/ping";
-         fullPath: "/api/ping";
-         preLoaderRoute: typeof ApiPingRouteImport;
-         parentRoute: typeof rootRouteImport;
-      };
-      "/api/health": {
-         id: "/api/health";
-         path: "/api/health";
-         fullPath: "/api/health";
-         preLoaderRoute: typeof ApiHealthRouteImport;
-         parentRoute: typeof rootRouteImport;
-      };
-      "/api/$": {
-         id: "/api/$";
-         path: "/api/$";
-         fullPath: "/api/$";
-         preLoaderRoute: typeof ApiSplatRouteImport;
-         parentRoute: typeof rootRouteImport;
-      };
-      "/_authenticated/onboarding": {
-         id: "/_authenticated/onboarding";
-         path: "/onboarding";
-         fullPath: "/onboarding";
-         preLoaderRoute: typeof AuthenticatedOnboardingRouteImport;
-         parentRoute: typeof AuthenticatedRoute;
-      };
-      "/_authenticated/$slug": {
-         id: "/_authenticated/$slug";
-         path: "/$slug";
-         fullPath: "/$slug";
-         preLoaderRoute: typeof AuthenticatedSlugRouteImport;
-         parentRoute: typeof AuthenticatedRoute;
-      };
-      "/auth/sign-in/": {
-         id: "/auth/sign-in/";
-         path: "/";
-         fullPath: "/auth/sign-in/";
-         preLoaderRoute: typeof AuthSignInIndexRouteImport;
-         parentRoute: typeof AuthSignInRoute;
-      };
-      "/auth/sign-in/email": {
-         id: "/auth/sign-in/email";
-         path: "/email";
-         fullPath: "/auth/sign-in/email";
-         preLoaderRoute: typeof AuthSignInEmailRouteImport;
-         parentRoute: typeof AuthSignInRoute;
-      };
-      "/api/sdk/$": {
-         id: "/api/sdk/$";
-         path: "/api/sdk/$";
-         fullPath: "/api/sdk/$";
-         preLoaderRoute: typeof ApiSdkSplatRouteImport;
-         parentRoute: typeof rootRouteImport;
-      };
-      "/api/rpc/$": {
-         id: "/api/rpc/$";
-         path: "/api/rpc/$";
-         fullPath: "/api/rpc/$";
-         preLoaderRoute: typeof ApiRpcSplatRouteImport;
-         parentRoute: typeof rootRouteImport;
-      };
-      "/api/files/$": {
-         id: "/api/files/$";
-         path: "/api/files/$";
-         fullPath: "/api/files/$";
-         preLoaderRoute: typeof ApiFilesSplatRouteImport;
-         parentRoute: typeof rootRouteImport;
-      };
-      "/api/auth/$": {
-         id: "/api/auth/$";
-         path: "/api/auth/$";
-         fullPath: "/api/auth/$";
-         preLoaderRoute: typeof ApiAuthSplatRouteImport;
-         parentRoute: typeof rootRouteImport;
-      };
-      "/_authenticated/$slug/$teamSlug": {
-         id: "/_authenticated/$slug/$teamSlug";
-         path: "/$teamSlug";
-         fullPath: "/$slug/$teamSlug";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugRouteImport;
-         parentRoute: typeof AuthenticatedSlugRoute;
-      };
-      "/callback/organization/invitation/$invitationId": {
-         id: "/callback/organization/invitation/$invitationId";
-         path: "/callback/organization/invitation/$invitationId";
-         fullPath: "/callback/organization/invitation/$invitationId";
-         preLoaderRoute: typeof CallbackOrganizationInvitationInvitationIdRouteImport;
-         parentRoute: typeof rootRouteImport;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard";
-         path: "";
-         fullPath: "/$slug/$teamSlug";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/transactions": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/transactions";
-         path: "/transactions";
-         fullPath: "/$slug/$teamSlug/transactions";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardTransactionsRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/tags": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/tags";
-         path: "/tags";
-         fullPath: "/$slug/$teamSlug/tags";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardTagsRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/settings": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/settings";
-         path: "/settings";
-         fullPath: "/$slug/$teamSlug/settings";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/credit-cards": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/credit-cards";
-         path: "/credit-cards";
-         fullPath: "/$slug/$teamSlug/credit-cards";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardCreditCardsRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/contacts": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/contacts";
-         path: "/contacts";
-         fullPath: "/$slug/$teamSlug/contacts";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardContactsRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/chat": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/chat";
-         path: "/chat";
-         fullPath: "/$slug/$teamSlug/chat";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardChatRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/categories": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/categories";
-         path: "/categories";
-         fullPath: "/$slug/$teamSlug/categories";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardCategoriesRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/billing": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/billing";
-         path: "/billing";
-         fullPath: "/$slug/$teamSlug/billing";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardBillingRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/bank-accounts": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/bank-accounts";
-         path: "/bank-accounts";
-         fullPath: "/$slug/$teamSlug/bank-accounts";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardBankAccountsRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/settings/": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/settings/";
-         path: "/";
-         fullPath: "/$slug/$teamSlug/settings/";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsIndexRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/inventory/": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/inventory/";
-         path: "/inventory";
-         fullPath: "/$slug/$teamSlug/inventory/";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardInventoryIndexRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/home/": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/home/";
-         path: "/home";
-         fullPath: "/$slug/$teamSlug/home/";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardHomeIndexRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/contacts/": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/contacts/";
-         path: "/";
-         fullPath: "/$slug/$teamSlug/contacts/";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardContactsIndexRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardContactsRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/settings/security": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/settings/security";
-         path: "/security";
-         fullPath: "/$slug/$teamSlug/settings/security";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsSecurityRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/settings/profile": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/settings/profile";
-         path: "/profile";
-         fullPath: "/$slug/$teamSlug/settings/profile";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProfileRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/settings/feature-previews": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/settings/feature-previews";
-         path: "/feature-previews";
-         fullPath: "/$slug/$teamSlug/settings/feature-previews";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsFeaturePreviewsRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/settings/danger-zone": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/settings/danger-zone";
-         path: "/danger-zone";
-         fullPath: "/$slug/$teamSlug/settings/danger-zone";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/settings/customization": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/settings/customization";
-         path: "/customization";
-         fullPath: "/$slug/$teamSlug/settings/customization";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/erp/services": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/erp/services";
-         path: "/erp/services";
-         fullPath: "/$slug/$teamSlug/erp/services";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardErpServicesRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/contacts/$contactId": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/contacts/$contactId";
-         path: "/$contactId";
-         fullPath: "/$slug/$teamSlug/contacts/$contactId";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardContactsContactIdRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardContactsRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management";
-         path: "/analytics/data-management";
-         fullPath: "/$slug/$teamSlug/analytics/data-management";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/";
-         path: "/analytics/insights";
-         fullPath: "/$slug/$teamSlug/analytics/insights/";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsIndexRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/";
-         path: "/";
-         fullPath: "/$slug/$teamSlug/analytics/data-management/";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementIndexRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/";
-         path: "/analytics/dashboards";
-         fullPath: "/$slug/$teamSlug/analytics/dashboards/";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsIndexRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/integrations": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/integrations";
-         path: "/project/integrations";
-         fullPath: "/$slug/$teamSlug/settings/project/integrations";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectIntegrationsRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/general": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/general";
-         path: "/project/general";
-         fullPath: "/$slug/$teamSlug/settings/project/general";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectGeneralRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/danger-zone": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/danger-zone";
-         path: "/project/danger-zone";
-         fullPath: "/$slug/$teamSlug/settings/project/danger-zone";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectDangerZoneRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/api-keys": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/api-keys";
-         path: "/project/api-keys";
-         fullPath: "/$slug/$teamSlug/settings/project/api-keys";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectApiKeysRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/members": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/members";
-         path: "/organization/members";
-         fullPath: "/$slug/$teamSlug/settings/organization/members";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationMembersRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/general": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/general";
-         path: "/organization/general";
-         fullPath: "/$slug/$teamSlug/settings/organization/general";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationGeneralRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/danger-zone": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/danger-zone";
-         path: "/organization/danger-zone";
-         fullPath: "/$slug/$teamSlug/settings/organization/danger-zone";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationDangerZoneRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/$insightId": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/$insightId";
-         path: "/analytics/insights/$insightId";
-         fullPath: "/$slug/$teamSlug/analytics/insights/$insightId";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsInsightIdRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/event-definitions": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/event-definitions";
-         path: "/event-definitions";
-         fullPath: "/$slug/$teamSlug/analytics/data-management/event-definitions";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementEventDefinitionsRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/destinations": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/destinations";
-         path: "/destinations";
-         fullPath: "/$slug/$teamSlug/analytics/data-management/destinations";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementDestinationsRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/$dashboardId": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/$dashboardId";
-         path: "/analytics/dashboards/$dashboardId";
-         fullPath: "/$slug/$teamSlug/analytics/dashboards/$dashboardId";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsDashboardIdRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/financeiro": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/financeiro";
-         path: "/project/products/financeiro";
-         fullPath: "/$slug/$teamSlug/settings/project/products/financeiro";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsFinanceiroRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/estoque": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/estoque";
-         path: "/project/products/estoque";
-         fullPath: "/$slug/$teamSlug/settings/project/products/estoque";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsEstoqueRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/contatos": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/contatos";
-         path: "/project/products/contatos";
-         fullPath: "/$slug/$teamSlug/settings/project/products/contatos";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsContatosRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute;
-      };
-      "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/ai-agents": {
-         id: "/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/ai-agents";
-         path: "/project/products/ai-agents";
-         fullPath: "/$slug/$teamSlug/settings/project/products/ai-agents";
-         preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsAiAgentsRouteImport;
-         parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute;
-      };
-   }
+declare module '@tanstack/react-router' {
+  interface FileRoutesByPath {
+    '/auth': {
+      id: '/auth'
+      path: '/auth'
+      fullPath: '/auth'
+      preLoaderRoute: typeof AuthRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_authenticated': {
+      id: '/_authenticated'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof AuthenticatedRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auth/sign-up': {
+      id: '/auth/sign-up'
+      path: '/sign-up'
+      fullPath: '/auth/sign-up'
+      preLoaderRoute: typeof AuthSignUpRouteImport
+      parentRoute: typeof AuthRoute
+    }
+    '/auth/sign-in': {
+      id: '/auth/sign-in'
+      path: '/sign-in'
+      fullPath: '/auth/sign-in'
+      preLoaderRoute: typeof AuthSignInRouteImport
+      parentRoute: typeof AuthRoute
+    }
+    '/auth/magic-link': {
+      id: '/auth/magic-link'
+      path: '/magic-link'
+      fullPath: '/auth/magic-link'
+      preLoaderRoute: typeof AuthMagicLinkRouteImport
+      parentRoute: typeof AuthRoute
+    }
+    '/auth/forgot-password': {
+      id: '/auth/forgot-password'
+      path: '/forgot-password'
+      fullPath: '/auth/forgot-password'
+      preLoaderRoute: typeof AuthForgotPasswordRouteImport
+      parentRoute: typeof AuthRoute
+    }
+    '/auth/email-verification': {
+      id: '/auth/email-verification'
+      path: '/email-verification'
+      fullPath: '/auth/email-verification'
+      preLoaderRoute: typeof AuthEmailVerificationRouteImport
+      parentRoute: typeof AuthRoute
+    }
+    '/auth/callback': {
+      id: '/auth/callback'
+      path: '/callback'
+      fullPath: '/auth/callback'
+      preLoaderRoute: typeof AuthCallbackRouteImport
+      parentRoute: typeof AuthRoute
+    }
+    '/api/ping': {
+      id: '/api/ping'
+      path: '/api/ping'
+      fullPath: '/api/ping'
+      preLoaderRoute: typeof ApiPingRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/health': {
+      id: '/api/health'
+      path: '/api/health'
+      fullPath: '/api/health'
+      preLoaderRoute: typeof ApiHealthRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/$': {
+      id: '/api/$'
+      path: '/api/$'
+      fullPath: '/api/$'
+      preLoaderRoute: typeof ApiSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_authenticated/onboarding': {
+      id: '/_authenticated/onboarding'
+      path: '/onboarding'
+      fullPath: '/onboarding'
+      preLoaderRoute: typeof AuthenticatedOnboardingRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/$slug': {
+      id: '/_authenticated/$slug'
+      path: '/$slug'
+      fullPath: '/$slug'
+      preLoaderRoute: typeof AuthenticatedSlugRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/auth/sign-in/': {
+      id: '/auth/sign-in/'
+      path: '/'
+      fullPath: '/auth/sign-in/'
+      preLoaderRoute: typeof AuthSignInIndexRouteImport
+      parentRoute: typeof AuthSignInRoute
+    }
+    '/auth/sign-in/email': {
+      id: '/auth/sign-in/email'
+      path: '/email'
+      fullPath: '/auth/sign-in/email'
+      preLoaderRoute: typeof AuthSignInEmailRouteImport
+      parentRoute: typeof AuthSignInRoute
+    }
+    '/api/sdk/$': {
+      id: '/api/sdk/$'
+      path: '/api/sdk/$'
+      fullPath: '/api/sdk/$'
+      preLoaderRoute: typeof ApiSdkSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/rpc/$': {
+      id: '/api/rpc/$'
+      path: '/api/rpc/$'
+      fullPath: '/api/rpc/$'
+      preLoaderRoute: typeof ApiRpcSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/files/$': {
+      id: '/api/files/$'
+      path: '/api/files/$'
+      fullPath: '/api/files/$'
+      preLoaderRoute: typeof ApiFilesSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/auth/$': {
+      id: '/api/auth/$'
+      path: '/api/auth/$'
+      fullPath: '/api/auth/$'
+      preLoaderRoute: typeof ApiAuthSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_authenticated/$slug/$teamSlug': {
+      id: '/_authenticated/$slug/$teamSlug'
+      path: '/$teamSlug'
+      fullPath: '/$slug/$teamSlug'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugRouteImport
+      parentRoute: typeof AuthenticatedSlugRoute
+    }
+    '/callback/organization/invitation/$invitationId': {
+      id: '/callback/organization/invitation/$invitationId'
+      path: '/callback/organization/invitation/$invitationId'
+      fullPath: '/callback/organization/invitation/$invitationId'
+      preLoaderRoute: typeof CallbackOrganizationInvitationInvitationIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard'
+      path: ''
+      fullPath: '/$slug/$teamSlug'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/transactions': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/transactions'
+      path: '/transactions'
+      fullPath: '/$slug/$teamSlug/transactions'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardTransactionsRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/tags': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/tags'
+      path: '/tags'
+      fullPath: '/$slug/$teamSlug/tags'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardTagsRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/settings': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/settings'
+      path: '/settings'
+      fullPath: '/$slug/$teamSlug/settings'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/credit-cards': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/credit-cards'
+      path: '/credit-cards'
+      fullPath: '/$slug/$teamSlug/credit-cards'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardCreditCardsRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/contacts': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/contacts'
+      path: '/contacts'
+      fullPath: '/$slug/$teamSlug/contacts'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardContactsRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/chat': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/chat'
+      path: '/chat'
+      fullPath: '/$slug/$teamSlug/chat'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardChatRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/categories': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/categories'
+      path: '/categories'
+      fullPath: '/$slug/$teamSlug/categories'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardCategoriesRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/billing': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/billing'
+      path: '/billing'
+      fullPath: '/$slug/$teamSlug/billing'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardBillingRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/bank-accounts': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/bank-accounts'
+      path: '/bank-accounts'
+      fullPath: '/$slug/$teamSlug/bank-accounts'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardBankAccountsRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/settings/': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/settings/'
+      path: '/'
+      fullPath: '/$slug/$teamSlug/settings/'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsIndexRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/inventory/': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/inventory/'
+      path: '/inventory'
+      fullPath: '/$slug/$teamSlug/inventory/'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardInventoryIndexRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/home/': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/home/'
+      path: '/home'
+      fullPath: '/$slug/$teamSlug/home/'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardHomeIndexRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/contacts/': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/contacts/'
+      path: '/'
+      fullPath: '/$slug/$teamSlug/contacts/'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardContactsIndexRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardContactsRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/settings/security': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/settings/security'
+      path: '/security'
+      fullPath: '/$slug/$teamSlug/settings/security'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsSecurityRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/settings/profile': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/settings/profile'
+      path: '/profile'
+      fullPath: '/$slug/$teamSlug/settings/profile'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProfileRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/settings/feature-previews': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/settings/feature-previews'
+      path: '/feature-previews'
+      fullPath: '/$slug/$teamSlug/settings/feature-previews'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsFeaturePreviewsRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/settings/danger-zone': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/settings/danger-zone'
+      path: '/danger-zone'
+      fullPath: '/$slug/$teamSlug/settings/danger-zone'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/settings/customization': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/settings/customization'
+      path: '/customization'
+      fullPath: '/$slug/$teamSlug/settings/customization'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/erp/services': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/erp/services'
+      path: '/erp/services'
+      fullPath: '/$slug/$teamSlug/erp/services'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardErpServicesRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/contacts/$contactId': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/contacts/$contactId'
+      path: '/$contactId'
+      fullPath: '/$slug/$teamSlug/contacts/$contactId'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardContactsContactIdRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardContactsRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management'
+      path: '/analytics/data-management'
+      fullPath: '/$slug/$teamSlug/analytics/data-management'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/'
+      path: '/analytics/insights'
+      fullPath: '/$slug/$teamSlug/analytics/insights/'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsIndexRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/'
+      path: '/'
+      fullPath: '/$slug/$teamSlug/analytics/data-management/'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementIndexRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/'
+      path: '/analytics/dashboards'
+      fullPath: '/$slug/$teamSlug/analytics/dashboards/'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsIndexRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/integrations': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/integrations'
+      path: '/project/integrations'
+      fullPath: '/$slug/$teamSlug/settings/project/integrations'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectIntegrationsRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/general': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/general'
+      path: '/project/general'
+      fullPath: '/$slug/$teamSlug/settings/project/general'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectGeneralRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/danger-zone': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/danger-zone'
+      path: '/project/danger-zone'
+      fullPath: '/$slug/$teamSlug/settings/project/danger-zone'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectDangerZoneRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/api-keys': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/api-keys'
+      path: '/project/api-keys'
+      fullPath: '/$slug/$teamSlug/settings/project/api-keys'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectApiKeysRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/members': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/members'
+      path: '/organization/members'
+      fullPath: '/$slug/$teamSlug/settings/organization/members'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationMembersRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/general': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/general'
+      path: '/organization/general'
+      fullPath: '/$slug/$teamSlug/settings/organization/general'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationGeneralRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/danger-zone': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/danger-zone'
+      path: '/organization/danger-zone'
+      fullPath: '/$slug/$teamSlug/settings/organization/danger-zone'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationDangerZoneRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/$insightId': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/analytics/insights/$insightId'
+      path: '/analytics/insights/$insightId'
+      fullPath: '/$slug/$teamSlug/analytics/insights/$insightId'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsInsightIdRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/event-definitions': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/event-definitions'
+      path: '/event-definitions'
+      fullPath: '/$slug/$teamSlug/analytics/data-management/event-definitions'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementEventDefinitionsRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/destinations': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/analytics/data-management/destinations'
+      path: '/destinations'
+      fullPath: '/$slug/$teamSlug/analytics/data-management/destinations'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementDestinationsRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/$dashboardId': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/analytics/dashboards/$dashboardId'
+      path: '/analytics/dashboards/$dashboardId'
+      fullPath: '/$slug/$teamSlug/analytics/dashboards/$dashboardId'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsDashboardIdRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/financeiro': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/financeiro'
+      path: '/project/products/financeiro'
+      fullPath: '/$slug/$teamSlug/settings/project/products/financeiro'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsFinanceiroRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/estoque': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/estoque'
+      path: '/project/products/estoque'
+      fullPath: '/$slug/$teamSlug/settings/project/products/estoque'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsEstoqueRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/contatos': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/contatos'
+      path: '/project/products/contatos'
+      fullPath: '/$slug/$teamSlug/settings/project/products/contatos'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsContatosRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute
+    }
+    '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/ai-agents': {
+      id: '/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/ai-agents'
+      path: '/project/products/ai-agents'
+      fullPath: '/$slug/$teamSlug/settings/project/products/ai-agents'
+      preLoaderRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsAiAgentsRouteImport
+      parentRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRoute
+    }
+  }
 }
 
 interface AuthenticatedSlugTeamSlugDashboardContactsRouteChildren {
-   AuthenticatedSlugTeamSlugDashboardContactsContactIdRoute: typeof AuthenticatedSlugTeamSlugDashboardContactsContactIdRoute;
-   AuthenticatedSlugTeamSlugDashboardContactsIndexRoute: typeof AuthenticatedSlugTeamSlugDashboardContactsIndexRoute;
+  AuthenticatedSlugTeamSlugDashboardContactsContactIdRoute: typeof AuthenticatedSlugTeamSlugDashboardContactsContactIdRoute
+  AuthenticatedSlugTeamSlugDashboardContactsIndexRoute: typeof AuthenticatedSlugTeamSlugDashboardContactsIndexRoute
 }
 
 const AuthenticatedSlugTeamSlugDashboardContactsRouteChildren: AuthenticatedSlugTeamSlugDashboardContactsRouteChildren =
-   {
-      AuthenticatedSlugTeamSlugDashboardContactsContactIdRoute:
-         AuthenticatedSlugTeamSlugDashboardContactsContactIdRoute,
-      AuthenticatedSlugTeamSlugDashboardContactsIndexRoute:
-         AuthenticatedSlugTeamSlugDashboardContactsIndexRoute,
-   };
+  {
+    AuthenticatedSlugTeamSlugDashboardContactsContactIdRoute:
+      AuthenticatedSlugTeamSlugDashboardContactsContactIdRoute,
+    AuthenticatedSlugTeamSlugDashboardContactsIndexRoute:
+      AuthenticatedSlugTeamSlugDashboardContactsIndexRoute,
+  }
 
 const AuthenticatedSlugTeamSlugDashboardContactsRouteWithChildren =
-   AuthenticatedSlugTeamSlugDashboardContactsRoute._addFileChildren(
-      AuthenticatedSlugTeamSlugDashboardContactsRouteChildren,
-   );
+  AuthenticatedSlugTeamSlugDashboardContactsRoute._addFileChildren(
+    AuthenticatedSlugTeamSlugDashboardContactsRouteChildren,
+  )
 
 interface AuthenticatedSlugTeamSlugDashboardSettingsRouteChildren {
-   AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRoute;
-   AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRoute;
-   AuthenticatedSlugTeamSlugDashboardSettingsFeaturePreviewsRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsFeaturePreviewsRoute;
-   AuthenticatedSlugTeamSlugDashboardSettingsProfileRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProfileRoute;
-   AuthenticatedSlugTeamSlugDashboardSettingsSecurityRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsSecurityRoute;
-   AuthenticatedSlugTeamSlugDashboardSettingsIndexRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsIndexRoute;
-   AuthenticatedSlugTeamSlugDashboardSettingsOrganizationDangerZoneRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationDangerZoneRoute;
-   AuthenticatedSlugTeamSlugDashboardSettingsOrganizationGeneralRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationGeneralRoute;
-   AuthenticatedSlugTeamSlugDashboardSettingsOrganizationMembersRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationMembersRoute;
-   AuthenticatedSlugTeamSlugDashboardSettingsProjectApiKeysRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectApiKeysRoute;
-   AuthenticatedSlugTeamSlugDashboardSettingsProjectDangerZoneRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectDangerZoneRoute;
-   AuthenticatedSlugTeamSlugDashboardSettingsProjectGeneralRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectGeneralRoute;
-   AuthenticatedSlugTeamSlugDashboardSettingsProjectIntegrationsRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectIntegrationsRoute;
-   AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsAiAgentsRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsAiAgentsRoute;
-   AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsContatosRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsContatosRoute;
-   AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsEstoqueRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsEstoqueRoute;
-   AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsFinanceiroRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsFinanceiroRoute;
+  AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRoute
+  AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRoute
+  AuthenticatedSlugTeamSlugDashboardSettingsFeaturePreviewsRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsFeaturePreviewsRoute
+  AuthenticatedSlugTeamSlugDashboardSettingsProfileRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProfileRoute
+  AuthenticatedSlugTeamSlugDashboardSettingsSecurityRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsSecurityRoute
+  AuthenticatedSlugTeamSlugDashboardSettingsIndexRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsIndexRoute
+  AuthenticatedSlugTeamSlugDashboardSettingsOrganizationDangerZoneRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationDangerZoneRoute
+  AuthenticatedSlugTeamSlugDashboardSettingsOrganizationGeneralRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationGeneralRoute
+  AuthenticatedSlugTeamSlugDashboardSettingsOrganizationMembersRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsOrganizationMembersRoute
+  AuthenticatedSlugTeamSlugDashboardSettingsProjectApiKeysRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectApiKeysRoute
+  AuthenticatedSlugTeamSlugDashboardSettingsProjectDangerZoneRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectDangerZoneRoute
+  AuthenticatedSlugTeamSlugDashboardSettingsProjectGeneralRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectGeneralRoute
+  AuthenticatedSlugTeamSlugDashboardSettingsProjectIntegrationsRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectIntegrationsRoute
+  AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsAiAgentsRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsAiAgentsRoute
+  AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsContatosRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsContatosRoute
+  AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsEstoqueRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsEstoqueRoute
+  AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsFinanceiroRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsFinanceiroRoute
 }
 
 const AuthenticatedSlugTeamSlugDashboardSettingsRouteChildren: AuthenticatedSlugTeamSlugDashboardSettingsRouteChildren =
-   {
-      AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRoute:
-         AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRoute,
-      AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRoute:
-         AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRoute,
-      AuthenticatedSlugTeamSlugDashboardSettingsFeaturePreviewsRoute:
-         AuthenticatedSlugTeamSlugDashboardSettingsFeaturePreviewsRoute,
-      AuthenticatedSlugTeamSlugDashboardSettingsProfileRoute:
-         AuthenticatedSlugTeamSlugDashboardSettingsProfileRoute,
-      AuthenticatedSlugTeamSlugDashboardSettingsSecurityRoute:
-         AuthenticatedSlugTeamSlugDashboardSettingsSecurityRoute,
-      AuthenticatedSlugTeamSlugDashboardSettingsIndexRoute:
-         AuthenticatedSlugTeamSlugDashboardSettingsIndexRoute,
-      AuthenticatedSlugTeamSlugDashboardSettingsOrganizationDangerZoneRoute:
-         AuthenticatedSlugTeamSlugDashboardSettingsOrganizationDangerZoneRoute,
-      AuthenticatedSlugTeamSlugDashboardSettingsOrganizationGeneralRoute:
-         AuthenticatedSlugTeamSlugDashboardSettingsOrganizationGeneralRoute,
-      AuthenticatedSlugTeamSlugDashboardSettingsOrganizationMembersRoute:
-         AuthenticatedSlugTeamSlugDashboardSettingsOrganizationMembersRoute,
-      AuthenticatedSlugTeamSlugDashboardSettingsProjectApiKeysRoute:
-         AuthenticatedSlugTeamSlugDashboardSettingsProjectApiKeysRoute,
-      AuthenticatedSlugTeamSlugDashboardSettingsProjectDangerZoneRoute:
-         AuthenticatedSlugTeamSlugDashboardSettingsProjectDangerZoneRoute,
-      AuthenticatedSlugTeamSlugDashboardSettingsProjectGeneralRoute:
-         AuthenticatedSlugTeamSlugDashboardSettingsProjectGeneralRoute,
-      AuthenticatedSlugTeamSlugDashboardSettingsProjectIntegrationsRoute:
-         AuthenticatedSlugTeamSlugDashboardSettingsProjectIntegrationsRoute,
-      AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsAiAgentsRoute:
-         AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsAiAgentsRoute,
-      AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsContatosRoute:
-         AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsContatosRoute,
-      AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsEstoqueRoute:
-         AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsEstoqueRoute,
-      AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsFinanceiroRoute:
-         AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsFinanceiroRoute,
-   };
+  {
+    AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRoute:
+      AuthenticatedSlugTeamSlugDashboardSettingsCustomizationRoute,
+    AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRoute:
+      AuthenticatedSlugTeamSlugDashboardSettingsDangerZoneRoute,
+    AuthenticatedSlugTeamSlugDashboardSettingsFeaturePreviewsRoute:
+      AuthenticatedSlugTeamSlugDashboardSettingsFeaturePreviewsRoute,
+    AuthenticatedSlugTeamSlugDashboardSettingsProfileRoute:
+      AuthenticatedSlugTeamSlugDashboardSettingsProfileRoute,
+    AuthenticatedSlugTeamSlugDashboardSettingsSecurityRoute:
+      AuthenticatedSlugTeamSlugDashboardSettingsSecurityRoute,
+    AuthenticatedSlugTeamSlugDashboardSettingsIndexRoute:
+      AuthenticatedSlugTeamSlugDashboardSettingsIndexRoute,
+    AuthenticatedSlugTeamSlugDashboardSettingsOrganizationDangerZoneRoute:
+      AuthenticatedSlugTeamSlugDashboardSettingsOrganizationDangerZoneRoute,
+    AuthenticatedSlugTeamSlugDashboardSettingsOrganizationGeneralRoute:
+      AuthenticatedSlugTeamSlugDashboardSettingsOrganizationGeneralRoute,
+    AuthenticatedSlugTeamSlugDashboardSettingsOrganizationMembersRoute:
+      AuthenticatedSlugTeamSlugDashboardSettingsOrganizationMembersRoute,
+    AuthenticatedSlugTeamSlugDashboardSettingsProjectApiKeysRoute:
+      AuthenticatedSlugTeamSlugDashboardSettingsProjectApiKeysRoute,
+    AuthenticatedSlugTeamSlugDashboardSettingsProjectDangerZoneRoute:
+      AuthenticatedSlugTeamSlugDashboardSettingsProjectDangerZoneRoute,
+    AuthenticatedSlugTeamSlugDashboardSettingsProjectGeneralRoute:
+      AuthenticatedSlugTeamSlugDashboardSettingsProjectGeneralRoute,
+    AuthenticatedSlugTeamSlugDashboardSettingsProjectIntegrationsRoute:
+      AuthenticatedSlugTeamSlugDashboardSettingsProjectIntegrationsRoute,
+    AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsAiAgentsRoute:
+      AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsAiAgentsRoute,
+    AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsContatosRoute:
+      AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsContatosRoute,
+    AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsEstoqueRoute:
+      AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsEstoqueRoute,
+    AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsFinanceiroRoute:
+      AuthenticatedSlugTeamSlugDashboardSettingsProjectProductsFinanceiroRoute,
+  }
 
 const AuthenticatedSlugTeamSlugDashboardSettingsRouteWithChildren =
-   AuthenticatedSlugTeamSlugDashboardSettingsRoute._addFileChildren(
-      AuthenticatedSlugTeamSlugDashboardSettingsRouteChildren,
-   );
+  AuthenticatedSlugTeamSlugDashboardSettingsRoute._addFileChildren(
+    AuthenticatedSlugTeamSlugDashboardSettingsRouteChildren,
+  )
 
 interface AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRouteChildren {
-   AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementDestinationsRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementDestinationsRoute;
-   AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementEventDefinitionsRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementEventDefinitionsRoute;
-   AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementIndexRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementIndexRoute;
+  AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementDestinationsRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementDestinationsRoute
+  AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementEventDefinitionsRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementEventDefinitionsRoute
+  AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementIndexRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementIndexRoute
 }
 
 const AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRouteChildren: AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRouteChildren =
-   {
-      AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementDestinationsRoute:
-         AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementDestinationsRoute,
-      AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementEventDefinitionsRoute:
-         AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementEventDefinitionsRoute,
-      AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementIndexRoute:
-         AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementIndexRoute,
-   };
+  {
+    AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementDestinationsRoute:
+      AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementDestinationsRoute,
+    AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementEventDefinitionsRoute:
+      AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementEventDefinitionsRoute,
+    AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementIndexRoute:
+      AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementIndexRoute,
+  }
 
 const AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRouteWithChildren =
-   AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRoute._addFileChildren(
-      AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRouteChildren,
-   );
+  AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRoute._addFileChildren(
+    AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRouteChildren,
+  )
 
 interface AuthenticatedSlugTeamSlugDashboardRouteChildren {
-   AuthenticatedSlugTeamSlugDashboardBankAccountsRoute: typeof AuthenticatedSlugTeamSlugDashboardBankAccountsRoute;
-   AuthenticatedSlugTeamSlugDashboardBillingRoute: typeof AuthenticatedSlugTeamSlugDashboardBillingRoute;
-   AuthenticatedSlugTeamSlugDashboardCategoriesRoute: typeof AuthenticatedSlugTeamSlugDashboardCategoriesRoute;
-   AuthenticatedSlugTeamSlugDashboardChatRoute: typeof AuthenticatedSlugTeamSlugDashboardChatRoute;
-   AuthenticatedSlugTeamSlugDashboardContactsRoute: typeof AuthenticatedSlugTeamSlugDashboardContactsRouteWithChildren;
-   AuthenticatedSlugTeamSlugDashboardCreditCardsRoute: typeof AuthenticatedSlugTeamSlugDashboardCreditCardsRoute;
-   AuthenticatedSlugTeamSlugDashboardSettingsRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRouteWithChildren;
-   AuthenticatedSlugTeamSlugDashboardTagsRoute: typeof AuthenticatedSlugTeamSlugDashboardTagsRoute;
-   AuthenticatedSlugTeamSlugDashboardTransactionsRoute: typeof AuthenticatedSlugTeamSlugDashboardTransactionsRoute;
-   AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRouteWithChildren;
-   AuthenticatedSlugTeamSlugDashboardErpServicesRoute: typeof AuthenticatedSlugTeamSlugDashboardErpServicesRoute;
-   AuthenticatedSlugTeamSlugDashboardHomeIndexRoute: typeof AuthenticatedSlugTeamSlugDashboardHomeIndexRoute;
-   AuthenticatedSlugTeamSlugDashboardInventoryIndexRoute: typeof AuthenticatedSlugTeamSlugDashboardInventoryIndexRoute;
-   AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsDashboardIdRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsDashboardIdRoute;
-   AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsInsightIdRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsInsightIdRoute;
-   AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsIndexRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsIndexRoute;
-   AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsIndexRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsIndexRoute;
+  AuthenticatedSlugTeamSlugDashboardBankAccountsRoute: typeof AuthenticatedSlugTeamSlugDashboardBankAccountsRoute
+  AuthenticatedSlugTeamSlugDashboardBillingRoute: typeof AuthenticatedSlugTeamSlugDashboardBillingRoute
+  AuthenticatedSlugTeamSlugDashboardCategoriesRoute: typeof AuthenticatedSlugTeamSlugDashboardCategoriesRoute
+  AuthenticatedSlugTeamSlugDashboardChatRoute: typeof AuthenticatedSlugTeamSlugDashboardChatRoute
+  AuthenticatedSlugTeamSlugDashboardContactsRoute: typeof AuthenticatedSlugTeamSlugDashboardContactsRouteWithChildren
+  AuthenticatedSlugTeamSlugDashboardCreditCardsRoute: typeof AuthenticatedSlugTeamSlugDashboardCreditCardsRoute
+  AuthenticatedSlugTeamSlugDashboardSettingsRoute: typeof AuthenticatedSlugTeamSlugDashboardSettingsRouteWithChildren
+  AuthenticatedSlugTeamSlugDashboardTagsRoute: typeof AuthenticatedSlugTeamSlugDashboardTagsRoute
+  AuthenticatedSlugTeamSlugDashboardTransactionsRoute: typeof AuthenticatedSlugTeamSlugDashboardTransactionsRoute
+  AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRouteWithChildren
+  AuthenticatedSlugTeamSlugDashboardErpServicesRoute: typeof AuthenticatedSlugTeamSlugDashboardErpServicesRoute
+  AuthenticatedSlugTeamSlugDashboardHomeIndexRoute: typeof AuthenticatedSlugTeamSlugDashboardHomeIndexRoute
+  AuthenticatedSlugTeamSlugDashboardInventoryIndexRoute: typeof AuthenticatedSlugTeamSlugDashboardInventoryIndexRoute
+  AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsDashboardIdRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsDashboardIdRoute
+  AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsInsightIdRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsInsightIdRoute
+  AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsIndexRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsIndexRoute
+  AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsIndexRoute: typeof AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsIndexRoute
 }
 
 const AuthenticatedSlugTeamSlugDashboardRouteChildren: AuthenticatedSlugTeamSlugDashboardRouteChildren =
-   {
-      AuthenticatedSlugTeamSlugDashboardBankAccountsRoute:
-         AuthenticatedSlugTeamSlugDashboardBankAccountsRoute,
-      AuthenticatedSlugTeamSlugDashboardBillingRoute:
-         AuthenticatedSlugTeamSlugDashboardBillingRoute,
-      AuthenticatedSlugTeamSlugDashboardCategoriesRoute:
-         AuthenticatedSlugTeamSlugDashboardCategoriesRoute,
-      AuthenticatedSlugTeamSlugDashboardChatRoute:
-         AuthenticatedSlugTeamSlugDashboardChatRoute,
-      AuthenticatedSlugTeamSlugDashboardContactsRoute:
-         AuthenticatedSlugTeamSlugDashboardContactsRouteWithChildren,
-      AuthenticatedSlugTeamSlugDashboardCreditCardsRoute:
-         AuthenticatedSlugTeamSlugDashboardCreditCardsRoute,
-      AuthenticatedSlugTeamSlugDashboardSettingsRoute:
-         AuthenticatedSlugTeamSlugDashboardSettingsRouteWithChildren,
-      AuthenticatedSlugTeamSlugDashboardTagsRoute:
-         AuthenticatedSlugTeamSlugDashboardTagsRoute,
-      AuthenticatedSlugTeamSlugDashboardTransactionsRoute:
-         AuthenticatedSlugTeamSlugDashboardTransactionsRoute,
-      AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRoute:
-         AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRouteWithChildren,
-      AuthenticatedSlugTeamSlugDashboardErpServicesRoute:
-         AuthenticatedSlugTeamSlugDashboardErpServicesRoute,
-      AuthenticatedSlugTeamSlugDashboardHomeIndexRoute:
-         AuthenticatedSlugTeamSlugDashboardHomeIndexRoute,
-      AuthenticatedSlugTeamSlugDashboardInventoryIndexRoute:
-         AuthenticatedSlugTeamSlugDashboardInventoryIndexRoute,
-      AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsDashboardIdRoute:
-         AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsDashboardIdRoute,
-      AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsInsightIdRoute:
-         AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsInsightIdRoute,
-      AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsIndexRoute:
-         AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsIndexRoute,
-      AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsIndexRoute:
-         AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsIndexRoute,
-   };
+  {
+    AuthenticatedSlugTeamSlugDashboardBankAccountsRoute:
+      AuthenticatedSlugTeamSlugDashboardBankAccountsRoute,
+    AuthenticatedSlugTeamSlugDashboardBillingRoute:
+      AuthenticatedSlugTeamSlugDashboardBillingRoute,
+    AuthenticatedSlugTeamSlugDashboardCategoriesRoute:
+      AuthenticatedSlugTeamSlugDashboardCategoriesRoute,
+    AuthenticatedSlugTeamSlugDashboardChatRoute:
+      AuthenticatedSlugTeamSlugDashboardChatRoute,
+    AuthenticatedSlugTeamSlugDashboardContactsRoute:
+      AuthenticatedSlugTeamSlugDashboardContactsRouteWithChildren,
+    AuthenticatedSlugTeamSlugDashboardCreditCardsRoute:
+      AuthenticatedSlugTeamSlugDashboardCreditCardsRoute,
+    AuthenticatedSlugTeamSlugDashboardSettingsRoute:
+      AuthenticatedSlugTeamSlugDashboardSettingsRouteWithChildren,
+    AuthenticatedSlugTeamSlugDashboardTagsRoute:
+      AuthenticatedSlugTeamSlugDashboardTagsRoute,
+    AuthenticatedSlugTeamSlugDashboardTransactionsRoute:
+      AuthenticatedSlugTeamSlugDashboardTransactionsRoute,
+    AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRoute:
+      AuthenticatedSlugTeamSlugDashboardAnalyticsDataManagementRouteWithChildren,
+    AuthenticatedSlugTeamSlugDashboardErpServicesRoute:
+      AuthenticatedSlugTeamSlugDashboardErpServicesRoute,
+    AuthenticatedSlugTeamSlugDashboardHomeIndexRoute:
+      AuthenticatedSlugTeamSlugDashboardHomeIndexRoute,
+    AuthenticatedSlugTeamSlugDashboardInventoryIndexRoute:
+      AuthenticatedSlugTeamSlugDashboardInventoryIndexRoute,
+    AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsDashboardIdRoute:
+      AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsDashboardIdRoute,
+    AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsInsightIdRoute:
+      AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsInsightIdRoute,
+    AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsIndexRoute:
+      AuthenticatedSlugTeamSlugDashboardAnalyticsDashboardsIndexRoute,
+    AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsIndexRoute:
+      AuthenticatedSlugTeamSlugDashboardAnalyticsInsightsIndexRoute,
+  }
 
 const AuthenticatedSlugTeamSlugDashboardRouteWithChildren =
-   AuthenticatedSlugTeamSlugDashboardRoute._addFileChildren(
-      AuthenticatedSlugTeamSlugDashboardRouteChildren,
-   );
+  AuthenticatedSlugTeamSlugDashboardRoute._addFileChildren(
+    AuthenticatedSlugTeamSlugDashboardRouteChildren,
+  )
 
 interface AuthenticatedSlugTeamSlugRouteChildren {
-   AuthenticatedSlugTeamSlugDashboardRoute: typeof AuthenticatedSlugTeamSlugDashboardRouteWithChildren;
+  AuthenticatedSlugTeamSlugDashboardRoute: typeof AuthenticatedSlugTeamSlugDashboardRouteWithChildren
 }
 
 const AuthenticatedSlugTeamSlugRouteChildren: AuthenticatedSlugTeamSlugRouteChildren =
-   {
-      AuthenticatedSlugTeamSlugDashboardRoute:
-         AuthenticatedSlugTeamSlugDashboardRouteWithChildren,
-   };
+  {
+    AuthenticatedSlugTeamSlugDashboardRoute:
+      AuthenticatedSlugTeamSlugDashboardRouteWithChildren,
+  }
 
 const AuthenticatedSlugTeamSlugRouteWithChildren =
-   AuthenticatedSlugTeamSlugRoute._addFileChildren(
-      AuthenticatedSlugTeamSlugRouteChildren,
-   );
+  AuthenticatedSlugTeamSlugRoute._addFileChildren(
+    AuthenticatedSlugTeamSlugRouteChildren,
+  )
 
 interface AuthenticatedSlugRouteChildren {
-   AuthenticatedSlugTeamSlugRoute: typeof AuthenticatedSlugTeamSlugRouteWithChildren;
+  AuthenticatedSlugTeamSlugRoute: typeof AuthenticatedSlugTeamSlugRouteWithChildren
 }
 
 const AuthenticatedSlugRouteChildren: AuthenticatedSlugRouteChildren = {
-   AuthenticatedSlugTeamSlugRoute: AuthenticatedSlugTeamSlugRouteWithChildren,
-};
+  AuthenticatedSlugTeamSlugRoute: AuthenticatedSlugTeamSlugRouteWithChildren,
+}
 
 const AuthenticatedSlugRouteWithChildren =
-   AuthenticatedSlugRoute._addFileChildren(AuthenticatedSlugRouteChildren);
+  AuthenticatedSlugRoute._addFileChildren(AuthenticatedSlugRouteChildren)
 
 interface AuthenticatedRouteChildren {
-   AuthenticatedSlugRoute: typeof AuthenticatedSlugRouteWithChildren;
-   AuthenticatedOnboardingRoute: typeof AuthenticatedOnboardingRoute;
+  AuthenticatedSlugRoute: typeof AuthenticatedSlugRouteWithChildren
+  AuthenticatedOnboardingRoute: typeof AuthenticatedOnboardingRoute
 }
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
-   AuthenticatedSlugRoute: AuthenticatedSlugRouteWithChildren,
-   AuthenticatedOnboardingRoute: AuthenticatedOnboardingRoute,
-};
+  AuthenticatedSlugRoute: AuthenticatedSlugRouteWithChildren,
+  AuthenticatedOnboardingRoute: AuthenticatedOnboardingRoute,
+}
 
 const AuthenticatedRouteWithChildren = AuthenticatedRoute._addFileChildren(
-   AuthenticatedRouteChildren,
-);
+  AuthenticatedRouteChildren,
+)
 
 interface AuthSignInRouteChildren {
-   AuthSignInEmailRoute: typeof AuthSignInEmailRoute;
-   AuthSignInIndexRoute: typeof AuthSignInIndexRoute;
+  AuthSignInEmailRoute: typeof AuthSignInEmailRoute
+  AuthSignInIndexRoute: typeof AuthSignInIndexRoute
 }
 
 const AuthSignInRouteChildren: AuthSignInRouteChildren = {
-   AuthSignInEmailRoute: AuthSignInEmailRoute,
-   AuthSignInIndexRoute: AuthSignInIndexRoute,
-};
+  AuthSignInEmailRoute: AuthSignInEmailRoute,
+  AuthSignInIndexRoute: AuthSignInIndexRoute,
+}
 
 const AuthSignInRouteWithChildren = AuthSignInRoute._addFileChildren(
-   AuthSignInRouteChildren,
-);
+  AuthSignInRouteChildren,
+)
 
 interface AuthRouteChildren {
-   AuthCallbackRoute: typeof AuthCallbackRoute;
-   AuthEmailVerificationRoute: typeof AuthEmailVerificationRoute;
-   AuthForgotPasswordRoute: typeof AuthForgotPasswordRoute;
-   AuthMagicLinkRoute: typeof AuthMagicLinkRoute;
-   AuthSignInRoute: typeof AuthSignInRouteWithChildren;
-   AuthSignUpRoute: typeof AuthSignUpRoute;
+  AuthCallbackRoute: typeof AuthCallbackRoute
+  AuthEmailVerificationRoute: typeof AuthEmailVerificationRoute
+  AuthForgotPasswordRoute: typeof AuthForgotPasswordRoute
+  AuthMagicLinkRoute: typeof AuthMagicLinkRoute
+  AuthSignInRoute: typeof AuthSignInRouteWithChildren
+  AuthSignUpRoute: typeof AuthSignUpRoute
 }
 
 const AuthRouteChildren: AuthRouteChildren = {
-   AuthCallbackRoute: AuthCallbackRoute,
-   AuthEmailVerificationRoute: AuthEmailVerificationRoute,
-   AuthForgotPasswordRoute: AuthForgotPasswordRoute,
-   AuthMagicLinkRoute: AuthMagicLinkRoute,
-   AuthSignInRoute: AuthSignInRouteWithChildren,
-   AuthSignUpRoute: AuthSignUpRoute,
-};
+  AuthCallbackRoute: AuthCallbackRoute,
+  AuthEmailVerificationRoute: AuthEmailVerificationRoute,
+  AuthForgotPasswordRoute: AuthForgotPasswordRoute,
+  AuthMagicLinkRoute: AuthMagicLinkRoute,
+  AuthSignInRoute: AuthSignInRouteWithChildren,
+  AuthSignUpRoute: AuthSignUpRoute,
+}
 
-const AuthRouteWithChildren = AuthRoute._addFileChildren(AuthRouteChildren);
+const AuthRouteWithChildren = AuthRoute._addFileChildren(AuthRouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
-   IndexRoute: IndexRoute,
-   AuthenticatedRoute: AuthenticatedRouteWithChildren,
-   AuthRoute: AuthRouteWithChildren,
-   ApiSplatRoute: ApiSplatRoute,
-   ApiHealthRoute: ApiHealthRoute,
-   ApiPingRoute: ApiPingRoute,
-   ApiAuthSplatRoute: ApiAuthSplatRoute,
-   ApiFilesSplatRoute: ApiFilesSplatRoute,
-   ApiRpcSplatRoute: ApiRpcSplatRoute,
-   ApiSdkSplatRoute: ApiSdkSplatRoute,
-   CallbackOrganizationInvitationInvitationIdRoute:
-      CallbackOrganizationInvitationInvitationIdRoute,
-};
+  IndexRoute: IndexRoute,
+  AuthenticatedRoute: AuthenticatedRouteWithChildren,
+  AuthRoute: AuthRouteWithChildren,
+  ApiSplatRoute: ApiSplatRoute,
+  ApiHealthRoute: ApiHealthRoute,
+  ApiPingRoute: ApiPingRoute,
+  ApiAuthSplatRoute: ApiAuthSplatRoute,
+  ApiFilesSplatRoute: ApiFilesSplatRoute,
+  ApiRpcSplatRoute: ApiRpcSplatRoute,
+  ApiSdkSplatRoute: ApiSdkSplatRoute,
+  CallbackOrganizationInvitationInvitationIdRoute:
+    CallbackOrganizationInvitationInvitationIdRoute,
+}
 export const routeTree = rootRouteImport
-   ._addFileChildren(rootRouteChildren)
-   ._addFileTypes<FileRouteTypes>();
+  ._addFileChildren(rootRouteChildren)
+  ._addFileTypes<FileRouteTypes>()
 
-import type { getRouter } from "./router.tsx";
-import type { createStart } from "@tanstack/react-start";
-declare module "@tanstack/react-start" {
-   interface Register {
-      ssr: true;
-      router: Awaited<ReturnType<typeof getRouter>>;
-   }
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
+declare module '@tanstack/react-start' {
+  interface Register {
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+  }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -211,6 +211,7 @@
         "@types/pg": "catalog:database",
         "dotenv-cli": "catalog:environment",
         "drizzle-kit": "catalog:database",
+        "drizzle-seed": "catalog:database",
         "drizzle-zod": "catalog:database",
         "typescript": "catalog:development",
       },
@@ -592,6 +593,7 @@
       "@types/pg": "^8.20.0",
       "drizzle-kit": "0.31.10",
       "drizzle-orm": "0.45.2",
+      "drizzle-seed": "0.3.1",
       "drizzle-zod": "0.8.3",
       "pg": "^8.18.0",
     },
@@ -2606,6 +2608,8 @@
     "drizzle-kit": ["drizzle-kit@0.31.10", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "tsx": "^4.21.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw=="],
 
     "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
+
+    "drizzle-seed": ["drizzle-seed@0.3.1", "", { "dependencies": { "pure-rand": "^6.1.0" }, "peerDependencies": { "drizzle-orm": ">=0.36.4" }, "optionalPeers": ["drizzle-orm"] }, "sha512-F/0lgvfOAsqlYoHM/QAGut4xXIOXoE5VoAdv2FIl7DpGYVXlAzKuJO+IphkKUFK3Dz+rFlOsQLnMNrvoQ0cx7g=="],
 
     "drizzle-zod": ["drizzle-zod@0.8.3", "", { "peerDependencies": { "drizzle-orm": ">=0.36.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-66yVOuvGhKJnTdiqj1/Xaaz9/qzOdRJADpDa68enqS6g3t0kpNkwNYjUuaeXgZfO/UWuIM9HIhSlJ6C5ZraMww=="],
 

--- a/core/database/__tests__/repositories/usage-events-repository.test.ts
+++ b/core/database/__tests__/repositories/usage-events-repository.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, afterAll, describe, it, expect } from "vitest";
+import { seed } from "drizzle-seed";
 import { setupTestDb } from "../helpers/setup-test-db";
-import { organization, team } from "@core/database/schemas/auth";
-import { contacts } from "@core/database/schemas/contacts";
+import * as schema from "@core/database/schema";
 import { upsertUsageEventSchema } from "@core/database/schemas/usage-events";
 import * as repo from "../../src/repositories/usage-events-repository";
 
@@ -15,37 +15,59 @@ afterAll(async () => {
    await testDb.cleanup();
 });
 
+function randomSeed() {
+   return Math.floor(Math.random() * 1_000_000);
+}
+
 async function seedTeam() {
-   const [org] = await testDb.db
-      .insert(organization)
-      .values({
-         name: "Test Org",
-         slug: `org-${crypto.randomUUID().slice(0, 8)}`,
-         createdAt: new Date(),
-      })
-      .returning();
-   const [tm] = await testDb.db
-      .insert(team)
-      .values({
-         name: "Test Team",
-         slug: `team-${crypto.randomUUID().slice(0, 8)}`,
-         organizationId: org!.id,
-         createdAt: new Date(),
-      })
-      .returning();
-   return tm!.id;
+   const orgId = crypto.randomUUID();
+   const teamId = crypto.randomUUID();
+
+   await seed(
+      testDb.db,
+      { organization: schema.organization },
+      { seed: randomSeed() },
+   ).refine((f) => ({
+      organization: {
+         count: 1,
+         columns: { id: f.default({ defaultValue: orgId }) },
+      },
+   }));
+
+   await seed(testDb.db, { team: schema.team }, { seed: randomSeed() }).refine(
+      (f) => ({
+         team: {
+            count: 1,
+            columns: {
+               id: f.default({ defaultValue: teamId }),
+               organizationId: f.default({ defaultValue: orgId }),
+            },
+         },
+      }),
+   );
+
+   return teamId;
 }
 
 async function seedContact(teamId: string) {
-   const [contact] = await testDb.db
-      .insert(contacts)
-      .values({
-         teamId,
-         name: `Contact ${crypto.randomUUID().slice(0, 8)}`,
-         type: "cliente",
-      })
-      .returning();
-   return contact!;
+   const contactId = crypto.randomUUID();
+
+   await seed(
+      testDb.db,
+      { contacts: schema.contacts },
+      { seed: randomSeed() },
+   ).refine((f) => ({
+      contacts: {
+         count: 1,
+         columns: {
+            id: f.default({ defaultValue: contactId }),
+            teamId: f.default({ defaultValue: teamId }),
+            type: f.default({ defaultValue: "cliente" }),
+         },
+      },
+   }));
+
+   return { id: contactId, teamId };
 }
 
 function validInput(teamId: string, overrides: Record<string, unknown> = {}) {

--- a/core/database/__tests__/repositories/usage-events-repository.test.ts
+++ b/core/database/__tests__/repositories/usage-events-repository.test.ts
@@ -1,0 +1,321 @@
+import { beforeAll, afterAll, describe, it, expect } from "vitest";
+import { setupTestDb } from "../helpers/setup-test-db";
+import { organization, team } from "@core/database/schemas/auth";
+import { contacts } from "@core/database/schemas/contacts";
+import { upsertUsageEventSchema } from "@core/database/schemas/usage-events";
+import * as repo from "../../src/repositories/usage-events-repository";
+
+let testDb: Awaited<ReturnType<typeof setupTestDb>>;
+
+beforeAll(async () => {
+   testDb = await setupTestDb();
+});
+
+afterAll(async () => {
+   await testDb.cleanup();
+});
+
+async function seedTeam() {
+   const [org] = await testDb.db
+      .insert(organization)
+      .values({
+         name: "Test Org",
+         slug: `org-${crypto.randomUUID().slice(0, 8)}`,
+         createdAt: new Date(),
+      })
+      .returning();
+   const [tm] = await testDb.db
+      .insert(team)
+      .values({
+         name: "Test Team",
+         slug: `team-${crypto.randomUUID().slice(0, 8)}`,
+         organizationId: org!.id,
+         createdAt: new Date(),
+      })
+      .returning();
+   return tm!.id;
+}
+
+async function seedContact(teamId: string) {
+   const [contact] = await testDb.db
+      .insert(contacts)
+      .values({
+         teamId,
+         name: `Contact ${crypto.randomUUID().slice(0, 8)}`,
+         type: "cliente",
+      })
+      .returning();
+   return contact!;
+}
+
+function validInput(teamId: string, overrides: Record<string, unknown> = {}) {
+   return {
+      teamId,
+      meterId: crypto.randomUUID(),
+      quantity: "10",
+      idempotencyKey: crypto.randomUUID(),
+      ...overrides,
+   };
+}
+
+describe("usage-events-repository", () => {
+   describe("upsertUsageEventSchema", () => {
+      it("accepts valid input", () => {
+         const result = upsertUsageEventSchema.safeParse(
+            validInput(crypto.randomUUID()),
+         );
+         expect(result.success).toBe(true);
+      });
+
+      it("rejects empty quantity", () => {
+         const result = upsertUsageEventSchema.safeParse(
+            validInput(crypto.randomUUID(), { quantity: "" }),
+         );
+         expect(result.success).toBe(false);
+      });
+
+      it("rejects non-numeric quantity", () => {
+         const result = upsertUsageEventSchema.safeParse(
+            validInput(crypto.randomUUID(), { quantity: "abc" }),
+         );
+         expect(result.success).toBe(false);
+      });
+
+      it("rejects negative quantity", () => {
+         const result = upsertUsageEventSchema.safeParse(
+            validInput(crypto.randomUUID(), { quantity: "-1" }),
+         );
+         expect(result.success).toBe(false);
+      });
+
+      it("rejects Infinity", () => {
+         const result = upsertUsageEventSchema.safeParse(
+            validInput(crypto.randomUUID(), { quantity: "Infinity" }),
+         );
+         expect(result.success).toBe(false);
+      });
+
+      it("rejects empty idempotencyKey", () => {
+         const result = upsertUsageEventSchema.safeParse(
+            validInput(crypto.randomUUID(), { idempotencyKey: "" }),
+         );
+         expect(result.success).toBe(false);
+      });
+
+      it("rejects invalid teamId uuid", () => {
+         const result = upsertUsageEventSchema.safeParse(
+            validInput("not-a-uuid"),
+         );
+         expect(result.success).toBe(false);
+      });
+
+      it("accepts decimal quantity", () => {
+         const result = upsertUsageEventSchema.safeParse(
+            validInput(crypto.randomUUID(), { quantity: "3.14" }),
+         );
+         expect(result.success).toBe(true);
+      });
+
+      it("accepts zero quantity", () => {
+         const result = upsertUsageEventSchema.safeParse(
+            validInput(crypto.randomUUID(), { quantity: "0" }),
+         );
+         expect(result.success).toBe(true);
+      });
+   });
+
+   describe("upsertUsageEvent", () => {
+      it("inserts and returns the event", async () => {
+         const teamId = await seedTeam();
+         const input = validInput(teamId);
+
+         const result = await repo.upsertUsageEvent(testDb.db, input);
+
+         expect(result.isOk()).toBe(true);
+         const row = result._unsafeUnwrap();
+         expect(row).not.toBeNull();
+         expect(row!.teamId).toBe(teamId);
+         expect(row!.meterId).toBe(input.meterId);
+         expect(Number(row!.quantity)).toBe(10);
+         expect(row!.idempotencyKey).toBe(input.idempotencyKey);
+      });
+
+      it("returns null on duplicate idempotencyKey — no error", async () => {
+         const teamId = await seedTeam();
+         const input = validInput(teamId);
+
+         await repo.upsertUsageEvent(testDb.db, input);
+         const duplicate = await repo.upsertUsageEvent(testDb.db, input);
+
+         expect(duplicate.isOk()).toBe(true);
+         expect(duplicate._unsafeUnwrap()).toBeNull();
+      });
+
+      it("same idempotencyKey on different team is allowed", async () => {
+         const [teamA, teamB] = await Promise.all([seedTeam(), seedTeam()]);
+         const key = crypto.randomUUID();
+
+         const a = await repo.upsertUsageEvent(
+            testDb.db,
+            validInput(teamA, { idempotencyKey: key }),
+         );
+         const b = await repo.upsertUsageEvent(
+            testDb.db,
+            validInput(teamB, { idempotencyKey: key }),
+         );
+
+         expect(a._unsafeUnwrap()).not.toBeNull();
+         expect(b._unsafeUnwrap()).not.toBeNull();
+      });
+
+      it("stores contactId when provided", async () => {
+         const teamId = await seedTeam();
+         const contact = await seedContact(teamId);
+
+         const result = await repo.upsertUsageEvent(
+            testDb.db,
+            validInput(teamId, { contactId: contact.id }),
+         );
+
+         expect(result._unsafeUnwrap()!.contactId).toBe(contact.id);
+      });
+
+      it("returns err on invalid input", async () => {
+         const result = await repo.upsertUsageEvent(
+            testDb.db,
+            validInput(crypto.randomUUID(), { quantity: "" }),
+         );
+         expect(result.isErr()).toBe(true);
+      });
+   });
+
+   describe("listUsageEventsByContact", () => {
+      it("returns only events for that contact", async () => {
+         const teamId = await seedTeam();
+         const contact = await seedContact(teamId);
+         const other = await seedContact(teamId);
+
+         await repo.upsertUsageEvent(
+            testDb.db,
+            validInput(teamId, { contactId: contact.id }),
+         );
+         await repo.upsertUsageEvent(
+            testDb.db,
+            validInput(teamId, { contactId: other.id }),
+         );
+
+         const result = await repo.listUsageEventsByContact(
+            testDb.db,
+            teamId,
+            contact.id,
+         );
+
+         expect(result.isOk()).toBe(true);
+         const rows = result._unsafeUnwrap();
+         expect(rows).toHaveLength(1);
+         expect(rows[0]!.contactId).toBe(contact.id);
+      });
+
+      it("returns empty array for contact with no events", async () => {
+         const teamId = await seedTeam();
+         const contact = await seedContact(teamId);
+
+         const result = await repo.listUsageEventsByContact(
+            testDb.db,
+            teamId,
+            contact.id,
+         );
+
+         expect(result._unsafeUnwrap()).toHaveLength(0);
+      });
+   });
+
+   describe("summarizeUsageByMeter", () => {
+      it("sums quantity per meter within period", async () => {
+         const teamId = await seedTeam();
+         const meterId = crypto.randomUUID();
+         const from = new Date(Date.now() - 60_000);
+         const to = new Date(Date.now() + 60_000);
+
+         await repo.upsertUsageEvent(
+            testDb.db,
+            validInput(teamId, { meterId, quantity: "5" }),
+         );
+         await repo.upsertUsageEvent(
+            testDb.db,
+            validInput(teamId, { meterId, quantity: "3" }),
+         );
+
+         const result = await repo.summarizeUsageByMeter(testDb.db, teamId, {
+            from,
+            to,
+         });
+
+         expect(result.isOk()).toBe(true);
+         const entry = result
+            ._unsafeUnwrap()
+            .find((s) => s.meterId === meterId);
+         expect(entry).toBeDefined();
+         expect(Number(entry!.total)).toBeCloseTo(8, 5);
+      });
+
+      it("excludes events outside period", async () => {
+         const teamId = await seedTeam();
+         const meterId = crypto.randomUUID();
+
+         await repo.upsertUsageEvent(
+            testDb.db,
+            validInput(teamId, { meterId, quantity: "99" }),
+         );
+
+         const result = await repo.summarizeUsageByMeter(testDb.db, teamId, {
+            from: new Date("2020-01-01"),
+            to: new Date("2020-12-31"),
+         });
+
+         const entry = result
+            ._unsafeUnwrap()
+            .find((s) => s.meterId === meterId);
+         expect(entry).toBeUndefined();
+      });
+
+      it("returns separate totals per meter", async () => {
+         const teamId = await seedTeam();
+         const meterA = crypto.randomUUID();
+         const meterB = crypto.randomUUID();
+         const from = new Date(Date.now() - 60_000);
+         const to = new Date(Date.now() + 60_000);
+
+         await repo.upsertUsageEvent(
+            testDb.db,
+            validInput(teamId, { meterId: meterA, quantity: "10" }),
+         );
+         await repo.upsertUsageEvent(
+            testDb.db,
+            validInput(teamId, { meterId: meterB, quantity: "7" }),
+         );
+
+         const result = await repo.summarizeUsageByMeter(testDb.db, teamId, {
+            from,
+            to,
+         });
+
+         const summary = result._unsafeUnwrap();
+         const a = summary.find((s) => s.meterId === meterA);
+         const b = summary.find((s) => s.meterId === meterB);
+         expect(Number(a!.total)).toBeCloseTo(10, 5);
+         expect(Number(b!.total)).toBeCloseTo(7, 5);
+      });
+
+      it("returns empty array when no events in period", async () => {
+         const teamId = await seedTeam();
+
+         const result = await repo.summarizeUsageByMeter(testDb.db, teamId, {
+            from: new Date("2020-01-01"),
+            to: new Date("2020-12-31"),
+         });
+
+         expect(result._unsafeUnwrap()).toHaveLength(0);
+      });
+   });
+});

--- a/core/database/package.json
+++ b/core/database/package.json
@@ -71,6 +71,7 @@
       "@types/pg": "catalog:database",
       "dotenv-cli": "catalog:environment",
       "drizzle-kit": "catalog:database",
+      "drizzle-seed": "catalog:database",
       "drizzle-zod": "catalog:database",
       "typescript": "catalog:development"
    }

--- a/core/database/src/relations.ts
+++ b/core/database/src/relations.ts
@@ -34,6 +34,7 @@ import {
    transactionItems,
    transactions,
 } from "@core/database/schemas/transactions";
+import { usageEvents } from "@core/database/schemas/usage-events";
 import {
    webhookDeliveries,
    webhookEndpoints,
@@ -317,6 +318,17 @@ export const transactionItemsRelations = relations(
       }),
    }),
 );
+
+export const usageEventsRelations = relations(usageEvents, ({ one }) => ({
+   team: one(team, {
+      fields: [usageEvents.teamId],
+      references: [team.id],
+   }),
+   contact: one(contacts, {
+      fields: [usageEvents.contactId],
+      references: [contacts.id],
+   }),
+}));
 
 export const webhookEndpointsRelations = relations(
    webhookEndpoints,

--- a/core/database/src/repositories/usage-events-repository.ts
+++ b/core/database/src/repositories/usage-events-repository.ts
@@ -1,5 +1,5 @@
 import { AppError, validateInput } from "@core/logging/errors";
-import { and, eq, gte, lte, sql, sum } from "drizzle-orm";
+import { and, eq, gte, lte, sum } from "drizzle-orm";
 import { fromPromise, fromThrowable } from "neverthrow";
 import type { DatabaseInstance } from "@core/database/client";
 import {
@@ -65,7 +65,7 @@ export function summarizeUsageByMeter(
       db
          .select({
             meterId: usageEvents.meterId,
-            total: sum(sql<number>`${usageEvents.quantity}::numeric`),
+            total: sum(usageEvents.quantity),
          })
          .from(usageEvents)
          .where(

--- a/core/database/src/repositories/usage-events-repository.ts
+++ b/core/database/src/repositories/usage-events-repository.ts
@@ -1,19 +1,16 @@
 import { AppError, validateInput } from "@core/logging/errors";
-import { eq } from "drizzle-orm";
-import { fromPromise, fromThrowable, ok, err } from "neverthrow";
+import { and, eq, gte, lte, sql, sum } from "drizzle-orm";
+import { fromPromise, fromThrowable } from "neverthrow";
 import type { DatabaseInstance } from "@core/database/client";
 import {
-   usageEvents,
    upsertUsageEventSchema,
    type UpsertUsageEventInput,
+   usageEvents,
 } from "@core/database/schemas/usage-events";
 
 const safeValidateUpsert = fromThrowable(
    (data: UpsertUsageEventInput) => validateInput(upsertUsageEventSchema, data),
-   (e) =>
-      e instanceof AppError
-         ? e
-         : AppError.validation("Dados inválidos.", { cause: e }),
+   (e) => AppError.validation("Dados inválidos.", { cause: e }),
 );
 
 export function upsertUsageEvent(
@@ -22,24 +19,70 @@ export function upsertUsageEvent(
 ) {
    return safeValidateUpsert(data).asyncAndThen((validated) =>
       fromPromise(
-         db
-            .insert(usageEvents)
-            .values(validated)
-            .onConflictDoNothing({
-               target: [usageEvents.teamId, usageEvents.idempotencyKey],
-            })
-            .returning(),
+         db.transaction(async (tx) => {
+            const [row] = await tx
+               .insert(usageEvents)
+               .values(validated)
+               .onConflictDoNothing({
+                  target: [usageEvents.teamId, usageEvents.idempotencyKey],
+               })
+               .returning();
+            return row ?? null;
+         }),
          (e) =>
             AppError.database("Falha ao registrar evento de uso.", {
                cause: e,
             }),
-      ).map(([row]) => row ?? null),
+      ),
    );
 }
 
-export function listUsageEventsByTeam(db: DatabaseInstance, teamId: string) {
+export function listUsageEventsByContact(
+   db: DatabaseInstance,
+   teamId: string,
+   contactId: string,
+) {
    return fromPromise(
-      db.select().from(usageEvents).where(eq(usageEvents.teamId, teamId)),
+      db.query.usageEvents.findMany({
+         where: (fields, { eq, and }) =>
+            and(eq(fields.teamId, teamId), eq(fields.contactId, contactId)),
+      }),
       (e) => AppError.database("Falha ao listar eventos de uso.", { cause: e }),
+   );
+}
+
+export type UsageSummaryByMeter = {
+   meterId: string;
+   total: string;
+};
+
+export function summarizeUsageByMeter(
+   db: DatabaseInstance,
+   teamId: string,
+   period: { from: Date; to: Date },
+): ReturnType<typeof fromPromise<UsageSummaryByMeter[], AppError>> {
+   return fromPromise(
+      db
+         .select({
+            meterId: usageEvents.meterId,
+            total: sum(sql<number>`${usageEvents.quantity}::numeric`),
+         })
+         .from(usageEvents)
+         .where(
+            and(
+               eq(usageEvents.teamId, teamId),
+               gte(usageEvents.timestamp, period.from),
+               lte(usageEvents.timestamp, period.to),
+            ),
+         )
+         .groupBy(usageEvents.meterId)
+         .then((rows) =>
+            rows.map((r) => ({
+               meterId: r.meterId,
+               total: r.total ?? "0",
+            })),
+         ),
+      (e) =>
+         AppError.database("Falha ao calcular uso por medidor.", { cause: e }),
    );
 }

--- a/core/database/src/repositories/usage-events-repository.ts
+++ b/core/database/src/repositories/usage-events-repository.ts
@@ -1,0 +1,45 @@
+import { AppError, validateInput } from "@core/logging/errors";
+import { eq } from "drizzle-orm";
+import { fromPromise, fromThrowable, ok, err } from "neverthrow";
+import type { DatabaseInstance } from "@core/database/client";
+import {
+   usageEvents,
+   upsertUsageEventSchema,
+   type UpsertUsageEventInput,
+} from "@core/database/schemas/usage-events";
+
+const safeValidateUpsert = fromThrowable(
+   (data: UpsertUsageEventInput) => validateInput(upsertUsageEventSchema, data),
+   (e) =>
+      e instanceof AppError
+         ? e
+         : AppError.validation("Dados inválidos.", { cause: e }),
+);
+
+export function upsertUsageEvent(
+   db: DatabaseInstance,
+   data: UpsertUsageEventInput,
+) {
+   return safeValidateUpsert(data).asyncAndThen((validated) =>
+      fromPromise(
+         db
+            .insert(usageEvents)
+            .values(validated)
+            .onConflictDoNothing({
+               target: [usageEvents.teamId, usageEvents.idempotencyKey],
+            })
+            .returning(),
+         (e) =>
+            AppError.database("Falha ao registrar evento de uso.", {
+               cause: e,
+            }),
+      ).map(([row]) => row ?? null),
+   );
+}
+
+export function listUsageEventsByTeam(db: DatabaseInstance, teamId: string) {
+   return fromPromise(
+      db.select().from(usageEvents).where(eq(usageEvents.teamId, teamId)),
+      (e) => AppError.database("Falha ao listar eventos de uso.", { cause: e }),
+   );
+}

--- a/core/database/src/schema.ts
+++ b/core/database/src/schema.ts
@@ -17,6 +17,7 @@ export * from "@core/database/schemas/settings-financial";
 export * from "@core/database/schemas/subscriptions";
 export * from "@core/database/schemas/tags";
 export * from "@core/database/schemas/transactions";
+export * from "@core/database/schemas/usage-events";
 export * from "@core/database/schemas/webhooks";
 export * from "@core/database/relations";
 export {

--- a/core/database/src/schemas/usage-events.ts
+++ b/core/database/src/schemas/usage-events.ts
@@ -2,6 +2,7 @@ import { sql } from "drizzle-orm";
 import {
    index,
    jsonb,
+   numeric,
    text,
    timestamp,
    uniqueIndex,
@@ -26,7 +27,7 @@ export const usageEvents = platformSchema.table(
          onDelete: "set null",
       }),
       meterId: text("meter_id").notNull(),
-      quantity: text("quantity").notNull(),
+      quantity: numeric("quantity", { precision: 20, scale: 6 }).notNull(),
       properties: jsonb("properties")
          .$type<Record<string, unknown>>()
          .notNull()
@@ -66,9 +67,13 @@ export const upsertUsageEventSchema = createInsertSchema(usageEvents)
          .nullable()
          .optional(),
       meterId: z.string().min(1, "ID do medidor é obrigatório."),
-      quantity: z.string().refine((v) => !Number.isNaN(Number(v)), {
-         message: "Quantidade deve ser um número válido.",
-      }),
+      quantity: z
+         .string()
+         .min(1, "Quantidade é obrigatória.")
+         .refine((v) => {
+            const n = Number(v);
+            return !Number.isNaN(n) && Number.isFinite(n) && n >= 0;
+         }, "Quantidade deve ser um número positivo finito."),
       properties: z.record(z.string(), z.unknown()).optional().default({}),
       idempotencyKey: z.string().min(1, "Chave de idempotência é obrigatória."),
    });

--- a/core/database/src/schemas/usage-events.ts
+++ b/core/database/src/schemas/usage-events.ts
@@ -1,0 +1,76 @@
+import { sql } from "drizzle-orm";
+import {
+   index,
+   jsonb,
+   text,
+   timestamp,
+   uniqueIndex,
+   uuid,
+} from "drizzle-orm/pg-core";
+import { createInsertSchema } from "drizzle-zod";
+import { z } from "zod";
+import { platformSchema } from "@core/database/schemas/schemas";
+import { team } from "@core/database/schemas/auth";
+import { contacts } from "@core/database/schemas/contacts";
+
+export const usageEvents = platformSchema.table(
+   "usage_events",
+   {
+      id: uuid("id")
+         .default(sql`pg_catalog.gen_random_uuid()`)
+         .primaryKey(),
+      teamId: uuid("team_id")
+         .notNull()
+         .references(() => team.id, { onDelete: "cascade" }),
+      contactId: uuid("contact_id").references(() => contacts.id, {
+         onDelete: "set null",
+      }),
+      meterId: text("meter_id").notNull(),
+      quantity: text("quantity").notNull(),
+      properties: jsonb("properties")
+         .$type<Record<string, unknown>>()
+         .notNull()
+         .default(sql`'{}'::jsonb`),
+      idempotencyKey: text("idempotency_key").notNull(),
+      timestamp: timestamp("timestamp").defaultNow().notNull(),
+   },
+   (table) => [
+      uniqueIndex("usage_events_team_idempotency_key_idx").on(
+         table.teamId,
+         table.idempotencyKey,
+      ),
+      index("usage_events_team_id_idx").on(table.teamId),
+      index("usage_events_contact_id_idx").on(table.contactId),
+      index("usage_events_meter_id_idx").on(table.meterId),
+      index("usage_events_timestamp_idx").on(table.timestamp),
+   ],
+);
+
+export type UsageEvent = typeof usageEvents.$inferSelect;
+export type NewUsageEvent = typeof usageEvents.$inferInsert;
+
+export const upsertUsageEventSchema = createInsertSchema(usageEvents)
+   .pick({
+      teamId: true,
+      contactId: true,
+      meterId: true,
+      quantity: true,
+      properties: true,
+      idempotencyKey: true,
+   })
+   .extend({
+      teamId: z.string().uuid("ID do time inválido."),
+      contactId: z
+         .string()
+         .uuid("ID do contato inválido.")
+         .nullable()
+         .optional(),
+      meterId: z.string().min(1, "ID do medidor é obrigatório."),
+      quantity: z.string().refine((v) => !Number.isNaN(Number(v)), {
+         message: "Quantidade deve ser um número válido.",
+      }),
+      properties: z.record(z.string(), z.unknown()).optional().default({}),
+      idempotencyKey: z.string().min(1, "Chave de idempotência é obrigatória."),
+   });
+
+export type UpsertUsageEventInput = z.infer<typeof upsertUsageEventSchema>;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
             "@types/pg": "^8.20.0",
             "drizzle-kit": "0.31.10",
             "drizzle-orm": "0.45.2",
+            "drizzle-seed": "0.3.1",
             "drizzle-zod": "0.8.3",
             "pg": "^8.18.0"
          },


### PR DESCRIPTION
## Summary

- Adds `usage_events` table in `platformSchema` with `teamId`, `contactId`, `meterId`, `quantity`, `properties (jsonb)`, `idempotencyKey`, and `timestamp`
- `UNIQUE(teamId, idempotencyKey)` constraint enables silent upsert dedup — duplicate `idempotencyKey` per team is ignored, preventing double-billing on network retries
- Repository uses full neverthrow chain (`fromThrowable` → `validateInput` → `fromPromise`) with Zod schema from `drizzle-zod`
- Drizzle relations added for `team` and `contact` FKs

## Test plan

- [ ] Run `bun run db:push` to apply schema
- [ ] Verify `upsertUsageEvent` returns `null` (not error) on duplicate `idempotencyKey`
- [ ] Typecheck passes: `bun run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adiciona a tabela `usage_events` no `platformSchema` e um repositório com upsert idempotente por time para evitar cobrança dupla em retries. Inclui relações, validação e testes; atende ao MON-515 (Services Pricing Paradigm).

- **New Features**
  - Schema: nova tabela `usage_events` (teamId, contactId?, meterId, quantity:numeric(20,6), properties:jsonb, idempotencyKey, timestamp) com UNIQUE(teamId, idempotencyKey) e índices; exportada via `@core/database/src/schema.ts`.
  - Relations: `usageEventsRelations` para `team` e `contacts`.
  - Repositório (`@core/database/src/repositories/usage-events-repository.ts`): `upsertUsageEvent` com `onConflictDoNothing([teamId, idempotencyKey])` retornando `null` em duplicatas; `listUsageEventsByContact(teamId, contactId)`; `summarizeUsageByMeter(teamId, {from,to})` com `sum(quantity)`; validação `drizzle-zod` + `neverthrow` via `validateInput` e `AppError`.
  - Testes: `core/database/__tests__/repositories/usage-events-repository.test.ts` cobre validações, idempotência por time, filtro por contato e somatórios no período; usa `drizzle-seed` para seeding.
  - Impacto por camadas: Router — nenhum (apenas regen de `routeTree.gen.ts`); Repositório — novo repositório/métodos; Componente — nenhum; Store — nenhum.

- **Migration**
  - Executar `bun run db:push`.
  - Rodar `bun run test` e `bun run typecheck`.
  - Checklist: duplicata (mesmo `teamId` + `idempotencyKey`) retorna `null`; mesma `idempotencyKey` em times diferentes insere; `listUsageEventsByContact` isola pelo contato; `summarizeUsageByMeter` soma por medidor dentro do período; eventos fora do período são ignorados.

<sup>Written for commit e02a6a09a52f79ba46411c1eea1fa16bded24460. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/804">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

