### PR TITLE
feat(services): oRPC routers for meters, benefits, coupons, service prices, subscription items

### DIFF
--- a/apps/web/src/integrations/orpc/router/billing.ts
+++ b/apps/web/src/integrations/orpc/router/billing.ts
@@ -7,6 +7,7 @@ import {
    FREE_TIER_LIMITS,
    STRIPE_METER_EVENTS,
 } from "@core/stripe/constants";
+import { getAllUsage } from "@packages/events/credits";
 import { z } from "zod";
 
 import { protectedProcedure } from "../server";
@@ -225,6 +226,34 @@ export const getEventCatalog = protectedProcedure.handler(
          (rows) => rows,
          (e) => {
             throw e;
+         },
+      );
+   },
+);
+
+export const getUsageSummary = protectedProcedure.handler(
+   async ({ context }) => {
+      const { db, redis, organizationId, userId } = context;
+
+      const userRecord = await db.query.user.findFirst({
+         where: (fields, { eq }) => eq(fields.id, userId),
+      });
+
+      const stripeCustomerId = userRecord?.stripeCustomerId ?? null;
+
+      const usageMap = await getAllUsage(organizationId, redis);
+
+      return Object.entries(FREE_TIER_LIMITS).map(
+         ([eventName, freeTierLimit]) => {
+            const used = usageMap[eventName] ?? 0;
+            return {
+               eventName,
+               used,
+               freeTierLimit,
+               pricePerEvent: EVENT_PRICES[eventName] ?? "0",
+               overageEnabled: !!stripeCustomerId,
+               withinFreeTier: used < freeTierLimit,
+            };
          },
       );
    },

--- a/apps/web/src/integrations/orpc/router/coupons.ts
+++ b/apps/web/src/integrations/orpc/router/coupons.ts
@@ -1,0 +1,159 @@
+import { WebAppError } from "@core/logging/errors";
+import {
+   createCouponSchema,
+   updateCouponSchema,
+} from "@core/database/schemas/coupons";
+import {
+   createCoupon,
+   ensureCouponOwnership,
+   getCoupon,
+   getCouponByCode,
+   listCoupons,
+   updateCoupon,
+} from "@core/database/repositories/coupons-repository";
+import { z } from "zod";
+import dayjs from "dayjs";
+import { protectedProcedure } from "../server";
+
+export const list = protectedProcedure.handler(async ({ context }) => {
+   return (await listCoupons(context.db, context.teamId)).match(
+      (value) => value,
+      (e) => {
+         throw WebAppError.fromAppError(e);
+      },
+   );
+});
+
+export const get = protectedProcedure
+   .input(z.object({ id: z.string().uuid() }))
+   .handler(async ({ context, input }) => {
+      await (
+         await ensureCouponOwnership(context.db, input.id, context.teamId)
+      ).match(
+         () => {},
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+
+      return (await getCoupon(context.db, input.id)).match(
+         (value) => value,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+   });
+
+export const create = protectedProcedure
+   .input(createCouponSchema)
+   .handler(async ({ context, input }) => {
+      return (await createCoupon(context.db, context.teamId, input)).match(
+         (value) => value,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+   });
+
+export const update = protectedProcedure
+   .input(z.object({ id: z.string().uuid() }).merge(updateCouponSchema))
+   .handler(async ({ context, input }) => {
+      await (
+         await ensureCouponOwnership(context.db, input.id, context.teamId)
+      ).match(
+         () => {},
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+
+      const { id, ...data } = input;
+
+      return (await updateCoupon(context.db, id, data)).match(
+         (value) => value,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+   });
+
+export const deactivate = protectedProcedure
+   .input(z.object({ id: z.string().uuid() }))
+   .handler(async ({ context, input }) => {
+      await (
+         await ensureCouponOwnership(context.db, input.id, context.teamId)
+      ).match(
+         () => {},
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+
+      return (
+         await updateCoupon(context.db, input.id, { isActive: false })
+      ).match(
+         (value) => value,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+   });
+
+export const validate = protectedProcedure
+   .input(
+      z.object({
+         code: z.string().min(1),
+         priceId: z.string().uuid().optional(),
+      }),
+   )
+   .handler(async ({ context, input }) => {
+      const result = await getCouponByCode(
+         context.db,
+         context.teamId,
+         input.code,
+      );
+
+      if (result.isErr()) {
+         throw WebAppError.fromAppError(result.error);
+      }
+
+      const coupon = result.value;
+
+      if (!coupon) {
+         return { valid: false, reason: "not_found" as const };
+      }
+
+      if (!coupon.isActive) {
+         return { valid: false, reason: "inactive" as const };
+      }
+
+      if (coupon.redeemBy && dayjs().isAfter(dayjs(coupon.redeemBy))) {
+         return { valid: false, reason: "expired" as const };
+      }
+
+      if (coupon.maxUses !== null && coupon.usedCount >= coupon.maxUses) {
+         return { valid: false, reason: "max_uses_reached" as const };
+      }
+
+      if (
+         coupon.scope === "price" &&
+         input.priceId &&
+         coupon.priceId !== input.priceId
+      ) {
+         return { valid: false, reason: "scope_mismatch" as const };
+      }
+
+      return {
+         valid: true as const,
+         coupon: {
+            id: coupon.id,
+            code: coupon.code,
+            type: coupon.type,
+            amount: coupon.amount,
+            duration: coupon.duration,
+            durationMonths: coupon.durationMonths,
+            scope: coupon.scope,
+            priceId: coupon.priceId ?? null,
+         },
+      };
+   });

--- a/apps/web/src/integrations/orpc/router/index.ts
+++ b/apps/web/src/integrations/orpc/router/index.ts
@@ -7,6 +7,7 @@ import * as billingRouter from "./billing";
 import * as categoriesRouter from "./categories";
 import * as contactSettingsRouter from "./contact-settings";
 import * as contactsRouter from "./contacts";
+import * as couponsRouter from "./coupons";
 import * as creditCardsRouter from "./credit-cards";
 import * as dashboardsRouter from "./dashboards";
 import * as financialSettingsRouter from "./financial-settings";
@@ -32,6 +33,7 @@ export default {
    categories: categoriesRouter,
    contactSettings: contactSettingsRouter,
    contacts: contactsRouter,
+   coupons: couponsRouter,
    dashboards: dashboardsRouter,
    financialSettings: financialSettingsRouter,
    insights: insightsRouter,

--- a/apps/web/src/integrations/orpc/router/services.ts
+++ b/apps/web/src/integrations/orpc/router/services.ts
@@ -1,6 +1,27 @@
 import { ensureContactOwnership } from "@core/database/repositories/contacts-repository";
-import { createBenefit as createBenefitRepo } from "@core/database/repositories/benefits-repository";
-import { createMeter as createMeterRepo } from "@core/database/repositories/meters-repository";
+import {
+   createBenefit as createBenefitRepo,
+   updateBenefit,
+   deleteBenefit,
+   ensureBenefitOwnership,
+   attachBenefitToService,
+   detachBenefitFromService,
+   listBenefitsByService,
+} from "@core/database/repositories/benefits-repository";
+import {
+   createMeter as createMeterRepo,
+   listMeters,
+   updateMeter,
+   deleteMeter,
+   ensureMeterOwnership,
+} from "@core/database/repositories/meters-repository";
+import {
+   addSubscriptionItem,
+   updateSubscriptionItemQuantity,
+   removeSubscriptionItem,
+   listSubscriptionItems,
+   ensureSubscriptionItemOwnership,
+} from "@core/database/repositories/subscription-items-repository";
 import {
    bulkCreateServices,
    createService,
@@ -22,8 +43,21 @@ import {
    listSubscriptionsByTeam,
    updateSubscription,
 } from "@core/database/repositories/subscriptions-repository";
-import { createBenefitSchema } from "@core/database/schemas/benefits";
-import { createMeterSchema } from "@core/database/schemas/meters";
+import {
+   createBenefitSchema,
+   benefits,
+   serviceBenefits,
+   updateBenefitSchema,
+} from "@core/database/schemas/benefits";
+import {
+   createMeterSchema,
+   updateMeterSchema,
+} from "@core/database/schemas/meters";
+import {
+   createSubscriptionItemSchema,
+   updateSubscriptionItemSchema,
+   subscriptionItems,
+} from "@core/database/schemas/subscription-items";
 import {
    createServiceSchema,
    updateServiceSchema,
@@ -31,7 +65,6 @@ import {
    updatePriceSchema as updateVariantSchema,
    servicePrices,
 } from "@core/database/schemas/services";
-import { subscriptionItems } from "@core/database/schemas/subscription-items";
 import {
    contactSubscriptions,
    createSubscriptionSchema,
@@ -45,7 +78,7 @@ import {
    emitUsageIngested,
 } from "@packages/events/service";
 import { enqueueUsageIngestionWorkflow } from "@packages/workflows/workflows/billing/usage-ingestion-workflow";
-import { eq, and, sum, sql } from "drizzle-orm";
+import { eq, and, sum, sql, count, asc } from "drizzle-orm";
 import { z } from "zod";
 import { createBillableProcedure } from "../billable";
 import { protectedProcedure } from "../server";
@@ -161,6 +194,18 @@ export const createVariant = protectedProcedure
    .input(z.object({ serviceId: z.string().uuid() }).merge(createVariantSchema))
    .handler(async ({ context, input }) => {
       const { serviceId, ...variantData } = input;
+      if (input.type === "metered") {
+         if (!input.meterId) {
+            throw WebAppError.badRequest(
+               "meterId é obrigatório para preços do tipo 'metered'.",
+            );
+         }
+         if (Number(input.basePrice) !== 0) {
+            throw WebAppError.badRequest(
+               "Preços do tipo 'metered' devem ter basePrice igual a '0'.",
+            );
+         }
+      }
       return (
          await ensureServiceOwnership(
             context.db,
@@ -186,6 +231,18 @@ export const updateVariant = protectedProcedure
    .input(idSchema.merge(updateVariantSchema))
    .handler(async ({ context, input }) => {
       const { id, ...data } = input;
+      if (input.type === "metered") {
+         if (input.meterId === null || input.meterId === undefined) {
+            throw WebAppError.badRequest(
+               "meterId é obrigatório para preços do tipo 'metered'.",
+            );
+         }
+         if (input.basePrice !== undefined && Number(input.basePrice) !== 0) {
+            throw WebAppError.badRequest(
+               "Preços do tipo 'metered' devem ter basePrice igual a '0'.",
+            );
+         }
+      }
       return (
          await ensureVariantOwnership(context.db, id, context.teamId).andThen(
             () => updateVariantRepo(context.db, id, data),
@@ -261,12 +318,20 @@ export const createSubscription = createBillableProcedure(
    "subscription.created",
 )
    .input(
-      createSubscriptionSchema.pick({
-         contactId: true,
-         startDate: true,
-         endDate: true,
-         notes: true,
-      }),
+      createSubscriptionSchema
+         .pick({
+            contactId: true,
+            startDate: true,
+            endDate: true,
+            notes: true,
+         })
+         .extend({
+            items: z
+               .array(
+                  createSubscriptionItemSchema.omit({ subscriptionId: true }),
+               )
+               .optional(),
+         }),
    )
    .handler(async ({ context, input }) => {
       const sub = (
@@ -287,6 +352,23 @@ export const createSubscription = createBillableProcedure(
             throw WebAppError.fromAppError(e);
          },
       );
+
+      if (input.items && input.items.length > 0) {
+         const itemResults = await Promise.allSettled(
+            input.items.map((item) =>
+               addSubscriptionItem(context.db, context.teamId, {
+                  ...item,
+                  subscriptionId: sub.id,
+               }),
+            ),
+         );
+         const failed = itemResults.filter((r) => r.status === "rejected");
+         if (failed.length > 0) {
+            throw WebAppError.internal(
+               "Falha ao adicionar itens à assinatura.",
+            );
+         }
+      }
 
       context.scheduleEmit(() =>
          emitSubscriptionCreated(context.emit, context.emitCtx, {
@@ -310,9 +392,9 @@ export const cancelSubscription = protectedProcedure
          },
       );
 
-      if (subscription.status !== "active") {
+      if (!["active", "trialing", "incomplete"].includes(subscription.status)) {
          throw WebAppError.badRequest(
-            "Apenas assinaturas ativas podem ser canceladas.",
+            "Apenas assinaturas ativas, em trial ou incompletas podem ser canceladas.",
          );
       }
 
@@ -334,16 +416,29 @@ export const cancelSubscription = protectedProcedure
       );
    });
 
-export const getExpiringSoon = protectedProcedure.handler(
-   async ({ context }) => {
-      return (await listExpiringSoon(context.db, context.teamId)).match(
+export const getExpiringSoon = protectedProcedure
+   .input(
+      z
+         .object({
+            status: z.enum(["active", "trialing"]).optional().default("active"),
+         })
+         .optional(),
+   )
+   .handler(async ({ context, input }) => {
+      return (
+         await listExpiringSoon(
+            context.db,
+            context.teamId,
+            undefined,
+            input?.status,
+         )
+      ).match(
          (rows) => rows,
          (e) => {
             throw WebAppError.fromAppError(e);
          },
       );
-   },
-);
+   });
 
 export const createMeter = createBillableProcedure("service.meter_created")
    .input(createMeterSchema)
@@ -446,3 +541,301 @@ export const getMrr = protectedProcedure.handler(async ({ context }) => {
 
    return { mrr: rows[0]?.total ?? "0" };
 });
+
+export const getMeters = protectedProcedure.handler(async ({ context }) => {
+   return (await listMeters(context.db, context.teamId)).match(
+      (rows) => rows,
+      (e) => {
+         throw WebAppError.fromAppError(e);
+      },
+   );
+});
+
+export const getMeterById = protectedProcedure
+   .input(z.object({ id: z.string().uuid() }))
+   .handler(async ({ context, input }) => {
+      return (
+         await ensureMeterOwnership(context.db, input.id, context.teamId)
+      ).match(
+         (meter) => meter,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+   });
+
+export const updateMeterById = protectedProcedure
+   .input(z.object({ id: z.string().uuid() }).merge(updateMeterSchema))
+   .handler(async ({ context, input }) => {
+      const { id, ...data } = input;
+      return (
+         await ensureMeterOwnership(context.db, id, context.teamId).andThen(
+            () => updateMeter(context.db, id, data),
+         )
+      ).match(
+         (meter) => meter,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+   });
+
+export const removeMeter = protectedProcedure
+   .input(z.object({ id: z.string().uuid() }))
+   .handler(async ({ context, input }) => {
+      return (
+         await ensureMeterOwnership(
+            context.db,
+            input.id,
+            context.teamId,
+         ).andThen(() => deleteMeter(context.db, input.id))
+      ).match(
+         () => ({ success: true }),
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+   });
+
+export const getBenefits = protectedProcedure.handler(async ({ context }) => {
+   const rows = await context.db
+      .select({
+         id: benefits.id,
+         teamId: benefits.teamId,
+         name: benefits.name,
+         type: benefits.type,
+         meterId: benefits.meterId,
+         creditAmount: benefits.creditAmount,
+         description: benefits.description,
+         isActive: benefits.isActive,
+         createdAt: benefits.createdAt,
+         updatedAt: benefits.updatedAt,
+         usedInServices: count(serviceBenefits.serviceId),
+      })
+      .from(benefits)
+      .leftJoin(serviceBenefits, eq(benefits.id, serviceBenefits.benefitId))
+      .where(eq(benefits.teamId, context.teamId))
+      .groupBy(benefits.id)
+      .orderBy(asc(benefits.name));
+   return rows;
+});
+
+export const getBenefitById = protectedProcedure
+   .input(z.object({ id: z.string().uuid() }))
+   .handler(async ({ context, input }) => {
+      return (
+         await ensureBenefitOwnership(context.db, input.id, context.teamId)
+      ).match(
+         (benefit) => benefit,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+   });
+
+export const updateBenefitById = protectedProcedure
+   .input(z.object({ id: z.string().uuid() }).merge(updateBenefitSchema))
+   .handler(async ({ context, input }) => {
+      const { id, ...data } = input;
+      return (
+         await ensureBenefitOwnership(context.db, id, context.teamId).andThen(
+            () => updateBenefit(context.db, id, data),
+         )
+      ).match(
+         (benefit) => benefit,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+   });
+
+export const removeBenefit = protectedProcedure
+   .input(z.object({ id: z.string().uuid() }))
+   .handler(async ({ context, input }) => {
+      return (
+         await ensureBenefitOwnership(
+            context.db,
+            input.id,
+            context.teamId,
+         ).andThen(() => deleteBenefit(context.db, input.id))
+      ).match(
+         () => ({ success: true }),
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+   });
+
+export const attachBenefit = protectedProcedure
+   .input(
+      z.object({
+         serviceId: z.string().uuid(),
+         benefitId: z.string().uuid(),
+      }),
+   )
+   .handler(async ({ context, input }) => {
+      return (
+         await ensureServiceOwnership(
+            context.db,
+            input.serviceId,
+            context.teamId,
+         )
+            .andThen(() =>
+               ensureBenefitOwnership(
+                  context.db,
+                  input.benefitId,
+                  context.teamId,
+               ),
+            )
+            .andThen(() =>
+               attachBenefitToService(
+                  context.db,
+                  input.serviceId,
+                  input.benefitId,
+               ),
+            )
+      ).match(
+         () => ({ success: true }),
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+   });
+
+export const detachBenefit = protectedProcedure
+   .input(
+      z.object({
+         serviceId: z.string().uuid(),
+         benefitId: z.string().uuid(),
+      }),
+   )
+   .handler(async ({ context, input }) => {
+      return (
+         await ensureServiceOwnership(
+            context.db,
+            input.serviceId,
+            context.teamId,
+         ).andThen(() =>
+            detachBenefitFromService(
+               context.db,
+               input.serviceId,
+               input.benefitId,
+            ),
+         )
+      ).match(
+         () => ({ success: true }),
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+   });
+
+export const getServiceBenefits = protectedProcedure
+   .input(z.object({ serviceId: z.string().uuid() }))
+   .handler(async ({ context, input }) => {
+      return (
+         await ensureServiceOwnership(
+            context.db,
+            input.serviceId,
+            context.teamId,
+         ).andThen(() => listBenefitsByService(context.db, input.serviceId))
+      ).match(
+         (rows) => rows,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+   });
+
+export const getActiveCountByPrice = protectedProcedure
+   .input(z.object({ priceId: z.string().uuid() }))
+   .handler(async ({ context, input }) => {
+      const rows = await context.db
+         .select({ count: count() })
+         .from(subscriptionItems)
+         .innerJoin(
+            contactSubscriptions,
+            eq(subscriptionItems.subscriptionId, contactSubscriptions.id),
+         )
+         .where(
+            and(
+               eq(subscriptionItems.priceId, input.priceId),
+               eq(subscriptionItems.teamId, context.teamId),
+               eq(contactSubscriptions.status, "active"),
+            ),
+         );
+      return { count: rows[0]?.count ?? 0 };
+   });
+
+export const addItem = protectedProcedure
+   .input(createSubscriptionItemSchema)
+   .handler(async ({ context, input }) => {
+      return (
+         await ensureSubscriptionOwnership(
+            context.db,
+            input.subscriptionId,
+            context.teamId,
+         ).andThen(() => addSubscriptionItem(context.db, context.teamId, input))
+      ).match(
+         (item) => item,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+   });
+
+export const updateItem = protectedProcedure
+   .input(
+      z.object({ id: z.string().uuid() }).merge(updateSubscriptionItemSchema),
+   )
+   .handler(async ({ context, input }) => {
+      const { id, ...data } = input;
+      return (
+         await ensureSubscriptionItemOwnership(
+            context.db,
+            id,
+            context.teamId,
+         ).andThen(() => updateSubscriptionItemQuantity(context.db, id, data))
+      ).match(
+         (item) => item,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+   });
+
+export const removeItem = protectedProcedure
+   .input(z.object({ id: z.string().uuid() }))
+   .handler(async ({ context, input }) => {
+      return (
+         await ensureSubscriptionItemOwnership(
+            context.db,
+            input.id,
+            context.teamId,
+         ).andThen(() => removeSubscriptionItem(context.db, input.id))
+      ).match(
+         () => ({ success: true }),
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+   });
+
+export const listItems = protectedProcedure
+   .input(z.object({ subscriptionId: z.string().uuid() }))
+   .handler(async ({ context, input }) => {
+      return (
+         await ensureSubscriptionOwnership(
+            context.db,
+            input.subscriptionId,
+            context.teamId,
+         ).andThen(() =>
+            listSubscriptionItems(context.db, input.subscriptionId),
+         )
+      ).match(
+         (items) => items,
+         (e) => {
+            throw WebAppError.fromAppError(e);
+         },
+      );
+   });

--- a/core/database/src/repositories/subscriptions-repository.ts
+++ b/core/database/src/repositories/subscriptions-repository.ts
@@ -194,6 +194,7 @@ export function listExpiringSoon(
    db: DatabaseInstance,
    teamId: string,
    withinDays = 30,
+   status: "active" | "trialing" = "active",
 ) {
    return fromPromise(
       (async () => {
@@ -205,7 +206,7 @@ export function listExpiringSoon(
             .where(
                and(
                   eq(contactSubscriptions.teamId, teamId),
-                  eq(contactSubscriptions.status, "active"),
+                  eq(contactSubscriptions.status, status),
                   gte(contactSubscriptions.endDate, now),
                   lte(contactSubscriptions.endDate, futureDate),
                ),


### PR DESCRIPTION
## Summary

- **Meters CRUD** — `getMeters`, `getMeterById`, `updateMeterById`, `removeMeter` with teamId ownership checks; `aggregation`/`eventName`/`filters` are read-only by schema design
- **Benefits CRUD + service_benefits** — `getBenefits` (includes `usedInServices` count via LEFT JOIN), `getBenefitById`, `updateBenefitById`, `removeBenefit`, `attachBenefit`, `detachBenefit`, `getServiceBenefits`
- **Coupons router** (new file) — `list`, `get`, `create`, `update`, `deactivate`, `validate`; validate returns structured `{ valid, reason }` without throwing for invalid coupons
- **Service prices** — enforce `meterId` required and `basePrice="0"` when `type="metered"` in `createVariant`/`updateVariant`; new `getActiveCountByPrice` procedure
- **Subscription items** — `addItem`, `updateItem`, `removeItem`, `listItems`; `createSubscription` now accepts optional `items` array
- **Billing** — new `getUsageSummary` procedure reads Redis via `getAllUsage`, works without a Stripe customer; returns per-event `used`, `freeTierLimit`, `pricePerEvent`, `overageEnabled`, `withinFreeTier`
- **cancelSubscription** — updated to allow `trialing` and `incomplete` statuses in addition to `active`
- **getExpiringSoon** — accepts optional `status` filter (`"active"` | `"trialing"`)

## Test plan

- [ ] Typecheck passes (`bun run typecheck`)
- [ ] Create a meter, list it, update name, remove
- [ ] Create a benefit, attach to service, list service benefits (verify count), detach, remove
- [ ] Create coupon, validate valid code, validate expired/max_uses/scope_mismatch
- [ ] Create subscription with items array, verify items created
- [ ] Cancel trialing subscription
- [ ] `getUsageSummary` returns data for org without Stripe customer
- [ ] `getActiveCountByPrice` returns correct count

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adiciona routers oRPC para medidores, benefícios, cupons, preços de serviço e itens de assinatura, além de `billing.getUsageSummary` via Redis; reforça regras para preços “metered” e amplia operações de assinatura. Atende MON-500 (Services Pricing Paradigm), reduzindo dependência do Stripe para uso.

- **New Features**
  - Routers (`apps/web/src/integrations/orpc/router/services.ts`)
    - Meters: `getMeters`, `getMeterById`, `updateMeterById`, `removeMeter` com verificação de `teamId`.
    - Benefits: CRUD + `attachBenefit`, `detachBenefit`, `getServiceBenefits`; `getBenefits` inclui `usedInServices` por LEFT JOIN.
    - Service prices: exige `meterId` e `basePrice="0"` quando `type="metered"` em `createVariant`/`updateVariant`; `getActiveCountByPrice`.
    - Subscription items: `addItem`, `updateItem`, `removeItem`, `listItems`; `createSubscription` aceita `items`; `cancelSubscription` permite `trialing`/`incomplete`; `getExpiringSoon` com filtro `status`.
  - Coupons (`apps/web/src/integrations/orpc/router/coupons.ts`): `list`, `get`, `create`, `update`, `deactivate`, `validate` retornando `{ valid, reason }` (sem exceção).
  - Billing (`apps/web/src/integrations/orpc/router/billing.ts`): `getUsageSummary` usa `getAllUsage` de `@packages/events/credits` e funciona sem Stripe.
  - Router index: registra `coupons`.
  - Repositório (`core/database/src/repositories/subscriptions-repository.ts`): `listExpiringSoon(status)` aceita `"active" | "trialing"`.
  - Impacto por camada:
    - Router: novos handlers e validações; API passa a exigir `meterId`/`basePrice=0` para preços `metered` e expõe CRUD/itens.
    - Repositório: ajuste em `listExpiringSoon`; demais repos já suportam as entidades.
    - Componente/Store: sem alterações diretas; clientes devem tratar `coupons.validate` não‑excepcional e enviar `meterId`/`basePrice` corretos.

- **Testes**
  - `bun run typecheck`.
  - Meters: criar, listar, atualizar, remover (com checagem de time).
  - Benefits: criar, anexar a serviço, listar com contagem, desanexar, remover.
  - Coupons: criar, validar código válido; validar `expired`/`max_uses_reached`/`scope_mismatch`.
  - Subscriptions: criar com `items` e verificar itens; cancelar `trialing` e `incomplete`.
  - Billing: `getUsageSummary` em organização sem Stripe.
  - Prices: `createVariant`/`updateVariant` falham se `type="metered"` sem `meterId` ou `basePrice != "0"`; `getActiveCountByPrice` retorna contagem correta.

<sup>Written for commit c94d5bb2bb4c9491363fc6f7fb50879c2e0ee50a. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/807">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

