### PR TITLE
feat(hyprpay-sdk): add subscriptions, usage, benefits, coupons, customerPortal namespaces (v0.2.0)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -79,6 +79,7 @@
       "drizzle-orm": "catalog:database",
       "drizzle-zod": "catalog:database",
       "foxact": "catalog:ui",
+      "jose": "^6.2.1",
       "lucide-react": "catalog:ui",
       "neverthrow": "^8.1.1",
       "posthog-js": "catalog:analytics-client",

--- a/apps/web/src/integrations/orpc/sdk/router/hyprpay/benefits.ts
+++ b/apps/web/src/integrations/orpc/sdk/router/hyprpay/benefits.ts
@@ -1,34 +1,18 @@
 import { implementerInternal } from "@orpc/server";
-import { err, ok } from "neverthrow";
-import type { Result } from "neverthrow";
 import { WebAppError } from "@core/logging/errors";
 
 type BenefitCheckStatus = "granted" | "revoked" | "not_found";
 import { hyprpayContract } from "@montte/hyprpay/contract";
 import { sdkProcedure } from "../../server";
-import type { SdkContext } from "../../server";
 import { getContactByExternalId } from "@core/database/repositories/contacts-repository";
 import { listGrantsWithBenefitsByContact } from "@core/database/repositories/benefit-grants-repository";
+import { requireTeamId } from "./utils";
 
 const impl = implementerInternal(
    hyprpayContract.benefits,
    sdkProcedure["~orpc"].config,
    [...sdkProcedure["~orpc"].middlewares],
 );
-
-function requireTeamId(
-   teamId: SdkContext["teamId"],
-): Result<string, WebAppError<"FORBIDDEN">> {
-   if (!teamId)
-      return err(
-         new WebAppError("FORBIDDEN", {
-            message:
-               "Esta operação requer uma chave de API vinculada a um projeto.",
-            source: "hyprpay",
-         }),
-      );
-   return ok(teamId);
-}
 
 export const check = impl.check.handler(async ({ context, input }) => {
    const teamIdResult = requireTeamId(context.teamId);
@@ -56,9 +40,11 @@ export const check = impl.check.handler(async ({ context, input }) => {
    );
    if (grantsResult.isErr()) throw WebAppError.fromAppError(grantsResult.error);
 
-   const match = grantsResult.value.find(
+   const allMatches = grantsResult.value.filter(
       (row) => row.benefit.id === input.benefitId,
    );
+   const match =
+      allMatches.find((row) => row.grant.status === "active") ?? allMatches[0];
 
    if (!match) {
       const status: BenefitCheckStatus = "not_found";

--- a/apps/web/src/integrations/orpc/sdk/router/hyprpay/benefits.ts
+++ b/apps/web/src/integrations/orpc/sdk/router/hyprpay/benefits.ts
@@ -1,0 +1,119 @@
+import { implementerInternal } from "@orpc/server";
+import { err, ok } from "neverthrow";
+import type { Result } from "neverthrow";
+import { WebAppError } from "@core/logging/errors";
+
+type BenefitCheckStatus = "granted" | "revoked" | "not_found";
+import { hyprpayContract } from "@montte/hyprpay/contract";
+import { sdkProcedure } from "../../server";
+import type { SdkContext } from "../../server";
+import { getContactByExternalId } from "@core/database/repositories/contacts-repository";
+import { listGrantsWithBenefitsByContact } from "@core/database/repositories/benefit-grants-repository";
+
+const impl = implementerInternal(
+   hyprpayContract.benefits,
+   sdkProcedure["~orpc"].config,
+   [...sdkProcedure["~orpc"].middlewares],
+);
+
+function requireTeamId(
+   teamId: SdkContext["teamId"],
+): Result<string, WebAppError<"FORBIDDEN">> {
+   if (!teamId)
+      return err(
+         new WebAppError("FORBIDDEN", {
+            message:
+               "Esta operação requer uma chave de API vinculada a um projeto.",
+            source: "hyprpay",
+         }),
+      );
+   return ok(teamId);
+}
+
+export const check = impl.check.handler(async ({ context, input }) => {
+   const teamIdResult = requireTeamId(context.teamId);
+   if (teamIdResult.isErr()) throw teamIdResult.error;
+   const teamId = teamIdResult.value;
+
+   const contactResult = await getContactByExternalId(
+      context.db,
+      input.customerId,
+      teamId,
+      "cliente",
+   );
+   if (contactResult.isErr())
+      throw WebAppError.fromAppError(contactResult.error);
+   if (!contactResult.value)
+      throw new WebAppError("NOT_FOUND", {
+         message: "Cliente não encontrado.",
+         source: "hyprpay",
+      });
+
+   const grantsResult = await listGrantsWithBenefitsByContact(
+      context.db,
+      teamId,
+      contactResult.value.id,
+   );
+   if (grantsResult.isErr()) throw WebAppError.fromAppError(grantsResult.error);
+
+   const match = grantsResult.value.find(
+      (row) => row.benefit.id === input.benefitId,
+   );
+
+   if (!match) {
+      const status: BenefitCheckStatus = "not_found";
+      return { status, grantedAt: null, revokedAt: null, subscriptionId: null };
+   }
+
+   const status: BenefitCheckStatus =
+      match.grant.status === "active" ? "granted" : "revoked";
+
+   return {
+      status,
+      grantedAt: match.grant.grantedAt.toISOString(),
+      revokedAt: match.grant.revokedAt?.toISOString() ?? null,
+      subscriptionId: match.grant.subscriptionId,
+   };
+});
+
+export const list = impl.list.handler(async ({ context, input }) => {
+   const teamIdResult = requireTeamId(context.teamId);
+   if (teamIdResult.isErr()) throw teamIdResult.error;
+   const teamId = teamIdResult.value;
+
+   const contactResult = await getContactByExternalId(
+      context.db,
+      input.customerId,
+      teamId,
+      "cliente",
+   );
+   if (contactResult.isErr())
+      throw WebAppError.fromAppError(contactResult.error);
+   if (!contactResult.value)
+      throw new WebAppError("NOT_FOUND", {
+         message: "Cliente não encontrado.",
+         source: "hyprpay",
+      });
+
+   const grantsResult = await listGrantsWithBenefitsByContact(
+      context.db,
+      teamId,
+      contactResult.value.id,
+   );
+   if (grantsResult.isErr()) throw WebAppError.fromAppError(grantsResult.error);
+
+   return grantsResult.value.map((row) => ({
+      id: row.grant.id,
+      benefitId: row.grant.benefitId,
+      subscriptionId: row.grant.subscriptionId,
+      status: row.grant.status,
+      grantedAt: row.grant.grantedAt.toISOString(),
+      revokedAt: row.grant.revokedAt?.toISOString() ?? null,
+      benefit: {
+         id: row.benefit.id,
+         name: row.benefit.name,
+         type: row.benefit.type,
+         description: row.benefit.description ?? null,
+      },
+   }));
+});

--- a/apps/web/src/integrations/orpc/sdk/router/hyprpay/coupons.ts
+++ b/apps/web/src/integrations/orpc/sdk/router/hyprpay/coupons.ts
@@ -1,5 +1,4 @@
 import { implementerInternal } from "@orpc/server";
-import { err, ok } from "neverthrow";
 import dayjs from "dayjs";
 import { WebAppError } from "@core/logging/errors";
 import { getCouponByCode } from "@core/database/repositories/coupons-repository";
@@ -7,29 +6,13 @@ import type { Coupon } from "@core/database/schemas/coupons";
 import { hyprpayContract } from "@montte/hyprpay/contract";
 import type { HyprPayCouponFromContract } from "@montte/hyprpay/contract";
 import { sdkProcedure } from "../../server";
-import type { SdkContext } from "../../server";
-import type { Result } from "neverthrow";
+import { requireTeamId } from "./utils";
 
 const impl = implementerInternal(
    hyprpayContract.coupons,
    sdkProcedure["~orpc"].config,
    [...sdkProcedure["~orpc"].middlewares],
 );
-
-function requireTeamId(
-   teamId: SdkContext["teamId"],
-): Result<string, WebAppError<"FORBIDDEN">> {
-   if (!teamId) {
-      return err(
-         new WebAppError("FORBIDDEN", {
-            message:
-               "Esta operação requer uma chave de API vinculada a um projeto.",
-            source: "hyprpay",
-         }),
-      );
-   }
-   return ok(teamId);
-}
 
 type InvalidReason =
    | "not_found"

--- a/apps/web/src/integrations/orpc/sdk/router/hyprpay/coupons.ts
+++ b/apps/web/src/integrations/orpc/sdk/router/hyprpay/coupons.ts
@@ -8,10 +8,10 @@ import { hyprpayContract } from "@montte/hyprpay/contract";
 import type { HyprPayCouponFromContract } from "@montte/hyprpay/contract";
 import { sdkProcedure } from "../../server";
 import type { SdkContext } from "../../server";
-import { Result } from "neverthrow";
+import type { Result } from "neverthrow";
 
 const impl = implementerInternal(
-   hyprpayContract,
+   hyprpayContract.coupons,
    sdkProcedure["~orpc"].config,
    [...sdkProcedure["~orpc"].middlewares],
 );
@@ -61,35 +61,27 @@ function mapCoupon(coupon: Coupon): HyprPayCouponFromContract {
    };
 }
 
-export const validate = impl.coupons.validate.handler(
-   async ({ context, input }) => {
-      const teamIdResult = requireTeamId(context.teamId);
-      if (teamIdResult.isErr()) throw teamIdResult.error;
-      const teamId = teamIdResult.value;
+export const validate = impl.validate.handler(async ({ context, input }) => {
+   const teamIdResult = requireTeamId(context.teamId);
+   if (teamIdResult.isErr()) throw teamIdResult.error;
+   const teamId = teamIdResult.value;
 
-      const couponResult = await getCouponByCode(
-         context.db,
-         teamId,
-         input.code,
-      );
-      if (couponResult.isErr())
-         throw WebAppError.fromAppError(couponResult.error);
+   const couponResult = await getCouponByCode(context.db, teamId, input.code);
+   if (couponResult.isErr()) throw WebAppError.fromAppError(couponResult.error);
 
-      const coupon = couponResult.value;
+   const coupon = couponResult.value;
 
-      if (!coupon) return invalid("not_found");
-      if (!coupon.isActive) return invalid("inactive");
-      if (coupon.redeemBy && dayjs().isAfter(coupon.redeemBy))
-         return invalid("expired");
-      if (coupon.maxUses != null && coupon.usedCount >= coupon.maxUses)
-         return invalid("max_uses_reached");
-      if (
-         coupon.scope === "price" &&
-         input.priceId != null &&
-         coupon.priceId !== input.priceId
-      )
-         return invalid("price_scope_mismatch");
+   if (!coupon) return invalid("not_found");
+   if (!coupon.isActive) return invalid("inactive");
+   if (coupon.redeemBy && dayjs().isAfter(coupon.redeemBy))
+      return invalid("expired");
+   if (coupon.maxUses != null && coupon.usedCount >= coupon.maxUses)
+      return invalid("max_uses_reached");
+   if (
+      coupon.scope === "price" &&
+      (input.priceId == null || coupon.priceId !== input.priceId)
+   )
+      return invalid("price_scope_mismatch");
 
-      return { valid: true, coupon: mapCoupon(coupon) };
-   },
-);
+   return { valid: true, coupon: mapCoupon(coupon) };
+});

--- a/apps/web/src/integrations/orpc/sdk/router/hyprpay/coupons.ts
+++ b/apps/web/src/integrations/orpc/sdk/router/hyprpay/coupons.ts
@@ -1,0 +1,95 @@
+import { implementerInternal } from "@orpc/server";
+import { err, ok } from "neverthrow";
+import dayjs from "dayjs";
+import { WebAppError } from "@core/logging/errors";
+import { getCouponByCode } from "@core/database/repositories/coupons-repository";
+import type { Coupon } from "@core/database/schemas/coupons";
+import { hyprpayContract } from "@montte/hyprpay/contract";
+import type { HyprPayCouponFromContract } from "@montte/hyprpay/contract";
+import { sdkProcedure } from "../../server";
+import type { SdkContext } from "../../server";
+import { Result } from "neverthrow";
+
+const impl = implementerInternal(
+   hyprpayContract,
+   sdkProcedure["~orpc"].config,
+   [...sdkProcedure["~orpc"].middlewares],
+);
+
+function requireTeamId(
+   teamId: SdkContext["teamId"],
+): Result<string, WebAppError<"FORBIDDEN">> {
+   if (!teamId) {
+      return err(
+         new WebAppError("FORBIDDEN", {
+            message:
+               "Esta operação requer uma chave de API vinculada a um projeto.",
+            source: "hyprpay",
+         }),
+      );
+   }
+   return ok(teamId);
+}
+
+type InvalidReason =
+   | "not_found"
+   | "inactive"
+   | "expired"
+   | "max_uses_reached"
+   | "price_scope_mismatch";
+
+function invalid(reason: InvalidReason): {
+   valid: false;
+   reason: InvalidReason;
+} {
+   return { valid: false, reason };
+}
+
+function mapCoupon(coupon: Coupon): HyprPayCouponFromContract {
+   return {
+      id: coupon.id,
+      code: coupon.code,
+      type: coupon.type,
+      amount: coupon.amount,
+      duration: coupon.duration,
+      durationMonths: coupon.durationMonths ?? null,
+      scope: coupon.scope,
+      priceId: coupon.priceId ?? null,
+      maxUses: coupon.maxUses ?? null,
+      usedCount: coupon.usedCount,
+      redeemBy: coupon.redeemBy ? coupon.redeemBy.toISOString() : null,
+   };
+}
+
+export const validate = impl.coupons.validate.handler(
+   async ({ context, input }) => {
+      const teamIdResult = requireTeamId(context.teamId);
+      if (teamIdResult.isErr()) throw teamIdResult.error;
+      const teamId = teamIdResult.value;
+
+      const couponResult = await getCouponByCode(
+         context.db,
+         teamId,
+         input.code,
+      );
+      if (couponResult.isErr())
+         throw WebAppError.fromAppError(couponResult.error);
+
+      const coupon = couponResult.value;
+
+      if (!coupon) return invalid("not_found");
+      if (!coupon.isActive) return invalid("inactive");
+      if (coupon.redeemBy && dayjs().isAfter(coupon.redeemBy))
+         return invalid("expired");
+      if (coupon.maxUses != null && coupon.usedCount >= coupon.maxUses)
+         return invalid("max_uses_reached");
+      if (
+         coupon.scope === "price" &&
+         input.priceId != null &&
+         coupon.priceId !== input.priceId
+      )
+         return invalid("price_scope_mismatch");
+
+      return { valid: true, coupon: mapCoupon(coupon) };
+   },
+);

--- a/apps/web/src/integrations/orpc/sdk/router/hyprpay/customer-portal.ts
+++ b/apps/web/src/integrations/orpc/sdk/router/hyprpay/customer-portal.ts
@@ -1,0 +1,77 @@
+import { implementerInternal } from "@orpc/server";
+import { err, fromPromise, ok } from "neverthrow";
+import { SignJWT } from "jose";
+import { WebAppError } from "@core/logging/errors";
+import { env } from "@core/environment/web";
+import { hyprpayContract } from "@montte/hyprpay/contract";
+import { sdkProcedure } from "../../server";
+import type { SdkContext } from "../../server";
+import { getContactByExternalId } from "@core/database/repositories/contacts-repository";
+import dayjs from "dayjs";
+
+const impl = implementerInternal(
+   hyprpayContract.customerPortal,
+   sdkProcedure["~orpc"].config,
+   [...sdkProcedure["~orpc"].middlewares],
+);
+
+function requireTeamId(teamId: SdkContext["teamId"]) {
+   if (!teamId)
+      return err(
+         new WebAppError("FORBIDDEN", {
+            message:
+               "Esta operação requer uma chave de API vinculada a um projeto.",
+            source: "hyprpay",
+         }),
+      );
+   return ok(teamId);
+}
+
+export const createSession = impl.createSession.handler(
+   async ({ context, input }) => {
+      const teamIdResult = requireTeamId(context.teamId);
+      if (teamIdResult.isErr()) throw teamIdResult.error;
+      const teamId = teamIdResult.value;
+
+      const contactResult = await getContactByExternalId(
+         context.db,
+         input.customerId,
+         teamId,
+         "cliente",
+      );
+      if (contactResult.isErr())
+         throw WebAppError.fromAppError(contactResult.error);
+      if (!contactResult.value)
+         throw new WebAppError("NOT_FOUND", {
+            message: "Cliente não encontrado.",
+            source: "hyprpay",
+         });
+
+      const secret = new TextEncoder().encode(env.JWT_SECRET);
+      const expiresAt = dayjs().add(15, "minute");
+
+      const signResult = await fromPromise(
+         new SignJWT({
+            sub: input.customerId,
+            teamId,
+            contactId: contactResult.value.id,
+         })
+            .setProtectedHeader({ alg: "HS256" })
+            .setIssuedAt()
+            .setExpirationTime(expiresAt.toDate())
+            .sign(secret),
+         (e) =>
+            new WebAppError("INTERNAL_SERVER_ERROR", {
+               message: "Falha ao gerar sessão do portal.",
+               source: "hyprpay",
+               cause: e,
+            }),
+      );
+      if (signResult.isErr()) throw signResult.error;
+
+      const baseUrl = env.APP_URL ?? "https://app.montte.co";
+      const url = `${baseUrl}/portal/${teamId}?token=${signResult.value}`;
+
+      return { url, expiresAt: expiresAt.toISOString() };
+   },
+);

--- a/apps/web/src/integrations/orpc/sdk/router/hyprpay/customer-portal.ts
+++ b/apps/web/src/integrations/orpc/sdk/router/hyprpay/customer-portal.ts
@@ -1,12 +1,13 @@
 import { implementerInternal } from "@orpc/server";
-import { err, fromPromise, ok } from "neverthrow";
+import { fromPromise } from "neverthrow";
 import { SignJWT } from "jose";
 import { WebAppError } from "@core/logging/errors";
 import { env } from "@core/environment/web";
+import { getDomain } from "@core/environment/helpers";
 import { hyprpayContract } from "@montte/hyprpay/contract";
 import { sdkProcedure } from "../../server";
-import type { SdkContext } from "../../server";
 import { getContactByExternalId } from "@core/database/repositories/contacts-repository";
+import { requireTeamId } from "./utils";
 import dayjs from "dayjs";
 
 const impl = implementerInternal(
@@ -14,18 +15,6 @@ const impl = implementerInternal(
    sdkProcedure["~orpc"].config,
    [...sdkProcedure["~orpc"].middlewares],
 );
-
-function requireTeamId(teamId: SdkContext["teamId"]) {
-   if (!teamId)
-      return err(
-         new WebAppError("FORBIDDEN", {
-            message:
-               "Esta operação requer uma chave de API vinculada a um projeto.",
-            source: "hyprpay",
-         }),
-      );
-   return ok(teamId);
-}
 
 export const createSession = impl.createSession.handler(
    async ({ context, input }) => {
@@ -69,7 +58,7 @@ export const createSession = impl.createSession.handler(
       );
       if (signResult.isErr()) throw signResult.error;
 
-      const baseUrl = env.APP_URL ?? "https://app.montte.co";
+      const baseUrl = getDomain();
       const url = `${baseUrl}/portal/${teamId}?token=${signResult.value}`;
 
       return { url, expiresAt: expiresAt.toISOString() };

--- a/apps/web/src/integrations/orpc/sdk/router/hyprpay/customers.ts
+++ b/apps/web/src/integrations/orpc/sdk/router/hyprpay/customers.ts
@@ -1,5 +1,4 @@
 import { implementerInternal } from "@orpc/server";
-import { Result, err, ok } from "neverthrow";
 import { WebAppError } from "@core/logging/errors";
 import {
    createContact,
@@ -10,28 +9,13 @@ import {
 import type { Contact } from "@core/database/schemas/contacts";
 import { hyprpayContract } from "@montte/hyprpay/contract";
 import { sdkProcedure } from "../../server";
-import type { SdkContext } from "../../server";
+import { requireTeamId } from "./utils";
 
 const impl = implementerInternal(
    hyprpayContract,
    sdkProcedure["~orpc"].config,
    [...sdkProcedure["~orpc"].middlewares],
 );
-
-function requireTeamId(
-   teamId: SdkContext["teamId"],
-): Result<string, WebAppError<"FORBIDDEN">> {
-   if (!teamId) {
-      return err(
-         new WebAppError("FORBIDDEN", {
-            message:
-               "Esta operação requer uma chave de API vinculada a um projeto.",
-            source: "hyprpay",
-         }),
-      );
-   }
-   return ok(teamId);
-}
 
 function mapCustomer(contact: Contact) {
    return {

--- a/apps/web/src/integrations/orpc/sdk/router/hyprpay/customers.ts
+++ b/apps/web/src/integrations/orpc/sdk/router/hyprpay/customers.ts
@@ -9,8 +9,8 @@ import {
 } from "@core/database/repositories/contacts-repository";
 import type { Contact } from "@core/database/schemas/contacts";
 import { hyprpayContract } from "@montte/hyprpay/contract";
-import { sdkProcedure } from "../server";
-import type { SdkContext } from "../server";
+import { sdkProcedure } from "../../server";
+import type { SdkContext } from "../../server";
 
 const impl = implementerInternal(
    hyprpayContract,

--- a/apps/web/src/integrations/orpc/sdk/router/hyprpay/index.ts
+++ b/apps/web/src/integrations/orpc/sdk/router/hyprpay/index.ts
@@ -1,4 +1,5 @@
 import { create, get, list, update } from "./customers";
 import * as subscriptions from "./subscriptions";
+import * as usage from "./usage";
 
-export default { create, get, list, update, subscriptions };
+export default { create, get, list, update, subscriptions, usage };

--- a/apps/web/src/integrations/orpc/sdk/router/hyprpay/index.ts
+++ b/apps/web/src/integrations/orpc/sdk/router/hyprpay/index.ts
@@ -3,6 +3,7 @@ import * as subscriptions from "./subscriptions";
 import * as usage from "./usage";
 import * as benefits from "./benefits";
 import * as coupons from "./coupons";
+import * as customerPortal from "./customer-portal";
 
 export default {
    create,
@@ -13,4 +14,5 @@ export default {
    usage,
    benefits,
    coupons,
+   customerPortal,
 };

--- a/apps/web/src/integrations/orpc/sdk/router/hyprpay/index.ts
+++ b/apps/web/src/integrations/orpc/sdk/router/hyprpay/index.ts
@@ -2,5 +2,15 @@ import { create, get, list, update } from "./customers";
 import * as subscriptions from "./subscriptions";
 import * as usage from "./usage";
 import * as benefits from "./benefits";
+import * as coupons from "./coupons";
 
-export default { create, get, list, update, subscriptions, usage, benefits };
+export default {
+   create,
+   get,
+   list,
+   update,
+   subscriptions,
+   usage,
+   benefits,
+   coupons,
+};

--- a/apps/web/src/integrations/orpc/sdk/router/hyprpay/index.ts
+++ b/apps/web/src/integrations/orpc/sdk/router/hyprpay/index.ts
@@ -1,0 +1,3 @@
+import { create, get, list, update } from "./customers";
+
+export default { create, get, list, update };

--- a/apps/web/src/integrations/orpc/sdk/router/hyprpay/index.ts
+++ b/apps/web/src/integrations/orpc/sdk/router/hyprpay/index.ts
@@ -1,5 +1,6 @@
 import { create, get, list, update } from "./customers";
 import * as subscriptions from "./subscriptions";
 import * as usage from "./usage";
+import * as benefits from "./benefits";
 
-export default { create, get, list, update, subscriptions, usage };
+export default { create, get, list, update, subscriptions, usage, benefits };

--- a/apps/web/src/integrations/orpc/sdk/router/hyprpay/index.ts
+++ b/apps/web/src/integrations/orpc/sdk/router/hyprpay/index.ts
@@ -1,3 +1,4 @@
 import { create, get, list, update } from "./customers";
+import * as subscriptions from "./subscriptions";
 
-export default { create, get, list, update };
+export default { create, get, list, update, subscriptions };

--- a/apps/web/src/integrations/orpc/sdk/router/hyprpay/subscriptions.ts
+++ b/apps/web/src/integrations/orpc/sdk/router/hyprpay/subscriptions.ts
@@ -1,0 +1,261 @@
+import { implementerInternal } from "@orpc/server";
+import { err, ok } from "neverthrow";
+import { WebAppError } from "@core/logging/errors";
+import { hyprpayContract } from "@montte/hyprpay/contract";
+import { sdkProcedure } from "../../server";
+import type { SdkContext } from "../../server";
+import {
+   createSubscription,
+   listSubscriptionsByContact,
+   updateSubscription,
+   ensureSubscriptionOwnership,
+} from "@core/database/repositories/subscriptions-repository";
+import {
+   addSubscriptionItem,
+   updateSubscriptionItemQuantity,
+   removeSubscriptionItem,
+   ensureSubscriptionItemOwnership,
+} from "@core/database/repositories/subscription-items-repository";
+import { getCouponByCode } from "@core/database/repositories/coupons-repository";
+import { getContactByExternalId } from "@core/database/repositories/contacts-repository";
+import type {
+   ContactSubscription,
+   UpdateSubscriptionInput,
+} from "@core/database/schemas/subscriptions";
+import type { SubscriptionItem } from "@core/database/schemas/subscription-items";
+import dayjs from "dayjs";
+
+const impl = implementerInternal(
+   hyprpayContract.subscriptions,
+   sdkProcedure["~orpc"].config,
+   [...sdkProcedure["~orpc"].middlewares],
+);
+
+function requireTeamId(teamId: SdkContext["teamId"]) {
+   if (!teamId)
+      return err(
+         new WebAppError("FORBIDDEN", {
+            message:
+               "Esta operação requer uma chave de API vinculada a um projeto.",
+            source: "hyprpay",
+         }),
+      );
+   return ok(teamId);
+}
+
+function mapSubscription(sub: ContactSubscription) {
+   return {
+      id: sub.id,
+      contactId: sub.contactId,
+      teamId: sub.teamId,
+      status: sub.status,
+      startDate: sub.startDate,
+      endDate: sub.endDate ?? null,
+      couponId: sub.couponId ?? null,
+      cancelAtPeriodEnd: sub.cancelAtPeriodEnd,
+      checkoutUrl: null satisfies string | null,
+      createdAt: sub.createdAt.toISOString(),
+      updatedAt: sub.updatedAt.toISOString(),
+   };
+}
+
+function mapItem(item: SubscriptionItem) {
+   return {
+      id: item.id,
+      subscriptionId: item.subscriptionId,
+      priceId: item.priceId,
+      quantity: item.quantity,
+      negotiatedPrice: item.negotiatedPrice ?? null,
+      createdAt: item.createdAt.toISOString(),
+      updatedAt: item.updatedAt.toISOString(),
+   };
+}
+
+export const create = impl.create.handler(async ({ context, input }) => {
+   const teamIdResult = requireTeamId(context.teamId);
+   if (teamIdResult.isErr()) throw teamIdResult.error;
+   const teamId = teamIdResult.value;
+
+   const contactResult = await getContactByExternalId(
+      context.db,
+      input.customerId,
+      teamId,
+      "cliente",
+   );
+   if (contactResult.isErr())
+      throw WebAppError.fromAppError(contactResult.error);
+   if (!contactResult.value || contactResult.value.isArchived) {
+      throw new WebAppError("NOT_FOUND", {
+         message: "Cliente não encontrado.",
+         source: "hyprpay",
+      });
+   }
+   const contact = contactResult.value;
+
+   let couponId: string | null = null;
+   if (input.couponCode) {
+      const couponResult = await getCouponByCode(
+         context.db,
+         teamId,
+         input.couponCode,
+      );
+      if (couponResult.isErr())
+         throw WebAppError.fromAppError(couponResult.error);
+      if (!couponResult.value || !couponResult.value.isActive) {
+         throw new WebAppError("BAD_REQUEST", {
+            message: "Cupom inválido ou inativo.",
+            source: "hyprpay",
+         });
+      }
+      couponId = couponResult.value.id;
+   }
+
+   const subscriptionResult = await createSubscription(context.db, teamId, {
+      contactId: contact.id,
+      startDate: dayjs().format("YYYY-MM-DD"),
+      status: "active",
+      source: "manual",
+      couponId,
+      cancelAtPeriodEnd: false,
+   });
+   if (subscriptionResult.isErr())
+      throw WebAppError.fromAppError(subscriptionResult.error);
+   const subscription = subscriptionResult.value;
+
+   for (const item of input.items) {
+      const itemResult = await addSubscriptionItem(context.db, teamId, {
+         subscriptionId: subscription.id,
+         priceId: item.priceId,
+         quantity: item.quantity ?? 1,
+      });
+      if (itemResult.isErr()) throw WebAppError.fromAppError(itemResult.error);
+   }
+
+   return { subscription: mapSubscription(subscription), checkoutUrl: null };
+});
+
+export const cancel = impl.cancel.handler(async ({ context, input }) => {
+   const teamIdResult = requireTeamId(context.teamId);
+   if (teamIdResult.isErr()) throw teamIdResult.error;
+   const teamId = teamIdResult.value;
+
+   const ownershipResult = await ensureSubscriptionOwnership(
+      context.db,
+      input.subscriptionId,
+      teamId,
+   );
+   if (ownershipResult.isErr())
+      throw WebAppError.fromAppError(ownershipResult.error);
+
+   const updateData: UpdateSubscriptionInput = input.cancelAtPeriodEnd
+      ? { cancelAtPeriodEnd: true }
+      : { status: "cancelled", cancelAtPeriodEnd: false };
+
+   const updatedResult = await updateSubscription(
+      context.db,
+      input.subscriptionId,
+      updateData,
+   );
+   if (updatedResult.isErr())
+      throw WebAppError.fromAppError(updatedResult.error);
+
+   return mapSubscription(updatedResult.value);
+});
+
+export const list = impl.list.handler(async ({ context, input }) => {
+   const teamIdResult = requireTeamId(context.teamId);
+   if (teamIdResult.isErr()) throw teamIdResult.error;
+   const teamId = teamIdResult.value;
+
+   const contactResult = await getContactByExternalId(
+      context.db,
+      input.customerId,
+      teamId,
+      "cliente",
+   );
+   if (contactResult.isErr())
+      throw WebAppError.fromAppError(contactResult.error);
+   if (!contactResult.value || contactResult.value.isArchived) {
+      throw new WebAppError("NOT_FOUND", {
+         message: "Cliente não encontrado.",
+         source: "hyprpay",
+      });
+   }
+
+   const subsResult = await listSubscriptionsByContact(
+      context.db,
+      contactResult.value.id,
+   );
+   if (subsResult.isErr()) throw WebAppError.fromAppError(subsResult.error);
+
+   return subsResult.value.map(mapSubscription);
+});
+
+export const addItem = impl.addItem.handler(async ({ context, input }) => {
+   const teamIdResult = requireTeamId(context.teamId);
+   if (teamIdResult.isErr()) throw teamIdResult.error;
+   const teamId = teamIdResult.value;
+
+   const itemResult = await addSubscriptionItem(context.db, teamId, {
+      subscriptionId: input.subscriptionId,
+      priceId: input.priceId,
+      quantity: input.quantity ?? 1,
+   });
+   if (itemResult.isErr()) throw WebAppError.fromAppError(itemResult.error);
+
+   return mapItem(itemResult.value);
+});
+
+export const updateItem = impl.updateItem.handler(
+   async ({ context, input }) => {
+      const teamIdResult = requireTeamId(context.teamId);
+      if (teamIdResult.isErr()) throw teamIdResult.error;
+      const teamId = teamIdResult.value;
+
+      const ownershipResult = await ensureSubscriptionItemOwnership(
+         context.db,
+         input.itemId,
+         teamId,
+      );
+      if (ownershipResult.isErr())
+         throw WebAppError.fromAppError(ownershipResult.error);
+
+      const updatedResult = await updateSubscriptionItemQuantity(
+         context.db,
+         input.itemId,
+         {
+            quantity: input.quantity,
+            negotiatedPrice: input.negotiatedPrice,
+         },
+      );
+      if (updatedResult.isErr())
+         throw WebAppError.fromAppError(updatedResult.error);
+
+      return mapItem(updatedResult.value);
+   },
+);
+
+export const removeItem = impl.removeItem.handler(
+   async ({ context, input }) => {
+      const teamIdResult = requireTeamId(context.teamId);
+      if (teamIdResult.isErr()) throw teamIdResult.error;
+      const teamId = teamIdResult.value;
+
+      const ownershipResult = await ensureSubscriptionItemOwnership(
+         context.db,
+         input.itemId,
+         teamId,
+      );
+      if (ownershipResult.isErr())
+         throw WebAppError.fromAppError(ownershipResult.error);
+
+      const removeResult = await removeSubscriptionItem(
+         context.db,
+         input.itemId,
+      );
+      if (removeResult.isErr())
+         throw WebAppError.fromAppError(removeResult.error);
+
+      return { success: true };
+   },
+);

--- a/apps/web/src/integrations/orpc/sdk/router/hyprpay/subscriptions.ts
+++ b/apps/web/src/integrations/orpc/sdk/router/hyprpay/subscriptions.ts
@@ -5,7 +5,7 @@ import { hyprpayContract } from "@montte/hyprpay/contract";
 import { sdkProcedure } from "../../server";
 import type { SdkContext } from "../../server";
 import {
-   createSubscription,
+   createSubscriptionWithItems,
    listSubscriptionsByContact,
    updateSubscription,
    ensureSubscriptionOwnership,
@@ -110,28 +110,29 @@ export const create = impl.create.handler(async ({ context, input }) => {
       couponId = couponResult.value.id;
    }
 
-   const subscriptionResult = await createSubscription(context.db, teamId, {
-      contactId: contact.id,
-      startDate: dayjs().format("YYYY-MM-DD"),
-      status: "active",
-      source: "manual",
-      couponId,
-      cancelAtPeriodEnd: false,
-   });
-   if (subscriptionResult.isErr())
-      throw WebAppError.fromAppError(subscriptionResult.error);
-   const subscription = subscriptionResult.value;
-
-   for (const item of input.items) {
-      const itemResult = await addSubscriptionItem(context.db, teamId, {
-         subscriptionId: subscription.id,
+   const subscriptionResult = await createSubscriptionWithItems(
+      context.db,
+      teamId,
+      {
+         contactId: contact.id,
+         startDate: dayjs().format("YYYY-MM-DD"),
+         status: "active",
+         source: "manual",
+         couponId,
+         cancelAtPeriodEnd: false,
+      },
+      input.items.map((item) => ({
          priceId: item.priceId,
          quantity: item.quantity ?? 1,
-      });
-      if (itemResult.isErr()) throw WebAppError.fromAppError(itemResult.error);
-   }
+      })),
+   );
+   if (subscriptionResult.isErr())
+      throw WebAppError.fromAppError(subscriptionResult.error);
 
-   return { subscription: mapSubscription(subscription), checkoutUrl: null };
+   return {
+      subscription: mapSubscription(subscriptionResult.value),
+      checkoutUrl: null,
+   };
 });
 
 export const cancel = impl.cancel.handler(async ({ context, input }) => {

--- a/apps/web/src/integrations/orpc/sdk/router/hyprpay/subscriptions.ts
+++ b/apps/web/src/integrations/orpc/sdk/router/hyprpay/subscriptions.ts
@@ -1,9 +1,8 @@
 import { implementerInternal } from "@orpc/server";
-import { err, ok } from "neverthrow";
 import { WebAppError } from "@core/logging/errors";
 import { hyprpayContract } from "@montte/hyprpay/contract";
 import { sdkProcedure } from "../../server";
-import type { SdkContext } from "../../server";
+import { requireTeamId } from "./utils";
 import {
    createSubscriptionWithItems,
    listSubscriptionsByContact,
@@ -30,18 +29,6 @@ const impl = implementerInternal(
    sdkProcedure["~orpc"].config,
    [...sdkProcedure["~orpc"].middlewares],
 );
-
-function requireTeamId(teamId: SdkContext["teamId"]) {
-   if (!teamId)
-      return err(
-         new WebAppError("FORBIDDEN", {
-            message:
-               "Esta operação requer uma chave de API vinculada a um projeto.",
-            source: "hyprpay",
-         }),
-      );
-   return ok(teamId);
-}
 
 function mapSubscription(sub: ContactSubscription) {
    return {
@@ -101,13 +88,32 @@ export const create = impl.create.handler(async ({ context, input }) => {
       );
       if (couponResult.isErr())
          throw WebAppError.fromAppError(couponResult.error);
-      if (!couponResult.value || !couponResult.value.isActive) {
+      const coupon = couponResult.value;
+      if (!coupon) {
          throw new WebAppError("BAD_REQUEST", {
-            message: "Cupom inválido ou inativo.",
+            message: "Cupom não encontrado.",
             source: "hyprpay",
          });
       }
-      couponId = couponResult.value.id;
+      if (!coupon.isActive) {
+         throw new WebAppError("BAD_REQUEST", {
+            message: "Cupom inativo.",
+            source: "hyprpay",
+         });
+      }
+      if (coupon.redeemBy && dayjs().isAfter(coupon.redeemBy)) {
+         throw new WebAppError("BAD_REQUEST", {
+            message: "Cupom expirado.",
+            source: "hyprpay",
+         });
+      }
+      if (coupon.maxUses != null && coupon.usedCount >= coupon.maxUses) {
+         throw new WebAppError("BAD_REQUEST", {
+            message: "Cupom sem usos restantes.",
+            source: "hyprpay",
+         });
+      }
+      couponId = coupon.id;
    }
 
    const subscriptionResult = await createSubscriptionWithItems(

--- a/apps/web/src/integrations/orpc/sdk/router/hyprpay/usage.ts
+++ b/apps/web/src/integrations/orpc/sdk/router/hyprpay/usage.ts
@@ -1,0 +1,114 @@
+import { implementerInternal } from "@orpc/server";
+import { err, ok, fromPromise } from "neverthrow";
+import type { Result } from "neverthrow";
+import { WebAppError } from "@core/logging/errors";
+import { hyprpayContract } from "@montte/hyprpay/contract";
+import { sdkProcedure } from "../../server";
+import type { SdkContext } from "../../server";
+import { getContactByExternalId } from "@core/database/repositories/contacts-repository";
+import { listUsageEventsByContact } from "@core/database/repositories/usage-events-repository";
+import { enqueueUsageIngestionWorkflow } from "@packages/workflows/workflows/billing/usage-ingestion-workflow";
+
+const impl = implementerInternal(
+   hyprpayContract.usage,
+   sdkProcedure["~orpc"].config,
+   [...sdkProcedure["~orpc"].middlewares],
+);
+
+function requireTeamId(
+   teamId: SdkContext["teamId"],
+): Result<string, WebAppError<"FORBIDDEN">> {
+   if (!teamId)
+      return err(
+         new WebAppError("FORBIDDEN", {
+            message:
+               "Esta operação requer uma chave de API vinculada a um projeto.",
+            source: "hyprpay",
+         }),
+      );
+   return ok(teamId);
+}
+
+export const ingest = impl.ingest.handler(async ({ context, input }) => {
+   const teamIdResult = requireTeamId(context.teamId);
+   if (teamIdResult.isErr()) throw teamIdResult.error;
+   const teamId = teamIdResult.value;
+
+   const contactResult = await getContactByExternalId(
+      context.db,
+      input.customerId,
+      teamId,
+      "cliente",
+   );
+   if (contactResult.isErr())
+      throw WebAppError.fromAppError(contactResult.error);
+   if (!contactResult.value)
+      throw new WebAppError("NOT_FOUND", {
+         message: "Cliente não encontrado.",
+         source: "hyprpay",
+      });
+
+   const idempotencyKey = input.idempotencyKey ?? crypto.randomUUID();
+
+   const enqueueResult = await fromPromise(
+      enqueueUsageIngestionWorkflow(context.workflowClient, {
+         teamId,
+         meterId: input.meterId,
+         quantity: String(input.quantity),
+         idempotencyKey,
+         contactId: contactResult.value.id,
+         properties: input.properties ?? {},
+      }),
+      (e) =>
+         new WebAppError("INTERNAL_SERVER_ERROR", {
+            message: "Falha ao enfileirar evento de uso.",
+            source: "hyprpay",
+            cause: e,
+         }),
+   );
+   if (enqueueResult.isErr()) throw enqueueResult.error;
+
+   return { queued: true, idempotencyKey };
+});
+
+export const list = impl.list.handler(async ({ context, input }) => {
+   const teamIdResult = requireTeamId(context.teamId);
+   if (teamIdResult.isErr()) throw teamIdResult.error;
+   const teamId = teamIdResult.value;
+
+   const contactResult = await getContactByExternalId(
+      context.db,
+      input.customerId,
+      teamId,
+      "cliente",
+   );
+   if (contactResult.isErr())
+      throw WebAppError.fromAppError(contactResult.error);
+   if (!contactResult.value)
+      throw new WebAppError("NOT_FOUND", {
+         message: "Cliente não encontrado.",
+         source: "hyprpay",
+      });
+
+   const eventsResult = await listUsageEventsByContact(
+      context.db,
+      teamId,
+      contactResult.value.id,
+   );
+   if (eventsResult.isErr()) throw WebAppError.fromAppError(eventsResult.error);
+
+   const events = eventsResult.value;
+   const filtered = input.meterId
+      ? events.filter((e) => e.meterId === input.meterId)
+      : events;
+
+   return filtered.map((e) => ({
+      teamId: e.teamId,
+      meterId: e.meterId,
+      quantity: e.quantity,
+      idempotencyKey: e.idempotencyKey,
+      contactId: e.contactId ?? null,
+      properties: e.properties,
+      timestamp: e.timestamp.toISOString(),
+   }));
+});

--- a/apps/web/src/integrations/orpc/sdk/router/hyprpay/usage.ts
+++ b/apps/web/src/integrations/orpc/sdk/router/hyprpay/usage.ts
@@ -1,33 +1,18 @@
 import { implementerInternal } from "@orpc/server";
-import { err, ok, fromPromise } from "neverthrow";
-import type { Result } from "neverthrow";
+import { fromPromise } from "neverthrow";
 import { WebAppError } from "@core/logging/errors";
 import { hyprpayContract } from "@montte/hyprpay/contract";
 import { sdkProcedure } from "../../server";
-import type { SdkContext } from "../../server";
 import { getContactByExternalId } from "@core/database/repositories/contacts-repository";
 import { listUsageEventsByContact } from "@core/database/repositories/usage-events-repository";
 import { enqueueUsageIngestionWorkflow } from "@packages/workflows/workflows/billing/usage-ingestion-workflow";
+import { requireTeamId } from "./utils";
 
 const impl = implementerInternal(
    hyprpayContract.usage,
    sdkProcedure["~orpc"].config,
    [...sdkProcedure["~orpc"].middlewares],
 );
-
-function requireTeamId(
-   teamId: SdkContext["teamId"],
-): Result<string, WebAppError<"FORBIDDEN">> {
-   if (!teamId)
-      return err(
-         new WebAppError("FORBIDDEN", {
-            message:
-               "Esta operação requer uma chave de API vinculada a um projeto.",
-            source: "hyprpay",
-         }),
-      );
-   return ok(teamId);
-}
 
 export const ingest = impl.ingest.handler(async ({ context, input }) => {
    const teamIdResult = requireTeamId(context.teamId);
@@ -94,18 +79,14 @@ export const list = impl.list.handler(async ({ context, input }) => {
       context.db,
       teamId,
       contactResult.value.id,
+      input.meterId,
    );
    if (eventsResult.isErr()) throw WebAppError.fromAppError(eventsResult.error);
 
-   const events = eventsResult.value;
-   const filtered = input.meterId
-      ? events.filter((e) => e.meterId === input.meterId)
-      : events;
-
-   return filtered.map((e) => ({
+   return eventsResult.value.map((e) => ({
       teamId: e.teamId,
       meterId: e.meterId,
-      quantity: e.quantity,
+      quantity: Number(e.quantity),
       idempotencyKey: e.idempotencyKey,
       contactId: e.contactId ?? null,
       properties: e.properties,

--- a/apps/web/src/integrations/orpc/sdk/router/hyprpay/utils.ts
+++ b/apps/web/src/integrations/orpc/sdk/router/hyprpay/utils.ts
@@ -1,0 +1,18 @@
+import { err, ok } from "neverthrow";
+import { WebAppError } from "@core/logging/errors";
+import type { SdkContext } from "../../server";
+import type { Result } from "neverthrow";
+
+export function requireTeamId(
+   teamId: SdkContext["teamId"],
+): Result<string, WebAppError<"FORBIDDEN">> {
+   if (!teamId)
+      return err(
+         new WebAppError("FORBIDDEN", {
+            message:
+               "Esta operação requer uma chave de API vinculada a um projeto.",
+            source: "hyprpay",
+         }),
+      );
+   return ok(teamId);
+}

--- a/apps/web/src/integrations/orpc/sdk/router/index.ts
+++ b/apps/web/src/integrations/orpc/sdk/router/index.ts
@@ -1,7 +1,7 @@
 import * as accounts from "./accounts";
 import * as transactions from "./transactions";
 import * as categories from "./categories";
-import * as hyprpay from "./hyprpay";
+import hyprpay from "./hyprpay/index";
 
 export default {
    accounts,

--- a/apps/web/src/integrations/orpc/sdk/server.ts
+++ b/apps/web/src/integrations/orpc/sdk/server.ts
@@ -4,11 +4,13 @@ import type { DatabaseInstance } from "@core/database/client";
 import { WebAppError } from "@core/logging/errors";
 import { authenticateRequest } from "./utils/sdk-auth";
 import type { AuthError } from "./utils/sdk-auth";
+import type { DBOSClient } from "@dbos-inc/dbos-sdk";
 
 interface BaseContext {
    db: DatabaseInstance;
    posthog: PostHog;
    request: Request;
+   workflowClient: DBOSClient;
 }
 
 interface SdkContext extends BaseContext {

--- a/apps/web/src/routes/api/sdk/$.ts
+++ b/apps/web/src/routes/api/sdk/$.ts
@@ -5,7 +5,7 @@ import { BatchHandlerPlugin } from "@orpc/server/plugins";
 import { FetchLoggingPlugin } from "@core/logging/orpc-plugin";
 import { createFileRoute } from "@tanstack/react-router";
 import pino from "pino";
-import { db, posthog } from "@/integrations/singletons";
+import { db, posthog, workflowClient } from "@/integrations/singletons";
 import sdkRouter from "@/integrations/orpc/sdk/router";
 
 const logger = pino({ name: "montte-web-sdk" });
@@ -25,7 +25,7 @@ const handler = new RPCHandler(sdkRouter, {
 async function handle({ request }: { request: Request }) {
    const { response } = await handler.handle(request, {
       prefix: "/api/sdk",
-      context: { db, posthog, request },
+      context: { db, posthog, request, workflowClient: await workflowClient },
    });
    return response ?? new Response("Not Found", { status: 404 });
 }

--- a/bun.lock
+++ b/bun.lock
@@ -1965,7 +1965,7 @@
 
     "@tanstack/hotkeys": ["@tanstack/hotkeys@0.7.1", "", { "dependencies": { "@tanstack/store": "^0.9.3" } }, "sha512-YHVO1z6wnvUCu7bg870Kv5k2D+FIuIOSIcbN0dAmTTsJ3mLMDLwcTVx0qVaq+SZp1B514JJTqGVstvUp85yIpQ=="],
 
-    "@tanstack/intent": ["@tanstack/intent@0.0.33", "", { "dependencies": { "cac": "^6.7.14", "yaml": "^2.7.0" }, "bin": { "intent": "dist/cli.mjs", "intent-library": "dist/intent-library.mjs" } }, "sha512-Gcg86NZebTTwEL9YVDnYuIhsy5z0nQshIpnszBmrcJ56uoN/oMOnwd+Mk631c4fIaHVoaId3DPVruwYNpnIANQ=="],
+    "@tanstack/intent": ["@tanstack/intent@0.0.34", "", { "dependencies": { "cac": "^6.7.14", "yaml": "^2.7.0" }, "bin": { "intent": "dist/cli.mjs", "intent-library": "dist/intent-library.mjs" } }, "sha512-J/uLkR7fj+HpxjboWLSj3BwCIu/5Ah7k/Xe1h+3lpj22EURT7lEn7mEOW61F71MftYAyePGdRIvy8QGyB1y6Dw=="],
 
     "@tanstack/match-sorter-utils": ["@tanstack/match-sorter-utils@8.19.4", "", { "dependencies": { "remove-accents": "0.5.0" } }, "sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -96,6 +96,7 @@
         "drizzle-orm": "catalog:database",
         "drizzle-zod": "catalog:database",
         "foxact": "catalog:ui",
+        "jose": "^6.2.1",
         "lucide-react": "catalog:ui",
         "neverthrow": "^8.1.1",
         "posthog-js": "catalog:analytics-client",
@@ -369,7 +370,7 @@
     },
     "libraries/hyprpay": {
       "name": "@montte/hyprpay",
-      "version": "0.1.6",
+      "version": "0.2.0",
       "dependencies": {
         "@orpc/client": "catalog:orpc",
         "@orpc/contract": "catalog:orpc",
@@ -523,6 +524,7 @@
         "@core/redis": "workspace:*",
         "@core/stripe": "workspace:*",
         "@dbos-inc/dbos-sdk": "catalog:workers",
+        "@f-o-t/money": "catalog:fot",
         "@packages/events": "workspace:*",
         "@packages/notifications": "workspace:*",
         "@tanstack/store": "catalog:tanstack",
@@ -1963,7 +1965,7 @@
 
     "@tanstack/hotkeys": ["@tanstack/hotkeys@0.7.1", "", { "dependencies": { "@tanstack/store": "^0.9.3" } }, "sha512-YHVO1z6wnvUCu7bg870Kv5k2D+FIuIOSIcbN0dAmTTsJ3mLMDLwcTVx0qVaq+SZp1B514JJTqGVstvUp85yIpQ=="],
 
-    "@tanstack/intent": ["@tanstack/intent@0.0.32", "", { "dependencies": { "cac": "^6.7.14", "yaml": "^2.7.0" }, "bin": { "intent": "dist/cli.mjs", "intent-library": "dist/intent-library.mjs" } }, "sha512-Dyv97rN1QhoJjYzUULztRsRUj8IYuq3k2+XsN9WVAF1IGoVSXpg50EykBWWQs0scti59HZmnIKSHQcw5DoxMHQ=="],
+    "@tanstack/intent": ["@tanstack/intent@0.0.33", "", { "dependencies": { "cac": "^6.7.14", "yaml": "^2.7.0" }, "bin": { "intent": "dist/cli.mjs", "intent-library": "dist/intent-library.mjs" } }, "sha512-Gcg86NZebTTwEL9YVDnYuIhsy5z0nQshIpnszBmrcJ56uoN/oMOnwd+Mk631c4fIaHVoaId3DPVruwYNpnIANQ=="],
 
     "@tanstack/match-sorter-utils": ["@tanstack/match-sorter-utils@8.19.4", "", { "dependencies": { "remove-accents": "0.5.0" } }, "sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg=="],
 

--- a/core/database/src/repositories/benefit-grants-repository.ts
+++ b/core/database/src/repositories/benefit-grants-repository.ts
@@ -1,9 +1,11 @@
 import { AppError } from "@core/logging/errors";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { fromPromise, ok } from "neverthrow";
 import dayjs from "dayjs";
 import type { DatabaseInstance } from "@core/database/client";
 import { benefitGrants } from "@core/database/schemas/benefit-grants";
+import { benefits } from "@core/database/schemas/benefits";
+import { contactSubscriptions } from "@core/database/schemas/subscriptions";
 
 export function grantBenefits(
    db: DatabaseInstance,
@@ -62,6 +64,43 @@ export function listGrantsBySubscription(
       }),
       (e) =>
          AppError.database("Falha ao listar concessões de benefícios.", {
+            cause: e,
+         }),
+   );
+}
+
+export function listGrantsWithBenefitsByContact(
+   db: DatabaseInstance,
+   teamId: string,
+   contactId: string,
+) {
+   return fromPromise(
+      (async () => {
+         const subs = await db
+            .select({ id: contactSubscriptions.id })
+            .from(contactSubscriptions)
+            .where(
+               and(
+                  eq(contactSubscriptions.contactId, contactId),
+                  eq(contactSubscriptions.teamId, teamId),
+               ),
+            );
+
+         if (subs.length === 0) return [];
+
+         const subIds = subs.map((s) => s.id);
+
+         return db
+            .select({
+               grant: benefitGrants,
+               benefit: benefits,
+            })
+            .from(benefitGrants)
+            .innerJoin(benefits, eq(benefitGrants.benefitId, benefits.id))
+            .where(inArray(benefitGrants.subscriptionId, subIds));
+      })(),
+      (e) =>
+         AppError.database("Falha ao buscar concessões de benefícios.", {
             cause: e,
          }),
    );

--- a/core/database/src/repositories/subscriptions-repository.ts
+++ b/core/database/src/repositories/subscriptions-repository.ts
@@ -1,6 +1,6 @@
 import dayjs from "dayjs";
 import { AppError, validateInput } from "@core/logging/errors";
-import { and, count, desc, eq, gte, lte, sql } from "drizzle-orm";
+import { and, count, desc, eq, gte, lte } from "drizzle-orm";
 import { fromPromise, fromThrowable, ok, err } from "neverthrow";
 import type { DatabaseInstance } from "@core/database/client";
 import {
@@ -81,12 +81,6 @@ export function createSubscriptionWithItems(
                   throw AppError.validation(
                      "Dados inválidos para item de assinatura.",
                   );
-
-               const lockRows = await tx.execute(
-                  sql`SELECT id FROM crm.contact_subscriptions WHERE id = ${subscription.id} AND team_id = ${teamId} FOR UPDATE`,
-               );
-               if (lockRows.rows.length === 0)
-                  throw AppError.notFound("Assinatura não encontrada.");
 
                const rows = await tx
                   .select({ itemCount: count() })

--- a/core/database/src/repositories/subscriptions-repository.ts
+++ b/core/database/src/repositories/subscriptions-repository.ts
@@ -1,6 +1,6 @@
 import dayjs from "dayjs";
 import { AppError, validateInput } from "@core/logging/errors";
-import { and, desc, eq, gte, lte } from "drizzle-orm";
+import { and, count, desc, eq, gte, lte, sql } from "drizzle-orm";
 import { fromPromise, fromThrowable, ok, err } from "neverthrow";
 import type { DatabaseInstance } from "@core/database/client";
 import {
@@ -11,6 +11,12 @@ import {
    createSubscriptionSchema,
    updateSubscriptionSchema,
 } from "@core/database/schemas/subscriptions";
+import {
+   subscriptionItems,
+   createSubscriptionItemSchema,
+} from "@core/database/schemas/subscription-items";
+
+const MAX_ITEMS_PER_SUBSCRIPTION = 20;
 
 const safeValidateCreate = fromThrowable(
    (data: CreateSubscriptionInput) =>
@@ -40,6 +46,76 @@ export function createSubscription(
          subscription
             ? ok(subscription)
             : err(AppError.database("Falha ao criar assinatura.")),
+      ),
+   );
+}
+
+type CreateSubscriptionItemData = {
+   priceId: string;
+   quantity: number;
+};
+
+export function createSubscriptionWithItems(
+   db: DatabaseInstance,
+   teamId: string,
+   data: CreateSubscriptionInput,
+   items: CreateSubscriptionItemData[],
+) {
+   return safeValidateCreate(data).asyncAndThen((validated) =>
+      fromPromise(
+         db.transaction(async (tx) => {
+            const [subscription] = await tx
+               .insert(contactSubscriptions)
+               .values({ ...validated, teamId })
+               .returning();
+            if (!subscription)
+               throw AppError.database("Falha ao criar assinatura.");
+
+            for (const item of items) {
+               const parsed = createSubscriptionItemSchema.safeParse({
+                  subscriptionId: subscription.id,
+                  priceId: item.priceId,
+                  quantity: item.quantity,
+               });
+               if (!parsed.success)
+                  throw AppError.validation(
+                     "Dados inválidos para item de assinatura.",
+                  );
+
+               const lockRows = await tx.execute(
+                  sql`SELECT id FROM crm.contact_subscriptions WHERE id = ${subscription.id} AND team_id = ${teamId} FOR UPDATE`,
+               );
+               if (lockRows.rows.length === 0)
+                  throw AppError.notFound("Assinatura não encontrada.");
+
+               const rows = await tx
+                  .select({ itemCount: count() })
+                  .from(subscriptionItems)
+                  .where(eq(subscriptionItems.subscriptionId, subscription.id));
+               const itemCount = rows[0]?.itemCount ?? 0;
+               if (itemCount >= MAX_ITEMS_PER_SUBSCRIPTION)
+                  throw AppError.validation(
+                     `Limite de ${MAX_ITEMS_PER_SUBSCRIPTION} itens por assinatura atingido.`,
+                  );
+
+               const [inserted] = await tx
+                  .insert(subscriptionItems)
+                  .values({ ...parsed.data, teamId })
+                  .returning();
+               if (!inserted)
+                  throw AppError.database(
+                     "Falha ao adicionar item à assinatura.",
+                  );
+            }
+
+            return subscription;
+         }),
+         (e) =>
+            e instanceof AppError
+               ? e
+               : AppError.database("Falha ao criar assinatura com itens.", {
+                    cause: e,
+                 }),
       ),
    );
 }

--- a/core/database/src/repositories/usage-events-repository.ts
+++ b/core/database/src/repositories/usage-events-repository.ts
@@ -41,11 +41,16 @@ export function listUsageEventsByContact(
    db: DatabaseInstance,
    teamId: string,
    contactId: string,
+   meterId?: string,
 ) {
    return fromPromise(
       db.query.usageEvents.findMany({
          where: (fields, { eq, and }) =>
-            and(eq(fields.teamId, teamId), eq(fields.contactId, contactId)),
+            and(
+               eq(fields.teamId, teamId),
+               eq(fields.contactId, contactId),
+               ...(meterId ? [eq(fields.meterId, meterId)] : []),
+            ),
       }),
       (e) => AppError.database("Falha ao listar eventos de uso.", { cause: e }),
    );

--- a/core/environment/src/web.ts
+++ b/core/environment/src/web.ts
@@ -7,6 +7,7 @@ export const env = createEnv({
       REDIS_URL: z.url().optional().default("redis://localhost:6379"),
 
       BETTER_AUTH_SECRET: z.string().min(32),
+      JWT_SECRET: z.string().min(32),
       BETTER_AUTH_URL: z.url().optional().default("http://localhost:3000"),
       BETTER_AUTH_TRUSTED_ORIGINS: z.string(),
       BETTER_AUTH_GOOGLE_CLIENT_ID: z.string(),

--- a/libraries/hyprpay/CHANGELOG.md
+++ b/libraries/hyprpay/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.2.0 — 2026-04-23
+
+### Added
+- `subscriptions` namespace: `create`, `cancel`, `list`, `addItem`, `updateItem`, `removeItem`
+- `usage` namespace: `ingest` (DBOS-backed, durable, idempotent), `list`
+- `benefits` namespace: `check` (granted/revoked/not_found), `list` with benefit details
+- `coupons` namespace: `validate` with structured error reasons and price-scope check
+- `customerPortal` namespace: `createSession` — signed JWT URL, 15-min TTL
+- New input types: `CreateSubscriptionInput`, `CancelSubscriptionInput`, `AddSubscriptionItemInput`, `UpdateSubscriptionItemInput`, `IngestUsageInput`, `ListUsageInput`, `CheckBenefitInput`, `ValidateCouponInput`
+
 ## [0.1.6]
 
 ### Added

--- a/libraries/hyprpay/package.json
+++ b/libraries/hyprpay/package.json
@@ -1,6 +1,6 @@
 {
    "name": "@montte/hyprpay",
-   "version": "0.1.6",
+   "version": "0.2.0",
    "private": false,
    "description": "HyprPay SDK — sincronize o ciclo de vida de clientes com o Montte",
    "keywords": [

--- a/libraries/hyprpay/skills/hyprpay/SKILL.md
+++ b/libraries/hyprpay/skills/hyprpay/SKILL.md
@@ -62,7 +62,10 @@ await hyprpay.subscriptions.cancel({ subscriptionId: sub.id });
 await hyprpay.subscriptions.cancel({ subscriptionId: sub.id, cancelAtPeriodEnd: true });
 
 // List
-const subs = await hyprpay.subscriptions.list(user.id).match(...);
+const subs = await hyprpay.subscriptions.list(user.id).match(
+   (v) => v,
+   (e) => { throw e },
+);
 
 // Manage items
 await hyprpay.subscriptions.addItem({ subscriptionId: sub.id, priceId: "price-456" });

--- a/libraries/hyprpay/skills/hyprpay/SKILL.md
+++ b/libraries/hyprpay/skills/hyprpay/SKILL.md
@@ -2,11 +2,12 @@
 name: "@montte/hyprpay/overview"
 description: >
    Use when integrating @montte/hyprpay SDK to sync customer lifecycle with Montte.
-   Covers createHyprPayClient setup, customers.create/get/update/list, HyprPayError handling,
+   Covers createHyprPayClient setup, customers.create/get/update/list, subscriptions,
+   usage ingestion, benefits, coupons, customer portal, HyprPayError handling,
    and the better-auth plugin for automatic customer creation on signup.
 type: core
 library: "@montte/hyprpay"
-library_version: "0.1.0"
+library_version: "0.2.0"
 sources:
    - "Montte-erp/montte-nx:libraries/hyprpay/src/index.ts"
    - "Montte-erp/montte-nx:libraries/hyprpay/src/client.ts"
@@ -44,6 +45,76 @@ await hyprpay.customers.update(user.id, { email: "novo@email.com" });
 
 // List (paginated)
 const { items, total } = await hyprpay.customers.list({ page: 1, limit: 20 });
+```
+
+## Subscriptions API
+
+```typescript
+// Create subscription with items
+const { subscription, checkoutUrl } = await hyprpay.subscriptions.create({
+   customerId: user.id,
+   items: [{ priceId: "price-123", quantity: 1 }],
+   couponCode: "PROMO10", // optional
+}).match((v) => v, (e) => { throw e });
+
+// Cancel
+await hyprpay.subscriptions.cancel({ subscriptionId: sub.id });
+await hyprpay.subscriptions.cancel({ subscriptionId: sub.id, cancelAtPeriodEnd: true });
+
+// List
+const subs = await hyprpay.subscriptions.list(user.id).match(...);
+
+// Manage items
+await hyprpay.subscriptions.addItem({ subscriptionId: sub.id, priceId: "price-456" });
+await hyprpay.subscriptions.updateItem({ itemId: item.id, quantity: 3 });
+await hyprpay.subscriptions.removeItem(item.id);
+```
+
+## Usage API
+
+```typescript
+// Ingest usage event (queued via DBOS — durable)
+await hyprpay.usage.ingest({
+   customerId: user.id,
+   meterId: "meter-abc",
+   quantity: 5,
+   properties: { source: "api" },
+   idempotencyKey: requestId, // optional but recommended
+});
+
+// List usage events
+const events = await hyprpay.usage.list({ customerId: user.id, meterId: "meter-abc" });
+```
+
+## Benefits API
+
+```typescript
+// Check a specific benefit
+const result = await hyprpay.benefits.check({ customerId: user.id, benefitId: "benefit-xyz" });
+// result.status: "granted" | "revoked" | "not_found"
+
+// List all benefit grants
+const grants = await hyprpay.benefits.list(user.id);
+```
+
+## Coupons API
+
+```typescript
+// Validate a coupon before subscription creation
+const validation = await hyprpay.coupons.validate({ code: "PROMO10" });
+if (validation.valid) {
+   // validation.coupon has type, amount, duration, scope
+} else {
+   // validation.reason: "not_found" | "inactive" | "expired" | "max_uses_reached" | "price_scope_mismatch"
+}
+```
+
+## Customer Portal API
+
+```typescript
+// Generate a short-lived signed portal URL (15 minutes)
+const { url, expiresAt } = await hyprpay.customerPortal.createSession(user.id);
+// Embed in email or show as "Gerenciar assinatura" link
 ```
 
 ## Error Handling

--- a/libraries/hyprpay/src/client.ts
+++ b/libraries/hyprpay/src/client.ts
@@ -6,10 +6,18 @@ import { hyprpayContract } from "./contract";
 import type { HyprPayCustomerFromContract as HyprPayCustomer } from "./contract";
 import { HyprPayError } from "./errors";
 import type {
+   AddSubscriptionItemInput,
+   CancelSubscriptionInput,
+   CheckBenefitInput,
    CreateCustomerInput,
+   CreateSubscriptionInput,
    HyprPayListResult,
+   IngestUsageInput,
    ListCustomersInput,
+   ListUsageInput,
    UpdateCustomerInput,
+   UpdateSubscriptionItemInput,
+   ValidateCouponInput,
 } from "./types";
 
 const DEFAULT_BASE_URL = "https://app.montte.co";
@@ -75,6 +83,96 @@ export function createHyprPayClient(config: HyprPayClientConfig) {
          ): ResultAsync<HyprPayCustomer, HyprPayError> {
             return ResultAsync.fromPromise(
                orpc.update({ externalId, ...data }),
+               mapToHyprPayError,
+            );
+         },
+      },
+
+      subscriptions: {
+         create(input: CreateSubscriptionInput) {
+            return ResultAsync.fromPromise(
+               orpc.subscriptions.create(input),
+               mapToHyprPayError,
+            );
+         },
+         cancel(input: CancelSubscriptionInput) {
+            return ResultAsync.fromPromise(
+               orpc.subscriptions.cancel({
+                  subscriptionId: input.subscriptionId,
+                  cancelAtPeriodEnd: input.cancelAtPeriodEnd ?? false,
+               }),
+               mapToHyprPayError,
+            );
+         },
+         list(customerId: string) {
+            return ResultAsync.fromPromise(
+               orpc.subscriptions.list({ customerId }),
+               mapToHyprPayError,
+            );
+         },
+         addItem(input: AddSubscriptionItemInput) {
+            return ResultAsync.fromPromise(
+               orpc.subscriptions.addItem(input),
+               mapToHyprPayError,
+            );
+         },
+         updateItem(input: UpdateSubscriptionItemInput) {
+            return ResultAsync.fromPromise(
+               orpc.subscriptions.updateItem(input),
+               mapToHyprPayError,
+            );
+         },
+         removeItem(itemId: string) {
+            return ResultAsync.fromPromise(
+               orpc.subscriptions.removeItem({ itemId }),
+               mapToHyprPayError,
+            );
+         },
+      },
+
+      usage: {
+         ingest(input: IngestUsageInput) {
+            return ResultAsync.fromPromise(
+               orpc.usage.ingest(input),
+               mapToHyprPayError,
+            );
+         },
+         list(input: ListUsageInput) {
+            return ResultAsync.fromPromise(
+               orpc.usage.list(input),
+               mapToHyprPayError,
+            );
+         },
+      },
+
+      benefits: {
+         check(input: CheckBenefitInput) {
+            return ResultAsync.fromPromise(
+               orpc.benefits.check(input),
+               mapToHyprPayError,
+            );
+         },
+         list(customerId: string) {
+            return ResultAsync.fromPromise(
+               orpc.benefits.list({ customerId }),
+               mapToHyprPayError,
+            );
+         },
+      },
+
+      coupons: {
+         validate(input: ValidateCouponInput) {
+            return ResultAsync.fromPromise(
+               orpc.coupons.validate(input),
+               mapToHyprPayError,
+            );
+         },
+      },
+
+      customerPortal: {
+         createSession(customerId: string) {
+            return ResultAsync.fromPromise(
+               orpc.customerPortal.createSession({ customerId }),
                mapToHyprPayError,
             );
          },

--- a/libraries/hyprpay/src/contract.ts
+++ b/libraries/hyprpay/src/contract.ts
@@ -112,6 +112,36 @@ const subscriptionsContract = {
       .output(z.object({ success: z.boolean() })),
 };
 
+const usageEventSchema = z.object({
+   teamId: z.string(),
+   meterId: z.string(),
+   quantity: z.string(),
+   idempotencyKey: z.string(),
+   contactId: z.string().nullable(),
+   properties: z.record(z.string(), z.unknown()),
+   timestamp: z.string(),
+});
+
+const usageContract = {
+   ingest: oc
+      .input(
+         z.object({
+            customerId: z.string(),
+            meterId: z.string(),
+            quantity: z.number().positive(),
+            properties: z.record(z.string(), z.unknown()).optional(),
+            idempotencyKey: z.string().optional(),
+         }),
+      )
+      .output(z.object({ queued: z.boolean(), idempotencyKey: z.string() })),
+
+   list: oc
+      .input(
+         z.object({ customerId: z.string(), meterId: z.string().optional() }),
+      )
+      .output(z.array(usageEventSchema)),
+};
+
 export const hyprpayContract = {
    create: oc
       .input(
@@ -148,8 +178,10 @@ export const hyprpayContract = {
       .output(customerSchema),
 
    subscriptions: subscriptionsContract,
+   usage: usageContract,
 };
 
+export type HyprPayUsageEventFromContract = z.infer<typeof usageEventSchema>;
 export type HyprPayCustomerFromContract = z.infer<typeof customerSchema>;
 export type HyprPaySubscriptionFromContract = z.infer<
    typeof subscriptionSchema

--- a/libraries/hyprpay/src/contract.ts
+++ b/libraries/hyprpay/src/contract.ts
@@ -174,6 +174,40 @@ const usageContract = {
       .output(z.array(usageEventSchema)),
 };
 
+const couponDetailSchema = z.object({
+   id: z.string(),
+   code: z.string(),
+   type: z.enum(["percent", "fixed"]),
+   amount: z.string(),
+   duration: z.enum(["once", "repeating", "forever"]),
+   durationMonths: z.number().nullable(),
+   scope: z.enum(["team", "price"]),
+   priceId: z.string().nullable(),
+   maxUses: z.number().nullable(),
+   usedCount: z.number(),
+   redeemBy: z.string().nullable(),
+});
+
+const couponsContract = {
+   validate: oc
+      .input(z.object({ code: z.string(), priceId: z.string().optional() }))
+      .output(
+         z.discriminatedUnion("valid", [
+            z.object({ valid: z.literal(true), coupon: couponDetailSchema }),
+            z.object({
+               valid: z.literal(false),
+               reason: z.enum([
+                  "not_found",
+                  "inactive",
+                  "expired",
+                  "max_uses_reached",
+                  "price_scope_mismatch",
+               ]),
+            }),
+         ]),
+      ),
+};
+
 export const hyprpayContract = {
    create: oc
       .input(
@@ -212,6 +246,7 @@ export const hyprpayContract = {
    subscriptions: subscriptionsContract,
    usage: usageContract,
    benefits: benefitsContract,
+   coupons: couponsContract,
 };
 
 export type HyprPayUsageEventFromContract = z.infer<typeof usageEventSchema>;
@@ -225,3 +260,4 @@ export type HyprPaySubscriptionItemFromContract = z.infer<
 export type HyprPayBenefitGrantFromContract = z.infer<
    typeof benefitGrantSchema
 >;
+export type HyprPayCouponFromContract = z.infer<typeof couponDetailSchema>;

--- a/libraries/hyprpay/src/contract.ts
+++ b/libraries/hyprpay/src/contract.ts
@@ -122,6 +122,38 @@ const usageEventSchema = z.object({
    timestamp: z.string(),
 });
 
+const benefitGrantSchema = z.object({
+   id: z.string(),
+   benefitId: z.string(),
+   subscriptionId: z.string(),
+   status: z.enum(["active", "revoked"]),
+   grantedAt: z.string(),
+   revokedAt: z.string().nullable(),
+   benefit: z.object({
+      id: z.string(),
+      name: z.string(),
+      type: z.enum(["credits", "feature_access", "custom"]),
+      description: z.string().nullable(),
+   }),
+});
+
+const benefitsContract = {
+   check: oc
+      .input(z.object({ customerId: z.string(), benefitId: z.string() }))
+      .output(
+         z.object({
+            status: z.enum(["granted", "revoked", "not_found"]),
+            grantedAt: z.string().nullable(),
+            revokedAt: z.string().nullable(),
+            subscriptionId: z.string().nullable(),
+         }),
+      ),
+
+   list: oc
+      .input(z.object({ customerId: z.string() }))
+      .output(z.array(benefitGrantSchema)),
+};
+
 const usageContract = {
    ingest: oc
       .input(
@@ -179,6 +211,7 @@ export const hyprpayContract = {
 
    subscriptions: subscriptionsContract,
    usage: usageContract,
+   benefits: benefitsContract,
 };
 
 export type HyprPayUsageEventFromContract = z.infer<typeof usageEventSchema>;
@@ -188,4 +221,7 @@ export type HyprPaySubscriptionFromContract = z.infer<
 >;
 export type HyprPaySubscriptionItemFromContract = z.infer<
    typeof subscriptionItemSchema
+>;
+export type HyprPayBenefitGrantFromContract = z.infer<
+   typeof benefitGrantSchema
 >;

--- a/libraries/hyprpay/src/contract.ts
+++ b/libraries/hyprpay/src/contract.ts
@@ -208,6 +208,12 @@ const couponsContract = {
       ),
 };
 
+const customerPortalContract = {
+   createSession: oc
+      .input(z.object({ customerId: z.string() }))
+      .output(z.object({ url: z.string(), expiresAt: z.string() })),
+};
+
 export const hyprpayContract = {
    create: oc
       .input(
@@ -247,6 +253,7 @@ export const hyprpayContract = {
    usage: usageContract,
    benefits: benefitsContract,
    coupons: couponsContract,
+   customerPortal: customerPortalContract,
 };
 
 export type HyprPayUsageEventFromContract = z.infer<typeof usageEventSchema>;

--- a/libraries/hyprpay/src/contract.ts
+++ b/libraries/hyprpay/src/contract.ts
@@ -21,6 +21,97 @@ const listResultSchema = z.object({
    pages: z.number(),
 });
 
+const subscriptionItemSchema = z.object({
+   id: z.string(),
+   subscriptionId: z.string(),
+   priceId: z.string(),
+   quantity: z.number(),
+   negotiatedPrice: z.string().nullable(),
+   createdAt: z.string(),
+   updatedAt: z.string(),
+});
+
+const subscriptionSchema = z.object({
+   id: z.string(),
+   contactId: z.string(),
+   teamId: z.string(),
+   status: z.enum([
+      "active",
+      "trialing",
+      "incomplete",
+      "completed",
+      "cancelled",
+   ]),
+   startDate: z.string(),
+   endDate: z.string().nullable(),
+   couponId: z.string().nullable(),
+   cancelAtPeriodEnd: z.boolean(),
+   checkoutUrl: z.string().nullable(),
+   createdAt: z.string(),
+   updatedAt: z.string(),
+});
+
+const subscriptionsContract = {
+   create: oc
+      .input(
+         z.object({
+            customerId: z.string(),
+            items: z
+               .array(
+                  z.object({
+                     priceId: z.string(),
+                     quantity: z.number().int().min(1).optional(),
+                  }),
+               )
+               .min(1),
+            couponCode: z.string().optional(),
+         }),
+      )
+      .output(
+         z.object({
+            subscription: subscriptionSchema,
+            checkoutUrl: z.string().nullable(),
+         }),
+      ),
+
+   cancel: oc
+      .input(
+         z.object({
+            subscriptionId: z.string(),
+            cancelAtPeriodEnd: z.boolean().default(false),
+         }),
+      )
+      .output(subscriptionSchema),
+
+   list: oc
+      .input(z.object({ customerId: z.string() }))
+      .output(z.array(subscriptionSchema)),
+
+   addItem: oc
+      .input(
+         z.object({
+            subscriptionId: z.string(),
+            priceId: z.string(),
+            quantity: z.number().int().min(1).optional(),
+         }),
+      )
+      .output(subscriptionItemSchema),
+
+   updateItem: oc
+      .input(
+         z.object({
+            itemId: z.string(),
+            quantity: z.number().int().min(1).optional(),
+            negotiatedPrice: z.string().nullable().optional(),
+         }),
+      )
+      .output(subscriptionItemSchema),
+
+   removeItem: oc
+      .input(z.object({ itemId: z.string() }))
+      .output(z.object({ success: z.boolean() })),
+};
+
 export const hyprpayContract = {
    create: oc
       .input(
@@ -55,6 +146,14 @@ export const hyprpayContract = {
          }),
       )
       .output(customerSchema),
+
+   subscriptions: subscriptionsContract,
 };
 
 export type HyprPayCustomerFromContract = z.infer<typeof customerSchema>;
+export type HyprPaySubscriptionFromContract = z.infer<
+   typeof subscriptionSchema
+>;
+export type HyprPaySubscriptionItemFromContract = z.infer<
+   typeof subscriptionItemSchema
+>;

--- a/libraries/hyprpay/src/contract.ts
+++ b/libraries/hyprpay/src/contract.ts
@@ -115,7 +115,7 @@ const subscriptionsContract = {
 const usageEventSchema = z.object({
    teamId: z.string(),
    meterId: z.string(),
-   quantity: z.string(),
+   quantity: z.number(),
    idempotencyKey: z.string(),
    contactId: z.string().nullable(),
    properties: z.record(z.string(), z.unknown()),

--- a/libraries/hyprpay/src/types.ts
+++ b/libraries/hyprpay/src/types.ts
@@ -24,3 +24,58 @@ export interface ListCustomersInput {
    page?: number;
    limit?: number;
 }
+
+// Subscriptions
+export interface CreateSubscriptionInput {
+   customerId: string;
+   items: Array<{ priceId: string; quantity?: number }>;
+   couponCode?: string;
+}
+
+export interface CancelSubscriptionInput {
+   subscriptionId: string;
+   cancelAtPeriodEnd?: boolean;
+}
+
+export interface AddSubscriptionItemInput {
+   subscriptionId: string;
+   priceId: string;
+   quantity?: number;
+}
+
+export interface UpdateSubscriptionItemInput {
+   itemId: string;
+   quantity?: number;
+   negotiatedPrice?: string | null;
+}
+
+// Usage
+export interface IngestUsageInput {
+   customerId: string;
+   meterId: string;
+   quantity: number;
+   properties?: Record<string, unknown>;
+   idempotencyKey?: string;
+}
+
+export interface ListUsageInput {
+   customerId: string;
+   meterId?: string;
+}
+
+// Benefits
+export interface CheckBenefitInput {
+   customerId: string;
+   benefitId: string;
+}
+
+// Coupons
+export interface ValidateCouponInput {
+   code: string;
+   priceId?: string;
+}
+
+// Portal
+export interface CreatePortalSessionInput {
+   customerId: string;
+}

--- a/libraries/hyprpay/src/types.ts
+++ b/libraries/hyprpay/src/types.ts
@@ -25,7 +25,6 @@ export interface ListCustomersInput {
    limit?: number;
 }
 
-// Subscriptions
 export interface CreateSubscriptionInput {
    customerId: string;
    items: Array<{ priceId: string; quantity?: number }>;
@@ -49,7 +48,6 @@ export interface UpdateSubscriptionItemInput {
    negotiatedPrice?: string | null;
 }
 
-// Usage
 export interface IngestUsageInput {
    customerId: string;
    meterId: string;
@@ -63,19 +61,16 @@ export interface ListUsageInput {
    meterId?: string;
 }
 
-// Benefits
 export interface CheckBenefitInput {
    customerId: string;
    benefitId: string;
 }
 
-// Coupons
 export interface ValidateCouponInput {
    code: string;
    priceId?: string;
 }
 
-// Portal
 export interface CreatePortalSessionInput {
    customerId: string;
 }


### PR DESCRIPTION
## Summary

Adds 5 new namespaces to `@montte/hyprpay` SDK, backed by oRPC procedures under `/api/sdk/hyprpay`. Bumps SDK to v0.2.0.

- **`subscriptions`** — `create` (transactional: subscription + items atomically), `cancel`, `list`, `addItem`, `updateItem`, `removeItem`
- **`usage`** — `ingest` (enqueues existing DBOS `usageIngestionWorkflow`, durable + idempotent), `list`
- **`benefits`** — `check` (returns `granted | revoked | not_found`), `list` with full benefit details via JOIN
- **`coupons`** — `validate` with structured error reasons (`inactive`, `expired`, `max_uses_reached`, `price_scope_mismatch`); price-scoped coupons validated against `priceId`
- **`customerPortal`** — `createSession` returns short-lived signed JWT URL (HS256, 15-min TTL) pointing to `/portal/:teamId`

## Architecture

- Contract-first: all procedures declared in `libraries/hyprpay/src/contract.ts` before implementation
- Router split into `hyprpay/` folder with one file per namespace
- SDK context extended with `workflowClient: DBOSClient` for usage ingestion
- New repo fn `createSubscriptionWithItems` — wraps subscription + item inserts in a single `db.transaction`
- New repo fn `listGrantsWithBenefitsByContact` — JOIN between `benefitGrants` and `benefits`
- `JWT_SECRET` added to web env (Zod-validated, min 32 chars)
- `jose` added to `apps/web` deps for JWT signing

## Test plan

- [ ] `hyprpay.subscriptions.create` — creates subscription + items atomically; partial item failure rolls back everything
- [ ] `hyprpay.subscriptions.cancel` with `cancelAtPeriodEnd: true` — sets flag, does not change status
- [ ] `hyprpay.subscriptions.cancel` with `cancelAtPeriodEnd: false` — sets `status: "cancelled"`
- [ ] `hyprpay.usage.ingest` — returns `{ queued: true, idempotencyKey }`; duplicate key is a no-op
- [ ] `hyprpay.benefits.check` — returns `not_found` for unknown benefit, `granted`/`revoked` for known
- [ ] `hyprpay.coupons.validate` with price-scoped coupon + wrong `priceId` → `price_scope_mismatch`
- [ ] `hyprpay.coupons.validate` with price-scoped coupon + no `priceId` → `price_scope_mismatch`
- [ ] `hyprpay.customerPortal.createSession` — returns URL + `expiresAt` 15min in future; JWT verifiable with `JWT_SECRET`
- [ ] All endpoints return `FORBIDDEN` when API key has no `teamId`
- [ ] Typecheck: `bun run typecheck` passes

## Known deferred issues

- `usage.list` does in-memory `meterId` filtering (needs DB predicate for scale)
- `requireTeamId` copy-pasted across 5 handler files (extract to shared guard in follow-up)
- Portal route (`/portal/:teamId`) not yet implemented — URL is generated but page doesn't exist
- `jose` uses bare semver pin instead of catalog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adiciona 5 novos namespaces ao SDK `@montte/hyprpay` com handlers oRPC em `/api/sdk/hyprpay` e libera a v0.2.0, cobrindo assinaturas, uso, benefícios, cupons e portal do cliente. Inclui guard compartilhado `requireTeamId`, filtro de `meterId` no repositório, validações de cupom/benefícios, geração correta da URL do portal e atualização de `@tanstack/intent` para 0.0.34. Atende o MON-501.

- **Novidades e impacto nas camadas**
  - Router (oRPC): novos handlers em `apps/web/src/integrations/orpc/sdk/router/hyprpay/*` para `subscriptions` (create/cancel/list + addItem/updateItem/removeItem), `usage` (ingest via DBOS + list), `benefits` (check/list), `coupons` (validate) e `customerPortal` (createSession); agregador `hyprpay/index`; `requireTeamId` extraído para `hyprpay/utils.ts`; contexto estendido com `workflowClient` (DBOS).
  - Repositório: `createSubscriptionWithItems` (transação; máx. 20 itens); `listGrantsWithBenefitsByContact` (JOIN grants↔benefits); `listUsageEventsByContact` agora filtra `meterId` no DB; reforço de ownership/validação em assinaturas/itens; regras de cupom (ativo, expiração `redeemBy`, limite `maxUses`, escopo por `priceId`).
  - Biblioteca SDK: contrato expandido (`libraries/hyprpay/src/contract.ts`) com `subscriptions`, `usage`, `benefits`, `coupons`, `customerPortal`; cliente com métodos correspondentes (`libraries/hyprpay/src/client.ts`); tipos alinhados (ex.: `usageEvent.quantity` como número); versão `0.2.0`; `SKILL.md` atualizado.
  - Env/Deps: `JWT_SECRET` adicionado; `jose` incluído em `apps/web` para assinar JWT do portal; URL do portal via `getDomain()`; upgrade de `@tanstack/intent` para `0.0.34`.
  - Componentes/Store: sem mudanças.

- **Checklist de teste**
  - Subscriptions: `create` (assinatura+itens atômicos; máx. 20 itens); `cancel` com/sem `cancelAtPeriodEnd`; `list`; `addItem`/`updateItem`/`removeItem` respeitam ownership/limites.
  - Usage: `ingest` retorna `{ queued: true, idempotencyKey }` (idempotente e durável via DBOS); `list` com filtro `meterId` aplicado no DB.
  - Benefits: `check` prioriza grant ativo quando múltiplos; `list` retorna grants com dados do benefício.
  - Coupons: `validate` cobre `not_found`, `inactive`, `expired`, `max_uses_reached`, `price_scope_mismatch` (quando `priceId` ausente/incorreto).
  - Customer Portal: `createSession` retorna URL com JWT HS256 e `expiresAt` ~15 min; base obtida por `getDomain()`; verificável com `JWT_SECRET`.
  - Segurança: endpoints retornam `FORBIDDEN` quando a API key não tem `teamId`.
  - Tipagem: `bun run typecheck` passa.

<sup>Written for commit 7a1bf56c84356697190017cfda3e86c72cc2fa6f. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/809">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

