### PR TITLE
fix(build): route web/worker builds through nx for dep ordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -234,9 +234,9 @@
       "test:scripts": "vitest run __tests__/workspace-scripts.test.ts",
       "test:coverage": "nx run-many -t test --parallel=3 -- --coverage",
       "typecheck": "nx run-many -t typecheck --parallel=8",
-      "web:build": "bun run --filter=web build",
+      "web:build": "nx run web:build",
       "web:start": "bun run --filter=web start",
-      "worker:build": "bun run --filter=worker build",
+      "worker:build": "nx run worker:build",
       "worker:start": "bun run --filter=worker start"
    },
    "devDependencies": {


### PR DESCRIPTION
## Summary
- Railway's `bun run web:build` ran `bun --filter=web build` directly, bypassing Nx — so workspace deps (`@core/hyprpay`, `@montte/hyprpay`) never built.
- Vite then resolved `@core/hyprpay` via tsconfig paths to its `src`, which imports bare `@montte/hyprpay`. Without its `dist`, Rolldown failed: `[vite]: Rolldown failed to resolve import "@montte/hyprpay" from "/app/core/hyprpay/src/client.ts"`.
- Switch `web:build` / `worker:build` to `nx run` so the `build` target's `dependsOn: ^build` chain builds all workspace deps first.

## Test plan
- [x] `rm -rf core/hyprpay/dist libraries/hyprpay/dist && bun run web:build` — green; Nx built 20 deps then web.
- [ ] Confirm Railway deploy succeeds on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redireciona os builds de web e worker para passar pelo `nx`, garantindo a ordem de build das dependências do monorepo e evitando erro de resolução em `@montte/hyprpay`. Corrige falhas de deploy no Railway e builds locais quando faltava `dist` das libs.

- **Bug Fixes**
  - O que mudou: scripts `web:build` e `worker:build` trocados de `bun run --filter ... build` para `nx run ...:build`.
  - Por quê: Railway executa `bun run web:build` direto, pulando `dependsOn` do `nx`; o `vite` resolve `@core/hyprpay/src` que importa `@montte/hyprpay` sem `dist`, causando falha do Rolldown.
  - Impacto nas camadas: router/repositório/componente/store sem mudanças de runtime; somente pipeline de build do workspace.
  - Checklist de testes:
    - Remover `dist` de `@core/hyprpay` e `@montte/hyprpay` e rodar `bun run web:build` — `nx` deve buildar deps antes do app.
    - Validar deploy no Railway com `bun run web:build` chamando `nx` e finalizando com sucesso.

<sup>Written for commit 0e91668f93896829a28570ec15704f30b0250515. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/812?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

