### PR TITLE
fix(release-weekly): avoid VERSION env clash with opencode installer

### DIFF
--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -73,14 +73,14 @@ jobs:
               OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
               CHANGES_FILE: changes.md
               OUTPUT_FILE: RELEASE_NOTES.md
-              VERSION: ${{ steps.version.outputs.version }}
+              RELEASE_VERSION: ${{ steps.version.outputs.version }}
            with:
               model: opencode-go/deepseek-v4-flash
               prompt: |
                  Leia o arquivo $CHANGES_FILE com commits e PRs mergeados desde a última release do Montte (ERP brasileiro).
 
                  Gere release notes em **português brasileiro** no arquivo $OUTPUT_FILE com:
-                 - Título: "Montte $VERSION"
+                 - Título: "Montte $RELEASE_VERSION"
                  - Resumo curto (2-3 linhas) destacando o tema da semana
                  - Seções agrupadas por tipo de mudança, na ordem: **Novidades** (feat), **Correções** (fix), **Melhorias** (refactor/perf), **Outros** (chore/docs/test)
                  - Cada item: linha curta descrevendo a mudança em pt-BR + link do PR (se existir) + referência MON-* (se mencionada no commit/PR)


### PR DESCRIPTION
## Summary

O install script do opencode lê `VERSION` do ambiente pra escolher a tag do binário. Passar o CalVer do Montte em `VERSION` fez o setup tentar baixar `v2026.04.30` do opencode e quebrar (ver run #2 de Release Weekly). Renomeio pra `RELEASE_VERSION`.

Follow-up de #823 / [MON-562](https://linear.app/montte/issue/MON-562/integrar-linear-releases-ao-fluxo-de-release).

## Test plan

- [ ] Disparar `release-weekly.yml` manualmente com `dry_run: true` — confere se a step "Generate release notes via opencode" passa do install
- [ ] Verificar que `RELEASE_NOTES.md` contém "Montte 2026.MM.DD" com a data correta

🤖 Generated with [Claude Code](https://claude.com/claude-code)