### PR TITLE
fix(release-weekly): handle opencode action push + use gh tag creation

### DIFF
--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -25,6 +25,7 @@ jobs:
            with:
               fetch-depth: 0
               fetch-tags: true
+              persist-credentials: false
 
          - name: Compute version
            id: version
@@ -68,6 +69,7 @@ jobs:
 
          - name: Generate release notes via opencode
            if: steps.version.outputs.skip != 'true'
+           continue-on-error: true
            uses: anomalyco/opencode/github@latest
            env:
               OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
@@ -88,15 +90,24 @@ jobs:
                  - Não inclua commits de merge automáticos
                  - Tom direto, sem emojis, sem fluff
 
+         - name: Verify release notes
+           if: steps.version.outputs.skip != 'true'
+           run: |
+              if [ ! -s RELEASE_NOTES.md ]; then
+                echo "RELEASE_NOTES.md missing or empty — opencode step failed" >&2
+                exit 1
+              fi
+
          - name: Create tag and GitHub release
            if: steps.version.outputs.skip != 'true' && inputs.dry_run != true
            env:
               GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               TAG: ${{ steps.version.outputs.tag }}
            run: |
-              git tag "$TAG"
-              git push origin "$TAG"
-              gh release create "$TAG" --title "Montte ${{ steps.version.outputs.version }}" --notes-file RELEASE_NOTES.md
+              gh release create "$TAG" \
+                --target "$GITHUB_SHA" \
+                --title "Montte ${{ steps.version.outputs.version }}" \
+                --notes-file RELEASE_NOTES.md
 
          - name: Create Linear release
            if: steps.version.outputs.skip != 'true' && inputs.dry_run != true


### PR DESCRIPTION
## Summary

Run #3 falhou em duas pontas:

1. Step "Generate release notes via opencode" gerou `RELEASE_NOTES.md` correto, mas **a action tenta fazer `git push -u origin opencode/dispatch-...`** e quebrou com `remote: Duplicate header: "Authorization"` — `actions/checkout` deixou credenciais persistidas e a action seta as suas próprias por cima.
2. Mesmo se passasse, nosso step de tag fazia `git tag` + `git push origin "$TAG"` — ia estourar igual.

Mudanças:

- `persist-credentials: false` no checkout
- `continue-on-error: true` no step do opencode (só precisamos do arquivo no disco)
- Novo step "Verify release notes" garante `RELEASE_NOTES.md` existe e não é vazio antes de publicar
- `gh release create --target $GITHUB_SHA` cria a tag sozinho — nunca mais `git push` no workflow

Follow-up de #823 / #824 / [MON-562](https://linear.app/montte/issue/MON-562/integrar-linear-releases-ao-fluxo-de-release).

## Test plan

- [ ] Disparar `release-weekly.yml` manualmente sem `dry_run` — confere que `gh release create` cria tag `vYYYY.MM.DD` e o GitHub Release
- [ ] Confere que o step do opencode não derruba o job mesmo se o push interno falhar
- [ ] Confere artifact `release-notes-*` enviado

🤖 Generated with [Claude Code](https://claude.com/claude-code)