### PR TITLE
feat(release-weekly): bullet-proof release notes prompt

### DIFF
--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -79,16 +79,80 @@ jobs:
            with:
               model: opencode-go/deepseek-v4-flash
               prompt: |
-                 Leia o arquivo $CHANGES_FILE com commits e PRs mergeados desde a última release do Montte (ERP brasileiro).
+                 Você gera release notes semanais do **Montte** (ERP brasileiro, SaaS, pt-BR). Audiência mista: usuários finais (donos de negócio, financeiro, operações) **e** time interno. Texto deve ser legível para os dois — direto, sem jargão desnecessário, sem marketing fluff.
 
-                 Gere release notes em **português brasileiro** no arquivo $OUTPUT_FILE com:
-                 - Título: "Montte $RELEASE_VERSION"
-                 - Resumo curto (2-3 linhas) destacando o tema da semana
-                 - Seções agrupadas por tipo de mudança, na ordem: **Novidades** (feat), **Correções** (fix), **Melhorias** (refactor/perf), **Outros** (chore/docs/test)
-                 - Cada item: linha curta descrevendo a mudança em pt-BR + link do PR (se existir) + referência MON-* (se mencionada no commit/PR)
-                 - Omita seções vazias
-                 - Não inclua commits de merge automáticos
-                 - Tom direto, sem emojis, sem fluff
+                 ## Entrada
+
+                 Arquivo `$CHANGES_FILE` contém duas seções:
+                 - `## Commits` — saída de `git log` no formato `- <subject> (<sha>) by <autor>`
+                 - `## Merged PRs` — PRs mergeados no GitHub no formato `- #<num> <título> by @<autor> — <url>`
+
+                 Os mesmos trabalhos aparecem nos dois lados (PR + commits do PR). **Use o PR como unidade canônica** quando existir; consolide os commits relacionados nele. Commits soltos sem PR viram itens próprios.
+
+                 ## Saída
+
+                 Escreva em `$OUTPUT_FILE` um Markdown com a estrutura abaixo. Seções vazias devem ser **omitidas inteiras** (não escreva "Nenhuma alteração").
+
+                 ```
+                 # Montte $RELEASE_VERSION
+
+                 <Resumo executivo: 2-4 frases em pt-BR descrevendo o tema da semana. Destaque os 1-3 pontos mais relevantes para usuários — entrega de produto, correção crítica, refatoração estrutural. Sem listar tudo. Tom de comunicado, não de bullet.>
+
+                 ## Destaques
+
+                 <Liste 3-5 itens de maior impacto, em ordem de relevância para o usuário final. Cada destaque é 1 frase explicando o **valor**, não a implementação. Exemplo: "Importação de extratos OFX agora aceita arquivos do Itaú e do Santander." e não "Adiciona parser OFX para bancos brasileiros." Inclua link do PR principal.>
+
+                 ## Mudanças que quebram compatibilidade
+
+                 <Apenas se houver. Liste cada breaking change com: o que mudou, quem é afetado, o que precisa ser feito. Detecte por: títulos com `!` (`feat!:`, `refactor!:`), texto "BREAKING CHANGE", remoção de rotas/campos/endpoints, migrations destrutivas.>
+
+                 ## Novidades
+
+                 <Tudo que é `feat:`. Agrupe por módulo/área quando 3+ itens compartilharem contexto (Faturamento, IA, Contatos, Estoque, Dashboards, Auth, Plataforma). Use `### <Área>` como subtítulo. Se for 1-2 itens, não subdivida.>
+
+                 ## Correções
+
+                 <Tudo que é `fix:`. Mesma regra de agrupamento.>
+
+                 ## Melhorias
+
+                 <`refactor:`, `perf:`, `style:` que tem efeito perceptível ou estrutural. Se for refactor puramente interno sem efeito visível, mande pra "Notas técnicas".>
+
+                 ## Notas técnicas
+
+                 <Para o time interno: refatorações grandes, mudanças de infra, atualizações de dependências relevantes, mudanças em workflows DBOS, schemas, RLS, observabilidade. Pode ser mais técnico aqui. Tom curto.>
+
+                 ## Manutenção
+
+                 <`chore:`, `docs:`, `test:`, `ci:` que não merecem destaque. 1 linha por item, agrupados se repetitivos. Se a lista ficar enorme (15+), resuma: "Atualização de dependências (X PRs)" + lista os PRs principais.>
+
+                 ---
+
+                 **Contribuíram nesta release:** @autor1, @autor2, ... (ordenado por nº de PRs, sem repetições, omita bots)
+                 ```
+
+                 ## Regras por item de lista
+
+                 - Cada item: **1 linha** começando em letra minúscula, descrevendo o que mudou em pt-BR claro.
+                 - Termine com referência: `([#PR](url))` para o PR. Se houver MON-XXX no título/corpo do commit ou PR, adicione `[MON-XXX](https://linear.app/montte/issue/MON-XXX)` antes do link do PR.
+                 - **Não inclua SHAs nem nomes de autores em itens individuais** (autores vão no rodapé).
+                 - **Não inclua** commits de merge (`Merge pull request`, `Merge branch`), commits de versão (`chore(release):`, `v1.2.3`), commits do dependabot/renovate sem efeito (use a linha de resumo).
+                 - Reescreva títulos crípticos em algo entendível. Ex.: `feat(billing): add ttp loop` → "fluxo de cobrança recorrente para clientes em trial".
+                 - **Sem emojis. Sem `simply`/`just`/`apenas`. Sem "We are excited". Sem markdown badges.** Tom: comunicado de produto sério.
+                 - Cada bullet entrega um fato. Se você não sabe o que a mudança faz pelo título, **omita** ou jogue em "Manutenção".
+
+                 ## Detecção de tipo
+
+                 Use o prefixo Conventional Commits no título do PR/commit. Se o título não tiver prefixo, infira pelo conteúdo: PR que adiciona arquivos sob `apps/web/src/routes/` é provavelmente `feat`; mudança em `*.test.ts` puro é `test`; bump de `package.json` é `chore(deps)`.
+
+                 ## Validação final antes de salvar
+
+                 - Resumo executivo está em pt-BR natural, não traduzido literal do inglês?
+                 - Destaques entregam **valor**, não implementação?
+                 - Toda referência MON-* virou link `[MON-XXX](https://linear.app/montte/issue/MON-XXX)`?
+                 - Nenhum item duplicado entre seções (PR e seus commits aparecem 1 vez só)?
+                 - Seções vazias removidas?
+                 - Rodapé de contribuidores ordenado por nº de PRs?
 
          - name: Verify release notes
            if: steps.version.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

Reescreve o prompt do opencode pra release notes muito mais robustas:

- **Audiência mista** (usuário final + time interno) — tom adaptado por seção
- **Estrutura clara**: Resumo executivo → Destaques (3-5, foco em valor) → Breaking changes → Novidades → Correções → Melhorias → Notas técnicas → Manutenção → Contribuidores
- **Agrupamento por módulo** (Faturamento, IA, Contatos, ...) quando 3+ itens compartilham contexto
- **Dedup explícito**: PR é a unidade canônica, commits do PR consolidam nele
- **Detecção de breaking changes** (`feat!:`, `BREAKING CHANGE`, removals)
- **Refator interno sem efeito visível** vai pra "Notas técnicas", não polui "Melhorias"
- **MON-XXX** sempre vira link `[MON-XXX](https://linear.app/montte/issue/MON-XXX)`
- **Regras anti-fluff**: sem emojis, sem "We are excited", reescreve títulos crípticos em pt-BR claro
- **Checklist final** que o modelo usa pra auto-validar antes de salvar

Follow-up de [MON-562](https://linear.app/montte/issue/MON-562/integrar-linear-releases-ao-fluxo-de-release).

## Test plan

- [ ] Disparar `release-weekly.yml` manualmente — confere se RELEASE_NOTES.md sai com a estrutura nova
- [ ] Confere se PRs sem MON-* não viram links quebrados
- [ ] Confere se commits de merge/dependabot não aparecem inflando seções

🤖 Generated with [Claude Code](https://claude.com/claude-code)