### PR TITLE
ops: add production Dockerfiles + docker-compose.prod for self-host (MON-576)

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,45 @@
+# Self-host Montte — production env. Copy to .env.production and fill in.
+# Generate secrets with: openssl rand -base64 32
+
+# ─── Postgres ────────────────────────────────────────────────────────────────
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=
+POSTGRES_DB=montte
+
+# ─── MinIO (S3-compatible storage) ───────────────────────────────────────────
+MINIO_ROOT_USER=
+MINIO_ROOT_PASSWORD=
+MINIO_BUCKET=montte-documents
+MINIO_API_PORT=9000
+MINIO_CONSOLE_PORT=9001
+
+# ─── App ─────────────────────────────────────────────────────────────────────
+NODE_ENV=production
+WEB_PORT=3000
+APP_URL=https://app.example.com
+SERVER_URL=https://app.example.com
+
+# ─── Auth (Better Auth) ──────────────────────────────────────────────────────
+BETTER_AUTH_SECRET=
+BETTER_AUTH_URL=https://app.example.com
+BETTER_AUTH_TRUSTED_ORIGINS=https://app.example.com
+
+# ─── PostHog ─────────────────────────────────────────────────────────────────
+POSTHOG_HOST=https://us.i.posthog.com
+POSTHOG_KEY=
+POSTHOG_PUBLIC_KEY=
+POSTHOG_PROJECT_ID=
+POSTHOG_PERSONAL_API_KEY=
+
+# ─── Email (Resend) ──────────────────────────────────────────────────────────
+RESEND_API_KEY=
+
+# ─── AI (optional) ───────────────────────────────────────────────────────────
+OPENROUTER_API_KEY=
+TAVILY_API_KEYS=
+EXA_API_KEYS=
+FIRECRAWL_API_KEYS=
+
+# ─── Worker ──────────────────────────────────────────────────────────────────
+WORKER_CONCURRENCY=10
+LOG_LEVEL=info

--- a/.env.production.example
+++ b/.env.production.example
@@ -3,12 +3,12 @@
 
 # ─── Postgres ────────────────────────────────────────────────────────────────
 POSTGRES_USER=postgres
-POSTGRES_PASSWORD=
+POSTGRES_PASSWORD=changeme
 POSTGRES_DB=montte
 
 # ─── MinIO (S3-compatible storage) ───────────────────────────────────────────
-MINIO_ROOT_USER=
-MINIO_ROOT_PASSWORD=
+MINIO_ROOT_USER=changeme
+MINIO_ROOT_PASSWORD=changeme
 MINIO_BUCKET=montte-documents
 MINIO_API_PORT=9000
 MINIO_CONSOLE_PORT=9001

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,49 @@
+name: Docker
+
+on:
+   pull_request:
+      branches: ["*"]
+      types: [opened, synchronize, reopened, ready_for_review]
+      paths:
+         - "apps/web/Dockerfile"
+         - "apps/worker/Dockerfile"
+         - "docker-compose.prod.yml"
+         - ".env.production.example"
+         - ".dockerignore"
+         - "package.json"
+         - "bun.lock"
+         - "core/**"
+         - "modules/**"
+         - "packages/**"
+         - "apps/web/**"
+         - "apps/worker/**"
+         - "tooling/**"
+         - "nx.json"
+         - "tsconfig.json"
+
+jobs:
+   build:
+      if: github.event.pull_request.draft == false
+      runs-on: blacksmith-4vcpu-ubuntu-2404
+      strategy:
+         fail-fast: false
+         matrix:
+            target: [web, worker]
+      steps:
+         - uses: actions/checkout@v4
+
+         - uses: docker/setup-buildx-action@v3
+
+         - name: Build ${{ matrix.target }} image
+           uses: docker/build-push-action@v6
+           with:
+              context: .
+              file: apps/${{ matrix.target }}/Dockerfile
+              push: false
+              load: false
+              cache-from: type=gha,scope=docker-${{ matrix.target }}
+              cache-to: type=gha,scope=docker-${{ matrix.target }},mode=max
+
+         - name: Validate compose file
+           if: matrix.target == 'web'
+           run: docker compose -f docker-compose.prod.yml --env-file .env.production.example config -q

--- a/README.md
+++ b/README.md
@@ -170,7 +170,19 @@ Authenticate with `x-api-key` (created in Settings → Project → API Keys) or 
 
 ## Self-host
 
-A production Dockerfile and `docker-compose.prod.yml` are coming as part of the launch (tracked in [MON-576](https://linear.app/montte/issue/MON-576)). For now `apps/web/docker-compose.yml` only spins up the local Postgres / Redis / MinIO stack for development.
+```bash
+cp .env.production.example .env.production
+# fill in secrets, then:
+docker compose -f docker-compose.prod.yml --env-file .env.production up -d
+```
+
+The stack runs `web` (TanStack Start, port 3000), `worker` (DBOS), `postgres` (ParadeDB), `redis` and `minio`. First boot only — push the schema from a dev checkout pointed at the same `DATABASE_URL`:
+
+```bash
+DATABASE_URL=postgresql://… bun run db:push
+```
+
+Per-app Dockerfiles live at `apps/web/Dockerfile` and `apps/worker/Dockerfile` (multi-stage Bun builds, build context is the repo root).
 
 ---
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1.7
+# Build context: monorepo root. Run from repo root:
+#   docker build -f apps/web/Dockerfile -t montte/web .
+
+ARG BUN_VERSION=1.3.12
+
+FROM oven/bun:${BUN_VERSION}-slim AS base
+WORKDIR /repo
+ENV CI=1 \
+    NODE_ENV=production \
+    HUSKY=0 \
+    LEFTHOOK=0
+
+FROM base AS deps
+COPY package.json bun.lock bunfig.toml ./
+COPY patches ./patches
+COPY tooling ./tooling
+COPY core ./core
+COPY packages ./packages
+COPY modules ./modules
+COPY apps/web/package.json ./apps/web/
+COPY apps/worker/package.json ./apps/worker/
+RUN bun install --frozen-lockfile
+
+FROM deps AS builder
+COPY nx.json tsconfig.json ./
+COPY scripts ./scripts
+COPY apps/web ./apps/web
+RUN bun run web:build
+
+FROM base AS runner
+RUN useradd --system --create-home --uid 1001 montte
+WORKDIR /app
+
+COPY --from=builder --chown=montte:montte /repo/apps/web/.output ./apps/web/.output
+COPY --from=builder --chown=montte:montte /repo/node_modules ./node_modules
+COPY --from=builder --chown=montte:montte /repo/package.json ./package.json
+
+USER montte
+ENV PORT=3000 \
+    HOST=0.0.0.0
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD bun -e "fetch('http://127.0.0.1:'+process.env.PORT+'/api/ping').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
+CMD ["bun", "apps/web/.output/server/index.mjs"]

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1.7
+# Build context: monorepo root. Run from repo root:
+#   docker build -f apps/worker/Dockerfile -t montte/worker .
+
+ARG BUN_VERSION=1.3.12
+
+FROM oven/bun:${BUN_VERSION}-slim AS base
+WORKDIR /repo
+ENV CI=1 \
+    NODE_ENV=production \
+    HUSKY=0 \
+    LEFTHOOK=0
+
+FROM base AS deps
+COPY package.json bun.lock bunfig.toml ./
+COPY patches ./patches
+COPY tooling ./tooling
+COPY core ./core
+COPY packages ./packages
+COPY modules ./modules
+COPY apps/web/package.json ./apps/web/
+COPY apps/worker/package.json ./apps/worker/
+RUN bun install --frozen-lockfile
+
+FROM deps AS builder
+COPY nx.json tsconfig.json ./
+COPY apps/worker ./apps/worker
+RUN bun run worker:build
+
+FROM base AS runner
+RUN useradd --system --create-home --uid 1001 montte
+WORKDIR /app
+
+COPY --from=builder --chown=montte:montte /repo/apps/worker/dist ./apps/worker/dist
+COPY --from=builder --chown=montte:montte /repo/node_modules ./node_modules
+COPY --from=builder --chown=montte:montte /repo/package.json ./package.json
+COPY --from=builder --chown=montte:montte /repo/apps/worker/package.json ./apps/worker/package.json
+
+USER montte
+
+CMD ["bun", "run", "apps/worker/dist/index.js"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,96 @@
+# Self-host Montte. From repo root:
+#   cp .env.production.example .env.production
+#   # edit secrets, then:
+#   docker compose -f docker-compose.prod.yml --env-file .env.production up -d
+#
+# First boot only — push the schema:
+#   docker compose -f docker-compose.prod.yml --env-file .env.production \
+#     run --rm web bun run --filter=@core/database db-push
+
+name: montte
+
+services:
+   postgres:
+      image: paradedb/paradedb:latest
+      command: postgres -c wal_level=logical
+      restart: unless-stopped
+      environment:
+         POSTGRES_USER: ${POSTGRES_USER:-postgres}
+         POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env.production}
+         POSTGRES_DB: ${POSTGRES_DB:-montte}
+      volumes:
+         - pgdata:/var/lib/postgresql
+      healthcheck:
+         test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-montte}"]
+         interval: 10s
+         timeout: 5s
+         retries: 10
+
+   redis:
+      image: redis:7-alpine
+      restart: unless-stopped
+      command: redis-server --appendonly yes
+      volumes:
+         - redisdata:/data
+      healthcheck:
+         test: ["CMD", "redis-cli", "ping"]
+         interval: 10s
+         timeout: 5s
+         retries: 5
+
+   minio:
+      image: minio/minio:latest
+      restart: unless-stopped
+      command: server /data --console-address ":9001"
+      environment:
+         MINIO_ROOT_USER: ${MINIO_ROOT_USER:?set MINIO_ROOT_USER in .env.production}
+         MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?set MINIO_ROOT_PASSWORD in .env.production}
+      volumes:
+         - miniodata:/data
+      ports:
+         - "${MINIO_API_PORT:-9000}:9000"
+         - "${MINIO_CONSOLE_PORT:-9001}:9001"
+      healthcheck:
+         test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+         interval: 30s
+         timeout: 10s
+         retries: 5
+
+   web:
+      build:
+         context: .
+         dockerfile: apps/web/Dockerfile
+      image: montte/web:latest
+      restart: unless-stopped
+      depends_on:
+         postgres: { condition: service_healthy }
+         redis: { condition: service_healthy }
+         minio: { condition: service_healthy }
+      env_file: .env.production
+      environment:
+         DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-montte}
+         REDIS_URL: redis://redis:6379
+         MINIO_ENDPOINT: minio:9000
+         MINIO_ACCESS_KEY: ${MINIO_ROOT_USER}
+         MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD}
+      ports:
+         - "${WEB_PORT:-3000}:3000"
+
+   worker:
+      build:
+         context: .
+         dockerfile: apps/worker/Dockerfile
+      image: montte/worker:latest
+      restart: unless-stopped
+      depends_on:
+         postgres: { condition: service_healthy }
+         redis: { condition: service_healthy }
+      env_file: .env.production
+      environment:
+         DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-montte}
+         REDIS_URL: redis://redis:6379
+
+volumes:
+   pgdata:
+   redisdata:
+   miniodata:


### PR DESCRIPTION
## Summary
- Multi-stage Bun Dockerfiles for `web` and `worker` (build context = repo root)
- `docker-compose.prod.yml` orchestrates web + worker + paradedb + redis + minio with healthchecks and named volumes
- `.env.production.example` documents required secrets
- New `Docker` GH Actions workflow builds both images on PRs that touch relevant paths and validates the compose file — we don't deploy via docker, but self-hosters do, so CI keeps the README honest
- README self-host section updated with real `docker compose up -d` instructions

Closes MON-576.

## Test plan
- [ ] CI `Docker` workflow goes green on this PR (web + worker images build)
- [ ] `docker compose -f docker-compose.prod.yml --env-file .env.production.example config -q` exits 0
- [ ] Self-hoster smoke: copy `.env.production.example`, fill secrets, `docker compose up -d`, hit `/api/ping`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Infra Docker de produção para self-host: Dockerfiles multi-stage (Bun) para `web` e `worker`, `docker-compose.prod.yml` com Postgres (`paradedb`), `redis` e `minio`, `.env.production.example` com placeholders válidos e validação em CI. Atende MON-576 e torna o README de self-host executável.

- **New Features**
  - `apps/web/Dockerfile` e `apps/worker/Dockerfile`: builds multi-stage com Bun; contexto no monorepo; `web` com healthcheck e usuário não-root.
  - `docker-compose.prod.yml`: orquestra `web`, `worker`, `paradedb` (com `wal_level=logical`), `redis` e `minio` com healthchecks e volumes nomeados; mapeia `DATABASE_URL`, `REDIS_URL` e `MINIO_*`; expõe `WEB_PORT`.
  - `.env.production.example`: variáveis obrigatórias com defaults `changeme` para passar `${VAR:?}` no `compose config -q`; usuários devem trocar antes do boot.
  - CI (`.github/workflows/docker.yml`): constrói imagens de `web` e `worker` em PRs relevantes e valida o compose.
  - README: instruções reais de `docker compose up -d`.

- **Migration**
  - Impacto por camada (conforme CLAUDE.md): router, repositório, componente e store sem mudanças; apenas empacotamento/execução via env (`DATABASE_URL`, `REDIS_URL`, `MINIO_*`, etc.).
  - Passos: `cp .env.production.example .env.production` → preencher segredos → `docker compose -f docker-compose.prod.yml --env-file .env.production up -d`; primeiro boot: aplicar schema com a mesma `DATABASE_URL` (ex.: `bun run db:push`).
  - Checklist de testes: CI Docker verde; `docker compose -f docker-compose.prod.yml --env-file .env.production config -q` retorna 0; smoke `GET /api/ping` 200 na porta 3000; healthchecks ok para `paradedb`, `redis` e `minio` (console 9001).

<sup>Written for commit 09120eaaa7bcb517e1c7b57d0f75730946e907b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

