### PR TITLE
docs: revisar guia de contribuição

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,129 +1,167 @@
-# Contributing to Montte
+# Contribuindo com o Montte
 
-## Prerequisites
+Montte é um ERP com IA em um monorepo Nx. O produto principal roda em `apps/web`, os workflows duráveis rodam em `apps/worker`, a infraestrutura compartilhada fica em `core/` e a lógica de domínio fica em `modules/`.
+
+## Pré-requisitos
 
 - [Bun](https://bun.sh) >= 1.x
 - [Node.js](https://nodejs.org) >= 20
-- [Docker](https://www.docker.com) or [Podman](https://podman.io) with Compose
+- [Docker](https://www.docker.com) ou [Podman](https://podman.io) com Compose
 - [Git](https://git-scm.com)
 
-## Getting Started
+## Setup Inicial
 
 ```bash
 git clone https://github.com/Montte-erp/montte-nx.git
 cd montte-nx
 bun install
-bun dev
+bun run setup
 ```
 
-That's it. `bun dev` is fully automatic on first run:
+Na primeira execução, `bun run setup` cria `apps/web/.env.local` a partir de `apps/web/.env.example` e para para você revisar as variáveis. Rode `bun run setup` novamente depois de preencher o arquivo; o script sobe os containers locais e aplica o schema com `bun run db:push`.
 
-1. Creates `apps/web/.env.local` from `.env.example` if missing
-2. Starts local containers (PostgreSQL on `5432`, Redis, MinIO) via Docker/Podman
-3. Pushes the database schema
-4. Seeds the event catalog
-5. Starts the web app at `http://localhost:3000`
+Use `bun dev` depois do setup. Ele garante `.env.local`, instala dependências se necessário, tenta subir os containers locais, roda `bun run db:push` e inicia `web` e `worker`.
 
-Placeholder values are pre-filled for external services (Stripe, PostHog, Google OAuth, Resend) so the app starts immediately. Replace them in `apps/web/.env.local` when you need those integrations to work.
-
-## Dev Commands
+## Comandos
 
 ```bash
-bun dev           # Local dev — auto-setup on first run
-bun dev:staging   # Dev against staging cloud services (needs apps/web/.env.staging.local)
-bun dev:all       # Web + all packages
+bun dev                  # dev-init + web + worker
+bun dev:staging          # web em modo staging
+bun dev:all              # todos os apps e pacotes com target dev
+bun run build            # build via Nx cache
+bun run typecheck        # typecheck via Nx
+bun run check            # oxlint
+bun run format           # oxfmt --write
+bun run format:check     # oxfmt --check
+bun run test             # testes via Nx
+bun run test:coverage    # testes via Nx com coverage
+bun run db:push          # aplica schema no banco local
+bun run db:push:prod     # aplica schema em produção
+bun run db:studio:local  # Drizzle Studio local
+bun run db:studio:prod   # Drizzle Studio produção
+bun run check-boundaries # valida regras de importação
+bun run doctor           # diagnóstico do ambiente
+bun run clean            # limpeza segura
+bun run clean:cache      # limpa cache
+bun run auth:generate    # regenera schema do Better Auth
 ```
 
-## Staging Environment
+Scripts de workspace usam `commander` quando aplicável. Exemplos relevantes: `scripts/seed-default-dashboard.ts`, `scripts/doctor.ts`, `scripts/clean.ts`, `scripts/dev-init.ts` e `scripts/setup.ts`.
 
-To run the local dev server against staging cloud services (no local containers needed):
+Se `bun dev` falhar antes de iniciar os apps, rode `bun run scripts/doctor.ts` e confira `apps/web/.env.local`.
+
+## Estrutura
+
+```text
+montte-nx/
+├── apps/
+│   ├── web/             # TanStack Start SSR + agregador oRPC
+│   └── worker/          # runtime DBOS para workflows duráveis
+├── core/                # infraestrutura compartilhada, sem regra de domínio
+│   ├── ai/
+│   ├── authentication/
+│   ├── database/
+│   ├── dbos/
+│   ├── environment/
+│   ├── files/
+│   ├── logging/
+│   ├── orpc/
+│   ├── posthog/
+│   ├── redis/
+│   ├── sse/
+│   ├── transactional/
+│   └── utils/
+├── modules/             # domínios de negócio
+│   ├── account/         # perfil, org, times, sessões, API keys, onboarding
+│   ├── agents/          # Rubi, threads, tools e skills
+│   ├── billing/         # serviços, medidores, preços, assinaturas, uso
+│   ├── classification/  # categorias, tags e workflows de categorização
+│   ├── finance/         # contas, transações e cartões
+│   └── insights/        # dashboards, insights e analytics
+├── packages/
+│   └── ui/              # componentes de UI compartilhados
+└── tooling/             # boundaries, oxc, Tailwind e tsconfigs
+```
+
+Novos domínios devem nascer em `modules/<nome>` como pacote `@modules/<nome>`. Cada módulo deve ser dono de seus `router/`, `services/`, `workflows/`, `contracts/` e `sse/` quando existirem.
+
+`apps/web` apenas hospeda a UI e agrega routers em `apps/web/src/integrations/orpc/router/index.ts`. `apps/worker` importa workflows dos módulos e executa DBOS fora do processo web.
+
+## Padrões De Código
+
+- Conteúdo de produto e mensagens visíveis ao usuário devem ser pt-BR.
+- oRPC usa `WebAppError`; não use `ORPCError`, `Error` cru ou strings em handlers.
+- Queries e schemas de banco ficam em Drizzle; schemas sempre usam namespaces, nunca `pgTable` cru.
+- Escritas no banco ficam dentro de `db.transaction(async (tx) => ...)`.
+- Não crie repository layer para routers; consulte `context.db` diretamente.
+- Use `neverthrow` para erros em TypeScript; evite `try/catch` fora de testes e scripts.
+- Não use type casts com `as`; corrija o tipo na origem.
+- Datas usam `dayjs`; evite `new Date()` fora das exceções documentadas em `AGENTS.md`.
+- Frontend chama oRPC via TanStack Query; componentes não devem chamar `orpc.*` diretamente.
+- Modais, sheets e drawers usam `useCredenza`; confirmações destrutivas usam `useAlertDialog`.
+
+## Skills
+
+Antes de mexer em um domínio, abra o skill correspondente. O conteúdo do skill tem precedência sobre instruções antigas.
+
+Skills do repositório ficam em `.agents/skills/<nome>/SKILL.md`. Skills específicos do OpenCode ficam em `.opencode/skills/<nome>/SKILL.md`.
+
+Mapa rápido:
+
+- oRPC handlers e erros: `neverthrow`
+- oRPC client e TanStack Query: `orpc-client`, `tanstack-query`
+- Banco, schemas e queries: `postgres-drizzle`
+- ParadeDB e busca: `paradedb-skill`
+- Redis: `redis-best-practices`
+- DBOS e workflows: `dbos-typescript`
+- Better Auth: `better-auth-best-practices`
+- Formulario: `tanstack-form`
+- Rotas e loaders: `tanstack-router`, `tanstack-start`
+- Tabelas: `tanstack-table`, `tanstack-virtual`
+- shadcn e UI primitives: `shadcn`
+- UI/UX e acessibilidade: `ui-ux-expert`, `wcag-audit-patterns`
+- Nx workspace: `nx-workspace`
+- Geradores Nx: `nx-generate`
+- Tarefas Nx: `nx-run-tasks`
+- CI Nx Cloud: `monitor-ci`
+- Linear: `linear-cli`
+
+Para skills TanStack Intent, siga o bloco de mapeamento em `AGENTS.md` e carregue com `npx @tanstack/intent@latest load <use>`.
+
+## Testes E Verificação
 
 ```bash
-cp apps/web/.env.staging.example apps/web/.env.staging.local
-# fill in your staging values
-bun dev:staging
+bun run format
+bun run check
+bun run typecheck
+bun run test
 ```
 
-## Database
+Prefira rodar tarefas via Nx (`bun nx run`, `bun nx run-many` ou scripts que já usam Nx). Não chame ferramentas internas diretamente quando houver target Nx equivalente.
+
+Testes vivem em `core/*`, `modules/*`, `packages/*` e `__tests__/` de workspace. Não adicione testes unitários, integração ou snapshots em `apps/*` enquanto o projeto não tiver E2E padronizado.
+
+Para um arquivo específico, use Vitest diretamente quando não houver target Nx mais adequado:
 
 ```bash
-bun run db:push          # Push schema changes to local DB
-bun run db:push:prod     # Push schema changes to production DB
-bun run db:studio:local  # Open Drizzle Studio for local DB
-bun run db:studio:prod   # Open Drizzle Studio for production DB
+npx vitest run modules/billing/src/__tests__/exemplo.test.ts
 ```
 
-## Seeding
+## Fluxo De PR
 
-```bash
-bun run seed:events   # Seed event catalog (runs automatically on bun dev)
-bun run seed:addons   # Seed addon subscriptions for an org
-```
+1. Atualize `master` antes de iniciar trabalho novo.
+2. Crie branch com o identificador da issue quando existir: `manoelnetocarvalho03/mon-123-descricao-curta`.
+3. Trabalhe em uma worktree quando houver outras mudanças locais em andamento.
+4. Mantenha o PR pequeno e focado; separe refactors amplos de mudanças comportamentais.
+5. Atualize documentação junto com mudanças de fluxo, comandos, arquitetura ou comportamento público.
+6. Rode as verificações relevantes antes de abrir o PR.
+7. Abra PR contra `master` com título objetivo, resumo do que mudou e validações executadas.
+8. Se houver risco conhecido ou validação que não foi rodada, declare isso no PR.
 
-## Diagnostics
+Commits devem ser curtos e descritivos, por exemplo `docs: revisar guia de contribuição`.
 
-```bash
-bun run doctor   # Check prerequisites and environment
-bun setup        # Re-run first-time setup manually
-```
+## Problemas E Sugestões
 
-## How to Contribute
-
-### Bugs
-
-- Report issues with steps to reproduce, expected vs. actual behavior, and your environment
-- Test your changes thoroughly before submitting
-
-### Features & Docs
-
-- Open an issue describing the use case before starting significant work
-- Keep user-facing content in Brazilian Portuguese (pt-BR)
-
-## Project Structure
-
-Nx monorepo — see [README.md](README.md) for the full structure.
-
-**Apps:** `web/` (TanStack Start SSR)
-**Core:** `agents/`, `authentication/`, `database/`, `environment/`, `files/`, `logging/`, `posthog/`, `redis/`, `stripe/`, `transactional/`, `utils/`
-**Packages:** `analytics/`, `events/`, `notifications/`, `ui/`
-
-## Code Standards
-
-**Formatting:** [oxfmt](https://oxc.rs) — run `bun run format`
-**Linting:** [oxlint](https://oxc.rs) — run `bun run check`
-**TypeScript:** Strict, no type casting (`as`), no `any`
-**React:** Function components, TanStack Router for routing
-**Commits:** Conventional format: `type(scope): description`
-
-Run all checks before opening a PR:
-
-```bash
-bun run format && bun run check && bun run typecheck && bun run test
-```
-
-## Workflow
-
-1. **Branch:** `git checkout -b feat/name` or `fix/issue-description`
-2. **Code:** Follow the standards in [CLAUDE.md](CLAUDE.md), write tests, update docs
-3. **Check:** `bun run format && bun run typecheck`
-4. **Commit:** `git commit -m "feat(scope): description"`
-5. **Push & PR:** Open a PR against `master` with a descriptive title and summary
-
-## Testing
-
-```bash
-bun run test                                                              # All tests
-npx vitest run apps/web/__tests__/integrations/orpc/router/foo.test.ts   # Single file
-```
-
-Tests live in `apps/web/__tests__/integrations/orpc/router/`. Write integration tests for new oRPC procedures.
-
-## Issues
-
-**Bugs:** Include description, steps to reproduce, expected/actual behavior, environment
-**Features:** Include description, use case, and implementation ideas
-**Questions:** Check the docs and existing issues first
-
----
-
-Thanks for contributing!
+- Bugs: inclua passos para reproduzir, comportamento esperado, comportamento atual e ambiente.
+- Features: descreva o caso de uso, impacto esperado e qualquer restrição conhecida.
+- Dúvidas: verifique `README.md`, `AGENTS.md`, issues e PRs existentes antes de abrir algo novo.


### PR DESCRIPTION
## Summary
- Atualiza o `CONTRIBUTING.md` para refletir o setup e os comandos atuais com Bun/Nx.
- Documenta a estrutura real com `modules/`, `core/`, `apps/worker` e agregação oRPC no web.
- Registra fluxo de PR e padrão de skills usados no repositório.

## Validation
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revisei o `CONTRIBUTING.md` para alinhar o onboarding com `bun` + `Nx`, a estrutura real do monorepo (`modules/`, `core/`, `apps/web`, `apps/worker`) e o fluxo de PR/skills. Isso reduz atrito no setup e padroniza práticas nas camadas de router, componentes e acesso a dados.

- Refactors
  - Atende à MON-577 (Linear): comandos atuais (`bun dev`, `modules/`), estrutura de módulos, fluxo de PR e padrão de skills.
  - Setup: adiciona `bun run setup` (gera `.env.local` e prepara ambiente), padroniza `bun dev` (web + worker, containers, `db:push`) e referencia `scripts/doctor.ts`.
  - Estrutura: documenta agregação oRPC em `apps/web/src/integrations/orpc/router/index.ts`, workflows duráveis no `apps/worker` (DBOS) e novos domínios em `modules/<nome>` como `@modules/<nome>` donos de `router/`, `services/`, `workflows/`, `contracts/`, `sse/`.
  - Padrões de código (conforme `CLAUDE.md`): oRPC com `WebAppError` e `neverthrow`; Drizzle com transações; sem repository layer nos routers (usar `context.db`); datas com `dayjs`; frontend consome via TanStack Query; UI com `useCredenza`/`useAlertDialog`; evitar `as`.
  - Comandos: centraliza alvos via `Nx` para build/test/typecheck/format/boundaries/DB e reforça usar `nx run` quando existir target equivalente.
  - Impacto nas camadas: Router — erros padronizados e acesso direto a `context.db` com `neverthrow`; Repositório — camada não usada por handlers oRPC (queries diretas do módulo); Componente — dados via TanStack Query, sem chamadas diretas a `orpc.*`, padrões de UI definidos; Store — cache/estado via TanStack Query, formulários com TanStack Form.
  - Checklist de teste: `bun run setup` cria `apps/web/.env.local` e aplica `bun run db:push`; `bun dev` inicia `web` e `worker` com containers; `bun run format && bun run check && bun run typecheck && bun run test` passam; `bun run check-boundaries` e `bun run doctor` sem erros.

<sup>Written for commit 81cfab53e96dff9f71b3fbdd302b63cf15db5efe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

