### PR TITLE
feat: OFX upload em lancamentos (MON-585)

### DIFF
--- a/apps/web/src/hooks/use-ofx-file.ts
+++ b/apps/web/src/hooks/use-ofx-file.ts
@@ -16,7 +16,7 @@ export function useOfxFile() {
       const txs = getTransactions(doc);
       const rows = txs.map((tx) => [
          dayjs(tx.DTPOSTED.toDate()).format("YYYY-MM-DD"),
-         String(tx.TRNAMT),
+         tx.TRNAMT.toFixed(2).replace(".", ","),
          tx.TRNTYPE,
          tx.NAME ?? tx.MEMO ?? "",
          tx.FITID ?? "",

--- a/apps/web/src/hooks/use-ofx-file.ts
+++ b/apps/web/src/hooks/use-ofx-file.ts
@@ -1,0 +1,28 @@
+import { getTransactions, parseBufferOrThrow } from "@f-o-t/ofx";
+import dayjs from "dayjs";
+import { useCallback } from "react";
+
+export type OfxData = {
+   headers: string[];
+   rows: string[][];
+};
+
+const HEADERS = ["date", "amount", "type", "name", "fitid"];
+
+export function useOfxFile() {
+   const parse = useCallback(async (file: File): Promise<OfxData> => {
+      const buffer = await file.arrayBuffer();
+      const doc = parseBufferOrThrow(new Uint8Array(buffer));
+      const txs = getTransactions(doc);
+      const rows = txs.map((tx) => [
+         dayjs(tx.DTPOSTED.toDate()).format("YYYY-MM-DD"),
+         String(tx.TRNAMT),
+         tx.TRNTYPE,
+         tx.NAME ?? tx.MEMO ?? "",
+         tx.FITID ?? "",
+      ]);
+      return { headers: HEADERS, rows };
+   }, []);
+
+   return { parse };
+}

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
@@ -51,6 +51,7 @@ import {
 } from "@/components/data-table/data-table-root";
 import { DataTableToolbar } from "@/components/data-table/data-table-toolbar";
 import { useCsvFile } from "@/hooks/use-csv-file";
+import { useOfxFile } from "@/hooks/use-ofx-file";
 import { useXlsxFile } from "@/hooks/use-xlsx-file";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import { orpc } from "@/integrations/orpc/client";
@@ -75,6 +76,7 @@ export function TransactionsList() {
    const [isDraftActive, setIsDraftActive] = useState(false);
    const { parse: parseCsv } = useCsvFile();
    const { parse: parseXlsx } = useXlsxFile();
+   const { parse: parseOfx } = useOfxFile();
 
    const handleSearch = useCallback(
       (value: string) => {
@@ -388,9 +390,11 @@ export function TransactionsList() {
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
                [".xlsx"],
             "application/vnd.ms-excel": [".xls"],
+            "application/x-ofx": [".ofx"],
          },
          parseFile: async (file: File) => {
             const ext = file.name.split(".").pop()?.toLowerCase();
+            if (ext === "ofx") return parseOfx(file);
             if (ext === "xlsx" || ext === "xls") return parseXlsx(file);
             return parseCsv(file);
          },
@@ -490,7 +494,7 @@ export function TransactionsList() {
             });
          },
       }),
-      [parseCsv, parseXlsx, importMutation, queryClient],
+      [parseCsv, parseXlsx, parseOfx, importMutation, queryClient],
    );
 
    const columns = useMemo(


### PR DESCRIPTION
## Summary
- Novo hook `useOfxFile` (`@f-o-t/ofx` `parseBufferOrThrow` + `arrayBuffer()`) → retorna `{headers, rows}` com `date|amount|type|name|fitid`
- `transactions-list.tsx`: `accept` ganha `.ofx`, `parseFile` faz branch por extensao; mapRow existente normaliza signed amount + CREDIT/DEBIT
- `DataTableImportButton` continua CSV/XLSX por padrao — OFX é override local da pagina de lancamentos
- User define `bankAccountId` por linha (col `bankAccountName` editavel) ou via `BulkAccountButton` no preview antes de salvar

## Test plan
- [ ] Upload .ofx em /transactions — rows aparecem no preview com data ISO, amount com sinal, type CREDIT/DEBIT
- [ ] mapRow detecta type via keyword (CREDIT→income, DEBIT→expense)
- [ ] Selecionar conta bancaria via inline edit ou bulk antes de salvar
- [ ] CSV e XLSX continuam funcionando
- [ ] Outras paginas com `DataTableImportButton` (bank-accounts, contacts, etc) nao aceitam .ofx

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Habilita upload de arquivos OFX na página de Lançamentos, parseando no cliente com `@f-o-t/ofx` e integrando ao preview antes de importar. Corrige a formatação do amount para pt-BR (vírgula) para evitar perda de casas decimais (MON-585).

- **Mudanças e impacto**
  - Novo hook `useOfxFile` com `parseBufferOrThrow`/`getTransactions` → `{ headers: ["date","amount","type","name","fitid"], rows }` (date ISO; amount `toFixed(2)` com vírgula).
  - Em `TransactionsList`, `DataTableImportButton` passa a aceitar MIME `application/x-ofx` e `.ofx`; `parseFile` faz branch por extensão e usa `useOfxFile` para OFX (CSV/XLSX inalterados).
  - Mapeamento CREDIT/DEBIT → income/expense mantido.
  - Camadas: Router — sem mudanças; Repositório — sem mudanças; Componente — ajuste local no accept/parsing do import; Store — sem mudanças (reuso de `importMutation`/estado existentes).

- **Checklist de teste**
  - Upload `.ofx` em /transactions exibe preview com date ISO e amount com vírgula (pt-BR) e sinal correto.
  - Mapeamento CREDIT→income e DEBIT→expense confirmado.
  - Definir `bankAccountId` por linha (edição inline em `bankAccountName`) ou em lote antes de salvar.
  - CSV e XLSX continuam funcionando; outras páginas com `DataTableImportButton` não aceitam `.ofx`.

<sup>Written for commit e862e75f5d1d2e970178de470de1a6df9a2ae6c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

