### PR TITLE
feat: autoCategorize com feedback SSE de progresso (MON-586)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ jobs:
       steps:
          - uses: actions/checkout@v4
 
-         - uses: docker/setup-buildx-action@v3
+         - uses: useblacksmith/setup-docker-builder@v1
 
          - name: Build ${{ matrix.target }} image
            uses: useblacksmith/build-push-action@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,7 +35,7 @@ jobs:
          - uses: docker/setup-buildx-action@v3
 
          - name: Build ${{ matrix.target }} image
-           uses: docker/build-push-action@v6
+           uses: useblacksmith/build-push-action@v2
            with:
               context: .
               file: apps/${{ matrix.target }}/Dockerfile

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,4 +46,6 @@ jobs:
 
          - name: Validate compose file
            if: matrix.target == 'web'
-           run: docker compose -f docker-compose.prod.yml --env-file .env.production.example config -q
+           run: |
+              cp .env.production.example .env.production
+              docker compose -f docker-compose.prod.yml --env-file .env.production config -q

--- a/apps/web/src/features/notifications/use-job-notifications.ts
+++ b/apps/web/src/features/notifications/use-job-notifications.ts
@@ -66,6 +66,29 @@ const knownEventSchema = z.discriminatedUnion("type", [
          count: z.number().int().nonnegative(),
       }),
    }),
+   z.object({
+      type: z.literal("classification.batch_started"),
+      payload: z.object({
+         batchId: z.string(),
+         total: z.number().int().nonnegative(),
+      }),
+   }),
+   z.object({
+      type: z.literal("classification.batch_progress"),
+      payload: z.object({
+         batchId: z.string(),
+         total: z.number().int().nonnegative(),
+         processed: z.number().int().nonnegative(),
+      }),
+   }),
+   z.object({
+      type: z.literal("classification.batch_completed"),
+      payload: z.object({
+         batchId: z.string(),
+         total: z.number().int().nonnegative(),
+         classified: z.number().int().nonnegative(),
+      }),
+   }),
 ]);
 
 type KnownEvent = z.infer<typeof knownEventSchema>;
@@ -111,6 +134,38 @@ function eventToToast(event: KnownEvent): ToastSpec | null {
             kind: "success",
             message: `Palavras-chave atualizadas em "${event.payload.entityName}" (${event.payload.count}).`,
          };
+      case "classification.batch_started":
+      case "classification.batch_progress":
+      case "classification.batch_completed":
+         return null;
+   }
+}
+
+function handleClassificationBatchEvent(event: KnownEvent) {
+   if (event.type === "classification.batch_started") {
+      toast.loading(
+         `Rubi categorizando ${event.payload.total} ${event.payload.total === 1 ? "transação" : "transações"}...`,
+         { id: `classify-${event.payload.batchId}` },
+      );
+      return;
+   }
+   if (event.type === "classification.batch_progress") {
+      toast.loading(
+         `Rubi categorizando ${event.payload.processed}/${event.payload.total} ${event.payload.total === 1 ? "transação" : "transações"}...`,
+         { id: `classify-${event.payload.batchId}` },
+      );
+      return;
+   }
+   if (event.type === "classification.batch_completed") {
+      const id = `classify-${event.payload.batchId}`;
+      if (event.payload.classified === 0) {
+         toast.dismiss(id);
+         return;
+      }
+      toast.success(
+         `Rubi categorizou ${event.payload.classified} de ${event.payload.total} ${event.payload.total === 1 ? "transação" : "transações"}.`,
+         { id },
+      );
    }
 }
 
@@ -128,6 +183,7 @@ export function useJobNotifications() {
          payload: data.payload,
       });
       if (!parsed.success) return;
+      handleClassificationBatchEvent(parsed.data);
       const spec = eventToToast(parsed.data);
       if (!spec) return;
       if (spec.kind === "success") toast.success(spec.message);

--- a/modules/classification/__tests__/workflows/classification.test.ts
+++ b/modules/classification/__tests__/workflows/classification.test.ts
@@ -65,6 +65,12 @@ beforeEach(async () => {
    mocks.setActiveDb(testDb.db);
 });
 
+function countSseByType(type: string): number {
+   return ssePublishSpy.mock.calls.filter(
+      (c) => (c[2] as { type: string }).type === type,
+   ).length;
+}
+
 async function getTransaction(id: string) {
    const [row] = await testDb.db
       .select()
@@ -119,7 +125,9 @@ describe("classifyTransactionsBatchWorkflow", () => {
       expect(t2?.suggestedTagId).toBe(ops.id);
       expect(t3?.suggestedTagId).toBe(ops.id);
 
-      expect(ssePublishSpy).toHaveBeenCalledTimes(3);
+      expect(countSseByType("classification.transaction_classified")).toBe(3);
+      expect(countSseByType("classification.batch_started")).toBe(1);
+      expect(countSseByType("classification.batch_completed")).toBe(1);
       expect(ssePublishSpy).toHaveBeenCalledWith(
          expect.anything(),
          { kind: "team", id: teamId },
@@ -174,7 +182,7 @@ describe("classifyTransactionsBatchWorkflow", () => {
       expect(t2?.suggestedCategoryId).toBe(misc.id);
       expect(t2?.suggestedTagId).toBeNull();
 
-      expect(ssePublishSpy).toHaveBeenCalledTimes(2);
+      expect(countSseByType("classification.transaction_classified")).toBe(2);
    });
 
    it("mixes keyword + AI — keyword writes 2, AI writes 3, all 5 go through", async () => {
@@ -229,7 +237,7 @@ describe("classifyTransactionsBatchWorkflow", () => {
       expect(a1?.suggestedCategoryId).toBe(fuel.id);
       expect(a1?.suggestedTagId).toBe(ops.id);
 
-      expect(ssePublishSpy).toHaveBeenCalledTimes(5);
+      expect(countSseByType("classification.transaction_classified")).toBe(5);
    });
 
    it("idempotency — skips transactions that already have categoryId set", async () => {
@@ -261,7 +269,7 @@ describe("classifyTransactionsBatchWorkflow", () => {
       expect(done?.suggestedCategoryId).toBeNull();
       expect(pending?.suggestedCategoryId).toBe(food.id);
 
-      expect(ssePublishSpy).toHaveBeenCalledTimes(1);
+      expect(countSseByType("classification.transaction_classified")).toBe(1);
    });
 
    it("chunks AI calls when unmatched > 20 — makes 2 distinct LLM calls for 25 unmatched", async () => {
@@ -357,7 +365,7 @@ describe("classifyTransactionsBatchWorkflow", () => {
             .filter(Boolean),
       );
       expect(distinctUserMessages.size).toBe(2);
-      expect(ssePublishSpy).toHaveBeenCalledTimes(25);
+      expect(countSseByType("classification.transaction_classified")).toBe(25);
    });
 
    it("handles AI returning fewer results than requested — only returned IDs get suggestedCategoryId", async () => {
@@ -398,7 +406,7 @@ describe("classifyTransactionsBatchWorkflow", () => {
       expect(t2?.suggestedCategoryId).toBe(food.id);
       expect(t3?.suggestedCategoryId).toBeNull();
 
-      expect(ssePublishSpy).toHaveBeenCalledTimes(2);
+      expect(countSseByType("classification.transaction_classified")).toBe(2);
       expect(posthogCaptureSpy).toBeDefined();
    });
 });

--- a/modules/classification/src/sse.ts
+++ b/modules/classification/src/sse.ts
@@ -12,6 +12,20 @@ const classificationEventDefinitions = {
       categoryName: z.string(),
       count: z.number().int().nonnegative(),
    }),
+   "classification.batch_started": z.object({
+      batchId: z.string(),
+      total: z.number().int().nonnegative(),
+   }),
+   "classification.batch_progress": z.object({
+      batchId: z.string(),
+      total: z.number().int().nonnegative(),
+      processed: z.number().int().nonnegative(),
+   }),
+   "classification.batch_completed": z.object({
+      batchId: z.string(),
+      total: z.number().int().nonnegative(),
+      classified: z.number().int().nonnegative(),
+   }),
 } as const;
 
 export const classificationSseEvents = defineSseEvents(

--- a/modules/classification/src/workflows/classification-workflow.ts
+++ b/modules/classification/src/workflows/classification-workflow.ts
@@ -190,6 +190,76 @@ const stepWrite = (writes: ClassificationWrite[], teamId: string) =>
       { name: "write-classifications" },
    );
 
+const emitBatchStarted = (teamId: string, batchId: string, total: number) =>
+   DBOS.runStep(
+      async () => {
+         const publish = await classificationSseEvents.publish(
+            getClassificationRedis(),
+            { kind: "team", id: teamId },
+            {
+               type: "classification.batch_started",
+               payload: { batchId, total },
+            },
+         );
+         if (publish.isErr()) {
+            DBOS.logger.warn(
+               `Failed to publish batch_started — team=${teamId} err=${publish.error.message}`,
+            );
+         }
+      },
+      { name: "emit-batch-started" },
+   );
+
+const emitBatchProgress = (
+   teamId: string,
+   batchId: string,
+   total: number,
+   processed: number,
+) =>
+   DBOS.runStep(
+      async () => {
+         const publish = await classificationSseEvents.publish(
+            getClassificationRedis(),
+            { kind: "team", id: teamId },
+            {
+               type: "classification.batch_progress",
+               payload: { batchId, total, processed },
+            },
+         );
+         if (publish.isErr()) {
+            DBOS.logger.warn(
+               `Failed to publish batch_progress — team=${teamId} err=${publish.error.message}`,
+            );
+         }
+      },
+      { name: "emit-batch-progress" },
+   );
+
+const emitBatchCompleted = (
+   teamId: string,
+   batchId: string,
+   total: number,
+   classified: number,
+) =>
+   DBOS.runStep(
+      async () => {
+         const publish = await classificationSseEvents.publish(
+            getClassificationRedis(),
+            { kind: "team", id: teamId },
+            {
+               type: "classification.batch_completed",
+               payload: { batchId, total, classified },
+            },
+         );
+         if (publish.isErr()) {
+            DBOS.logger.warn(
+               `Failed to publish batch_completed — team=${teamId} err=${publish.error.message}`,
+            );
+         }
+      },
+      { name: "emit-batch-completed" },
+   );
+
 const stepEmitSse = (writes: ClassificationWrite[], teamId: string) =>
    DBOS.runStep(
       async () => {
@@ -223,13 +293,17 @@ const stepEmitSse = (writes: ClassificationWrite[], teamId: string) =>
 async function classifyTransactionsBatchWorkflowFn(
    input: ClassifyTransactionsBatchInput,
 ) {
-   const log = `[classify-batch] team=${input.teamId} count=${input.transactionIds.length}`;
+   const batchId = buildWorkflowId(input);
+   const total = input.transactionIds.length;
+   const log = `[classify-batch] team=${input.teamId} count=${total} batch=${batchId}`;
    DBOS.logger.info(`${log} started`);
 
-   if (input.transactionIds.length === 0) {
+   if (total === 0) {
       DBOS.logger.info(`${log} empty input — nothing to classify`);
       return;
    }
+
+   await emitBatchStarted(input.teamId, batchId, total).catch(() => undefined);
 
    const loadResult = await fromPromise(stepLoadInputs(input), (e) =>
       WorkflowError.database("Falha ao carregar dados de classificação.", {
@@ -242,6 +316,9 @@ async function classifyTransactionsBatchWorkflowFn(
    if (loaded.transactions.length === 0) {
       DBOS.logger.info(
          `${log} no pending transactions to classify — already classified or filtered out`,
+      );
+      await emitBatchCompleted(input.teamId, batchId, total, 0).catch(
+         () => undefined,
       );
       return;
    }
@@ -268,6 +345,14 @@ async function classifyTransactionsBatchWorkflowFn(
    const unmatched = named.filter((t) => !matchedIds.has(t.id));
 
    const aiResults: ClassifyBatchResult[] = [];
+   if (keywordHits.length > 0) {
+      await emitBatchProgress(
+         input.teamId,
+         batchId,
+         total,
+         keywordHits.length,
+      ).catch(() => undefined);
+   }
    if (unmatched.length > 0 && loaded.categories.length > 0) {
       const chunks = chunk(unmatched, AI_CHUNK_SIZE);
       for (let i = 0; i < chunks.length; i += 1) {
@@ -285,6 +370,12 @@ async function classifyTransactionsBatchWorkflowFn(
          );
          if (ai.isErr()) throw ai.error;
          aiResults.push(...ai.value);
+         await emitBatchProgress(
+            input.teamId,
+            batchId,
+            total,
+            keywordHits.length + aiResults.length,
+         ).catch(() => undefined);
       }
    }
 
@@ -307,6 +398,9 @@ async function classifyTransactionsBatchWorkflowFn(
 
    if (writes.length === 0) {
       DBOS.logger.info(`${log} no classifications produced — exiting`);
+      await emitBatchCompleted(input.teamId, batchId, total, 0).catch(
+         () => undefined,
+      );
       return;
    }
 
@@ -321,6 +415,10 @@ async function classifyTransactionsBatchWorkflowFn(
          WorkflowError.internal("Falha ao emitir eventos SSE.", { cause: e }),
    );
    if (emitResult.isErr()) throw emitResult.error;
+
+   await emitBatchCompleted(input.teamId, batchId, total, writes.length).catch(
+      () => undefined,
+   );
 
    DBOS.logger.info(
       `${log} completed — keyword=${keywordHits.length} ai=${aiResults.length} written=${writes.length}`,


### PR DESCRIPTION
## Summary
- Workflow de classificação emite eventos SSE `classification.batch_started` / `batch_progress` / `batch_completed` via `@core/sse`, keyado por `batchId` determinístico.
- `useJobNotifications` converte os eventos em toast loading/success ("Rubi categorizando N/M transações..." → "Rubi categorizou X de M.") atualizado in-place via `toast.id`.
- CI: troca `docker/build-push-action@v6` por `useblacksmith/build-push-action@v2`.

## Test plan
- [ ] Importar OFX/CSV/XLSX com `autoCategorize: true` e validar toast aparece, atualiza progresso e finaliza.
- [ ] Importar lote sem categorias cadastradas → toast finaliza/dispensa sem sucesso enganoso.
- [ ] Importar lote 100% keyword match → progresso vai direto p/ completed.
- [ ] Importar lote >20 transações → progresso atualiza por chunk de IA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mostra o progresso do autoCategorize em tempo real via SSE, com toasts que iniciam, avançam (após keywords e por chunk) e concluem por lote após o import. Atende MON-586 e ajusta o CI para validar o compose com `.env.production`.

- **New Features**
  - Backend (workflow): emite `classification.batch_started` / `classification.batch_progress` / `classification.batch_completed` via `@core/sse`, chaveados por `batchId` determinístico; progresso após keywords e a cada chunk; conclusão com `classified`; logs de warn em falhas; schema SSE atualizado.
  - Frontend (notificações): `useJobNotifications` consome esses eventos e usa `toast.loading`/`toast.success` com `id = classify-${batchId}`, atualizando in-place e dispensando quando `classified = 0`.
  - Camadas afetadas: Router — nenhuma. Repositório — nenhuma. Componente — nenhum novo (UI via toasts). Store — hook de notificações atualizado.
  - CI: troca `docker/setup-buildx-action@v3` por `useblacksmith/setup-docker-builder@v1`, `docker/build-push-action@v6` por `useblacksmith/build-push-action@v2`, e copia `.env.production.example` para `.env.production` antes do `docker compose config`.

- **Testes**
  - Importar OFX/CSV/XLSX com `autoCategorize: true`: toast inicia, atualiza progresso e finaliza.
  - Lote sem categorias cadastradas: `batch_completed` com `classified = 0` e toast é descartado.
  - Lote 100% keyword match: vai direto para completed com contagens corretas.
  - Lote >20 transações: progresso avança por chunk; unitários passam a contar SSE por tipo (`transaction_classified`, `batch_started`, `batch_completed`).

<sup>Written for commit ca75fcdb46813ee2c09ae5e6b6f5519d7f7a64ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

