### PR TITLE
ci: cache bun store, node_modules, and Nx via Blacksmith

### DIFF
--- a/.github/actions/setup-bun-nx/action.yml
+++ b/.github/actions/setup-bun-nx/action.yml
@@ -6,9 +6,41 @@ runs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
+      - name: Cache Bun global install dir
+        uses: useblacksmith/cache@v5
+        with:
+           path: ~/.bun/install/cache
+           key: ${{ runner.os }}-bun-store-${{ hashFiles('bun.lock') }}
+           restore-keys: |
+              ${{ runner.os }}-bun-store-
+
+      - name: Cache node_modules
+        uses: useblacksmith/cache@v5
+        with:
+           path: |
+              node_modules
+              apps/*/node_modules
+              core/*/node_modules
+              modules/*/node_modules
+              packages/*/node_modules
+              tooling/*/node_modules
+           key: ${{ runner.os }}-node-modules-${{ hashFiles('bun.lock') }}
+           restore-keys: |
+              ${{ runner.os }}-node-modules-
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
         shell: bash
+
+      - name: Cache Nx
+        uses: useblacksmith/cache@v5
+        with:
+           path: .nx/cache
+           key: ${{ runner.os }}-nx-${{ github.ref_name }}-${{ github.sha }}
+           restore-keys: |
+              ${{ runner.os }}-nx-${{ github.ref_name }}-
+              ${{ runner.os }}-nx-master-
+              ${{ runner.os }}-nx-
 
       - name: Set Nx SHAs
         uses: nrwl/nx-set-shas@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
            run: bunx nx affected -t test --base=origin/master --head=HEAD -- --coverage --coverage.reporter=lcov
 
          - name: Upload coverage reports to Codecov
+           if: hashFiles('apps/*/coverage/lcov.info', 'core/*/coverage/lcov.info', 'packages/*/coverage/lcov.info') != ''
            uses: codecov/codecov-action@v5
            with:
               token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Drops cold-install + cold-Nx overhead on every PR job by adding `useblacksmith/cache@v5` layers inside the shared `setup-bun-nx` composite action.
- Cache layers added:
  - `~/.bun/install/cache` keyed on `bun.lock` — Bun global package store (skips network downloads).
  - workspace `node_modules` (root + `apps/*`, `core/*`, `modules/*`, `packages/*`, `tooling/*`) keyed on `bun.lock` — `bun install --frozen-lockfile` becomes a no-op on cache hit.
  - `.nx/cache` with `branch → master → any` restore-keys so `nx affected -t <target>` reuses prior task results across runs.
- Runners already use `blacksmith-4vcpu-ubuntu-2404`, so `useblacksmith/cache` is the matched drop-in (4x faster than `actions/cache` per Blacksmith docs).

## Test plan
- [ ] First PR run populates all three caches (visible as `Cache saved` in `Setup Bun & Nx`).
- [ ] Subsequent run on same branch shows cache hits for bun store + node_modules.
- [ ] Nx affected jobs (build/check/test/typecheck) show shorter total time after warm `.nx/cache`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Acelera os jobs de PR com cache do Bun store, `node_modules` e resultados do Nx via `useblacksmith/cache@v5`. Evita falhas no Codecov quando não há cobertura gerada.

- **CI e Performance**
  - Cache: `~/.bun/install/cache`, `node_modules` (root, `apps/*`, `core/*`, `modules/*`, `packages/*`, `tooling/*`), `.nx/cache`.
  - Chaves: por `bun.lock` (Nx usa `os-branch-sha`) com restore-keys `branch → master → any` para reuso do `nx affected`.
  - Codecov: upload só ocorre quando existem `lcov.info` nas pastas de apps/core/packages; evita falhas em PRs sem projetos afetados.
  - Impacto nas camadas: nenhuma mudança em router, repositório, componentes ou store; apenas CI, conforme CLAUDE.md.

- **Checklist de teste**
  - [ ] Primeiro run salva os três caches no step de setup.
  - [ ] Runs seguintes na mesma branch mostram hit para Bun store e `node_modules`.
  - [ ] Jobs `nx affected` ficam mais rápidos com `.nx/cache` aquecido.
  - [ ] PRs sem testes afetados pulam o upload ao Codecov e o job passa.

<sup>Written for commit ec23f2c15b39939f775a4e1f55eaba50ee3a9e08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

