### PR TITLE
ci: add opencode PR readiness and CI triage

### DIFF
--- a/.github/workflows/ci-failure-triage.yml
+++ b/.github/workflows/ci-failure-triage.yml
@@ -1,0 +1,173 @@
+name: CI Failure Triage
+
+on:
+   workflow_dispatch:
+      inputs:
+         run_id:
+            description: "Failed workflow run ID"
+            required: true
+            type: string
+         pr_number:
+            description: "Pull request number to comment on"
+            required: false
+            type: number
+   workflow_run:
+      workflows: [Build, Tests, Typecheck, Check, Boundary, Docker]
+      types: [completed]
+
+permissions:
+   id-token: write
+   contents: read
+   pull-requests: write
+   issues: write
+   actions: read
+   checks: read
+
+jobs:
+   triage:
+      if: |
+         github.event_name == 'workflow_dispatch' ||
+         github.event.workflow_run.conclusion == 'failure'
+      runs-on: blacksmith-4vcpu-ubuntu-2404
+      steps:
+         - name: Resolve failed run context
+           id: run
+           env:
+              GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              EVENT_NAME: ${{ github.event_name }}
+              INPUT_RUN_ID: ${{ inputs.run_id }}
+              INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+              WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+              WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+              WORKFLOW_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+              WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+              WORKFLOW_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+              WORKFLOW_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+           run: |
+              if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+                RUN_ID="$INPUT_RUN_ID"
+                RUN_JSON=$(gh run view "$RUN_ID" --json name,conclusion,headSha,headBranch,event,url)
+                WORKFLOW_NAME=$(jq -r '.name' <<< "$RUN_JSON")
+                WORKFLOW_CONCLUSION=$(jq -r '.conclusion' <<< "$RUN_JSON")
+                WORKFLOW_HEAD_SHA=$(jq -r '.headSha' <<< "$RUN_JSON")
+                WORKFLOW_HEAD_BRANCH=$(jq -r '.headBranch' <<< "$RUN_JSON")
+              else
+                RUN_ID="$WORKFLOW_RUN_ID"
+              fi
+
+              PR_NUMBER="$INPUT_PR_NUMBER"
+              if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "0" ]; then
+                PR_NUMBER="$WORKFLOW_PR_NUMBER"
+              fi
+              if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "0" ]; then
+                PR_NUMBER=$(gh pr list --head "$WORKFLOW_HEAD_BRANCH" --state open --json number --jq '.[0].number // empty')
+              fi
+
+              {
+                echo "run_id=$RUN_ID"
+                echo "workflow_name=$WORKFLOW_NAME"
+                echo "conclusion=$WORKFLOW_CONCLUSION"
+                echo "head_sha=$WORKFLOW_HEAD_SHA"
+                echo "head_branch=$WORKFLOW_HEAD_BRANCH"
+                echo "pr_number=$PR_NUMBER"
+              } >> "$GITHUB_OUTPUT"
+
+         - name: Checkout failed head
+           uses: actions/checkout@v6
+           with:
+              ref: ${{ steps.run.outputs.head_sha }}
+              fetch-depth: 0
+              persist-credentials: false
+
+         - name: Collect CI failure context
+           env:
+              GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              RUN_ID: ${{ steps.run.outputs.run_id }}
+              PR_NUMBER: ${{ steps.run.outputs.pr_number }}
+              WORKFLOW_NAME: ${{ steps.run.outputs.workflow_name }}
+              HEAD_BRANCH: ${{ steps.run.outputs.head_branch }}
+              HEAD_SHA: ${{ steps.run.outputs.head_sha }}
+           run: |
+              {
+                echo "# CI failure"
+                echo
+                echo "## Failed run"
+                gh run view "$RUN_ID" --json name,displayTitle,conclusion,event,url,createdAt,updatedAt,headBranch,headSha,jobs \
+                  --jq '{name, displayTitle, conclusion, event, url, createdAt, updatedAt, headBranch, headSha, jobs: [.jobs[] | {name, conclusion, startedAt, completedAt, steps: [.steps[] | select(.conclusion == "failure") | {name, conclusion, number}]}]}'
+                echo
+                echo "## Failed logs"
+                gh run view "$RUN_ID" --log-failed || true
+                echo
+                if [ -n "$PR_NUMBER" ]; then
+                  echo "## PR metadata"
+                  gh pr view "$PR_NUMBER" --json number,title,author,isDraft,mergeable,reviewDecision,changedFiles,additions,deletions,labels,url \
+                    --jq '{number, title, author: .author.login, isDraft, mergeable, reviewDecision, changedFiles, additions, deletions, labels: [.labels[].name], url}'
+                  echo
+                  echo "## Changed files"
+                  gh pr diff "$PR_NUMBER" --name-only
+                fi
+                echo
+                echo "## Recent commits"
+                git log --pretty=format:'- %s (%h)' -n 20
+              } > ci-failure-context.md
+
+         - name: Generate CI triage via opencode
+           uses: anomalyco/opencode/github@latest
+           env:
+              OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+              CONTEXT_FILE: ci-failure-context.md
+              OUTPUT_FILE: CI_TRIAGE.md
+           with:
+              model: opencode-go/deepseek-v4-flash
+              prompt: |
+                 Você é um engenheiro senior fazendo triagem de CI no monorepo Montte.
+
+                 Leia `$CONTEXT_FILE` e escreva `$OUTPUT_FILE` em Markdown pt-BR com diagnóstico curto e acionável.
+
+                 Estrutura obrigatória:
+
+                 ```markdown
+                 ## CI Failure Triage
+
+                 **Workflow:** <nome>
+                 **Status:** falha reproduzível | falha provável de infra | precisa investigar
+
+                 ## Causa Provável
+                 <1-3 bullets com a causa mais provável, citando job/step/comando quando existir>
+
+                 ## Correção Recomendada
+                 <passos concretos; se for código, indique arquivos ou áreas prováveis; se for infra/cache, indique re-run ou ajuste>
+
+                 ## Validação
+                 <comandos reais do repo para rodar localmente ou no CI>
+                 ```
+
+                 Regras:
+                 - Não invente arquivos, erros ou stack traces que não aparecem no contexto.
+                 - Diferencie erro de código de erro de infraestrutura/cache/dependência externa.
+                 - Priorize comandos Nx/Bun reais: `bun run typecheck`, `bun run test`, `bun run build`, `bun run check`, `bun run check-boundaries`.
+                 - Se a causa envolver stale dist ou package linking, cite o pacote afetado e o comando mínimo provável.
+                 - Não proponha `git reset`, `--force`, `--no-verify` ou aumento de `NODE_OPTIONS`.
+                 - Use bullets curtos, sem nested bullets.
+
+         - name: Verify CI triage report
+           run: |
+              if [ ! -s CI_TRIAGE.md ]; then
+                echo "CI_TRIAGE.md missing or empty" >&2
+                exit 1
+              fi
+
+         - name: Comment CI triage on PR
+           if: steps.run.outputs.pr_number != ''
+           env:
+              GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              PR_NUMBER: ${{ steps.run.outputs.pr_number }}
+           run: gh pr comment "$PR_NUMBER" --body-file CI_TRIAGE.md
+
+         - name: Upload CI triage artifacts
+           uses: actions/upload-artifact@v4
+           with:
+              name: ci-failure-triage-${{ steps.run.outputs.run_id }}
+              path: |
+                 ci-failure-context.md
+                 CI_TRIAGE.md

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -25,9 +25,9 @@ jobs:
         with:
           persist-credentials: false
 
-         - name: Run opencode
-           uses: anomalyco/opencode/github@latest
-           env:
-              OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-           with:
-              model: opencode-go/deepseek-v4-flash
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+        with:
+           model: opencode-go/deepseek-v4-flash

--- a/.github/workflows/pr-readiness.yml
+++ b/.github/workflows/pr-readiness.yml
@@ -1,0 +1,151 @@
+name: PR Readiness
+
+on:
+   workflow_dispatch:
+      inputs:
+         pr_number:
+            description: "Pull request number"
+            required: true
+            type: number
+   pull_request_review:
+      types: [submitted]
+
+permissions:
+   id-token: write
+   contents: read
+   pull-requests: write
+   issues: write
+   actions: read
+   checks: read
+
+jobs:
+   readiness:
+      if: |
+         github.event_name == 'workflow_dispatch' ||
+         github.event.review.user.login == 'cubic-dev-ai[bot]' ||
+         contains(github.event.review.user.login, 'cubic')
+      runs-on: blacksmith-4vcpu-ubuntu-2404
+      steps:
+         - name: Resolve PR metadata
+           id: pr
+           env:
+              GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              EVENT_NAME: ${{ github.event_name }}
+              INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+              REVIEW_PR_NUMBER: ${{ github.event.pull_request.number }}
+           run: |
+              if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+                PR_NUMBER="$INPUT_PR_NUMBER"
+              else
+                PR_NUMBER="$REVIEW_PR_NUMBER"
+              fi
+
+              gh pr view "$PR_NUMBER" --json number,headRefName,headRefOid,baseRefName,headRepositoryOwner --jq '
+                "number=\(.number)\nhead_ref=\(.headRefName)\nhead_sha=\(.headRefOid)\nbase_ref=\(.baseRefName)\nhead_owner=\(.headRepositoryOwner.login)"
+              ' >> "$GITHUB_OUTPUT"
+
+         - name: Checkout PR head
+           uses: actions/checkout@v6
+           with:
+              ref: ${{ steps.pr.outputs.head_sha }}
+              fetch-depth: 0
+              persist-credentials: false
+
+         - name: Collect PR context
+           env:
+              GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              PR_NUMBER: ${{ steps.pr.outputs.number }}
+              BASE_REF: ${{ steps.pr.outputs.base_ref }}
+           run: |
+              git fetch origin "$BASE_REF" --depth=1
+
+              {
+                echo "# PR #$PR_NUMBER"
+                echo
+                echo "## PR metadata"
+                gh pr view "$PR_NUMBER" --json title,author,state,isDraft,mergeable,reviewDecision,additions,deletions,changedFiles,labels,url,body \
+                  --jq '{title, author: .author.login, state, isDraft, mergeable, reviewDecision, additions, deletions, changedFiles, labels: [.labels[].name], url, body}'
+                echo
+                echo "## Changed files"
+                gh pr diff "$PR_NUMBER" --name-only
+                echo
+                echo "## Commits"
+                git log --pretty=format:'- %s (%h) by %an' "origin/$BASE_REF..HEAD"
+                echo
+                echo
+                echo "## Current CI checks"
+                gh pr checks "$PR_NUMBER" || true
+                echo
+                echo "## Cubic reviews"
+                gh pr view "$PR_NUMBER" --json reviews \
+                  --jq '.reviews[] | select((.author.login | ascii_downcase | contains("cubic"))) | {state, submittedAt, author: .author.login, body}' || true
+                echo
+                echo "## Cubic inline comments"
+                gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/comments" --paginate \
+                  --jq '.[] | select((.user.login | ascii_downcase | contains("cubic"))) | {path, line, user: .user.login, body, html_url}' || true
+              } > pr-readiness-context.md
+
+         - name: Generate readiness report via opencode
+           uses: anomalyco/opencode/github@latest
+           env:
+              OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+              CONTEXT_FILE: pr-readiness-context.md
+              OUTPUT_FILE: PR_READINESS.md
+           with:
+              model: opencode-go/deepseek-v4-flash
+              prompt: |
+                 Você é um engenheiro senior revisando readiness de PR no Montte.
+
+                 Leia `$CONTEXT_FILE` e escreva `$OUTPUT_FILE` em Markdown pt-BR com um relatório curto, objetivo e acionável.
+
+                 Objetivo: complementar o review do Cubic, não repetir. Use os achados do Cubic como insumo, mas foque em decidir se o PR está pronto para merge.
+
+                 Estrutura obrigatória:
+
+                 ```markdown
+                 ## PR Readiness
+
+                 **Status:** pronto | atenção | bloquear
+
+                 **Resumo:** <2-3 frases sobre impacto e risco>
+
+                 ## Bloqueios
+                 <somente problemas que devem impedir merge; omita a seção se não houver>
+
+                 ## Pontos de Atenção
+                 <riscos, testes ausentes, migrações, UX, segurança, billing, DBOS, oRPC, env, release; omita se vazio>
+
+                 ## Validação Recomendada
+                 <comandos ou checks que faltam, usando comandos reais do repo quando aplicável>
+
+                 ## Cubic
+                 <resuma se o Cubic trouxe algo pendente, resolvido ou irrelevante. Não copie comentários longos.>
+                 ```
+
+                 Regras:
+                 - Seja conservador com `bloquear`: use apenas para risco real, CI vermelho, conflito, migração destrutiva sem plano, quebra de contrato, segredo, ou bug claro.
+                 - Se o Cubic não comentou nada relevante, diga isso.
+                 - Não invente detalhes que não estão no contexto.
+                 - Não inclua SHAs longos nem autores, exceto links já presentes.
+                 - Use bullets curtos, sem nested bullets.
+
+         - name: Verify readiness report
+           run: |
+              if [ ! -s PR_READINESS.md ]; then
+                echo "PR_READINESS.md missing or empty" >&2
+                exit 1
+              fi
+
+         - name: Comment readiness report
+           env:
+              GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              PR_NUMBER: ${{ steps.pr.outputs.number }}
+           run: gh pr comment "$PR_NUMBER" --body-file PR_READINESS.md
+
+         - name: Upload readiness artifacts
+           uses: actions/upload-artifact@v4
+           with:
+              name: pr-readiness-${{ steps.pr.outputs.number }}
+              path: |
+                 pr-readiness-context.md
+                 PR_READINESS.md


### PR DESCRIPTION
## Summary
- Adds an opencode PR readiness workflow that runs manually or after Cubic submits a PR review.
- Adds an opencode CI failure triage workflow for failed Build, Tests, Typecheck, Check, Boundary, and Docker runs.
- Fixes the existing opencode workflow indentation so its action step is valid YAML.

## Validation
- Ran actionlint via `go run github.com/rhysd/actionlint/cmd/actionlint@latest` with the repository's custom Blacksmith runner label ignored.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adiciona workflows de readiness de PR e triagem de falhas de CI com `anomalyco/opencode/github`, comentando relatórios curtos no PR. Também corrige a indentação do `opencode.yml`.

- **New Features**
  - `PR Readiness`: roda via `workflow_dispatch` ou após review do Cubic; coleta metadados, arquivos, commits, checks e comentários; gera `PR_READINESS.md` e comenta no PR com `opencode-go/deepseek-v4-flash`.
  - `CI Failure Triage`: roda em falhas de Build/Tests/Typecheck/Check/Boundary/Docker ou manual; resolve `run_id`/PR, extrai jobs/steps que falharam, logs, diff e commits; gera `CI_TRIAGE.md` e comenta no PR.
  - Por quê: padronizar diagnóstico de CI e decidir prontidão sem repetir o review do Cubic.
  - Impacto: apenas automação/CI; sem alterações em router, repositório, componente ou store.
  - Checklist de teste:
    - Validar YAML com `actionlint` (já feito).
    - Disparar `PR Readiness` com `workflow_dispatch` informando `pr_number` e verificar comentário/artefatos.
    - Forçar uma falha em `Build`/`Tests` e confirmar comentário do `CI Failure Triage` com `CI_TRIAGE.md`.
    - Testar `workflow_dispatch` do triage com `run_id` e, opcionalmente, `pr_number`; checar artefatos e saída do `gh pr view --comments`.

- **Bug Fixes**
  - Corrige a indentação do passo "Run opencode" em `.github/workflows/opencode.yml` para YAML válido.

<sup>Written for commit a0c6ca999e5c90df33fb0c71c9a7486bbb6dff9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

