### PR TITLE
Manoelnetocarvalho03/mon 694 navbar redesign abacate pay style

### DIFF
--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -13,6 +13,7 @@
    "dependencies": {
       "@astrojs/check": "catalog:astro",
       "@astrojs/react": "catalog:astro",
+      "@lucide/astro": "catalog:astro",
       "@packages/ui": "workspace:*",
       "@tailwindcss/vite": "catalog:vite",
       "@tooling/css": "workspace:*",

--- a/apps/landing/railway.json
+++ b/apps/landing/railway.json
@@ -7,8 +7,6 @@
    },
    "deploy": {
       "startCommand": "bun run landing:start",
-      "healthcheckPath": "/",
-      "healthcheckTimeout": 60,
       "numReplicas": 1,
       "sleepApplication": true,
       "restartPolicyType": "ON_FAILURE",

--- a/apps/landing/src/blocks/cta-block.astro
+++ b/apps/landing/src/blocks/cta-block.astro
@@ -1,4 +1,5 @@
 ---
+import { Image } from "astro:assets";
 ---
 
 <section
@@ -65,7 +66,7 @@
                   <span
                      class="inline-flex size-10 items-center justify-center rounded-lg bg-primary/15 ring-1 ring-primary/30"
                   >
-                     <img class="size-5" src="/favicon.svg" alt="" />
+                     <Image class="size-5" src="/favicon.svg" alt="" width={20} height={20} />
                   </span>
                   <div class="flex flex-col gap-0.5">
                      <span class="text-sm font-bold text-foreground">Montte 2026</span>

--- a/apps/landing/src/blocks/footer-block.astro
+++ b/apps/landing/src/blocks/footer-block.astro
@@ -1,4 +1,6 @@
 ---
+import { Image } from "astro:assets";
+
 const groups = [
    {
       title: "Produto",
@@ -33,7 +35,7 @@ const groups = [
       <div class="flex flex-col gap-4">
          <a class="inline-flex items-center gap-2" href="/" aria-label="Montte">
             <span class="inline-flex size-7 items-center justify-center rounded-lg bg-primary/15 ring-1 ring-primary/30">
-               <img class="size-4" src="/favicon.svg" alt="" />
+                <Image class="size-4" src="/favicon.svg" alt="" width={16} height={16} />
             </span>
             <span class="text-base font-semibold tracking-tight">Montte</span>
          </a>

--- a/apps/landing/src/blocks/navbar-block.astro
+++ b/apps/landing/src/blocks/navbar-block.astro
@@ -1,107 +1,74 @@
 ---
+import { Image } from "astro:assets";
+import { ArrowRight, Menu } from "@lucide/astro";
+import { Button } from "@packages/ui/components/button";
+import { AstroSheet } from "../components/astro-sheet";
+import { LandingNavButton } from "../components/landing-nav-button";
+
 const navItems = [
-   { title: "Produto", href: "#produto", hasMenu: true },
-   { title: "Preços", href: "#precos", hasMenu: true },
-   { title: "Docs", href: "#docs", hasMenu: true },
-   { title: "Comunidade", href: "#", hasMenu: true },
-   { title: "Empresa", href: "#", hasMenu: true },
-   { title: "Mais", href: "#", hasMenu: true },
+   { title: "Preços", href: "#precos" },
+   { title: "Documentação", href: "#documentacao" },
+   { title: "Blog", href: "#blog" },
+   { title: "Comunidade", href: "#comunidade" },
 ];
 ---
 
 <header class="sticky top-0 z-40 w-full border-b border-border/40 bg-background/70 backdrop-blur-xl">
    <nav
-      class="mx-auto flex h-14 max-w-7xl items-center gap-2 px-4 sm:px-6"
+      class="mx-auto flex h-16 max-w-7xl items-center gap-4 px-4 sm:px-6"
       aria-label="Principal"
    >
-      <a
-         class="group mr-2 inline-flex items-center gap-2 text-sm font-semibold tracking-tight text-foreground"
-         href="/"
-         aria-label="Montte"
-      >
-         <span class="inline-flex size-7 items-center justify-center rounded-lg bg-primary/15 ring-1 ring-primary/30 transition-transform group-hover:rotate-12">
-            <img class="size-4" src="/favicon.svg" alt="" />
-         </span>
-         <span class="text-base">Montte</span>
+      <a class="inline-flex items-center" href="/" aria-label="Montte">
+         <Image class="size-8" src="/favicon.svg" alt="" width={32} height={32} />
       </a>
 
-      <div class="hidden items-center md:flex">
+      <div class="hidden flex-1 items-center justify-end gap-2 md:flex">
          {
             navItems.map((item) => (
-               <a
-                  href={item.href}
-                  class="group inline-flex h-9 items-center gap-1 rounded-lg px-3 text-sm font-medium text-foreground/80 transition-colors hover:bg-accent/50 hover:text-foreground"
-               >
+               <LandingNavButton href={item.href} variant="link">
                   {item.title}
-                  {item.hasMenu && (
-                     <svg
-                        class="size-3 text-muted-foreground transition-transform group-hover:translate-y-0.5"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="2.5"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                     >
-                        <path d="M6 9l6 6 6-6" />
-                     </svg>
-                  )}
-               </a>
+               </LandingNavButton>
             ))
          }
       </div>
 
-      <div class="ml-auto flex items-center gap-1">
-         <a
-            class="group inline-flex h-9 items-center gap-1.5 rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground shadow-sm transition-all hover:scale-[1.02] hover:shadow-lg hover:shadow-primary/30"
-            href="/dashboard"
+      <div class="hidden md:block">
+         <LandingNavButton href="/dashboard" variant="default">
+            Acessar Plataforma
+            <ArrowRight data-icon="inline-end" aria-hidden="true" />
+         </LandingNavButton>
+      </div>
+
+      <div class="flex flex-1 justify-end md:hidden">
+         <AstroSheet
+            title="Menu principal"
+            contentClassName="gap-4 border-border/60 bg-background/95 p-4 pt-14 backdrop-blur-xl"
+            client:load
          >
-            Dashboard
-         </a>
-         <button
-            type="button"
-            aria-label="Buscar"
-            class="inline-flex size-9 items-center justify-center rounded-lg text-foreground/70 transition-colors hover:bg-accent/50 hover:text-foreground"
-         >
-            <svg
-               class="size-4"
-               viewBox="0 0 24 24"
-               fill="none"
-               stroke="currentColor"
-               stroke-width="2"
-               stroke-linecap="round"
-               stroke-linejoin="round"
-               ><circle cx="11" cy="11" r="7"></circle><path d="M21 21l-4.3-4.3"
-               ></path></svg
+            <Button
+               slot="trigger"
+               type="button"
+               variant="outline"
+               size="icon-lg"
+               aria-label="Abrir menu"
             >
-         </button>
-         <button
-            type="button"
-            aria-label="Atalhos"
-            class="hidden h-9 items-center justify-center rounded-lg px-2 text-foreground/70 transition-colors hover:bg-accent/50 hover:text-foreground sm:inline-flex"
-         >
-            <kbd
-               class="rounded border border-border/60 bg-card px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground"
-               >⌘K</kbd
-            >
-         </button>
-         <a
-            href="/dashboard"
-            aria-label="Conta"
-            class="inline-flex size-9 items-center justify-center rounded-lg text-foreground/70 transition-colors hover:bg-accent/50 hover:text-foreground"
-         >
-            <svg
-               class="size-4"
-               viewBox="0 0 24 24"
-               fill="none"
-               stroke="currentColor"
-               stroke-width="2"
-               stroke-linecap="round"
-               stroke-linejoin="round"
-               ><circle cx="12" cy="8" r="4"></circle><path
-                  d="M4 21a8 8 0 0116 0"></path></svg
-            >
-         </a>
+               <Menu aria-hidden="true" />
+            </Button>
+
+            <div class="flex flex-col gap-2">
+               {
+                  navItems.map((item) => (
+                     <LandingNavButton href={item.href} variant="link">
+                        {item.title}
+                     </LandingNavButton>
+                  ))
+               }
+            </div>
+            <LandingNavButton href="/dashboard" variant="default">
+               Acessar Plataforma
+               <ArrowRight data-icon="inline-end" aria-hidden="true" />
+            </LandingNavButton>
+         </AstroSheet>
       </div>
    </nav>
 </header>

--- a/apps/landing/src/components/astro-sheet.tsx
+++ b/apps/landing/src/components/astro-sheet.tsx
@@ -1,0 +1,44 @@
+import {
+   Sheet,
+   SheetContent,
+   SheetTitle,
+   SheetTrigger,
+} from "@packages/ui/components/sheet";
+import { useState, type ReactNode } from "react";
+
+interface AstroSheetProps {
+   children: ReactNode;
+   contentClassName?: string;
+   title: string;
+   trigger?: ReactNode;
+}
+
+export function AstroSheet({
+   children,
+   contentClassName,
+   title,
+   trigger,
+}: AstroSheetProps) {
+   const [open, setOpen] = useState(false);
+
+   if (!trigger) return null;
+
+   return (
+      <Sheet open={open} onOpenChange={setOpen}>
+         <SheetTrigger asChild>{trigger}</SheetTrigger>
+         <SheetContent className={contentClassName}>
+            <SheetTitle className="sr-only">{title}</SheetTitle>
+            <div
+               className="flex flex-col gap-4"
+               onClick={(event) => {
+                  if (!(event.target instanceof Element)) return;
+                  if (!event.target.closest("a")) return;
+                  setOpen(false);
+               }}
+            >
+               {children}
+            </div>
+         </SheetContent>
+      </Sheet>
+   );
+}

--- a/apps/landing/src/components/landing-nav-button.tsx
+++ b/apps/landing/src/components/landing-nav-button.tsx
@@ -1,0 +1,20 @@
+import { Button } from "@packages/ui/components/button";
+import type { ReactNode } from "react";
+
+interface LandingNavButtonProps {
+   children: ReactNode;
+   href: string;
+   variant?: "default" | "link";
+}
+
+export function LandingNavButton({
+   children,
+   href,
+   variant = "link",
+}: LandingNavButtonProps) {
+   return (
+      <Button asChild variant={variant}>
+         <a href={href}>{children}</a>
+      </Button>
+   );
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -37,7 +37,13 @@ const config = defineConfig({
          rollupConfig: {
             external: (id: string) =>
                id === "@dbos-inc/dbos-sdk" ||
-               id.startsWith("@dbos-inc/dbos-sdk/"),
+               id.startsWith("@dbos-inc/dbos-sdk/") ||
+               id === "katex" ||
+               id.startsWith("katex/") ||
+               id === "mermaid" ||
+               id.startsWith("mermaid/") ||
+               id === "streamdown" ||
+               id.startsWith("streamdown/"),
          },
       }),
       viteReact(),

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
       "dependencies": {
         "@astrojs/check": "catalog:astro",
         "@astrojs/react": "catalog:astro",
+        "@lucide/astro": "catalog:astro",
         "@packages/ui": "workspace:*",
         "@tailwindcss/vite": "catalog:vite",
         "@tooling/css": "workspace:*",
@@ -1447,6 +1448,8 @@
     "@langchain/langgraph-checkpoint": ["@langchain/langgraph-checkpoint@1.0.1", "", { "dependencies": { "uuid": "^10.0.0" }, "peerDependencies": { "@langchain/core": "^1.0.1" } }, "sha512-HM0cJLRpIsSlWBQ/xuDC67l52SqZ62Bh2Y61DX+Xorqwoh5e1KxYvfCD7GnSTbWWhjBOutvnR0vPhu4orFkZfw=="],
 
     "@langchain/langgraph-sdk": ["@langchain/langgraph-sdk@1.8.9", "", { "dependencies": { "@types/json-schema": "^7.0.15", "p-queue": "^9.0.1", "p-retry": "^7.1.1", "uuid": "^13.0.0" }, "peerDependencies": { "@langchain/core": "^1.1.16", "react": "^18 || ^19", "react-dom": "^18 || ^19", "svelte": "^4.0.0 || ^5.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@langchain/core", "react", "react-dom", "svelte", "vue"] }, "sha512-vpz90auS4iFTNy2X/CFexOEoeFSvaK+MyI7iSmzYs9gGcfzwRjWUJ4MWsuc5ZNRecLStwho0PExVXRgGOXtcRw=="],
+
+    "@lucide/astro": ["@lucide/astro@1.14.0", "", { "peerDependencies": { "astro": "^4 || ^5 || ^6" } }, "sha512-RaCwEeeTQT0TOvoCu6cS0XMrjK56qrSzPVIUv1ycwqCUbfu9TjDmh7svJ/677kGhLje1IT2vxXg5nD53ta1jcg=="],
 
     "@maskito/core": ["@maskito/core@5.2.2", "", {}, "sha512-OFLK9NMQrz4eCgNgJ74S4x6IklqGQ71pcQToNGRzkIYnlEZbGpO+pzLREKLN/iKh4oBz8PI/9JnD3HtkN5Rl+w=="],
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Redesenha a navbar da landing no estilo Abacate Pay, simplificando navegação (4 links) e CTA claro. Atende MON-694 e melhora acessibilidade, mobile e performance de imagens.

- **Mudanças**
  - Navbar reescrita em `apps/landing/src/blocks/navbar-block.astro`: logo à esquerda, links “Preços”, “Documentação”, “Blog”, “Comunidade”, e CTA “Acessar Plataforma →” para `/dashboard`.
  - Remoção de busca, atalho ⌘K, avatar e dropdowns “Mais/Empresa”.
  - Mobile: hambúrguer com drawer via `AstroSheet` (fecha ao clicar em links), ícones `Menu` e `ArrowRight` de `@lucide/astro`.
  - Extração de componentes: `AstroSheet` (wrapper de `@packages/ui/components/sheet`) e `LandingNavButton` (usa `Button` com `asChild`).
  - Imagens migradas para `astro:assets/Image` em CTA e Footer (largura/altura explícitas).
  - Deps/Build: adiciona `@lucide/astro` em `apps/landing`; externaliza `katex`, `mermaid` e `streamdown` em `apps/web/vite.config.ts`.
  - CI/Infra: remove `healthcheckPath` e `healthcheckTimeout` de `apps/landing/railway.json` (mantém `startCommand` e políticas).
  - Impacto por camada:
    - Router: apenas âncoras locais e link para `/dashboard` (sem rotas novas).
    - Componentes: novos `AstroSheet` e `LandingNavButton`; atualizações em `navbar-block.astro`, `cta-block.astro`, `footer-block.astro`.
    - Store: sem mudanças.
    - Repositório (dados): sem mudanças.

- **Testes**
  - Desktop: 4 links funcionam; CTA leva a `/dashboard`.
  - Mobile: botão abre/fecha drawer; clique em link/CTA fecha; navegação por foco ok.
  - A11y: `aria-label` no logo/trigger; ícones com `aria-hidden`; ordem de tab correta.
  - Visual: navbar sticky com blur/borda; estados hover/active.
  - Imagens: `Image` renderiza favicon nos blocos CTA/Footer com dimensões corretas.
  - Build: `apps/landing` compila sem warnings; `apps/web` compila com `katex`, `mermaid` e `streamdown` como externals.
  - Railway: deploy sem healthcheck dedicado (somente `startCommand`).

<sup>Written for commit 8912c707e00ef5d7ca8021a99a107b74c8258f9f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

