### PR TITLE
fix(web): group email OTP inputs

### DIFF
--- a/.github/workflows/pr-readiness.yml
+++ b/.github/workflows/pr-readiness.yml
@@ -30,6 +30,7 @@ jobs:
            id: pr
            env:
               GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              GH_REPO: ${{ github.repository }}
               EVENT_NAME: ${{ github.event_name }}
               INPUT_PR_NUMBER: ${{ inputs.pr_number }}
               REVIEW_PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -40,7 +41,7 @@ jobs:
                 PR_NUMBER="$REVIEW_PR_NUMBER"
               fi
 
-              gh pr view "$PR_NUMBER" --json number,headRefName,headRefOid,baseRefName,headRepositoryOwner --jq '
+              gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json number,headRefName,headRefOid,baseRefName,headRepositoryOwner --jq '
                 "number=\(.number)\nhead_ref=\(.headRefName)\nhead_sha=\(.headRefOid)\nbase_ref=\(.baseRefName)\nhead_owner=\(.headRepositoryOwner.login)"
               ' >> "$GITHUB_OUTPUT"
 
@@ -54,6 +55,7 @@ jobs:
          - name: Collect PR context
            env:
               GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              GH_REPO: ${{ github.repository }}
               PR_NUMBER: ${{ steps.pr.outputs.number }}
               BASE_REF: ${{ steps.pr.outputs.base_ref }}
            run: |
@@ -63,21 +65,21 @@ jobs:
                 echo "# PR #$PR_NUMBER"
                 echo
                 echo "## PR metadata"
-                gh pr view "$PR_NUMBER" --json title,author,state,isDraft,mergeable,reviewDecision,additions,deletions,changedFiles,labels,url,body \
+                gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json title,author,state,isDraft,mergeable,reviewDecision,additions,deletions,changedFiles,labels,url,body \
                   --jq '{title, author: .author.login, state, isDraft, mergeable, reviewDecision, additions, deletions, changedFiles, labels: [.labels[].name], url, body}'
                 echo
                 echo "## Changed files"
-                gh pr diff "$PR_NUMBER" --name-only
+                gh pr diff "$PR_NUMBER" --repo "$GH_REPO" --name-only
                 echo
                 echo "## Commits"
                 git log --pretty=format:'- %s (%h) by %an' "origin/$BASE_REF..HEAD"
                 echo
                 echo
                 echo "## Current CI checks"
-                gh pr checks "$PR_NUMBER" || true
+                gh pr checks "$PR_NUMBER" --repo "$GH_REPO" || true
                 echo
                 echo "## Cubic reviews"
-                gh pr view "$PR_NUMBER" --json reviews \
+                gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json reviews \
                   --jq '.reviews[] | select((.author.login | ascii_downcase | contains("cubic"))) | {state, submittedAt, author: .author.login, body}' || true
                 echo
                 echo "## Cubic inline comments"
@@ -139,8 +141,9 @@ jobs:
          - name: Comment readiness report
            env:
               GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              GH_REPO: ${{ github.repository }}
               PR_NUMBER: ${{ steps.pr.outputs.number }}
-           run: gh pr comment "$PR_NUMBER" --body-file PR_READINESS.md
+           run: gh pr comment "$PR_NUMBER" --repo "$GH_REPO" --body-file PR_READINESS.md
 
          - name: Upload readiness artifacts
            uses: actions/upload-artifact@v4

--- a/apps/web/src/routes/auth/email-verification.tsx
+++ b/apps/web/src/routes/auth/email-verification.tsx
@@ -8,7 +8,6 @@ import {
 import {
    InputOTP,
    InputOTPGroup,
-   InputOTPSeparator,
    InputOTPSlot,
 } from "@packages/ui/components/input-otp";
 import { useForm } from "@tanstack/react-form";
@@ -145,14 +144,10 @@ function EmailVerificationPage() {
                                     <InputOTPGroup>
                                        <InputOTPSlot index={0} />
                                        <InputOTPSlot index={1} />
-                                    </InputOTPGroup>
-                                    <InputOTPSeparator />
-                                    <InputOTPGroup>
                                        <InputOTPSlot index={2} />
-                                       <InputOTPSlot index={3} />
                                     </InputOTPGroup>
-                                    <InputOTPSeparator />
                                     <InputOTPGroup>
+                                       <InputOTPSlot index={3} />
                                        <InputOTPSlot index={4} />
                                        <InputOTPSlot index={5} />
                                     </InputOTPGroup>


### PR DESCRIPTION
## Summary
- Group the email verification OTP input into two 3-digit blocks to match the email template formatting.
- Remove the extra separators from the previous 2-2-2 layout.

## Testing
- Not run: this isolated worktree does not have node_modules installed, so Nx cannot initialize here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Agrupa o OTP de e-mail em dois blocos de 3 dígitos (3-3) e remove os separadores para alinhar a UI ao template e reduzir erros. Também corrige o workflow de PR para resolver metadados via GitHub CLI de forma confiável.

- **Bug Fixes**
  - Por quê: alinhar com o template (3-3) para melhorar leitura/consistência e corrigir coleta de metadados do PR na CI sem checkout.
  - Impacto nas camadas: Router (apps/web/src/routes/auth/email-verification.tsx); Componente (`@packages/ui/components/input-otp`). Sem mudanças em repositório ou store. CI (.github/workflows/pr-readiness.yml): passa `GH_REPO` e usa `--repo` no `gh` para resolver metadados sem checkout.
  - Checklist de teste:
    - UI exibe 2 grupos: [0,1,2] e [3,4,5], sem separadores.
    - Digitação sequencial preenche os 6 slots corretamente.
    - Backspace navega entre slots e entre grupos como esperado.
    - Colar 6 dígitos distribui corretamente pelos slots.
    - Submissão e validações permanecem funcionando.

<sup>Written for commit 4abfacf2167c7530039e6f25aa1494bd14597a50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

