### PR TITLE
docs: add design-md skill and update project documentation

### DIFF
--- a/.agents/skills/design-md/README.md
+++ b/.agents/skills/design-md/README.md
@@ -1,0 +1,34 @@
+# Stitch Design System Documentation Skill
+
+## Install
+
+```bash
+npx skills add google-labs-code/stitch-skills --skill design-md --global
+```
+
+## Example Prompt
+
+```text
+Analyze my Furniture Collection project's Home screen and generate a comprehensive DESIGN.md file documenting the design system.
+```
+
+## Skill Structure
+
+This repository follows the **Agent Skills** open standard. Each skill is self-contained with its own logic, workflow, and reference materials.
+
+```text
+design-md/
+├── SKILL.md           — Core instructions & workflow
+├── examples/          — Sample DESIGN.md outputs
+└── README.md          — This file
+```
+
+## How it Works
+
+When activated, the agent follows a structured design analysis pipeline:
+
+1. **Retrieval**: Uses the Stitch MCP Server to fetch project screens, HTML code, and design metadata.
+2. **Extraction**: Identifies design tokens including colors, typography, spacing, and component patterns.
+3. **Translation**: Converts technical CSS/Tailwind values into descriptive, natural design language.
+4. **Synthesis**: Generates a comprehensive DESIGN.md following the semantic design system format.
+5. **Alignment**: Ensures output follows Stitch Effective Prompting Guide principles for optimal screen generation.

--- a/.agents/skills/design-md/SKILL.md
+++ b/.agents/skills/design-md/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: design-md
+description: Analyze Stitch projects and synthesize a semantic design system into DESIGN.md files
+allowed-tools:
+  - "stitch*:*"
+  - "Read"
+  - "Write"
+  - "web_fetch"
+---
+
+# Stitch DESIGN.md Skill
+
+You are an expert Design Systems Lead. Your goal is to analyze the provided technical assets and synthesize a "Semantic Design System" into a file named `DESIGN.md`.
+
+## Overview
+
+This skill helps you create `DESIGN.md` files that serve as the "source of truth" for prompting Stitch to generate new screens that align perfectly with existing design language. Stitch interprets design through "Visual Descriptions" supported by specific color values.
+
+## Prerequisites
+
+- Access to the Stitch MCP Server
+- A Stitch project with at least one designed screen
+- Access to the Stitch Effective Prompting Guide: https://stitch.withgoogle.com/docs/learn/prompting/
+
+## The Goal
+
+The `DESIGN.md` file will serve as the "source of truth" for prompting Stitch to generate new screens that align perfectly with the existing design language. Stitch interprets design through "Visual Descriptions" supported by specific color values.
+
+## Retrieval and Networking
+
+To analyze a Stitch project, you must retrieve screen metadata and design assets using the Stitch MCP Server tools:
+
+1. **Namespace discovery**: Run `list_tools` to find the Stitch MCP prefix. Use this prefix (e.g., `mcp_stitch:`) for all subsequent calls.
+
+2. **Project lookup** (if Project ID is not provided):
+   - Call `[prefix]:list_projects` with `filter: "view=owned"` to retrieve all user projects
+   - Identify the target project by title or URL pattern
+   - Extract the Project ID from the `name` field (e.g., `projects/13534454087919359824`)
+
+3. **Screen lookup** (if Screen ID is not provided):
+   - Call `[prefix]:list_screens` with the `projectId` (just the numeric ID, not the full path)
+   - Review screen titles to identify the target screen (e.g., "Home", "Landing Page")
+   - Extract the Screen ID from the screen's `name` field
+
+4. **Metadata fetch**: 
+   - Call `[prefix]:get_screen` with both `projectId` and `screenId` (both as numeric IDs only)
+   - This returns the complete screen object including:
+     - `screenshot.downloadUrl` - Visual reference of the design
+     - `htmlCode.downloadUrl` - Full HTML/CSS source code
+     - `width`, `height`, `deviceType` - Screen dimensions and target platform
+     - Project metadata including `designTheme` with color and style information
+
+5. **Asset download**:
+   - Use `web_fetch` or `read_url_content` to download the HTML code from `htmlCode.downloadUrl`
+   - Optionally download the screenshot from `screenshot.downloadUrl` for visual reference
+   - Parse the HTML to extract Tailwind classes, custom CSS, and component patterns
+
+6. **Project metadata extraction**:
+   - Call `[prefix]:get_project` with the project `name` (full path: `projects/{id}`) to get:
+     - `designTheme` object with color mode, fonts, roundness, custom colors
+     - Project-level design guidelines and descriptions
+     - Device type preferences and layout principles
+
+## Analysis & Synthesis Instructions
+
+### 1. Extract Project Identity (JSON)
+- Locate the Project Title
+- Locate the specific Project ID (e.g., from the `name` field in the JSON)
+
+### 2. Define the Atmosphere (Image/HTML)
+Evaluate the screenshot and HTML structure to capture the overall "vibe." Use evocative adjectives to describe the mood (e.g., "Airy," "Dense," "Minimalist," "Utilitarian").
+
+### 3. Map the Color Palette (Tailwind Config/JSON)
+Identify the key colors in the system. For each color, provide:
+- A descriptive, natural language name that conveys its character (e.g., "Deep Muted Teal-Navy")
+- The specific hex code in parentheses for precision (e.g., "#294056")
+- Its specific functional role (e.g., "Used for primary actions")
+
+### 4. Translate Geometry & Shape (CSS/Tailwind)
+Convert technical `border-radius` and layout values into physical descriptions:
+- Describe `rounded-full` as "Pill-shaped"
+- Describe `rounded-lg` as "Subtly rounded corners"
+- Describe `rounded-none` as "Sharp, squared-off edges"
+
+### 5. Describe Depth & Elevation
+Explain how the UI handles layers. Describe the presence and quality of shadows (e.g., "Flat," "Whisper-soft diffused shadows," or "Heavy, high-contrast drop shadows").
+
+## Output Guidelines
+
+- **Language:** Use descriptive design terminology and natural language exclusively
+- **Format:** Generate a clean Markdown file following the structure below
+- **Precision:** Include exact hex codes for colors while using descriptive names
+- **Context:** Explain the "why" behind design decisions, not just the "what"
+
+## Output Format (DESIGN.md Structure)
+
+```markdown
+# Design System: [Project Title]
+**Project ID:** [Insert Project ID Here]
+
+## 1. Visual Theme & Atmosphere
+(Description of the mood, density, and aesthetic philosophy.)
+
+## 2. Color Palette & Roles
+(List colors by Descriptive Name + Hex Code + Functional Role.)
+
+## 3. Typography Rules
+(Description of font family, weight usage for headers vs. body, and letter-spacing character.)
+
+## 4. Component Stylings
+* **Buttons:** (Shape description, color assignment, behavior).
+* **Cards/Containers:** (Corner roundness description, background color, shadow depth).
+* **Inputs/Forms:** (Stroke style, background).
+
+## 5. Layout Principles
+(Description of whitespace strategy, margins, and grid alignment.)
+```
+
+## Usage Example
+
+To use this skill for the Furniture Collection project:
+
+1. **Retrieve project information:**
+   ```
+   Use the Stitch MCP Server to get the Furniture Collection project
+   ```
+
+2. **Get the Home page screen details:**
+   ```
+   Retrieve the Home page screen's code, image, and screen object information
+   ```
+
+3. **Reference best practices:**
+   ```
+   Review the Stitch Effective Prompting Guide at:
+   https://stitch.withgoogle.com/docs/learn/prompting/
+   ```
+
+4. **Analyze and synthesize:**
+   - Extract all relevant design tokens from the screen
+   - Translate technical values into descriptive language
+   - Organize information according to the DESIGN.md structure
+
+5. **Generate the file:**
+   - Create `DESIGN.md` in the project directory
+   - Follow the prescribed format exactly
+   - Ensure all color codes are accurate
+   - Use evocative, designer-friendly language
+
+## Best Practices
+
+- **Be Descriptive:** Avoid generic terms like "blue" or "rounded." Use "Ocean-deep Cerulean (#0077B6)" or "Gently curved edges"
+- **Be Functional:** Always explain what each design element is used for
+- **Be Consistent:** Use the same terminology throughout the document
+- **Be Visual:** Help readers visualize the design through your descriptions
+- **Be Precise:** Include exact values (hex codes, pixel values) in parentheses after natural language descriptions
+
+## Tips for Success
+
+1. **Start with the big picture:** Understand the overall aesthetic before diving into details
+2. **Look for patterns:** Identify consistent spacing, sizing, and styling patterns
+3. **Think semantically:** Name colors by their purpose, not just their appearance
+4. **Consider hierarchy:** Document how visual weight and importance are communicated
+5. **Reference the guide:** Use language and patterns from the Stitch Effective Prompting Guide
+
+## Common Pitfalls to Avoid
+
+- ❌ Using technical jargon without translation (e.g., "rounded-xl" instead of "generously rounded corners")
+- ❌ Omitting color codes or using only descriptive names
+- ❌ Forgetting to explain functional roles of design elements
+- ❌ Being too vague in atmosphere descriptions
+- ❌ Ignoring subtle design details like shadows or spacing patterns

--- a/.agents/skills/design-md/examples/DESIGN.md
+++ b/.agents/skills/design-md/examples/DESIGN.md
@@ -1,0 +1,154 @@
+# Design System: Furniture Collections List
+**Project ID:** 13534454087919359824
+
+## 1. Visual Theme & Atmosphere
+
+The Furniture Collections List embodies a **sophisticated, minimalist sanctuary** that marries the pristine simplicity of Scandinavian design with the refined visual language of luxury editorial presentation. The interface feels **spacious and tranquil**, prioritizing breathing room and visual clarity above all else. The design philosophy is gallery-like and photography-first, allowing each furniture piece to command attention as an individual art object.
+
+The overall mood is **airy yet grounded**, creating an aspirational aesthetic that remains approachable and welcoming. The interface feels **utilitarian in its restraint** but elegant in its execution, with every element serving a clear purpose while maintaining visual sophistication. The atmosphere evokes the serene ambiance of a high-end furniture showroom where customers can browse thoughtfully without visual overwhelm.
+
+**Key Characteristics:**
+- Expansive whitespace creating generous breathing room between elements
+- Clean, architectural grid system with structured content blocks
+- Photography-first presentation with minimal UI interference
+- Whisper-soft visual hierarchy that guides without shouting
+- Refined, understated interactive elements
+- Professional yet inviting editorial tone
+
+## 2. Color Palette & Roles
+
+### Primary Foundation
+- **Warm Barely-There Cream** (#FCFAFA) – Primary background color. Creates an almost imperceptible warmth that feels more inviting than pure white, serving as the serene canvas for the entire experience.
+- **Crisp Very Light Gray** (#F5F5F5) – Secondary surface color used for card backgrounds and content areas. Provides subtle visual separation while maintaining the airy, ethereal quality.
+
+### Accent & Interactive
+- **Deep Muted Teal-Navy** (#294056) – The sole vibrant accent in the palette. Used exclusively for primary call-to-action buttons (e.g., "Shop Now", "View all products"), active navigation links, selected filter states, and subtle interaction highlights. This sophisticated anchor color creates visual focus points without disrupting the serene neutral foundation.
+
+### Typography & Text Hierarchy
+- **Charcoal Near-Black** (#2C2C2C) – Primary text color for headlines and product names. Provides strong readable contrast while being softer and more refined than pure black.
+- **Soft Warm Gray** (#6B6B6B) – Secondary text used for body copy, product descriptions, and supporting metadata. Creates clear typographic hierarchy without harsh contrast.
+- **Ultra-Soft Silver Gray** (#E0E0E0) – Tertiary color for borders, dividers, and subtle structural elements. Creates separation so gentle it's almost imperceptible.
+
+### Functional States (Reserved for system feedback)
+- **Success Moss** (#10B981) – Stock availability, confirmation states, positive indicators
+- **Alert Terracotta** (#EF4444) – Low stock warnings, error states, critical alerts
+- **Informational Slate** (#64748B) – Neutral system messages, informational callouts
+
+## 3. Typography Rules
+
+**Primary Font Family:** Manrope  
+**Character:** Modern, geometric sans-serif with gentle humanist warmth. Slightly rounded letterforms that feel contemporary yet approachable.
+
+### Hierarchy & Weights
+- **Display Headlines (H1):** Semi-bold weight (600), generous letter-spacing (0.02em for elegance), 2.75-3.5rem size. Used sparingly for hero sections and major page titles.
+- **Section Headers (H2):** Semi-bold weight (600), subtle letter-spacing (0.01em), 2-2.5rem size. Establishes clear content zones and featured collections.
+- **Subsection Headers (H3):** Medium weight (500), normal letter-spacing, 1.5-1.75rem size. Product names and category labels.
+- **Body Text:** Regular weight (400), relaxed line-height (1.7), 1rem size. Descriptions and supporting content prioritize comfortable readability.
+- **Small Text/Meta:** Regular weight (400), slightly tighter line-height (1.5), 0.875rem size. Prices, availability, and metadata remain legible but visually recessive.
+- **CTA Buttons:** Medium weight (500), subtle letter-spacing (0.01em), 1rem size. Balanced presence without visual aggression.
+
+### Spacing Principles
+- Headers use slightly expanded letter-spacing for refined elegance
+- Body text maintains generous line-height (1.7) for effortless reading
+- Consistent vertical rhythm with 2-3rem between related text blocks
+- Large margins (4-6rem) between major sections to reinforce spaciousness
+
+## 4. Component Stylings
+
+### Buttons
+- **Shape:** Subtly rounded corners (8px/0.5rem radius) – approachable and modern without appearing playful or childish
+- **Primary CTA:** Deep Muted Teal-Navy (#294056) background with pure white text, comfortable padding (0.875rem vertical, 2rem horizontal)
+- **Hover State:** Subtle darkening to deeper navy, smooth 250ms ease-in-out transition
+- **Focus State:** Soft outer glow in the primary color for keyboard navigation accessibility
+- **Secondary CTA (if needed):** Outlined style with Deep Muted Teal-Navy border, transparent background, hover fills with whisper-soft teal tint
+
+### Cards & Product Containers
+- **Corner Style:** Gently rounded corners (12px/0.75rem radius) creating soft, refined edges
+- **Background:** Alternates between Warm Barely-There Cream and Crisp Very Light Gray based on layering needs
+- **Shadow Strategy:** Flat by default. On hover, whisper-soft diffused shadow appears (`0 2px 8px rgba(0,0,0,0.06)`) creating subtle depth
+- **Border:** Optional hairline border (1px) in Ultra-Soft Silver Gray for delicate definition when shadows aren't present
+- **Internal Padding:** Generous 2-2.5rem creating comfortable breathing room for content
+- **Image Treatment:** Full-bleed at the top of cards, square or 4:3 ratio, seamless edge-to-edge presentation
+
+### Navigation
+- **Style:** Clean horizontal layout with generous spacing (2-3rem) between menu items
+- **Typography:** Medium weight (500), subtle uppercase, expanded letter-spacing (0.06em) for refined sophistication
+- **Default State:** Charcoal Near-Black text
+- **Active/Hover State:** Smooth 200ms color transition to Deep Muted Teal-Navy
+- **Active Indicator:** Thin underline (2px) in Deep Muted Teal-Navy appearing below current section
+- **Mobile:** Converts to elegant hamburger menu with sliding drawer
+
+### Inputs & Forms
+- **Stroke Style:** Refined 1px border in Soft Warm Gray
+- **Background:** Warm Barely-There Cream with transition to Crisp Very Light Gray on focus
+- **Corner Style:** Matching button roundness (8px/0.5rem) for visual consistency
+- **Focus State:** Border color shifts to Deep Muted Teal-Navy with subtle outer glow
+- **Padding:** Comfortable 0.875rem vertical, 1.25rem horizontal for touch-friendly targets
+- **Placeholder Text:** Ultra-Soft Silver Gray, elegant and unobtrusive
+
+### Product Cards (Specific Pattern)
+- **Image Area:** Square (1:1) or landscape (4:3) ratio filling card width completely
+- **Content Stack:** Product name (H3), brief descriptor, material/finish, price
+- **Price Display:** Emphasized with semi-bold weight (600) in Charcoal Near-Black
+- **Hover Behavior:** Gentle lift effect (translateY -4px) combined with enhanced shadow
+- **Spacing:** Consistent 1.5rem internal padding below image
+
+## 5. Layout Principles
+
+### Grid & Structure
+- **Max Content Width:** 1440px for optimal readability and visual balance on large displays
+- **Grid System:** Responsive 12-column grid with fluid gutters (24px mobile, 32px desktop)
+- **Product Grid:** 4 columns on large desktop, 3 on desktop, 2 on tablet, 1 on mobile
+- **Breakpoints:** 
+  - Mobile: <768px
+  - Tablet: 768-1024px  
+  - Desktop: 1024-1440px
+  - Large Desktop: >1440px
+
+### Whitespace Strategy (Critical to the Design)
+- **Base Unit:** 8px for micro-spacing, 16px for component spacing
+- **Vertical Rhythm:** Consistent 2rem (32px) base unit between related elements
+- **Section Margins:** Generous 5-8rem (80-128px) between major sections creating dramatic breathing room
+- **Edge Padding:** 1.5rem (24px) mobile, 3rem (48px) tablet/desktop for comfortable framing
+- **Hero Sections:** Extra-generous top/bottom padding (8-12rem) for impactful presentation
+
+### Alignment & Visual Balance
+- **Text Alignment:** Left-aligned for body and navigation (optimal readability), centered for hero headlines and featured content
+- **Image to Text Ratio:** Heavily weighted toward imagery (70-30 split) reinforcing photography-first philosophy
+- **Asymmetric Balance:** Large hero images offset by compact, refined text blocks
+- **Visual Weight Distribution:** Strategic use of whitespace to draw eyes to hero products and primary CTAs
+- **Reading Flow:** Clear top-to-bottom, left-to-right pattern with intentional focal points
+
+### Responsive Behavior & Touch
+- **Mobile-First Foundation:** Core experience designed and perfected for smallest screens first
+- **Progressive Enhancement:** Additional columns, imagery, and details added gracefully at larger breakpoints
+- **Touch Targets:** Minimum 44x44px for all interactive elements (WCAG AAA compliant)
+- **Image Optimization:** Responsive images with appropriate resolutions for each breakpoint, lazy-loading for performance
+- **Collapsing Strategy:** Navigation collapses to hamburger, grid reduces columns, padding scales proportionally
+
+## 6. Design System Notes for Stitch Generation
+
+When creating new screens for this project using Stitch, reference these specific instructions:
+
+### Language to Use
+- **Atmosphere:** "Sophisticated minimalist sanctuary with gallery-like spaciousness"
+- **Button Shapes:** "Subtly rounded corners" (not "rounded-md" or "8px")
+- **Shadows:** "Whisper-soft diffused shadows on hover" (not "shadow-sm")
+- **Spacing:** "Generous breathing room" and "expansive whitespace"
+
+### Color References
+Always use the descriptive names with hex codes:
+- Primary CTA: "Deep Muted Teal-Navy (#294056)"
+- Backgrounds: "Warm Barely-There Cream (#FCFAFA)" or "Crisp Very Light Gray (#F5F5F5)"
+- Text: "Charcoal Near-Black (#2C2C2C)" or "Soft Warm Gray (#6B6B6B)"
+
+### Component Prompts
+- "Create a product card with gently rounded corners, full-bleed square product image, and whisper-soft shadow on hover"
+- "Design a primary call-to-action button in Deep Muted Teal-Navy (#294056) with subtle rounded corners and comfortable padding"
+- "Add a navigation bar with generous spacing between items, using medium-weight Manrope with subtle uppercase and expanded letter-spacing"
+
+### Incremental Iteration
+When refining existing screens:
+1. Focus on ONE component at a time (e.g., "Update the product grid cards")
+2. Be specific about what to change (e.g., "Increase the internal padding of product cards from 1.5rem to 2rem")
+3. Reference this design system language consistently

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ AI-powered ERP. Nx monorepo, Bun, TanStack Start (SSR), oRPC, TanStack Query, Dr
 ## Commands
 
 ```bash
-bun dev                  # seeds event catalog (local) then starts web + worker + landing
+bun dev                  # dev-init (env.local, install, containers, db:push) then web + worker + landing
 bun dev:all              # all apps + packages
 bun run build            # Nx-cached build
 bun run typecheck
@@ -23,13 +23,13 @@ bun run landing:build    # build Astro landing page
 bun run landing:start    # preview landing on Railway-compatible host/port
 ```
 
-Scripts (`commander run|check`, `--env`, `--dry-run`): `scripts/seed-default-dashboard.ts`, `scripts/seed-event-catalog.ts`, `scripts/doctor.ts`.
+Scripts: `scripts/dev-init.ts`, `scripts/setup.ts`, `scripts/doctor.ts`, `scripts/clean.ts`, `scripts/db-push.ts`, `scripts/ensure-schemas.ts`, `scripts/check-env.ts`, `scripts/env-setup.ts`, `scripts/seed-default-dashboard.ts`, `scripts/backfill-category-icons.ts`.
 
-First-time setup: `bun run setup` → `cd apps/web && docker compose up -d` → `bun run db:push`.
+First-time setup: `bun run setup` (creates `apps/web/.env.local`, starts containers, runs `db:push`). After that, `bun dev` is the daily driver.
 
 **Gotchas:**
 
-- `bun dev` re-seeds the event catalog every start, then runs `web`, `worker`, and `landing`; if seeding fails dev won't launch. Debug: `scripts/seed-event-catalog.ts run --env local`.
+- `bun dev` runs `scripts/dev-init.ts` (ensures `.env.local`, installs deps, starts local containers, `db:push`), then `nx run-many` for `web`, `worker`, `landing`. If containers fail it warns but continues — verify with `bun run doctor`.
 - "Module has no exported member" on typecheck → stale dist. `cd core/<pkg> && bun run build`.
 - Never bump `NODE_OPTIONS` memory — fix the root cause.
 - `apps/web/src/routeTree.gen.ts` is generated — never edit.
@@ -56,10 +56,10 @@ Domain → skill map (open before coding):
 core/         # ai, authentication, database, dbos, environment, files, logging,
               # orpc, posthog, redis, sse, transactional, utils
 modules/      # account, agents, billing, classification, finance, insights
-              # — domain modules (router, services, workflows, sse per module)
+              # — domain modules (router, services, workflows per module; not every module has all three)
 apps/         # web (TanStack Start + oRPC), worker (DBOS), landing (Astro)
 packages/     # ui (shadcn primitives + Montte components)
-tooling/      # oxc, tsconfigs
+tooling/      # boundary, css (Tailwind), oxc, typescript
 ```
 
 `apps/landing` is the public Astro landing page. It imports `@tooling/css/globals.css`, can server-render static shadcn components from `@packages/ui`, uses `public/favicon.svg`, and runs on port `3001` in development.
@@ -177,10 +177,12 @@ Vite plugin order is critical: `tanstackStart({ router: { autoCodeSplitting: tru
 
 Schemas in `core/database/src/schemas/`. **Always namespace** — never raw `pgTable(...)`:
 
-- `financeSchema` → transactions, bank-accounts, bills, credit-cards, financial-goals, financial-settings
-- `crmSchema` → contacts, contact-settings, tags
-- `platformSchema` → dashboards, insights, event-catalog, webhooks, subscriptions, agents
-- `auth` → Better Auth managed, **read-only** (use `additionalFields` in auth config)
+- `financeSchema` → transactions, transaction-items, bank-accounts, credit-cards, credit-card-statements, credit-card-statement-totals, categories
+- `crmSchema` → contacts, contact-settings, contact-subscriptions, services, service-prices, service-benefits, benefits, benefit-grants, meters, subscription-items, coupons, coupon-redemptions, resources, tags
+- `platformSchema` → dashboards, insights, agent-settings, invoices, usage-events
+- `settingsSchema` → financial config
+- `agentsSchema` → threads
+- `authSchema` → Better Auth managed (user, session, account, organization, team, member, invitation, twoFactor, apikey) — **read-only** (extend via `additionalFields` in auth config)
 
 Local DB image is `paradedb/paradedb` — don't swap.
 
@@ -188,7 +190,7 @@ Local DB image is `paradedb/paradedb` — don't swap.
 
 ## Auth (Better Auth)
 
-Config: `core/authentication/src/server.ts`. Plugins: Magic Link, Email OTP, 2FA, Anonymous, HyprPay.
+Config: `core/authentication/src/server.ts`. Plugins: Magic Link, Email OTP, 2FA, Organization, API Key.
 
 - Auth schema is read-only; extend via `additionalFields`.
 - Queries → oRPC (`orpc.organization.*`). Mutations → `authClient` directly (never `useMutation`).
@@ -210,7 +212,7 @@ DBOS runs in `apps/worker` — never the web process. Web enqueues via `context.
 - Self-rescheduling: re-check status in tx → do work → compute next wake **inside `DBOS.runStep`** → `DBOS.startWorkflow(self, { workflowID: "<deterministic-per-period>", queueName, enqueueOptions: { delaySeconds } })`.
 - Workflow inputs always carry both `teamId` and `organizationId` — don't look them up inside steps.
 
-Existing queues: `workflow:categorize` (10), `workflow:derive-keywords` (5), `workflow:benefit-lifecycle`, `workflow:period-end-invoice`, `workflow:trial-expiry`.
+Existing queues (modules with workflows: `billing`, `classification`): `workflow:classify`, `workflow:derive-keywords`, `workflow:benefit-lifecycle`, `workflow:period-end-invoice`, `workflow:trial-expiry`. Worker startup (`apps/worker/src/index.ts`): `initOtel` → `setupBillingWorkflows(deps)` + `setupClassificationWorkflows(deps)` → `DBOS.setConfig` → `DBOS.launch()`.
 
 **Testing:** mock `@dbos-inc/dbos-sdk` with `vi.hoisted` + `dbosSdkMockFactory` / `drizzleDataSourceMockFactory` from `@core/dbos/testing/mock-dbos` — `registerWorkflow` must return the function directly. pglite-backed `setupTestDb()` for assertions. Time-mocked: `vi.useFakeTimers()` + `vi.setSystemTime(T0)`. End-to-end real-runtime smoke: `__tests__/integration/dbos-smoke.test.ts` (pglite + `@electric-sql/pglite-socket`). Example: `__tests__/workflows/period-end-invoice.test.ts`.
 
@@ -229,22 +231,17 @@ const result = await chat({
 });
 ```
 
-Single agent `rubiAgent` via `mastra.getAgent("rubiAgent")` + `createRequestContext({ userId, teamId, organizationId, model, language: "pt-BR" })` from `@packages/agents`.
+Rubi agent lives in `modules/agents/src/rubi.ts`. Built on `@tanstack/ai` + `@tanstack/ai-openrouter`; tools wrap oRPC procedures via `createRubiToolClient` (`modules/agents/src/orpc-tool-router.ts`); skill catalog from `modules/agents/src/skills.ts`. No Mastra, no `@packages/agents`.
 
 ---
 
 ## Billing (HyprPay)
 
-100% usage-based. Customer = Better Auth organization (`externalId = organization.id`). Subscriptions support seats via item `quantity`. Stripe is legacy-only — `@core/stripe` will be removed.
+100% usage-based. Customer = Better Auth organization. Subscriptions support seats via item `quantity`.
 
 **Bill only what costs us** (AI calls, email, storage, webhook egress). UI/CRUD/listings are free.
 
-Two ingestion paths converge on `ingestUsageEvent`:
-
-1. **Workflow steps** — call `ingestUsageEvent` inside `DBOS.runStep` after the cost-incurring action succeeds.
-2. **Router-triggered costs** — `billableProcedure` + `.meta({ billableEvent })` → `onSuccess` middleware ingests one event per success.
-
-Event names live in module `constants.ts` (e.g. `CLASSIFICATION_USAGE_EVENTS`, `TRANSACTIONAL_USAGE_EVENTS`). `ingestUsageEvent` is no-op without a configured meter and never throws — failed ingestion logs only, never rolls back the work. Always pass an `idempotencyKey`.
+Routers tag cost-incurring procedures with `billableProcedure` + `.meta({ billableEvent: "<name>" })` (`core/orpc/src/server.ts` — `BillableMeta`). Pure CRUD stays on `protectedProcedure`. Workflows write usage rows directly to the `usage-events` schema; the period-end-invoice workflow aggregates them via `summarizeUsageByMeter`. HyprPay ingestion middleware is planned but not wired yet — don't reference helpers that aren't in the codebase.
 
 ---
 
@@ -405,4 +402,4 @@ skills:
   use: "@tanstack/devtools#devtools-app-setup"
 - when: "Working with .env files, dotenv config, encrypted env, variable expansion"
 use: "dotenv#dotenv"
-  <!-- intent-skills:end -->
+ <!-- intent-skills:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ AI-powered ERP. Nx monorepo, Bun, TanStack Start (SSR), oRPC, TanStack Query, Dr
 ## Commands
 
 ```bash
-bun dev                  # seeds event catalog (local) then starts web + worker + landing
+bun dev                  # dev-init (env.local, install, containers, db:push) then web + worker + landing
 bun dev:all              # all apps + packages
 bun run build            # Nx-cached build
 bun run typecheck
@@ -23,13 +23,13 @@ bun run landing:build    # build Astro landing page
 bun run landing:start    # preview landing on Railway-compatible host/port
 ```
 
-Scripts (`commander run|check`, `--env`, `--dry-run`): `scripts/seed-default-dashboard.ts`, `scripts/seed-event-catalog.ts`, `scripts/doctor.ts`.
+Scripts: `scripts/dev-init.ts`, `scripts/setup.ts`, `scripts/doctor.ts`, `scripts/clean.ts`, `scripts/db-push.ts`, `scripts/ensure-schemas.ts`, `scripts/check-env.ts`, `scripts/env-setup.ts`, `scripts/seed-default-dashboard.ts`, `scripts/backfill-category-icons.ts`.
 
-First-time setup: `bun run setup` → `cd apps/web && docker compose up -d` → `bun run db:push`.
+First-time setup: `bun run setup` (creates `apps/web/.env.local`, starts containers, runs `db:push`). After that, `bun dev` is the daily driver.
 
 **Gotchas:**
 
-- `bun dev` re-seeds the event catalog every start, then runs `web`, `worker`, and `landing`; if seeding fails dev won't launch. Debug: `scripts/seed-event-catalog.ts run --env local`.
+- `bun dev` runs `scripts/dev-init.ts` (ensures `.env.local`, installs deps, starts local containers, `db:push`), then `nx run-many` for `web`, `worker`, `landing`. If containers fail it warns but continues — verify with `bun run doctor`.
 - "Module has no exported member" on typecheck → stale dist. `cd core/<pkg> && bun run build`.
 - Never bump `NODE_OPTIONS` memory — fix the root cause.
 - `apps/web/src/routeTree.gen.ts` is generated — never edit.
@@ -56,10 +56,10 @@ Domain → skill map (open before coding):
 core/         # ai, authentication, database, dbos, environment, files, logging,
               # orpc, posthog, redis, sse, transactional, utils
 modules/      # account, agents, billing, classification, finance, insights
-              # — domain modules (router, services, workflows, sse per module)
+              # — domain modules (router, services, workflows per module; not every module has all three)
 apps/         # web (TanStack Start + oRPC), worker (DBOS), landing (Astro)
 packages/     # ui (shadcn primitives + Montte components)
-tooling/      # oxc, tsconfigs
+tooling/      # boundary, css (Tailwind), oxc, typescript
 ```
 
 `apps/landing` is the public Astro landing page. It imports `@tooling/css/globals.css`, can server-render static shadcn components from `@packages/ui`, uses `public/favicon.svg`, and runs on port `3001` in development.
@@ -177,10 +177,12 @@ Vite plugin order is critical: `tanstackStart({ router: { autoCodeSplitting: tru
 
 Schemas in `core/database/src/schemas/`. **Always namespace** — never raw `pgTable(...)`:
 
-- `financeSchema` → transactions, bank-accounts, bills, credit-cards, financial-goals, financial-settings
-- `crmSchema` → contacts, contact-settings, tags
-- `platformSchema` → dashboards, insights, event-catalog, webhooks, subscriptions, agents
-- `auth` → Better Auth managed, **read-only** (use `additionalFields` in auth config)
+- `financeSchema` → transactions, transaction-items, bank-accounts, credit-cards, credit-card-statements, credit-card-statement-totals, categories
+- `crmSchema` → contacts, contact-settings, contact-subscriptions, services, service-prices, service-benefits, benefits, benefit-grants, meters, subscription-items, coupons, coupon-redemptions, resources, tags
+- `platformSchema` → dashboards, insights, agent-settings, invoices, usage-events
+- `settingsSchema` → financial config
+- `agentsSchema` → threads
+- `authSchema` → Better Auth managed (user, session, account, organization, team, member, invitation, twoFactor, apikey) — **read-only** (extend via `additionalFields` in auth config)
 
 Local DB image is `paradedb/paradedb` — don't swap.
 
@@ -188,7 +190,7 @@ Local DB image is `paradedb/paradedb` — don't swap.
 
 ## Auth (Better Auth)
 
-Config: `core/authentication/src/server.ts`. Plugins: Magic Link, Email OTP, 2FA, Anonymous, HyprPay.
+Config: `core/authentication/src/server.ts`. Plugins: Magic Link, Email OTP, 2FA, Organization, API Key.
 
 - Auth schema is read-only; extend via `additionalFields`.
 - Queries → oRPC (`orpc.organization.*`). Mutations → `authClient` directly (never `useMutation`).
@@ -210,7 +212,7 @@ DBOS runs in `apps/worker` — never the web process. Web enqueues via `context.
 - Self-rescheduling: re-check status in tx → do work → compute next wake **inside `DBOS.runStep`** → `DBOS.startWorkflow(self, { workflowID: "<deterministic-per-period>", queueName, enqueueOptions: { delaySeconds } })`.
 - Workflow inputs always carry both `teamId` and `organizationId` — don't look them up inside steps.
 
-Existing queues: `workflow:categorize` (10), `workflow:derive-keywords` (5), `workflow:benefit-lifecycle`, `workflow:period-end-invoice`, `workflow:trial-expiry`.
+Existing queues (modules with workflows: `billing`, `classification`): `workflow:classify`, `workflow:derive-keywords`, `workflow:benefit-lifecycle`, `workflow:period-end-invoice`, `workflow:trial-expiry`. Worker startup (`apps/worker/src/index.ts`): `initOtel` → `setupBillingWorkflows(deps)` + `setupClassificationWorkflows(deps)` → `DBOS.setConfig` → `DBOS.launch()`.
 
 **Testing:** mock `@dbos-inc/dbos-sdk` with `vi.hoisted` + `dbosSdkMockFactory` / `drizzleDataSourceMockFactory` from `@core/dbos/testing/mock-dbos` — `registerWorkflow` must return the function directly. pglite-backed `setupTestDb()` for assertions. Time-mocked: `vi.useFakeTimers()` + `vi.setSystemTime(T0)`. End-to-end real-runtime smoke: `__tests__/integration/dbos-smoke.test.ts` (pglite + `@electric-sql/pglite-socket`). Example: `__tests__/workflows/period-end-invoice.test.ts`.
 
@@ -229,22 +231,17 @@ const result = await chat({
 });
 ```
 
-Single agent `rubiAgent` via `mastra.getAgent("rubiAgent")` + `createRequestContext({ userId, teamId, organizationId, model, language: "pt-BR" })` from `@packages/agents`.
+Rubi agent lives in `modules/agents/src/rubi.ts`. Built on `@tanstack/ai` + `@tanstack/ai-openrouter`; tools wrap oRPC procedures via `createRubiToolClient` (`modules/agents/src/orpc-tool-router.ts`); skill catalog from `modules/agents/src/skills.ts`. No Mastra, no `@packages/agents`.
 
 ---
 
 ## Billing (HyprPay)
 
-100% usage-based. Customer = Better Auth organization (`externalId = organization.id`). Subscriptions support seats via item `quantity`. Stripe is legacy-only — `@core/stripe` will be removed.
+100% usage-based. Customer = Better Auth organization. Subscriptions support seats via item `quantity`.
 
 **Bill only what costs us** (AI calls, email, storage, webhook egress). UI/CRUD/listings are free.
 
-Two ingestion paths converge on `ingestUsageEvent`:
-
-1. **Workflow steps** — call `ingestUsageEvent` inside `DBOS.runStep` after the cost-incurring action succeeds.
-2. **Router-triggered costs** — `billableProcedure` + `.meta({ billableEvent })` → `onSuccess` middleware ingests one event per success.
-
-Event names live in module `constants.ts` (e.g. `CLASSIFICATION_USAGE_EVENTS`, `TRANSACTIONAL_USAGE_EVENTS`). `ingestUsageEvent` is no-op without a configured meter and never throws — failed ingestion logs only, never rolls back the work. Always pass an `idempotencyKey`.
+Routers tag cost-incurring procedures with `billableProcedure` + `.meta({ billableEvent: "<name>" })` (`core/orpc/src/server.ts` — `BillableMeta`). Pure CRUD stays on `protectedProcedure`. Workflows write usage rows directly to the `usage-events` schema; the period-end-invoice workflow aggregates them via `summarizeUsageByMeter`. HyprPay ingestion middleware is planned but not wired yet — don't reference helpers that aren't in the codebase.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Montte é um ERP com IA em um monorepo Nx. O produto principal roda em `apps/web
 ## Pré-requisitos
 
 - [Bun](https://bun.sh) >= 1.x
-- [Node.js](https://nodejs.org) >= 20
+- [Node.js](https://nodejs.org) >= 22.12 (engines)
 - [Docker](https://www.docker.com) ou [Podman](https://podman.io) com Compose
 - [Git](https://git-scm.com)
 
@@ -46,7 +46,7 @@ bun run clean:cache      # limpa cache
 bun run auth:generate    # regenera schema do Better Auth
 ```
 
-Scripts de workspace usam `commander` quando aplicável. Exemplos relevantes: `scripts/seed-default-dashboard.ts`, `scripts/doctor.ts`, `scripts/clean.ts`, `scripts/dev-init.ts` e `scripts/setup.ts`.
+Scripts de workspace ficam em `scripts/`: `setup.ts`, `dev-init.ts`, `doctor.ts`, `clean.ts`, `db-push.ts`, `ensure-schemas.ts`, `check-env.ts`, `env-setup.ts`, `seed-default-dashboard.ts`, `backfill-category-icons.ts`.
 
 Se `bun dev` falhar antes de iniciar os apps, rode `bun run scripts/doctor.ts` e confira `apps/web/.env.local`.
 
@@ -109,7 +109,7 @@ Skills do repositório ficam em `.agents/skills/<nome>/SKILL.md`. Skills especí
 Mapa rápido:
 
 - oRPC handlers e erros: `neverthrow`
-- oRPC client e TanStack Query: `orpc-client`, `tanstack-query`
+- oRPC client e TanStack Query: `tanstack-query`
 - Banco, schemas e queries: `postgres-drizzle`
 - ParadeDB e busca: `paradedb-skill`
 - Redis: `redis-best-practices`

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ bun install
 bun dev
 ```
 
-`bun dev` handles everything on first run — creates `apps/web/.env.local`, starts containers, pushes the DB schema, seeds the event catalog, and starts the dashboard at `http://localhost:3000` plus the landing page at `http://localhost:3001`.
+`bun dev` handles everything on first run — creates `apps/web/.env.local` from `.env.example`, installs dependencies if missing, starts the local containers, pushes the DB schema, then runs `web` (http://localhost:3000), `worker` (DBOS), and `landing` (http://localhost:3001) in parallel.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for staging setup and all available commands.
 
@@ -76,10 +76,10 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for staging setup and all available comma
 
 ### Auth & security (`@core/authentication`)
 
-- Email/password, Google OAuth, Magic Link, Email OTP
+- Email/password, Magic Link, Email OTP
 - Two-factor authentication (2FA)
+- Organization + API key plugins
 - Session management with device tracking
-- Rate limiting and bot detection via Arcjet
 
 ### What's NOT in the box yet
 
@@ -104,11 +104,10 @@ Built as an **Nx** monorepo with **Bun**.
 | **Frontend**  | React 19, TanStack Start (SSR), Astro landing, TanStack Router, TanStack Query, shadcn/ui, Tailwind CSS, TypeScript |
 | **AI**        | TanStack AI + `@tanstack/ai-openrouter`                                                              |
 | **Backend**   | oRPC (type-safe API + OpenAPI), Drizzle ORM, PostgreSQL (ParadeDB image)                             |
-| **Auth**      | Better Auth (Magic Link, Email OTP, 2FA, Anonymous, HyprPay plugins)                                 |
+| **Auth**      | Better Auth (Magic Link, Email OTP, 2FA, Organization, API Key plugins)                              |
 | **Workflows** | DBOS (durable workflows, queues, cron, retries) running in `apps/worker`                             |
 | **Realtime**  | `@core/sse` — scope-routed Redis pub/sub (user / team / org)                                         |
 | **Storage**   | MinIO (S3-compatible)                                                                                |
-| **Security**  | Arcjet (rate limiting & bot detection)                                                               |
 | **Analytics** | PostHog (server + client; surveys + feature flags + early-access)                                    |
 | **Email**     | Resend (React Email templates)                                                                       |
 | **Tooling**   | Nx, oxlint, oxfmt                                                                                    |
@@ -126,7 +125,7 @@ montte-nx/
 ├── core/                # Infra packages (no domain logic)
 │   ├── ai/              # AI primitives (chat, middleware, schemas)
 │   ├── authentication/  # Better Auth setup (server + client)
-│   ├── database/        # Drizzle schemas + client (auth, finance, crm, platform, settings, agents)
+│   ├── database/        # Drizzle schemas + client (schemas: auth, finance, crm, platform, settings, agents)
 │   ├── dbos/            # DBOS factory + testing helpers
 │   ├── environment/     # Zod-validated env vars (web + worker)
 │   ├── files/           # MinIO file storage client

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -38,6 +38,12 @@
          "sourceType": "github",
          "computedHash": "0ea184b3ade54eedfd7109e041ec44803b12f7abc89116d9fab21a47ef40f295"
       },
+      "design-md": {
+         "source": "google-labs-code/stitch-skills",
+         "sourceType": "github",
+         "skillPath": "skills/design-md/SKILL.md",
+         "computedHash": "d3a4c7d2f2715a33662c8b06ffc16035d01965a8b4ed81c2958fb22ae94760f8"
+      },
       "email-and-password-best-practices": {
          "source": "better-auth/skills",
          "sourceType": "github",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adiciona a skill `design-md` para documentar sistemas de design de projetos Stitch e atualiza a documentação do repo para refletir o estado atual (scripts, schemas, auth, billing e boot do `bun dev`). Sem impacto em router, repositório, componentes ou store; apenas docs e catálogo de skills.

- **New Features**
  - Nova skill `.agents/skills/design-md` (+ README, SKILL e exemplo `DESIGN.md`) para analisar projetos Stitch e gerar `DESIGN.md` padronizado.
  - Atualiza `skills-lock.json` com a entrada `design-md` de `google-labs-code/stitch-skills`.

- **Refactors**
  - Alinha `AGENTS.md` e `CLAUDE.md` ao estado real do projeto:
    - `bun dev` agora usa `scripts/dev-init.ts` (env, install, containers, `db:push`) e inicia `web`, `worker` e `landing`.
    - Scripts documentados: `setup.ts`, `dev-init.ts`, `doctor.ts`, `clean.ts`, `db-push.ts`, `ensure-schemas.ts`, `check-env.ts`, `env-setup.ts`, `seed-default-dashboard.ts`, `backfill-category-icons.ts`.
    - Schemas Drizzle atualizados: `financeSchema`, `crmSchema`, `platformSchema`, `settingsSchema`, `agentsSchema`, `authSchema`.
    - Worker: filas vigentes e bootstrap descritos; classificação e billing como módulos com workflows.
    - Agente Rubi documentado em `modules/agents/src/rubi.ts` (sem Mastra), baseado em `@tanstack/ai` + `@tanstack/ai-openrouter`; tools via `createRubiToolClient`.
    - Billing: rotas com `billableProcedure` + meta `billableEvent`; workflows escrevem em `usage-events`. Integração HyprPay futura (não wireada).
  - `CONTRIBUTING.md`: engines `Node.js >= 22.12`, lista de scripts do workspace, clientes `tanstack-query`.
  - `README.md`: comportamento do `bun dev`, plugins do Better Auth (Organization, API Key), remove menções a Arcjet.
  - Motivação: reduzir desvio entre docs e código, facilitar setup local e clarificar arquitetura conforme `CLAUDE.md`.

Checklist de teste
- Executar `bun dev` em uma máquina limpa: criar `.env.local`, subir containers e aplicar `db:push` sem intervenção.
- Validar que as rotas/serviços existentes continuam intactos (sem mudanças em router/repo/componentes/store).
- Instalar a skill: `npx skills add google-labs-code/stitch-skills --skill design-md --global` e confirmar entrada em `skills-lock.json`.
- Abrir `.agents/skills/design-md/examples/DESIGN.md` e conferir estrutura/links (inclui guia de prompting do Stitch).

<sup>Written for commit 2e6b57e39242225750b7d67c53c3bbbc4a2600e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

