### PR TITLE
fix(data-table): corrigir ordem invertida das setas de importar e exportar

### DIFF
--- a/apps/web/src/components/data-table/data-table-export.tsx
+++ b/apps/web/src/components/data-table/data-table-export.tsx
@@ -1,5 +1,5 @@
 import dayjs from "dayjs";
-import { Download } from "lucide-react";
+import { Upload } from "lucide-react";
 import { useCallback, useMemo } from "react";
 import { Button } from "@packages/ui/components/button";
 import {
@@ -102,7 +102,7 @@ export function DataTableExportButton() {
       <DropdownMenu>
          <DropdownMenuTrigger asChild>
             <Button tooltip="Exportar" variant="outline" size="icon-sm">
-               <Download />
+               <Upload />
                <span className="sr-only">Exportar</span>
             </Button>
          </DropdownMenuTrigger>
@@ -137,7 +137,7 @@ export function DataTableExportSelectedButton() {
       <DropdownMenu>
          <DropdownMenuTrigger asChild>
             <Button variant="outline" size="sm">
-               <Download data-icon="inline-start" />
+               <Upload data-icon="inline-start" />
                Exportar
             </Button>
          </DropdownMenuTrigger>

--- a/apps/web/src/components/data-table/data-table-import.tsx
+++ b/apps/web/src/components/data-table/data-table-import.tsx
@@ -1,6 +1,6 @@
 import { fromPromise } from "neverthrow";
 import { useState, useTransition } from "react";
-import { FileSpreadsheet, Loader2, Upload } from "lucide-react";
+import { Download, FileSpreadsheet, Loader2 } from "lucide-react";
 import {
    Popover,
    PopoverContent,
@@ -142,7 +142,7 @@ export function DataTableImportButton({
                type="button"
                variant="outline"
             >
-               <Upload />
+               <Download />
                <span className="sr-only">Importar dados</span>
             </Button>
          </PopoverTrigger>


### PR DESCRIPTION
## Summary
- Botão Importar agora usa ícone `Download` (seta para dentro)
- Botão Exportar agora usa ícone `Upload` (seta para fora)

Closes MON-874

## Test plan
- [ ] Acessar tela de lançamentos
- [ ] Verificar setas dos botões importar/exportar no canto superior direito

🤖 Generated with [Claude Code](https://claude.com/claude-code)