### PR TITLE
feat: set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -2,7 +2,10 @@
    "$schema": "./node_modules/nx/schemas/nx-schema.json",
    "defaultBase": "master",
    "namedInputs": {
-      "default": ["{projectRoot}/**/*", "sharedGlobals"],
+      "default": [
+         "{projectRoot}/**/*",
+         "sharedGlobals"
+      ],
       "sharedGlobals": [
          "{workspaceRoot}/biome.json",
          "{workspaceRoot}/tsconfig.json",
@@ -41,28 +44,52 @@
    "targetDefaults": {
       "build": {
          "cache": true,
-         "dependsOn": ["^build"],
-         "inputs": ["production", "^production"],
-         "outputs": ["{projectRoot}/dist", "{projectRoot}/.cache"]
+         "dependsOn": [
+            "^build"
+         ],
+         "inputs": [
+            "production",
+            "^production"
+         ],
+         "outputs": [
+            "{projectRoot}/dist",
+            "{projectRoot}/.cache"
+         ]
       },
       "typecheck": {
          "cache": true,
-         "dependsOn": ["^typecheck"],
-         "inputs": ["default", "^default"],
-         "outputs": ["{projectRoot}/.cache/tsbuildinfo.json"]
+         "dependsOn": [
+            "^typecheck"
+         ],
+         "inputs": [
+            "default",
+            "^default"
+         ],
+         "outputs": [
+            "{projectRoot}/.cache/tsbuildinfo.json"
+         ]
       },
       "check": {
          "cache": true,
-         "inputs": ["default"]
+         "inputs": [
+            "default"
+         ]
       },
       "dev": {
          "cache": false
       },
       "test": {
          "cache": true,
-         "dependsOn": ["^build"],
-         "inputs": ["default", "^production"],
-         "outputs": ["{projectRoot}/coverage"]
+         "dependsOn": [
+            "^build"
+         ],
+         "inputs": [
+            "default",
+            "^production"
+         ],
+         "outputs": [
+            "{projectRoot}/coverage"
+         ]
       }
    },
    "release": {
@@ -78,7 +105,11 @@
          "commit": true,
          "tag": true
       },
-      "projects": ["core/*", "apps/*", "packages/*"],
+      "projects": [
+         "core/*",
+         "apps/*",
+         "packages/*"
+      ],
       "projectsRelationship": "independent",
       "releaseTagPattern": "{projectName}@{version}",
       "releaseTagPatternRequireSemver": true,
@@ -100,5 +131,6 @@
    },
    "useDaemonProcess": true,
    "parallel": 8,
-   "analytics": true
+   "analytics": true,
+   "nxCloudId": "69fe3a00161948205a62c856"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/69fe39fe0f8aa3c9195d7ef2/workspaces/69fe3a00161948205a62c856

> [!TIP]
> Run `npx nx generate ci-workflow` if you don't have a CI script configured yet.

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.