### PR TITLE
feat: add cost center import template

### DIFF
--- a/apps/web/src/components/data-table/data-table-import.tsx
+++ b/apps/web/src/components/data-table/data-table-import.tsx
@@ -1,6 +1,6 @@
 import { fromPromise } from "neverthrow";
-import { useState, useTransition } from "react";
-import { Download, FileSpreadsheet, Loader2 } from "lucide-react";
+import { useCallback, useState, useTransition } from "react";
+import { Download, FileDown, FileSpreadsheet, Loader2 } from "lucide-react";
 import {
    Popover,
    PopoverContent,
@@ -14,6 +14,7 @@ import {
 import { Button } from "@packages/ui/components/button";
 import { toast } from "sonner";
 import { useDataTable } from "./data-table-root";
+import { useFileDownload } from "@/hooks/use-file-download";
 
 export type RawImportData = {
    headers: string[];
@@ -28,6 +29,12 @@ export interface DataTableImportConfig {
       index: number,
    ) => Record<string, unknown>;
    onImport: (rows: Record<string, unknown>[]) => Promise<void>;
+   template?: {
+      filename: string;
+      label?: string;
+      description?: string;
+      createBlob: () => Blob;
+   };
 }
 
 const DEFAULT_ACCEPT = {
@@ -70,6 +77,7 @@ export function DataTableImportButton({
    importConfig: DataTableImportConfig;
 }) {
    const { table, store } = useDataTable();
+   const { download } = useFileDownload();
 
    const importableColumns = table
       .getAllColumns()
@@ -91,6 +99,12 @@ export function DataTableImportButton({
    const [open, setOpen] = useState(false);
    const [isParsing, startParsing] = useTransition();
    const [selectedFile, setSelectedFile] = useState<File>();
+
+   const handleDownloadTemplate = useCallback(() => {
+      const template = importConfig.template;
+      if (!template) return;
+      download(template.createBlob(), template.filename);
+   }, [download, importConfig.template]);
 
    function handleDrop([file]: File[]) {
       if (!file) return;
@@ -157,6 +171,25 @@ export function DataTableImportButton({
                   Selecione um arquivo para começar
                </p>
             </div>
+            {importConfig.template && (
+               <Button
+                  className="justify-start h-auto"
+                  onClick={handleDownloadTemplate}
+                  type="button"
+                  variant="outline"
+               >
+                  <FileDown data-icon="inline-start" />
+                  <span className="flex flex-col items-start gap-2 text-left">
+                     <span className="text-sm font-medium">
+                        {importConfig.template.label ?? "Baixar modelo"}
+                     </span>
+                     <span className="text-xs text-muted-foreground">
+                        {importConfig.template.description ??
+                           "Use o arquivo modelo para conferir as colunas esperadas."}
+                     </span>
+                  </span>
+               </Button>
+            )}
             <Dropzone
                accept={importConfig.accept ?? DEFAULT_ACCEPT}
                disabled={isParsing}

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
@@ -114,39 +114,8 @@ function TagsList() {
    const navigate = Route.useNavigate();
    const { search, includeArchived, page, pageSize } = Route.useSearch();
    const [isDraftActive, setIsDraftActive] = useState(false);
-   const { parse: parseCsv } = useCsvFile();
+   const { generate: generateCsv, parse: parseCsv } = useCsvFile();
    const { parse: parseXlsx } = useXlsxFile();
-
-   const importConfig: DataTableImportConfig = useMemo(
-      () => ({
-         accept: {
-            "text/csv": [".csv"],
-            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
-               [".xlsx"],
-            "application/vnd.ms-excel": [".xls"],
-         },
-         parseFile: async (file: File) => {
-            const ext = file.name.split(".").pop()?.toLowerCase();
-            if (ext === "xlsx" || ext === "xls") return parseXlsx(file);
-            return parseCsv(file);
-         },
-         mapRow: (row, i) => ({
-            id: `__import_${i}`,
-            name: row.name ?? "",
-            description: row.description?.trim() || null,
-            isArchived: false,
-            isDefault: false,
-         }),
-         onImport: async (rows) => {
-            const items = rows.map((r) => ({
-               name: String(r.name ?? ""),
-               description: r.description ? String(r.description).trim() : null,
-            }));
-            await bulkCreateMutation.mutateAsync({ items });
-         },
-      }),
-      [parseCsv, parseXlsx],
-   );
 
    const { data: result } = useSuspenseQuery(
       orpc.tags.getAll.queryOptions({
@@ -223,6 +192,57 @@ function TagsList() {
          onError: (e) =>
             toast.error(e.message || "Erro ao atualizar centro de custo."),
       }),
+   );
+
+   const importConfig: DataTableImportConfig = useMemo(
+      () => ({
+         accept: {
+            "text/csv": [".csv"],
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
+               [".xlsx"],
+            "application/vnd.ms-excel": [".xls"],
+         },
+         parseFile: async (file: File) => {
+            const ext = file.name.split(".").pop()?.toLowerCase();
+            if (ext === "xlsx" || ext === "xls") return parseXlsx(file);
+            return parseCsv(file);
+         },
+         mapRow: (row, i) => ({
+            id: `__import_${i}`,
+            name: row.name ?? "",
+            description: row.description?.trim() || null,
+            isArchived: false,
+            isDefault: false,
+         }),
+         template: {
+            filename: "modelo-centros-de-custo.csv",
+            label: "Baixar modelo CSV",
+            description:
+               "Inclui as colunas Nome e Descrição com exemplos de preenchimento.",
+            createBlob: () =>
+               generateCsv(
+                  [
+                     {
+                        Nome: "Marketing",
+                        Descrição: "Campanhas, mídia paga e eventos",
+                     },
+                     {
+                        Nome: "Operações",
+                        Descrição: "Custos recorrentes da operação",
+                     },
+                  ],
+                  ["Nome", "Descrição"],
+               ),
+         },
+         onImport: async (rows) => {
+            const items = rows.map((r) => ({
+               name: String(r.name ?? ""),
+               description: r.description ? String(r.description).trim() : null,
+            }));
+            await bulkCreateMutation.mutateAsync({ items });
+         },
+      }),
+      [bulkCreateMutation, generateCsv, parseCsv, parseXlsx],
    );
 
    const handleCreate = useCallback(() => {


### PR DESCRIPTION
## Resumo
- adiciona suporte a arquivo modelo no popover de importação da DataTable
- disponibiliza modelo CSV para importação de Centros de Custo com Nome e Descrição

## Validação
- bun nx run web:typecheck
- bun nx run web:check