### PR TITLE
fix: preserve search input focus on cost centers table

### DIFF
--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
@@ -20,7 +20,7 @@ import type { DataTableImportConfig } from "@/components/data-table/data-table-i
 import { DataTableExternalFilter } from "@/components/data-table/data-table-root";
 import { useCsvFile } from "@/hooks/use-csv-file";
 import { useXlsxFile } from "@/hooks/use-xlsx-file";
-import { useCallback, useMemo, useState } from "react";
+import { startTransition, useCallback, useMemo, useState } from "react";
 
 import { DataTablePagination } from "@/components/data-table/data-table-pagination";
 import { z } from "zod";
@@ -395,9 +395,11 @@ function TagsList() {
                searchPlaceholder="Buscar centros de custo..."
                searchDefaultValue={search}
                onSearch={(value) =>
-                  navigate({
-                     search: (prev) => ({ ...prev, search: value, page: 1 }),
-                     replace: true,
+                  startTransition(() => {
+                     navigate({
+                        search: (prev) => ({ ...prev, search: value, page: 1 }),
+                        replace: true,
+                     });
                   })
                }
             >


### PR DESCRIPTION
## Summary
- Wrap `navigate` em `startTransition` na busca de Centros de Custo (`tags.tsx`).
- `DataTableToolbar` já debouncava 350ms (`useAsyncDebouncedCallback`), mas a navegação trocava `search` na URL → `useSuspenseQuery` suspendia → `QueryBoundary` montava `TagsSkeleton` → input desmontava, perdia foco e cortava a digitação.
- Com `startTransition`, React mantém a UI anterior durante o refetch; input permanece montado e focado. Debounce do toolbar continua agindo.

Closes MON-892

## Test plan
- [ ] Abrir `/$slug/$teamSlug/tags`, digitar termo no campo de busca: input não perde foco, sem flash de skeleton.
- [ ] Tabela atualiza após o intervalo de debounce (350ms) com o termo digitado.
- [ ] Limpar busca via botão `X` continua funcionando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)