### PR TITLE
feat: padronizar criação de cartões de crédito via side sheet

### DIFF
--- a/apps/web-e2e/helpers/db.ts
+++ b/apps/web-e2e/helpers/db.ts
@@ -14,6 +14,7 @@ import {
    user as userTable,
 } from "@core/database/schemas/auth";
 import { bankAccounts } from "@core/database/schemas/bank-accounts";
+import { creditCards } from "@core/database/schemas/credit-cards";
 import { categories } from "@core/database/schemas/categories";
 import { tags } from "@core/database/schemas/tags";
 import { transactions } from "@core/database/schemas/transactions";
@@ -208,6 +209,38 @@ export async function deleteBankAccountById(teamId: string, id: string) {
    await db()
       .delete(bankAccounts)
       .where(and(eq(bankAccounts.teamId, teamId), eq(bankAccounts.id, id)));
+}
+
+export async function findCreditCardByName(teamId: string, name: string) {
+   return db().query.creditCards.findFirst({
+      where: (f, { and, eq }) => and(eq(f.teamId, teamId), eq(f.name, name)),
+   });
+}
+
+export async function deleteCreditCardById(teamId: string, id: string) {
+   await db()
+      .delete(creditCards)
+      .where(and(eq(creditCards.teamId, teamId), eq(creditCards.id, id)));
+}
+
+export async function findAnyBankAccount(teamId: string) {
+   return db().query.bankAccounts.findFirst({
+      where: (f, { eq }) => eq(f.teamId, teamId),
+   });
+}
+
+export async function insertBankAccount(teamId: string, name: string) {
+   const [row] = await db()
+      .insert(bankAccounts)
+      .values({
+         teamId,
+         name,
+         type: "cash",
+         color: "#6366f1",
+         initialBalance: "0",
+      })
+      .returning();
+   return row;
 }
 
 export async function findTransactionByName(teamId: string, name: string) {

--- a/apps/web-e2e/helpers/db.ts
+++ b/apps/web-e2e/helpers/db.ts
@@ -229,15 +229,21 @@ export async function findAnyBankAccount(teamId: string) {
    });
 }
 
-export async function insertBankAccount(teamId: string, name: string) {
+export async function insertBankAccount(
+   teamId: string,
+   name: string,
+   extras?: { bankCode?: string; bankName?: string },
+) {
    const [row] = await db()
       .insert(bankAccounts)
       .values({
          teamId,
          name,
-         type: "cash",
+         type: extras?.bankCode ? "checking" : "cash",
          color: "#6366f1",
          initialBalance: "0",
+         bankCode: extras?.bankCode ?? null,
+         bankName: extras?.bankName ?? null,
       })
       .returning();
    return row;

--- a/apps/web-e2e/tests/credit-cards-create.spec.ts
+++ b/apps/web-e2e/tests/credit-cards-create.spec.ts
@@ -1,0 +1,132 @@
+import type { Page } from "@playwright/test";
+import { expect, test, type E2ESession } from "../fixtures";
+import {
+   deleteBankAccountById,
+   deleteCreditCardById,
+   findAnyBankAccount,
+   findCreditCardByName,
+   findTeamByOrgAndSlug,
+   insertBankAccount,
+} from "../helpers/db";
+
+const stamp = () => `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+const createdCardIds: string[] = [];
+const createdBankAccountIds: string[] = [];
+
+async function gotoCreditCards(page: Page, session: E2ESession) {
+   await page.goto(`/${session.orgSlug}/${session.teamSlug}/credit-cards`);
+   await expect(
+      page.getByRole("heading", { name: "Cartões de Crédito" }),
+   ).toBeVisible();
+}
+
+async function ensureBankAccount(session: E2ESession) {
+   const team = await findTeamByOrgAndSlug(session.orgSlug, session.teamSlug);
+   if (!team) throw new Error("team not found");
+   const existing = await findAnyBankAccount(team.id);
+   if (existing) return existing;
+   const created = await insertBankAccount(team.id, `Conta E2E ${stamp()}`);
+   if (!created) throw new Error("failed to create bank account");
+   createdBankAccountIds.push(created.id);
+   return created;
+}
+
+async function rememberCard(session: E2ESession, name: string) {
+   const team = await findTeamByOrgAndSlug(session.orgSlug, session.teamSlug);
+   if (!team) return;
+   const card = await findCreditCardByName(team.id, name);
+   if (!card) return;
+   createdCardIds.push(card.id);
+}
+
+test.afterEach(async ({ e2eSession }) => {
+   const team = await findTeamByOrgAndSlug(
+      e2eSession.orgSlug,
+      e2eSession.teamSlug,
+   );
+   if (!team) return;
+   for (const id of createdCardIds.splice(0)) {
+      await deleteCreditCardById(team.id, id);
+   }
+   for (const id of createdBankAccountIds.splice(0)) {
+      await deleteBankAccountById(team.id, id);
+   }
+});
+
+test("cria cartão via side sheet com validações", async ({
+   page,
+   e2eSession,
+}) => {
+   await ensureBankAccount(e2eSession);
+   const name = `Cartão E2E ${stamp()}`;
+
+   await gotoCreditCards(page, e2eSession);
+   await page.getByRole("button", { name: "Novo Cartão" }).click();
+
+   const sheet = page.getByRole("dialog");
+   await expect(
+      sheet.getByRole("heading", { name: "Novo cartão de crédito" }),
+   ).toBeVisible();
+   const submit = sheet.getByRole("button", { name: "Criar cartão" });
+
+   await expect(submit).toBeDisabled();
+
+   await sheet.getByLabel("Nome").fill("a");
+   await sheet.getByLabel("Nome").blur();
+   await expect(
+      sheet.getByText("Nome deve ter no mínimo 2 caracteres."),
+   ).toBeVisible();
+   await sheet.getByLabel("Nome").fill(name);
+
+   await sheet.getByLabel("Conta vinculada").click();
+   await page.getByRole("option").first().click();
+
+   await expect(submit).toBeEnabled();
+   await submit.click();
+
+   await expect(page.getByText("Cartão criado com sucesso.")).toBeVisible();
+   await expect(page.getByRole("cell", { name })).toBeVisible();
+   await rememberCard(e2eSession, name);
+});
+
+test("cancelar fecha sheet sem criar", async ({ page, e2eSession }) => {
+   await ensureBankAccount(e2eSession);
+   await gotoCreditCards(page, e2eSession);
+
+   await page.getByRole("button", { name: "Novo Cartão" }).click();
+   const sheet = page.getByRole("dialog");
+   await sheet.getByLabel("Nome").fill("Não deve criar");
+   await sheet.getByRole("button", { name: "Cancelar" }).click();
+
+   await expect(sheet).not.toBeVisible();
+   await expect(
+      page.getByRole("cell", { name: "Não deve criar" }),
+   ).not.toBeVisible();
+});
+
+test("edição inline do nome continua funcionando", async ({
+   page,
+   e2eSession,
+}) => {
+   await ensureBankAccount(e2eSession);
+   const name = `Cartão Inline ${stamp()}`;
+   const renamed = `${name} renomeado`;
+
+   await gotoCreditCards(page, e2eSession);
+   await page.getByRole("button", { name: "Novo Cartão" }).click();
+   const sheet = page.getByRole("dialog");
+   await sheet.getByLabel("Nome").fill(name);
+   await sheet.getByLabel("Conta vinculada").click();
+   await page.getByRole("option").first().click();
+   await sheet.getByRole("button", { name: "Criar cartão" }).click();
+   await expect(page.getByRole("cell", { name })).toBeVisible();
+   await rememberCard(e2eSession, name);
+
+   const cell = page.getByRole("cell", { name });
+   await cell.click();
+   const inlineInput = cell.getByRole("textbox");
+   await expect(inlineInput).toBeVisible();
+   await inlineInput.fill(renamed);
+   await inlineInput.press("Enter");
+   await expect(page.getByRole("cell", { name: renamed })).toBeVisible();
+});

--- a/apps/web-e2e/tests/credit-cards-logos.spec.ts
+++ b/apps/web-e2e/tests/credit-cards-logos.spec.ts
@@ -67,8 +67,8 @@ test("exibe logo do banco emissor e da bandeira na listagem", async ({
    await sheet.getByLabel("Nome").fill(name);
    await sheet.getByLabel("Conta vinculada").click();
    await page.getByRole("option", { name: account.name }).click();
-   await sheet.getByLabel("Bandeira").click();
-   await page.getByRole("option", { name: "Visa" }).click();
+   await sheet.getByLabel("4 primeiros dígitos").fill("4111");
+   await sheet.getByLabel("4 últimos dígitos").fill("1234");
    await sheet.getByRole("button", { name: "Criar cartão" }).click();
 
    await expect(page.getByText("Cartão criado com sucesso.")).toBeVisible();
@@ -84,6 +84,8 @@ test("exibe logo do banco emissor e da bandeira na listagem", async ({
    await expect(
       row.locator('img[src*="img.logo.dev/itau.com.br"]'),
    ).toBeVisible();
+
+   await expect(row.getByText("Final 1234")).toBeVisible();
 
    await expect(
       page.getByRole("link", { name: "Logos by Logo.dev" }),

--- a/apps/web-e2e/tests/credit-cards-logos.spec.ts
+++ b/apps/web-e2e/tests/credit-cards-logos.spec.ts
@@ -57,7 +57,7 @@ test("exibe logo do banco emissor e da bandeira na listagem", async ({
    page,
    e2eSession,
 }) => {
-   await setupItauAccount(e2eSession);
+   const account = await setupItauAccount(e2eSession);
    const name = `Cartão Logo ${stamp()}`;
 
    await gotoCreditCards(page, e2eSession);
@@ -66,7 +66,7 @@ test("exibe logo do banco emissor e da bandeira na listagem", async ({
    const sheet = page.getByRole("dialog");
    await sheet.getByLabel("Nome").fill(name);
    await sheet.getByLabel("Conta vinculada").click();
-   await page.getByRole("option").first().click();
+   await page.getByRole("option", { name: account.name }).click();
    await sheet.getByLabel("Bandeira").click();
    await page.getByRole("option", { name: "Visa" }).click();
    await sheet.getByRole("button", { name: "Criar cartão" }).click();
@@ -77,17 +77,14 @@ test("exibe logo do banco emissor e da bandeira na listagem", async ({
 
    const row = page.getByRole("row", { name: new RegExp(name) });
 
-   // bandeira via simple-icons
    await expect(
       row.locator('img[src*="cdn.simpleicons.org/visa"]'),
    ).toBeVisible();
 
-   // banco emissor via logo.dev (domain itau.com.br)
    await expect(
       row.locator('img[src*="img.logo.dev/itau.com.br"]'),
    ).toBeVisible();
 
-   // atribuição Logo.dev exigida pela licença
    await expect(
       page.getByRole("link", { name: "Logos by Logo.dev" }),
    ).toBeVisible();
@@ -108,7 +105,7 @@ test("autocomplete de banco mostra logos nas opções", async ({
    const sheet = page.getByRole("dialog");
    await sheet.getByPlaceholder("Digite o nome ou código").fill("itau");
 
-   const option = page.getByRole("option").first();
+   const option = page.getByRole("option", { name: /341/ });
    await expect(option).toBeVisible();
    await expect(
       option.locator('img[src*="img.logo.dev/itau.com.br"]'),

--- a/apps/web-e2e/tests/credit-cards-logos.spec.ts
+++ b/apps/web-e2e/tests/credit-cards-logos.spec.ts
@@ -1,0 +1,116 @@
+import type { Page } from "@playwright/test";
+import { expect, test, type E2ESession } from "../fixtures";
+import {
+   deleteBankAccountById,
+   deleteCreditCardById,
+   findCreditCardByName,
+   findTeamByOrgAndSlug,
+   insertBankAccount,
+} from "../helpers/db";
+
+const stamp = () => `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+const createdCardIds: string[] = [];
+const createdBankAccountIds: string[] = [];
+
+async function gotoCreditCards(page: Page, session: E2ESession) {
+   await page.goto(`/${session.orgSlug}/${session.teamSlug}/credit-cards`);
+   await expect(
+      page.getByRole("heading", { name: "Cartões de Crédito" }),
+   ).toBeVisible();
+}
+
+async function setupItauAccount(session: E2ESession) {
+   const team = await findTeamByOrgAndSlug(session.orgSlug, session.teamSlug);
+   if (!team) throw new Error("team not found");
+   const account = await insertBankAccount(team.id, `Itaú E2E ${stamp()}`, {
+      bankCode: "341",
+      bankName: "Itaú",
+   });
+   if (!account) throw new Error("failed to create bank account");
+   createdBankAccountIds.push(account.id);
+   return account;
+}
+
+async function rememberCard(session: E2ESession, name: string) {
+   const team = await findTeamByOrgAndSlug(session.orgSlug, session.teamSlug);
+   if (!team) return;
+   const card = await findCreditCardByName(team.id, name);
+   if (!card) return;
+   createdCardIds.push(card.id);
+}
+
+test.afterEach(async ({ e2eSession }) => {
+   const team = await findTeamByOrgAndSlug(
+      e2eSession.orgSlug,
+      e2eSession.teamSlug,
+   );
+   if (!team) return;
+   for (const id of createdCardIds.splice(0)) {
+      await deleteCreditCardById(team.id, id);
+   }
+   for (const id of createdBankAccountIds.splice(0)) {
+      await deleteBankAccountById(team.id, id);
+   }
+});
+
+test("exibe logo do banco emissor e da bandeira na listagem", async ({
+   page,
+   e2eSession,
+}) => {
+   await setupItauAccount(e2eSession);
+   const name = `Cartão Logo ${stamp()}`;
+
+   await gotoCreditCards(page, e2eSession);
+   await page.getByRole("button", { name: "Novo Cartão" }).click();
+
+   const sheet = page.getByRole("dialog");
+   await sheet.getByLabel("Nome").fill(name);
+   await sheet.getByLabel("Conta vinculada").click();
+   await page.getByRole("option").first().click();
+   await sheet.getByLabel("Bandeira").click();
+   await page.getByRole("option", { name: "Visa" }).click();
+   await sheet.getByRole("button", { name: "Criar cartão" }).click();
+
+   await expect(page.getByText("Cartão criado com sucesso.")).toBeVisible();
+   await expect(page.getByRole("cell", { name })).toBeVisible();
+   await rememberCard(e2eSession, name);
+
+   const row = page.getByRole("row", { name: new RegExp(name) });
+
+   // bandeira via simple-icons
+   await expect(
+      row.locator('img[src*="cdn.simpleicons.org/visa"]'),
+   ).toBeVisible();
+
+   // banco emissor via logo.dev (domain itau.com.br)
+   await expect(
+      row.locator('img[src*="img.logo.dev/itau.com.br"]'),
+   ).toBeVisible();
+
+   // atribuição Logo.dev exigida pela licença
+   await expect(
+      page.getByRole("link", { name: "Logos by Logo.dev" }),
+   ).toBeVisible();
+});
+
+test("autocomplete de banco mostra logos nas opções", async ({
+   page,
+   e2eSession,
+}) => {
+   await page.goto(
+      `/${e2eSession.orgSlug}/${e2eSession.teamSlug}/bank-accounts`,
+   );
+   await expect(
+      page.getByRole("heading", { name: "Contas Bancárias" }),
+   ).toBeVisible();
+
+   await page.getByRole("button", { name: "Nova Conta" }).click();
+   const sheet = page.getByRole("dialog");
+   await sheet.getByPlaceholder("Digite o nome ou código").fill("itau");
+
+   const option = page.getByRole("option").first();
+   await expect(option).toBeVisible();
+   await expect(
+      option.locator('img[src*="img.logo.dev/itau.com.br"]'),
+   ).toBeVisible();
+});

--- a/apps/web/src/components/logo-dev-attribution.tsx
+++ b/apps/web/src/components/logo-dev-attribution.tsx
@@ -16,15 +16,13 @@ export function LogoDevAttribution({ className }: { className?: string }) {
          rel="noopener noreferrer"
          target="_blank"
       >
-         <Avatar className="size-4 rounded-md bg-white ring-1 ring-border">
+         <Avatar className="size-4 rounded-lg bg-white ring-1 ring-border">
             <AvatarImage
                alt="Logo.dev"
                className="object-contain"
                src={LOGO_DEV_ATTRIBUTION.logoUrl}
             />
-            <AvatarFallback className="rounded-md text-[10px]">
-               LD
-            </AvatarFallback>
+            <AvatarFallback className="rounded-lg text-xs">LD</AvatarFallback>
          </Avatar>
          {LOGO_DEV_ATTRIBUTION.text}
       </a>

--- a/apps/web/src/components/logo-dev-attribution.tsx
+++ b/apps/web/src/components/logo-dev-attribution.tsx
@@ -1,3 +1,8 @@
+import {
+   Avatar,
+   AvatarFallback,
+   AvatarImage,
+} from "@packages/ui/components/avatar";
 import { LOGO_DEV_ATTRIBUTION } from "@/lib/logos";
 
 export function LogoDevAttribution({ className }: { className?: string }) {
@@ -11,6 +16,16 @@ export function LogoDevAttribution({ className }: { className?: string }) {
          rel="noopener noreferrer"
          target="_blank"
       >
+         <Avatar className="size-4 rounded-md bg-white ring-1 ring-border">
+            <AvatarImage
+               alt="Logo.dev"
+               className="object-contain"
+               src={LOGO_DEV_ATTRIBUTION.logoUrl}
+            />
+            <AvatarFallback className="rounded-md text-[10px]">
+               LD
+            </AvatarFallback>
+         </Avatar>
          {LOGO_DEV_ATTRIBUTION.text}
       </a>
    );

--- a/apps/web/src/components/logo-dev-attribution.tsx
+++ b/apps/web/src/components/logo-dev-attribution.tsx
@@ -1,0 +1,17 @@
+import { LOGO_DEV_ATTRIBUTION } from "@/lib/logos";
+
+export function LogoDevAttribution({ className }: { className?: string }) {
+   return (
+      <a
+         className={
+            className ??
+            "text-xs text-muted-foreground hover:underline self-end"
+         }
+         href={LOGO_DEV_ATTRIBUTION.url}
+         rel="noopener noreferrer"
+         target="_blank"
+      >
+         {LOGO_DEV_ATTRIBUTION.text}
+      </a>
+   );
+}

--- a/apps/web/src/integrations/public-env.ts
+++ b/apps/web/src/integrations/public-env.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 const publicEnvSchema = z.object({
    POSTHOG_HOST: z.string().url(),
    POSTHOG_KEY: z.string().min(1),
+   LOGO_DEV_TOKEN: z.string().min(1).optional(),
 });
 
 export type PublicEnv = z.infer<typeof publicEnvSchema>;
@@ -11,5 +12,6 @@ export function getPublicEnv(): PublicEnv {
    return publicEnvSchema.parse({
       POSTHOG_HOST: process.env["POSTHOG_HOST"],
       POSTHOG_KEY: process.env["POSTHOG_KEY"],
+      LOGO_DEV_TOKEN: process.env["LOGO_DEV_TOKEN"],
    });
 }

--- a/apps/web/src/lib/logos.ts
+++ b/apps/web/src/lib/logos.ts
@@ -16,6 +16,14 @@ export const BRAND_COLOR: Record<string, string> = {
    other: "#6B7280",
 };
 
+export type CreditCardBrand =
+   | "visa"
+   | "mastercard"
+   | "elo"
+   | "amex"
+   | "hipercard"
+   | "other";
+
 const BRAND_LOGO_SLUG: Record<string, string> = {
    visa: "visa",
    mastercard: "mastercard",
@@ -78,6 +86,43 @@ export function brandLogoUrl(brand: string): string | undefined {
    const slug = BRAND_LOGO_SLUG[brand];
    if (!slug) return undefined;
    return `https://cdn.simpleicons.org/${slug}`;
+}
+
+export function creditCardBrandFromPrefix(
+   prefix: string,
+): CreditCardBrand | undefined {
+   if (!/^\d{4}$/.test(prefix)) return undefined;
+
+   const firstTwo = Number(prefix.slice(0, 2));
+   const firstFour = Number(prefix);
+
+   if (
+      firstFour === 4011 ||
+      firstFour === 4312 ||
+      firstFour === 4389 ||
+      firstFour === 4514 ||
+      firstFour === 4576 ||
+      firstFour === 5041 ||
+      firstFour === 6277 ||
+      firstFour === 6362 ||
+      firstFour === 6363 ||
+      (firstFour >= 5067 && firstFour <= 5090) ||
+      (firstFour >= 6504 && firstFour <= 6505)
+   ) {
+      return "elo";
+   }
+
+   if (firstFour === 6062) return "hipercard";
+   if (firstTwo === 34 || firstTwo === 37) return "amex";
+   if (
+      (firstTwo >= 51 && firstTwo <= 55) ||
+      (firstFour >= 2221 && firstFour <= 2720)
+   ) {
+      return "mastercard";
+   }
+   if (prefix.startsWith("4")) return "visa";
+
+   return undefined;
 }
 
 export function bankInitials(name: string): string {

--- a/apps/web/src/lib/logos.ts
+++ b/apps/web/src/lib/logos.ts
@@ -1,0 +1,88 @@
+export const BRAND_LABEL: Record<string, string> = {
+   visa: "Visa",
+   mastercard: "Mastercard",
+   elo: "Elo",
+   amex: "Amex",
+   hipercard: "Hipercard",
+   other: "Outra",
+};
+
+export const BRAND_COLOR: Record<string, string> = {
+   visa: "#1A1F71",
+   mastercard: "#EB001B",
+   elo: "#000000",
+   amex: "#2E77BC",
+   hipercard: "#822124",
+   other: "#6B7280",
+};
+
+const BRAND_LOGO_SLUG: Record<string, string> = {
+   visa: "visa",
+   mastercard: "mastercard",
+   elo: "elo",
+   amex: "americanexpress",
+   hipercard: "hipercard",
+};
+
+const BANK_DOMAIN: Record<string, string> = {
+   "001": "bb.com.br",
+   "033": "santander.com.br",
+   "077": "bancointer.com.br",
+   "104": "caixa.gov.br",
+   "208": "btgpactual.com",
+   "212": "original.com.br",
+   "237": "bradesco.com.br",
+   "246": "abcbrasil.com.br",
+   "260": "nubank.com.br",
+   "290": "pagseguro.com.br",
+   "318": "bancobmg.com.br",
+   "323": "mercadopago.com.br",
+   "336": "bancoc6.com.br",
+   "341": "itau.com.br",
+   "380": "picpay.com",
+   "389": "mercantildobrasil.com.br",
+   "422": "safra.com.br",
+   "623": "pan.com.br",
+   "655": "votorantim.com.br",
+   "735": "banconeon.com.br",
+   "739": "cetelem.com.br",
+   "748": "sicredi.com.br",
+   "756": "sicoobnet.com.br",
+};
+
+export function bankDomain(
+   bankCode: string | null | undefined,
+): string | undefined {
+   if (!bankCode) return undefined;
+   return BANK_DOMAIN[bankCode.padStart(3, "0")];
+}
+
+const DEFAULT_LOGO_DEV_TOKEN = "pk_P3xoj_JDT9ub1E6jZ_j7fw";
+
+export function bankLogoUrl(
+   bankCode: string | null | undefined,
+   logoDevToken?: string,
+): string | undefined {
+   const domain = bankDomain(bankCode);
+   if (!domain) return undefined;
+   const token = logoDevToken ?? DEFAULT_LOGO_DEV_TOKEN;
+   return `https://img.logo.dev/${domain}?token=${token}&size=64&format=webp&retina=true`;
+}
+
+export const LOGO_DEV_ATTRIBUTION = {
+   url: "https://logo.dev",
+   text: "Logos by Logo.dev",
+} as const;
+
+export function brandLogoUrl(brand: string): string | undefined {
+   const slug = BRAND_LOGO_SLUG[brand];
+   if (!slug) return undefined;
+   return `https://cdn.simpleicons.org/${slug}`;
+}
+
+export function bankInitials(name: string): string {
+   const parts = name.trim().split(/\s+/).filter(Boolean);
+   if (parts.length === 0) return "?";
+   if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase();
+   return (parts[0]![0]! + parts[1]![0]!).toUpperCase();
+}

--- a/apps/web/src/lib/logos.ts
+++ b/apps/web/src/lib/logos.ts
@@ -83,6 +83,9 @@ export function brandLogoUrl(brand: string): string | undefined {
 export function bankInitials(name: string): string {
    const parts = name.trim().split(/\s+/).filter(Boolean);
    if (parts.length === 0) return "?";
-   if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase();
-   return (parts[0]![0]! + parts[1]![0]!).toUpperCase();
+   const [first, second] = parts;
+   if (!first) return "?";
+   if (parts.length === 1) return first.slice(0, 2).toUpperCase();
+   if (!second) return first.slice(0, 2).toUpperCase();
+   return (first[0] + second[0]).toUpperCase();
 }

--- a/apps/web/src/lib/logos.ts
+++ b/apps/web/src/lib/logos.ts
@@ -35,6 +35,7 @@ const BRAND_LOGO_SLUG: Record<string, string> = {
 const BANK_DOMAIN: Record<string, string> = {
    "001": "bb.com.br",
    "033": "santander.com.br",
+   "070": "brb.com.br",
    "077": "bancointer.com.br",
    "104": "caixa.gov.br",
    "208": "btgpactual.com",
@@ -65,21 +66,27 @@ export function bankDomain(
    return BANK_DOMAIN[bankCode.padStart(3, "0")];
 }
 
-const DEFAULT_LOGO_DEV_TOKEN = "pk_P3xoj_JDT9ub1E6jZ_j7fw";
-
 export function bankLogoUrl(
    bankCode: string | null | undefined,
    logoDevToken?: string,
 ): string | undefined {
    const domain = bankDomain(bankCode);
    if (!domain) return undefined;
-   const token = logoDevToken ?? DEFAULT_LOGO_DEV_TOKEN;
-   return `https://img.logo.dev/${domain}?token=${token}&size=64&format=webp&retina=true`;
+   const token = logoDevToken?.trim();
+   const params = new URLSearchParams({
+      fallback: "monogram",
+      format: "webp",
+      retina: "true",
+      size: "128",
+   });
+   if (token) params.set("token", token);
+   return `https://img.logo.dev/${domain}?${params.toString()}`;
 }
 
 export const LOGO_DEV_ATTRIBUTION = {
    url: "https://logo.dev",
-   text: "Logos by Logo.dev",
+   text: "Logos por Logo.dev",
+   logoUrl: "https://www.logo.dev/favicon.ico",
 } as const;
 
 export function brandLogoUrl(brand: string): string | undefined {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -62,7 +62,21 @@ export const Route = createRootRouteWithContext<RouterContext>()({
             href: "/favicon.svg",
             rel: "icon",
          },
-
+         {
+            rel: "preconnect",
+            href: "https://img.logo.dev",
+            crossOrigin: "anonymous",
+         },
+         {
+            rel: "preconnect",
+            href: "https://cdn.simpleicons.org",
+            crossOrigin: "anonymous",
+         },
+         {
+            rel: "preconnect",
+            href: "https://icons.duckduckgo.com",
+            crossOrigin: "anonymous",
+         },
          {
             rel: "stylesheet",
             href: appCss,

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/-context-panel/context-panel-rail.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/-context-panel/context-panel-rail.tsx
@@ -15,6 +15,7 @@ import {
 import { useSelector } from "@tanstack/react-store";
 import { Ellipsis, ExternalLink, Keyboard, Sparkles, X } from "lucide-react";
 import { POSTHOG_SURVEYS } from "@core/posthog/config";
+import { LogoDevAttribution } from "@/components/logo-dev-attribution";
 import { useSurveyModal } from "@/hooks/use-survey-modal";
 import { openKeyboardShortcuts } from "../-layout/keyboard-shortcuts-sheet";
 import { contextPanelStore, TAB_METAS } from "./context-panel-store";
@@ -65,6 +66,10 @@ function RailMenuButton() {
                      <ExternalLink className="size-4" />
                      Documentação
                   </a>
+               </DropdownMenuItem>
+               <DropdownMenuSeparator />
+               <DropdownMenuItem asChild className="cursor-pointer gap-2">
+                  <LogoDevAttribution className="flex items-center gap-2" />
                </DropdownMenuItem>
             </DropdownMenuContent>
          </DropdownMenu>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-bank-accounts/bank-account-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-bank-accounts/bank-account-form-sheet.tsx
@@ -2,6 +2,11 @@ import { of, toMajorUnitsString } from "@f-o-t/money";
 import type { MaskitoOptions } from "@maskito/core";
 import { useMaskito } from "@maskito/react";
 import { Autocomplete } from "@packages/ui/components/autocomplete";
+import {
+   Avatar,
+   AvatarFallback,
+   AvatarImage,
+} from "@packages/ui/components/avatar";
 import { Button } from "@packages/ui/components/button";
 import { Field, FieldError, FieldLabel } from "@packages/ui/components/field";
 import { Input } from "@packages/ui/components/input";
@@ -23,6 +28,7 @@ import {
 import { toast } from "@packages/ui/components/sonner";
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { useRouter } from "@tanstack/react-router";
 import {
    CreditCard,
    Landmark,
@@ -35,7 +41,9 @@ import type { ReactNode } from "react";
 import { z } from "zod";
 import { useSheet } from "@/hooks/use-sheet";
 import { orpc } from "@/integrations/orpc/client";
+import { LogoDevAttribution } from "@/components/logo-dev-attribution";
 import { QueryBoundary } from "@/components/query-boundary";
+import { bankInitials, bankLogoUrl } from "@/lib/logos";
 
 const BANK_ACCOUNT_TYPES = [
    "checking",
@@ -159,6 +167,8 @@ export function BankAccountFormSheet() {
 
 function BankAccountFormSheetContent() {
    const { closeTopSheet } = useSheet();
+   const router = useRouter();
+   const logoDevToken = router.options.context.publicEnv?.LOGO_DEV_TOKEN;
    const bankCodeMaskRef = useMaskito({ options: BANK_CODE_MASK });
    const branchMaskRef = useMaskito({ options: BRANCH_MASK });
    const accountNumberMaskRef = useMaskito({ options: ACCOUNT_NUMBER_MASK });
@@ -171,6 +181,30 @@ function BankAccountFormSheetContent() {
       value: b.code,
       label: b.name,
    }));
+
+   const renderBankOption = (option: { value: string; label: string }) => {
+      const logo = bankLogoUrl(option.value, logoDevToken);
+      return (
+         <div className="flex min-w-0 items-center gap-2">
+            <Avatar className="size-5 shrink-0 bg-white ring-1 ring-border">
+               {logo ? (
+                  <AvatarImage
+                     alt={option.label}
+                     className="object-contain p-0.5"
+                     src={logo}
+                  />
+               ) : null}
+               <AvatarFallback className="text-[9px] font-semibold">
+                  {bankInitials(option.label)}
+               </AvatarFallback>
+            </Avatar>
+            <span className="truncate">{option.label}</span>
+            <span className="ml-auto text-xs text-muted-foreground tabular-nums">
+               {option.value}
+            </span>
+         </div>
+      );
+   };
 
    const createMutation = useMutation(
       orpc.bankAccounts.create.mutationOptions({
@@ -315,6 +349,7 @@ function BankAccountFormSheetContent() {
                                           isLoading={false}
                                           options={bankOptions}
                                           placeholder="Digite o nome ou código"
+                                          renderOption={renderBankOption}
                                           value={selectedOption}
                                           onBlur={field.handleBlur}
                                           onValueChange={(opt) => {
@@ -447,6 +482,9 @@ function BankAccountFormSheetContent() {
             </form.Field>
          </form>
 
+         <div className="px-4">
+            <LogoDevAttribution className="text-xs text-muted-foreground hover:underline" />
+         </div>
          <SheetFooter>
             <SheetClose asChild>
                <Button variant="outline">Cancelar</Button>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-bank-accounts/bank-account-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-bank-accounts/bank-account-form-sheet.tsx
@@ -41,7 +41,6 @@ import type { ReactNode } from "react";
 import { z } from "zod";
 import { useSheet } from "@/hooks/use-sheet";
 import { orpc } from "@/integrations/orpc/client";
-import { LogoDevAttribution } from "@/components/logo-dev-attribution";
 import { QueryBoundary } from "@/components/query-boundary";
 import { bankInitials, bankLogoUrl } from "@/lib/logos";
 
@@ -482,9 +481,6 @@ function BankAccountFormSheetContent() {
             </form.Field>
          </form>
 
-         <div className="px-4">
-            <LogoDevAttribution className="text-xs text-muted-foreground hover:underline" />
-         </div>
          <SheetFooter>
             <SheetClose asChild>
                <Button variant="outline">Cancelar</Button>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-bank-accounts/bank-account-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-bank-accounts/bank-account-form-sheet.tsx
@@ -186,11 +186,11 @@ function BankAccountFormSheetContent() {
       const logo = bankLogoUrl(option.value, logoDevToken);
       return (
          <div className="flex min-w-0 items-center gap-2">
-            <Avatar className="size-5 shrink-0 bg-white ring-1 ring-border">
+            <Avatar className="size-4 shrink-0 bg-white ring-1 ring-border">
                {logo ? (
                   <AvatarImage
                      alt={option.label}
-                     className="object-contain p-0.5"
+                     className="object-contain p-2"
                      src={logo}
                   />
                ) : null}

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-bank-accounts/bank-account-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-bank-accounts/bank-account-form-sheet.tsx
@@ -185,7 +185,7 @@ function BankAccountFormSheetContent() {
       const logo = bankLogoUrl(option.value, logoDevToken);
       return (
          <div className="flex min-w-0 items-center gap-2">
-            <Avatar className="size-4 shrink-0 bg-white ring-1 ring-border">
+            <Avatar className="size-4 shrink-0 rounded-lg bg-white ring-1 ring-border">
                {logo ? (
                   <AvatarImage
                      alt={option.label}
@@ -193,7 +193,7 @@ function BankAccountFormSheetContent() {
                      src={logo}
                   />
                ) : null}
-               <AvatarFallback className="text-[9px] font-semibold">
+               <AvatarFallback className="rounded-lg text-xs font-semibold">
                   {bankInitials(option.label)}
                </AvatarFallback>
             </Avatar>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-card-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-card-form-sheet.tsx
@@ -1,8 +1,14 @@
 import { of, toMajorUnitsString } from "@f-o-t/money";
+import {
+   Avatar,
+   AvatarFallback,
+   AvatarImage,
+} from "@packages/ui/components/avatar";
 import { Button } from "@packages/ui/components/button";
 import { Field, FieldError, FieldLabel } from "@packages/ui/components/field";
 import { Input } from "@packages/ui/components/input";
 import { MoneyInput } from "@packages/ui/components/money-input";
+import { NumberInput } from "@packages/ui/components/number-input";
 import {
    Select,
    SelectContent,
@@ -25,7 +31,11 @@ import { z } from "zod";
 import { QueryBoundary } from "@/components/query-boundary";
 import { useSheet } from "@/hooks/use-sheet";
 import { orpc } from "@/integrations/orpc/client";
-import { BRAND_LABEL, creditCardBrandFromPrefix } from "@/lib/logos";
+import {
+   BRAND_LABEL,
+   brandLogoUrl,
+   creditCardBrandFromPrefix,
+} from "@/lib/logos";
 
 const daySchema = z
    .number({ error: "Dia é obrigatório." })
@@ -47,7 +57,7 @@ const formSchema = z.object({
          (value) => value === "" || /^\d{4}$/.test(value),
          "Informe os 4 últimos dígitos.",
       ),
-   creditLimit: z.number().min(0, "Limite não pode ser negativo."),
+   creditLimit: z.number().min(0.01, "Limite é obrigatório."),
    closingDay: daySchema,
    dueDay: daySchema,
 });
@@ -149,7 +159,9 @@ function CreditCardFormSheetContent() {
             <form.Field name="name">
                {(field) => (
                   <Field data-invalid={isFieldInvalid(field) || undefined}>
-                     <FieldLabel htmlFor={field.name}>Nome</FieldLabel>
+                     <FieldLabel htmlFor={field.name} required>
+                        Nome
+                     </FieldLabel>
                      <Input
                         aria-invalid={isFieldInvalid(field)}
                         id={field.name}
@@ -171,7 +183,7 @@ function CreditCardFormSheetContent() {
             <form.Field name="bankAccountId">
                {(field) => (
                   <Field data-invalid={isFieldInvalid(field) || undefined}>
-                     <FieldLabel htmlFor={field.name}>
+                     <FieldLabel htmlFor={field.name} required>
                         Conta vinculada
                      </FieldLabel>
                      <Select
@@ -214,37 +226,71 @@ function CreditCardFormSheetContent() {
                   const detectedBrand = creditCardBrandFromPrefix(
                      field.state.value,
                   );
+                  const detectedBrandLogo = detectedBrand
+                     ? brandLogoUrl(detectedBrand)
+                     : undefined;
                   return (
                      <Field data-invalid={isFieldInvalid(field) || undefined}>
-                        <FieldLabel htmlFor={field.name}>
-                           4 primeiros dígitos
-                        </FieldLabel>
-                        <Input
-                           aria-invalid={isFieldInvalid(field)}
-                           id={field.name}
-                           inputMode="numeric"
-                           maxLength={4}
-                           name={field.name}
-                           placeholder="Ex.: 4111"
-                           value={field.state.value}
-                           onBlur={field.handleBlur}
-                           onChange={(e) =>
-                              field.handleChange(
-                                 e.target.value.replace(/\D/g, "").slice(0, 4),
-                              )
-                           }
-                        />
-                        {isFieldInvalid(field) ? (
+                        {detectedBrand ? (
+                           <>
+                              <FieldLabel required>Bandeira</FieldLabel>
+                              <div className="flex items-center justify-between rounded-md bg-muted px-4 py-2">
+                                 <div className="flex min-w-0 items-center gap-2">
+                                    {detectedBrandLogo ? (
+                                       <Avatar className="size-4 shrink-0 rounded-md bg-white ring-1 ring-border">
+                                          <AvatarImage
+                                             alt={BRAND_LABEL[detectedBrand]}
+                                             className="object-contain"
+                                             src={detectedBrandLogo}
+                                          />
+                                          <AvatarFallback className="rounded-md text-[10px]">
+                                             {BRAND_LABEL[detectedBrand][0]}
+                                          </AvatarFallback>
+                                       </Avatar>
+                                    ) : null}
+                                    <span className="truncate text-sm font-medium text-foreground">
+                                       {BRAND_LABEL[detectedBrand]}
+                                    </span>
+                                 </div>
+                                 <Button
+                                    size="sm"
+                                    type="button"
+                                    variant="ghost"
+                                    onClick={() => field.handleChange("")}
+                                 >
+                                    Alterar
+                                 </Button>
+                              </div>
+                           </>
+                        ) : (
+                           <>
+                              <FieldLabel htmlFor={field.name} required>
+                                 4 primeiros dígitos
+                              </FieldLabel>
+                              <Input
+                                 aria-invalid={isFieldInvalid(field)}
+                                 id={field.name}
+                                 inputMode="numeric"
+                                 maxLength={4}
+                                 name={field.name}
+                                 placeholder="Ex.: 4111"
+                                 value={field.state.value}
+                                 onBlur={field.handleBlur}
+                                 onChange={(e) =>
+                                    field.handleChange(
+                                       e.target.value
+                                          .replace(/\D/g, "")
+                                          .slice(0, 4),
+                                    )
+                                 }
+                              />
+                           </>
+                        )}
+                        {isFieldInvalid(field) && !detectedBrand ? (
                            <FieldError>
                               {field.state.meta.errors[0]?.message}
                            </FieldError>
-                        ) : (
-                           <span className="text-xs text-muted-foreground">
-                              {detectedBrand
-                                 ? `Bandeira: ${BRAND_LABEL[detectedBrand]}`
-                                 : "Bandeira não identificada"}
-                           </span>
-                        )}
+                        ) : null}
                      </Field>
                   );
                }}
@@ -283,7 +329,9 @@ function CreditCardFormSheetContent() {
             <form.Field name="creditLimit">
                {(field) => (
                   <Field data-invalid={isFieldInvalid(field) || undefined}>
-                     <FieldLabel htmlFor={field.name}>Limite</FieldLabel>
+                     <FieldLabel htmlFor={field.name} required>
+                        Limite
+                     </FieldLabel>
                      <MoneyInput
                         aria-invalid={isFieldInvalid(field)}
                         id={field.name}
@@ -305,27 +353,19 @@ function CreditCardFormSheetContent() {
                <form.Field name="closingDay">
                   {(field) => (
                      <Field data-invalid={isFieldInvalid(field) || undefined}>
-                        <FieldLabel htmlFor={field.name}>
+                        <FieldLabel htmlFor={field.name} required>
                            Dia de fechamento
                         </FieldLabel>
-                        <Input
+                        <NumberInput
                            aria-invalid={isFieldInvalid(field)}
                            id={field.name}
-                           inputMode="numeric"
                            max={31}
                            min={1}
                            name={field.name}
                            placeholder="1"
-                           type="number"
                            value={field.state.value}
                            onBlur={field.handleBlur}
-                           onChange={(e) =>
-                              field.handleChange(
-                                 e.target.value === ""
-                                    ? 0
-                                    : Number(e.target.value),
-                              )
-                           }
+                           onChange={(value) => field.handleChange(value)}
                         />
                         {isFieldInvalid(field) ? (
                            <FieldError>
@@ -339,27 +379,19 @@ function CreditCardFormSheetContent() {
                <form.Field name="dueDay">
                   {(field) => (
                      <Field data-invalid={isFieldInvalid(field) || undefined}>
-                        <FieldLabel htmlFor={field.name}>
+                        <FieldLabel htmlFor={field.name} required>
                            Dia de vencimento
                         </FieldLabel>
-                        <Input
+                        <NumberInput
                            aria-invalid={isFieldInvalid(field)}
                            id={field.name}
-                           inputMode="numeric"
                            max={31}
                            min={1}
                            name={field.name}
                            placeholder="10"
-                           type="number"
                            value={field.state.value}
                            onBlur={field.handleBlur}
-                           onChange={(e) =>
-                              field.handleChange(
-                                 e.target.value === ""
-                                    ? 0
-                                    : Number(e.target.value),
-                              )
-                           }
+                           onChange={(value) => field.handleChange(value)}
                         />
                         {isFieldInvalid(field) ? (
                            <FieldError>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-card-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-card-form-sheet.tsx
@@ -25,27 +25,7 @@ import { z } from "zod";
 import { QueryBoundary } from "@/components/query-boundary";
 import { useSheet } from "@/hooks/use-sheet";
 import { orpc } from "@/integrations/orpc/client";
-
-const BRANDS = [
-   "visa",
-   "mastercard",
-   "elo",
-   "amex",
-   "hipercard",
-   "other",
-] as const;
-type Brand = (typeof BRANDS)[number];
-
-const BRAND_LABEL: Record<Brand, string> = {
-   visa: "Visa",
-   mastercard: "Mastercard",
-   elo: "Elo",
-   amex: "Amex",
-   hipercard: "Hipercard",
-   other: "Outra",
-};
-
-const NONE_BRAND = "__none__";
+import { BRAND_LABEL, creditCardBrandFromPrefix } from "@/lib/logos";
 
 const daySchema = z
    .number({ error: "Dia é obrigatório." })
@@ -60,7 +40,13 @@ const formSchema = z.object({
       .min(2, "Nome deve ter no mínimo 2 caracteres.")
       .max(80, "Nome deve ter no máximo 80 caracteres."),
    bankAccountId: z.string().uuid("Selecione uma conta vinculada."),
-   brand: z.enum([NONE_BRAND, ...BRANDS]),
+   cardPrefix: z.string().regex(/^\d{4}$/, "Informe os 4 primeiros dígitos."),
+   last4: z
+      .string()
+      .refine(
+         (value) => value === "" || /^\d{4}$/.test(value),
+         "Informe os 4 últimos dígitos.",
+      ),
    creditLimit: z.number().min(0, "Limite não pode ser negativo."),
    closingDay: daySchema,
    dueDay: daySchema,
@@ -71,7 +57,8 @@ type FormValues = z.input<typeof formSchema>;
 const DEFAULT_VALUES: FormValues = {
    name: "",
    bankAccountId: "",
-   brand: NONE_BRAND,
+   cardPrefix: "",
+   last4: "",
    creditLimit: 0,
    closingDay: 1,
    dueDay: 10,
@@ -81,11 +68,6 @@ function isFieldInvalid(field: {
    state: { meta: { isTouched: boolean; errors: unknown[] } };
 }) {
    return field.state.meta.isTouched && field.state.meta.errors.length > 0;
-}
-
-function parseBrand(value: string): Brand | typeof NONE_BRAND | undefined {
-   if (value === NONE_BRAND) return NONE_BRAND;
-   return BRANDS.find((b) => b === value);
 }
 
 export function CreditCardFormSheet() {
@@ -131,7 +113,8 @@ function CreditCardFormSheetContent() {
             createMutation.mutateAsync({
                name: value.name.trim(),
                bankAccountId: value.bankAccountId,
-               brand: value.brand === NONE_BRAND ? null : value.brand,
+               brand: creditCardBrandFromPrefix(value.cardPrefix) ?? null,
+               last4: value.last4 || null,
                color: "#6366f1",
                creditLimit: toMajorUnitsString(
                   of(String(value.creditLimit), "BRL"),
@@ -226,32 +209,73 @@ function CreditCardFormSheetContent() {
                )}
             </form.Field>
 
-            <form.Field name="brand">
+            <form.Field name="cardPrefix">
+               {(field) => {
+                  const detectedBrand = creditCardBrandFromPrefix(
+                     field.state.value,
+                  );
+                  return (
+                     <Field data-invalid={isFieldInvalid(field) || undefined}>
+                        <FieldLabel htmlFor={field.name}>
+                           4 primeiros dígitos
+                        </FieldLabel>
+                        <Input
+                           aria-invalid={isFieldInvalid(field)}
+                           id={field.name}
+                           inputMode="numeric"
+                           maxLength={4}
+                           name={field.name}
+                           placeholder="Ex.: 4111"
+                           value={field.state.value}
+                           onBlur={field.handleBlur}
+                           onChange={(e) =>
+                              field.handleChange(
+                                 e.target.value.replace(/\D/g, "").slice(0, 4),
+                              )
+                           }
+                        />
+                        {isFieldInvalid(field) ? (
+                           <FieldError>
+                              {field.state.meta.errors[0]?.message}
+                           </FieldError>
+                        ) : (
+                           <span className="text-xs text-muted-foreground">
+                              {detectedBrand
+                                 ? `Bandeira: ${BRAND_LABEL[detectedBrand]}`
+                                 : "Bandeira não identificada"}
+                           </span>
+                        )}
+                     </Field>
+                  );
+               }}
+            </form.Field>
+
+            <form.Field name="last4">
                {(field) => (
-                  <Field>
-                     <FieldLabel htmlFor={field.name}>Bandeira</FieldLabel>
-                     <Select
+                  <Field data-invalid={isFieldInvalid(field) || undefined}>
+                     <FieldLabel htmlFor={field.name}>
+                        4 últimos dígitos
+                     </FieldLabel>
+                     <Input
+                        aria-invalid={isFieldInvalid(field)}
+                        id={field.name}
+                        inputMode="numeric"
+                        maxLength={4}
+                        name={field.name}
+                        placeholder="Opcional"
                         value={field.state.value}
-                        onValueChange={(v) => {
-                           const parsed = parseBrand(v);
-                           if (!parsed) return;
-                           field.handleChange(parsed);
-                        }}
-                     >
-                        <SelectTrigger id={field.name} name={field.name}>
-                           <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                           <SelectItem value={NONE_BRAND}>
-                              Sem bandeira
-                           </SelectItem>
-                           {BRANDS.map((b) => (
-                              <SelectItem key={b} value={b}>
-                                 {BRAND_LABEL[b]}
-                              </SelectItem>
-                           ))}
-                        </SelectContent>
-                     </Select>
+                        onBlur={field.handleBlur}
+                        onChange={(e) =>
+                           field.handleChange(
+                              e.target.value.replace(/\D/g, "").slice(0, 4),
+                           )
+                        }
+                     />
+                     {isFieldInvalid(field) ? (
+                        <FieldError>
+                           {field.state.meta.errors[0]?.message}
+                        </FieldError>
+                     ) : null}
                   </Field>
                )}
             </form.Field>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-card-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-card-form-sheet.tsx
@@ -1,0 +1,369 @@
+import { of, toMajorUnitsString } from "@f-o-t/money";
+import { Button } from "@packages/ui/components/button";
+import { Field, FieldError, FieldLabel } from "@packages/ui/components/field";
+import { Input } from "@packages/ui/components/input";
+import { MoneyInput } from "@packages/ui/components/money-input";
+import {
+   Select,
+   SelectContent,
+   SelectItem,
+   SelectTrigger,
+   SelectValue,
+} from "@packages/ui/components/select";
+import {
+   SheetClose,
+   SheetDescription,
+   SheetFooter,
+   SheetHeader,
+   SheetTitle,
+} from "@packages/ui/components/sheet";
+import { toast } from "@packages/ui/components/sonner";
+import { useForm } from "@tanstack/react-form";
+import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { fromPromise } from "neverthrow";
+import { z } from "zod";
+import { QueryBoundary } from "@/components/query-boundary";
+import { useSheet } from "@/hooks/use-sheet";
+import { orpc } from "@/integrations/orpc/client";
+
+const BRANDS = [
+   "visa",
+   "mastercard",
+   "elo",
+   "amex",
+   "hipercard",
+   "other",
+] as const;
+type Brand = (typeof BRANDS)[number];
+
+const BRAND_LABEL: Record<Brand, string> = {
+   visa: "Visa",
+   mastercard: "Mastercard",
+   elo: "Elo",
+   amex: "Amex",
+   hipercard: "Hipercard",
+   other: "Outra",
+};
+
+const NONE_BRAND = "__none__";
+
+const daySchema = z
+   .number({ error: "Dia é obrigatório." })
+   .int("Dia deve ser inteiro.")
+   .min(1, "Dia deve ser entre 1 e 31.")
+   .max(31, "Dia deve ser entre 1 e 31.");
+
+const formSchema = z.object({
+   name: z
+      .string()
+      .trim()
+      .min(2, "Nome deve ter no mínimo 2 caracteres.")
+      .max(80, "Nome deve ter no máximo 80 caracteres."),
+   bankAccountId: z.string().uuid("Selecione uma conta vinculada."),
+   brand: z.enum([NONE_BRAND, ...BRANDS]),
+   creditLimit: z.number().min(0, "Limite não pode ser negativo."),
+   closingDay: daySchema,
+   dueDay: daySchema,
+});
+
+type FormValues = z.input<typeof formSchema>;
+
+const DEFAULT_VALUES: FormValues = {
+   name: "",
+   bankAccountId: "",
+   brand: NONE_BRAND,
+   creditLimit: 0,
+   closingDay: 1,
+   dueDay: 10,
+};
+
+function isFieldInvalid(field: {
+   state: { meta: { isTouched: boolean; errors: unknown[] } };
+}) {
+   return field.state.meta.isTouched && field.state.meta.errors.length > 0;
+}
+
+function parseBrand(value: string): Brand | typeof NONE_BRAND | undefined {
+   if (value === NONE_BRAND) return NONE_BRAND;
+   return BRANDS.find((b) => b === value);
+}
+
+export function CreditCardFormSheet() {
+   return (
+      <QueryBoundary
+         fallback={
+            <div className="flex flex-col gap-4 p-4">
+               <SheetHeader>
+                  <SheetTitle>Novo cartão de crédito</SheetTitle>
+                  <SheetDescription>Carregando contas...</SheetDescription>
+               </SheetHeader>
+            </div>
+         }
+         errorTitle="Erro ao carregar contas"
+      >
+         <CreditCardFormSheetContent />
+      </QueryBoundary>
+   );
+}
+
+function CreditCardFormSheetContent() {
+   const { closeTopSheet } = useSheet();
+
+   const { data: bankAccounts } = useSuspenseQuery(
+      orpc.bankAccounts.getAll.queryOptions({}),
+   );
+
+   const createMutation = useMutation(
+      orpc.creditCards.create.mutationOptions({
+         onSuccess: () => {
+            toast.success("Cartão criado com sucesso.");
+            closeTopSheet();
+         },
+         onError: (e) => toast.error(e.message),
+      }),
+   );
+
+   const form = useForm({
+      defaultValues: DEFAULT_VALUES,
+      validators: { onMount: formSchema, onChange: formSchema },
+      onSubmit: async ({ value }) => {
+         const result = await fromPromise(
+            createMutation.mutateAsync({
+               name: value.name.trim(),
+               bankAccountId: value.bankAccountId,
+               brand: value.brand === NONE_BRAND ? null : value.brand,
+               color: "#6366f1",
+               creditLimit: toMajorUnitsString(
+                  of(String(value.creditLimit), "BRL"),
+               ),
+               closingDay: value.closingDay,
+               dueDay: value.dueDay,
+            }),
+            (e) => e,
+         );
+         if (result.isErr()) return;
+      },
+   });
+
+   const hasBankAccounts = bankAccounts.length > 0;
+
+   return (
+      <>
+         <SheetHeader>
+            <SheetTitle>Novo cartão de crédito</SheetTitle>
+            <SheetDescription>
+               Cadastre um cartão para controlar gastos e faturas.
+            </SheetDescription>
+         </SheetHeader>
+
+         <form
+            className="flex flex-1 min-h-0 flex-col gap-4 overflow-y-auto px-4"
+            onSubmit={(e) => {
+               e.preventDefault();
+               form.handleSubmit();
+            }}
+         >
+            <form.Field name="name">
+               {(field) => (
+                  <Field data-invalid={isFieldInvalid(field) || undefined}>
+                     <FieldLabel htmlFor={field.name}>Nome</FieldLabel>
+                     <Input
+                        aria-invalid={isFieldInvalid(field)}
+                        id={field.name}
+                        name={field.name}
+                        placeholder='Ex.: "Nubank Roxinho"'
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                     />
+                     {isFieldInvalid(field) ? (
+                        <FieldError>
+                           {field.state.meta.errors[0]?.message}
+                        </FieldError>
+                     ) : null}
+                  </Field>
+               )}
+            </form.Field>
+
+            <form.Field name="bankAccountId">
+               {(field) => (
+                  <Field data-invalid={isFieldInvalid(field) || undefined}>
+                     <FieldLabel htmlFor={field.name}>
+                        Conta vinculada
+                     </FieldLabel>
+                     <Select
+                        disabled={!hasBankAccounts}
+                        value={field.state.value || undefined}
+                        onValueChange={(v) => field.handleChange(v)}
+                     >
+                        <SelectTrigger id={field.name} name={field.name}>
+                           <SelectValue
+                              placeholder={
+                                 hasBankAccounts
+                                    ? "Selecione uma conta"
+                                    : "Crie uma conta bancária primeiro"
+                              }
+                           />
+                        </SelectTrigger>
+                        <SelectContent>
+                           {bankAccounts.map((b) => (
+                              <SelectItem key={b.id} value={b.id}>
+                                 {b.name}
+                              </SelectItem>
+                           ))}
+                        </SelectContent>
+                     </Select>
+                     {isFieldInvalid(field) ? (
+                        <FieldError>
+                           {field.state.meta.errors[0]?.message}
+                        </FieldError>
+                     ) : null}
+                  </Field>
+               )}
+            </form.Field>
+
+            <form.Field name="brand">
+               {(field) => (
+                  <Field>
+                     <FieldLabel htmlFor={field.name}>Bandeira</FieldLabel>
+                     <Select
+                        value={field.state.value}
+                        onValueChange={(v) => {
+                           const parsed = parseBrand(v);
+                           if (!parsed) return;
+                           field.handleChange(parsed);
+                        }}
+                     >
+                        <SelectTrigger id={field.name} name={field.name}>
+                           <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                           <SelectItem value={NONE_BRAND}>
+                              Sem bandeira
+                           </SelectItem>
+                           {BRANDS.map((b) => (
+                              <SelectItem key={b} value={b}>
+                                 {BRAND_LABEL[b]}
+                              </SelectItem>
+                           ))}
+                        </SelectContent>
+                     </Select>
+                  </Field>
+               )}
+            </form.Field>
+
+            <form.Field name="creditLimit">
+               {(field) => (
+                  <Field data-invalid={isFieldInvalid(field) || undefined}>
+                     <FieldLabel htmlFor={field.name}>Limite</FieldLabel>
+                     <MoneyInput
+                        aria-invalid={isFieldInvalid(field)}
+                        id={field.name}
+                        name={field.name}
+                        value={field.state.value}
+                        valueInCents={false}
+                        onChange={(v) => field.handleChange(v ?? 0)}
+                     />
+                     {isFieldInvalid(field) ? (
+                        <FieldError>
+                           {field.state.meta.errors[0]?.message}
+                        </FieldError>
+                     ) : null}
+                  </Field>
+               )}
+            </form.Field>
+
+            <div className="grid grid-cols-2 gap-4">
+               <form.Field name="closingDay">
+                  {(field) => (
+                     <Field data-invalid={isFieldInvalid(field) || undefined}>
+                        <FieldLabel htmlFor={field.name}>
+                           Dia de fechamento
+                        </FieldLabel>
+                        <Input
+                           aria-invalid={isFieldInvalid(field)}
+                           id={field.name}
+                           inputMode="numeric"
+                           max={31}
+                           min={1}
+                           name={field.name}
+                           placeholder="1"
+                           type="number"
+                           value={field.state.value}
+                           onBlur={field.handleBlur}
+                           onChange={(e) =>
+                              field.handleChange(
+                                 e.target.value === ""
+                                    ? 0
+                                    : Number(e.target.value),
+                              )
+                           }
+                        />
+                        {isFieldInvalid(field) ? (
+                           <FieldError>
+                              {field.state.meta.errors[0]?.message}
+                           </FieldError>
+                        ) : null}
+                     </Field>
+                  )}
+               </form.Field>
+
+               <form.Field name="dueDay">
+                  {(field) => (
+                     <Field data-invalid={isFieldInvalid(field) || undefined}>
+                        <FieldLabel htmlFor={field.name}>
+                           Dia de vencimento
+                        </FieldLabel>
+                        <Input
+                           aria-invalid={isFieldInvalid(field)}
+                           id={field.name}
+                           inputMode="numeric"
+                           max={31}
+                           min={1}
+                           name={field.name}
+                           placeholder="10"
+                           type="number"
+                           value={field.state.value}
+                           onBlur={field.handleBlur}
+                           onChange={(e) =>
+                              field.handleChange(
+                                 e.target.value === ""
+                                    ? 0
+                                    : Number(e.target.value),
+                              )
+                           }
+                        />
+                        {isFieldInvalid(field) ? (
+                           <FieldError>
+                              {field.state.meta.errors[0]?.message}
+                           </FieldError>
+                        ) : null}
+                     </Field>
+                  )}
+               </form.Field>
+            </div>
+         </form>
+
+         <SheetFooter>
+            <SheetClose asChild>
+               <Button variant="outline">Cancelar</Button>
+            </SheetClose>
+            <form.Subscribe
+               selector={(s) => ({
+                  canSubmit: s.canSubmit,
+                  isSubmitting: s.isSubmitting,
+               })}
+            >
+               {({ canSubmit, isSubmitting }) => (
+                  <Button
+                     disabled={!canSubmit || isSubmitting}
+                     onClick={() => form.handleSubmit()}
+                  >
+                     Criar cartão
+                  </Button>
+               )}
+            </form.Subscribe>
+         </SheetFooter>
+      </>
+   );
+}

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-card-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-card-form-sheet.tsx
@@ -196,7 +196,11 @@ function CreditCardFormSheetContent() {
                         value={field.state.value || undefined}
                         onValueChange={(v) => field.handleChange(v)}
                      >
-                        <SelectTrigger id={field.name} name={field.name}>
+                        <SelectTrigger
+                           aria-invalid={isFieldInvalid(field)}
+                           id={field.name}
+                           name={field.name}
+                        >
                            <SelectValue
                               placeholder={
                                  hasBankAccounts

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-card-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-card-form-sheet.tsx
@@ -237,13 +237,13 @@ function CreditCardFormSheetContent() {
                               <div className="flex items-center justify-between rounded-md bg-muted px-4 py-2">
                                  <div className="flex min-w-0 items-center gap-2">
                                     {detectedBrandLogo ? (
-                                       <Avatar className="size-4 shrink-0 rounded-md bg-white ring-1 ring-border">
+                                       <Avatar className="size-4 shrink-0 rounded-lg bg-white ring-1 ring-border">
                                           <AvatarImage
                                              alt={BRAND_LABEL[detectedBrand]}
                                              className="object-contain"
                                              src={detectedBrandLogo}
                                           />
-                                          <AvatarFallback className="rounded-md text-[10px]">
+                                          <AvatarFallback className="rounded-lg text-xs">
                                              {BRAND_LABEL[detectedBrand][0]}
                                           </AvatarFallback>
                                        </Avatar>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-cards-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-cards-columns.tsx
@@ -100,7 +100,7 @@ export function buildCreditCardColumns(options?: {
             const logo = brandLogoUrl(brand);
             return (
                <div className="flex items-center gap-2 min-w-0">
-                  <Avatar className="size-4 shrink-0 rounded-md bg-white ring-1 ring-border">
+                  <Avatar className="size-4 shrink-0 rounded-lg bg-white ring-1 ring-border">
                      {logo ? (
                         <AvatarImage
                            alt={BRAND_LABEL[brand] ?? brand}
@@ -109,7 +109,7 @@ export function buildCreditCardColumns(options?: {
                         />
                      ) : null}
                      <AvatarFallback
-                        className="rounded-md text-[10px] font-semibold text-white"
+                        className="rounded-lg text-xs font-semibold text-white"
                         style={{ backgroundColor: color }}
                      >
                         <CreditCardIcon className="size-2" />
@@ -186,7 +186,7 @@ export function buildCreditCardColumns(options?: {
             const logo = bankLogoUrl(account.bankCode, logoDevToken);
             return (
                <div className="flex items-center gap-2 min-w-0">
-                  <Avatar className="size-4 shrink-0 bg-white ring-1 ring-border">
+                  <Avatar className="size-4 shrink-0 rounded-lg bg-white ring-1 ring-border">
                      {logo ? (
                         <AvatarImage
                            alt={issuer}
@@ -195,7 +195,7 @@ export function buildCreditCardColumns(options?: {
                         />
                      ) : null}
                      <AvatarFallback
-                        className="text-[10px] font-semibold text-white"
+                        className="rounded-lg text-xs font-semibold text-white"
                         style={{
                            backgroundColor: account.color ?? "#6366f1",
                         }}

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-cards-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-cards-columns.tsx
@@ -1,5 +1,9 @@
 import { format, of } from "@f-o-t/money";
-import { Avatar, AvatarFallback } from "@packages/ui/components/avatar";
+import {
+   Avatar,
+   AvatarFallback,
+   AvatarImage,
+} from "@packages/ui/components/avatar";
 import { Badge } from "@packages/ui/components/badge";
 import {
    Announcement,
@@ -40,6 +44,54 @@ const BRAND_COLOR: Record<string, string> = {
    hipercard: "#822124",
    other: "#6B7280",
 };
+
+const BRAND_LOGO_SLUG: Record<string, string> = {
+   visa: "visa",
+   mastercard: "mastercard",
+   elo: "elo",
+   amex: "americanexpress",
+   hipercard: "hipercard",
+};
+
+const BANK_DOMAIN: Record<string, string> = {
+   "001": "bb.com.br",
+   "033": "santander.com.br",
+   "077": "bancointer.com.br",
+   "104": "caixa.gov.br",
+   "208": "btgpactual.com",
+   "212": "original.com.br",
+   "237": "bradesco.com.br",
+   "246": "abcbrasil.com.br",
+   "260": "nubank.com.br",
+   "290": "pagseguro.com.br",
+   "318": "bancobmg.com.br",
+   "323": "mercadopago.com.br",
+   "336": "bancoc6.com.br",
+   "341": "itau.com.br",
+   "380": "picpay.com",
+   "389": "mercantildobrasil.com.br",
+   "422": "safra.com.br",
+   "623": "pan.com.br",
+   "655": "votorantim.com.br",
+   "735": "banconeon.com.br",
+   "739": "cetelem.com.br",
+   "748": "sicredi.com.br",
+   "756": "sicoobnet.com.br",
+};
+
+function bankLogoUrl(bankCode: string | null | undefined): string | undefined {
+   if (!bankCode) return undefined;
+   const padded = bankCode.padStart(3, "0");
+   const domain = BANK_DOMAIN[padded];
+   if (!domain) return undefined;
+   return `https://logo.clearbit.com/${domain}`;
+}
+
+function brandLogoUrl(brand: string): string | undefined {
+   const slug = BRAND_LOGO_SLUG[brand];
+   if (!slug) return undefined;
+   return `https://cdn.simpleicons.org/${slug}`;
+}
 
 function bankInitials(name: string): string {
    const parts = name.trim().split(/\s+/).filter(Boolean);
@@ -100,18 +152,28 @@ export function buildCreditCardColumns(options?: {
             const brand = row.original.brand;
             if (!brand) return <span className="text-muted-foreground">—</span>;
             const color = BRAND_COLOR[brand] ?? BRAND_COLOR.other!;
+            const logo = brandLogoUrl(brand);
             return (
-               <Announcement>
-                  <AnnouncementTag
-                     className="flex items-center text-white"
-                     style={{ backgroundColor: color }}
-                  >
-                     <CreditCardIcon className="size-3" />
-                  </AnnouncementTag>
-                  <AnnouncementTitle>
+               <div className="flex items-center gap-2 min-w-0">
+                  <Avatar className="size-6 shrink-0 rounded-md bg-white p-0.5 ring-1 ring-border">
+                     {logo ? (
+                        <AvatarImage
+                           alt={BRAND_LABEL[brand] ?? brand}
+                           className="object-contain"
+                           src={logo}
+                        />
+                     ) : null}
+                     <AvatarFallback
+                        className="rounded-md text-[10px] font-semibold text-white"
+                        style={{ backgroundColor: color }}
+                     >
+                        <CreditCardIcon className="size-3" />
+                     </AvatarFallback>
+                  </Avatar>
+                  <span className="text-sm truncate">
                      {BRAND_LABEL[brand] ?? brand}
-                  </AnnouncementTitle>
-               </Announcement>
+                  </span>
+               </div>
             );
          },
          meta: { label: "Bandeira" },
@@ -175,9 +237,17 @@ export function buildCreditCardColumns(options?: {
             if (!account)
                return <span className="text-muted-foreground">—</span>;
             const issuer = account.bankName?.trim() || account.name;
+            const logo = bankLogoUrl(account.bankCode);
             return (
                <div className="flex items-center gap-2 min-w-0">
-                  <Avatar className="size-6 shrink-0">
+                  <Avatar className="size-6 shrink-0 bg-white ring-1 ring-border">
+                     {logo ? (
+                        <AvatarImage
+                           alt={issuer}
+                           className="object-contain p-0.5"
+                           src={logo}
+                        />
+                     ) : null}
                      <AvatarFallback
                         className="text-[10px] font-semibold text-white"
                         style={{

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-cards-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-cards-columns.tsx
@@ -20,84 +20,18 @@ import {
 } from "lucide-react";
 import { z } from "zod";
 import type { Outputs } from "@/integrations/orpc/client";
+import {
+   BRAND_COLOR,
+   BRAND_LABEL,
+   bankInitials,
+   bankLogoUrl,
+   brandLogoUrl,
+} from "@/lib/logos";
 
 export type CreditCardRow = Outputs["creditCards"]["getAll"]["data"][number];
 
 function formatBRL(value: string | number): string {
    return format(of(String(value), "BRL"), "pt-BR");
-}
-
-const BRAND_LABEL: Record<string, string> = {
-   visa: "Visa",
-   mastercard: "Mastercard",
-   elo: "Elo",
-   amex: "Amex",
-   hipercard: "Hipercard",
-   other: "Outra",
-};
-
-const BRAND_COLOR: Record<string, string> = {
-   visa: "#1A1F71",
-   mastercard: "#EB001B",
-   elo: "#000000",
-   amex: "#2E77BC",
-   hipercard: "#822124",
-   other: "#6B7280",
-};
-
-const BRAND_LOGO_SLUG: Record<string, string> = {
-   visa: "visa",
-   mastercard: "mastercard",
-   elo: "elo",
-   amex: "americanexpress",
-   hipercard: "hipercard",
-};
-
-const BANK_DOMAIN: Record<string, string> = {
-   "001": "bb.com.br",
-   "033": "santander.com.br",
-   "077": "bancointer.com.br",
-   "104": "caixa.gov.br",
-   "208": "btgpactual.com",
-   "212": "original.com.br",
-   "237": "bradesco.com.br",
-   "246": "abcbrasil.com.br",
-   "260": "nubank.com.br",
-   "290": "pagseguro.com.br",
-   "318": "bancobmg.com.br",
-   "323": "mercadopago.com.br",
-   "336": "bancoc6.com.br",
-   "341": "itau.com.br",
-   "380": "picpay.com",
-   "389": "mercantildobrasil.com.br",
-   "422": "safra.com.br",
-   "623": "pan.com.br",
-   "655": "votorantim.com.br",
-   "735": "banconeon.com.br",
-   "739": "cetelem.com.br",
-   "748": "sicredi.com.br",
-   "756": "sicoobnet.com.br",
-};
-
-function bankLogoUrl(bankCode: string | null | undefined): string | undefined {
-   if (!bankCode) return undefined;
-   const padded = bankCode.padStart(3, "0");
-   const domain = BANK_DOMAIN[padded];
-   if (!domain) return undefined;
-   return `https://logo.clearbit.com/${domain}`;
-}
-
-function brandLogoUrl(brand: string): string | undefined {
-   const slug = BRAND_LOGO_SLUG[brand];
-   if (!slug) return undefined;
-   return `https://cdn.simpleicons.org/${slug}`;
-}
-
-function bankInitials(name: string): string {
-   const parts = name.trim().split(/\s+/).filter(Boolean);
-   if (parts.length === 0) return "?";
-   if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase();
-   return (parts[0]![0]! + parts[1]![0]!).toUpperCase();
 }
 
 type BankAccountOption = {
@@ -122,10 +56,12 @@ const STATUS_LABEL = {
 
 export function buildCreditCardColumns(options?: {
    bankAccounts?: Array<BankAccountOption>;
+   logoDevToken?: string;
 }): ColumnDef<CreditCardRow>[] {
    const bankAccountsById = new Map(
       (options?.bankAccounts ?? []).map((b) => [b.id, b] as const),
    );
+   const logoDevToken = options?.logoDevToken;
    return [
       {
          accessorKey: "name",
@@ -237,7 +173,7 @@ export function buildCreditCardColumns(options?: {
             if (!account)
                return <span className="text-muted-foreground">—</span>;
             const issuer = account.bankName?.trim() || account.name;
-            const logo = bankLogoUrl(account.bankCode);
+            const logo = bankLogoUrl(account.bankCode, logoDevToken);
             return (
                <div className="flex items-center gap-2 min-w-0">
                   <Avatar className="size-6 shrink-0 bg-white ring-1 ring-border">

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-cards-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-cards-columns.tsx
@@ -75,7 +75,16 @@ export function buildCreditCardColumns(options?: {
                   className="size-2 rounded-full shrink-0"
                   style={{ backgroundColor: row.original.color }}
                />
-               <span className="font-medium truncate">{row.original.name}</span>
+               <div className="flex min-w-0 flex-col">
+                  <span className="font-medium truncate">
+                     {row.original.name}
+                  </span>
+                  {row.original.last4 ? (
+                     <span className="text-xs text-muted-foreground tabular-nums">
+                        Final {row.original.last4}
+                     </span>
+                  ) : null}
+               </div>
             </div>
          ),
          meta: {
@@ -90,7 +99,7 @@ export function buildCreditCardColumns(options?: {
          cell: ({ row }) => {
             const brand = row.original.brand;
             if (!brand) return <span className="text-muted-foreground">—</span>;
-            const color = BRAND_COLOR[brand] ?? BRAND_COLOR.other!;
+            const color = BRAND_COLOR[brand] ?? BRAND_COLOR.other ?? "#000000";
             const logo = brandLogoUrl(brand);
             return (
                <div className="flex items-center gap-2 min-w-0">

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-cards-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-cards-columns.tsx
@@ -1,4 +1,5 @@
 import { format, of } from "@f-o-t/money";
+import { Avatar, AvatarFallback } from "@packages/ui/components/avatar";
 import { Badge } from "@packages/ui/components/badge";
 import {
    Announcement,
@@ -6,7 +7,13 @@ import {
    AnnouncementTitle,
 } from "@/components/blocks/announcement";
 import type { ColumnDef } from "@tanstack/react-table";
-import { Banknote, Calendar, CalendarClock } from "lucide-react";
+import {
+   Banknote,
+   Calendar,
+   CalendarClock,
+   CreditCard as CreditCardIcon,
+   Landmark,
+} from "lucide-react";
 import { z } from "zod";
 import type { Outputs } from "@/integrations/orpc/client";
 
@@ -25,6 +32,30 @@ const BRAND_LABEL: Record<string, string> = {
    other: "Outra",
 };
 
+const BRAND_COLOR: Record<string, string> = {
+   visa: "#1A1F71",
+   mastercard: "#EB001B",
+   elo: "#000000",
+   amex: "#2E77BC",
+   hipercard: "#822124",
+   other: "#6B7280",
+};
+
+function bankInitials(name: string): string {
+   const parts = name.trim().split(/\s+/).filter(Boolean);
+   if (parts.length === 0) return "?";
+   if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase();
+   return (parts[0]![0]! + parts[1]![0]!).toUpperCase();
+}
+
+type BankAccountOption = {
+   id: string;
+   name: string;
+   bankName?: string | null;
+   bankCode?: string | null;
+   color?: string | null;
+};
+
 const STATUS_VARIANT = {
    active: "success",
    blocked: "secondary",
@@ -38,8 +69,11 @@ const STATUS_LABEL = {
 } as const;
 
 export function buildCreditCardColumns(options?: {
-   bankAccounts?: Array<{ id: string; name: string }>;
+   bankAccounts?: Array<BankAccountOption>;
 }): ColumnDef<CreditCardRow>[] {
+   const bankAccountsById = new Map(
+      (options?.bankAccounts ?? []).map((b) => [b.id, b] as const),
+   );
    return [
       {
          accessorKey: "name",
@@ -65,8 +99,19 @@ export function buildCreditCardColumns(options?: {
          cell: ({ row }) => {
             const brand = row.original.brand;
             if (!brand) return <span className="text-muted-foreground">—</span>;
+            const color = BRAND_COLOR[brand] ?? BRAND_COLOR.other!;
             return (
-               <span className="text-sm">{BRAND_LABEL[brand] ?? brand}</span>
+               <Announcement>
+                  <AnnouncementTag
+                     className="flex items-center text-white"
+                     style={{ backgroundColor: color }}
+                  >
+                     <CreditCardIcon className="size-3" />
+                  </AnnouncementTag>
+                  <AnnouncementTitle>
+                     {BRAND_LABEL[brand] ?? brand}
+                  </AnnouncementTitle>
+               </Announcement>
             );
          },
          meta: { label: "Bandeira" },
@@ -125,7 +170,38 @@ export function buildCreditCardColumns(options?: {
       {
          accessorKey: "bankAccountId",
          header: "Conta Bancária",
-         cell: () => <span className="text-muted-foreground">—</span>,
+         cell: ({ row }) => {
+            const account = bankAccountsById.get(row.original.bankAccountId);
+            if (!account)
+               return <span className="text-muted-foreground">—</span>;
+            const issuer = account.bankName?.trim() || account.name;
+            return (
+               <div className="flex items-center gap-2 min-w-0">
+                  <Avatar className="size-6 shrink-0">
+                     <AvatarFallback
+                        className="text-[10px] font-semibold text-white"
+                        style={{
+                           backgroundColor: account.color ?? "#6366f1",
+                        }}
+                     >
+                        {account.bankName ? (
+                           bankInitials(account.bankName)
+                        ) : (
+                           <Landmark className="size-3" />
+                        )}
+                     </AvatarFallback>
+                  </Avatar>
+                  <div className="flex min-w-0 flex-col">
+                     <span className="text-sm truncate">{issuer}</span>
+                     {account.bankCode ? (
+                        <span className="text-xs text-muted-foreground tabular-nums">
+                           {account.bankCode}
+                        </span>
+                     ) : null}
+                  </div>
+               </div>
+            );
+         },
          meta: {
             label: "Conta Bancária",
             cellComponent: "combobox" as const,

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-cards-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-cards-columns.tsx
@@ -34,6 +34,11 @@ function formatBRL(value: string | number): string {
    return format(of(String(value), "BRL"), "pt-BR");
 }
 
+function formatBankIssuerName(name: string): string {
+   const parts = name.split(" - ");
+   return parts.at(-1)?.trim() || name;
+}
+
 type BankAccountOption = {
    id: string;
    name: string;
@@ -70,21 +75,13 @@ export function buildCreditCardColumns(options?: {
          accessorKey: "name",
          header: "Nome",
          cell: ({ row }) => (
-            <div className="flex items-center gap-2 min-w-0">
-               <span
-                  className="size-2 rounded-full shrink-0"
-                  style={{ backgroundColor: row.original.color }}
-               />
-               <div className="flex min-w-0 flex-col">
-                  <span className="font-medium truncate">
-                     {row.original.name}
+            <div className="flex min-w-0 flex-col">
+               <span className="font-medium truncate">{row.original.name}</span>
+               {row.original.last4 ? (
+                  <span className="text-xs text-muted-foreground/90 tabular-nums">
+                     Final {row.original.last4}
                   </span>
-                  {row.original.last4 ? (
-                     <span className="text-xs text-muted-foreground tabular-nums">
-                        Final {row.original.last4}
-                     </span>
-                  ) : null}
-               </div>
+               ) : null}
             </div>
          ),
          meta: {
@@ -103,7 +100,7 @@ export function buildCreditCardColumns(options?: {
             const logo = brandLogoUrl(brand);
             return (
                <div className="flex items-center gap-2 min-w-0">
-                  <Avatar className="size-4 shrink-0 rounded-md bg-white p-2 ring-1 ring-border">
+                  <Avatar className="size-4 shrink-0 rounded-md bg-white ring-1 ring-border">
                      {logo ? (
                         <AvatarImage
                            alt={BRAND_LABEL[brand] ?? brand}
@@ -131,10 +128,10 @@ export function buildCreditCardColumns(options?: {
          header: "Limite",
          cell: ({ row }) => (
             <Announcement>
-               <AnnouncementTag className="flex items-center text-muted-foreground">
-                  <Banknote className="size-2" />
+               <AnnouncementTag>
+                  <Banknote className="size-2 text-emerald-500" />
                </AnnouncementTag>
-               <AnnouncementTitle className="tabular-nums">
+               <AnnouncementTitle>
                   {formatBRL(row.original.creditLimit)}
                </AnnouncementTitle>
             </Announcement>
@@ -146,8 +143,8 @@ export function buildCreditCardColumns(options?: {
          header: "Fechamento",
          cell: ({ row }) => (
             <Announcement>
-               <AnnouncementTag className="flex items-center text-muted-foreground">
-                  <CalendarClock className="size-2" />
+               <AnnouncementTag>
+                  <CalendarClock className="size-2 text-amber-500" />
                </AnnouncementTag>
                <AnnouncementTitle>
                   Dia {row.original.closingDay}
@@ -165,8 +162,8 @@ export function buildCreditCardColumns(options?: {
          header: "Vencimento",
          cell: ({ row }) => (
             <Announcement>
-               <AnnouncementTag className="flex items-center text-muted-foreground">
-                  <Calendar className="size-2" />
+               <AnnouncementTag>
+                  <Calendar className="size-2 text-sky-500" />
                </AnnouncementTag>
                <AnnouncementTitle>Dia {row.original.dueDay}</AnnouncementTitle>
             </Announcement>
@@ -185,6 +182,7 @@ export function buildCreditCardColumns(options?: {
             if (!account)
                return <span className="text-muted-foreground">—</span>;
             const issuer = account.bankName?.trim() || account.name;
+            const issuerName = formatBankIssuerName(issuer);
             const logo = bankLogoUrl(account.bankCode, logoDevToken);
             return (
                <div className="flex items-center gap-2 min-w-0">
@@ -192,7 +190,7 @@ export function buildCreditCardColumns(options?: {
                      {logo ? (
                         <AvatarImage
                            alt={issuer}
-                           className="object-contain p-2"
+                           className="object-contain"
                            src={logo}
                         />
                      ) : null}
@@ -209,14 +207,7 @@ export function buildCreditCardColumns(options?: {
                         )}
                      </AvatarFallback>
                   </Avatar>
-                  <div className="flex min-w-0 flex-col">
-                     <span className="text-sm truncate">{issuer}</span>
-                     {account.bankCode ? (
-                        <span className="text-xs text-muted-foreground tabular-nums">
-                           {account.bankCode}
-                        </span>
-                     ) : null}
-                  </div>
+                  <span className="text-sm truncate">{issuerName}</span>
                </div>
             );
          },

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-cards-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-cards-columns.tsx
@@ -58,8 +58,11 @@ export function buildCreditCardColumns(options?: {
    bankAccounts?: Array<BankAccountOption>;
    logoDevToken?: string;
 }): ColumnDef<CreditCardRow>[] {
-   const bankAccountsById = new Map(
-      (options?.bankAccounts ?? []).map((b) => [b.id, b] as const),
+   const bankAccountEntries: Array<
+      [BankAccountOption["id"], BankAccountOption]
+   > = (options?.bankAccounts ?? []).map((b) => [b.id, b]);
+   const bankAccountsById = new Map<BankAccountOption["id"], BankAccountOption>(
+      bankAccountEntries,
    );
    const logoDevToken = options?.logoDevToken;
    return [
@@ -69,7 +72,7 @@ export function buildCreditCardColumns(options?: {
          cell: ({ row }) => (
             <div className="flex items-center gap-2 min-w-0">
                <span
-                  className="size-3 rounded-full shrink-0"
+                  className="size-2 rounded-full shrink-0"
                   style={{ backgroundColor: row.original.color }}
                />
                <span className="font-medium truncate">{row.original.name}</span>
@@ -91,7 +94,7 @@ export function buildCreditCardColumns(options?: {
             const logo = brandLogoUrl(brand);
             return (
                <div className="flex items-center gap-2 min-w-0">
-                  <Avatar className="size-6 shrink-0 rounded-md bg-white p-0.5 ring-1 ring-border">
+                  <Avatar className="size-4 shrink-0 rounded-md bg-white p-2 ring-1 ring-border">
                      {logo ? (
                         <AvatarImage
                            alt={BRAND_LABEL[brand] ?? brand}
@@ -103,7 +106,7 @@ export function buildCreditCardColumns(options?: {
                         className="rounded-md text-[10px] font-semibold text-white"
                         style={{ backgroundColor: color }}
                      >
-                        <CreditCardIcon className="size-3" />
+                        <CreditCardIcon className="size-2" />
                      </AvatarFallback>
                   </Avatar>
                   <span className="text-sm truncate">
@@ -120,7 +123,7 @@ export function buildCreditCardColumns(options?: {
          cell: ({ row }) => (
             <Announcement>
                <AnnouncementTag className="flex items-center text-muted-foreground">
-                  <Banknote className="size-3" />
+                  <Banknote className="size-2" />
                </AnnouncementTag>
                <AnnouncementTitle className="tabular-nums">
                   {formatBRL(row.original.creditLimit)}
@@ -135,7 +138,7 @@ export function buildCreditCardColumns(options?: {
          cell: ({ row }) => (
             <Announcement>
                <AnnouncementTag className="flex items-center text-muted-foreground">
-                  <CalendarClock className="size-3" />
+                  <CalendarClock className="size-2" />
                </AnnouncementTag>
                <AnnouncementTitle>
                   Dia {row.original.closingDay}
@@ -154,7 +157,7 @@ export function buildCreditCardColumns(options?: {
          cell: ({ row }) => (
             <Announcement>
                <AnnouncementTag className="flex items-center text-muted-foreground">
-                  <Calendar className="size-3" />
+                  <Calendar className="size-2" />
                </AnnouncementTag>
                <AnnouncementTitle>Dia {row.original.dueDay}</AnnouncementTitle>
             </Announcement>
@@ -176,11 +179,11 @@ export function buildCreditCardColumns(options?: {
             const logo = bankLogoUrl(account.bankCode, logoDevToken);
             return (
                <div className="flex items-center gap-2 min-w-0">
-                  <Avatar className="size-6 shrink-0 bg-white ring-1 ring-border">
+                  <Avatar className="size-4 shrink-0 bg-white ring-1 ring-border">
                      {logo ? (
                         <AvatarImage
                            alt={issuer}
-                           className="object-contain p-0.5"
+                           className="object-contain p-2"
                            src={logo}
                         />
                      ) : null}
@@ -193,7 +196,7 @@ export function buildCreditCardColumns(options?: {
                         {account.bankName ? (
                            bankInitials(account.bankName)
                         ) : (
-                           <Landmark className="size-3" />
+                           <Landmark className="size-2" />
                         )}
                      </AvatarFallback>
                   </Avatar>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards.tsx
@@ -213,10 +213,13 @@ function CreditCardsList() {
    const columns = useMemo(
       () =>
          buildCreditCardColumns({
-            bankAccounts: (bankAccounts ?? []) as Array<{
-               id: string;
-               name: string;
-            }>,
+            bankAccounts: (bankAccounts ?? []).map((b) => ({
+               id: b.id,
+               name: b.name,
+               bankName: b.bankName,
+               bankCode: b.bankCode,
+               color: b.color,
+            })),
          }),
       [bankAccounts],
    );

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards.tsx
@@ -9,11 +9,13 @@ import {
 import { useMutation, useSuspenseQueries } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { CreditCard, Plus, Trash2 } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { toast } from "sonner";
 import { z } from "zod";
 import { DefaultHeader } from "../-layout/default-header";
 import { QueryBoundary } from "@/components/query-boundary";
+import { useSheet } from "@/hooks/use-sheet";
+import { CreditCardFormSheet } from "./-credit-cards/credit-card-form-sheet";
 import {
    DataTableBulkActions,
    SelectionActionButton,
@@ -95,6 +97,7 @@ function CreditCardsList() {
    const navigate = Route.useNavigate();
    const { columnFilters, page, pageSize, search, status } = Route.useSearch();
    const { openAlertDialog } = useAlertDialog();
+   const { openSheet } = useSheet();
    const { parse: parseCsv } = useCsvFile();
    const { parse: parseXlsx } = useXlsxFile();
 
@@ -106,13 +109,6 @@ function CreditCardsList() {
          orpc.bankAccounts.getAll.queryOptions({}),
       ],
    });
-
-   const createMutation = useMutation(
-      orpc.creditCards.create.mutationOptions({
-         onSuccess: () => toast.success("Cartão criado com sucesso."),
-         onError: (e) => toast.error(e.message),
-      }),
-   );
 
    const deleteMutation = useMutation(
       orpc.creditCards.remove.mutationOptions({
@@ -144,29 +140,9 @@ function CreditCardsList() {
       }),
    );
 
-   const [isDraftActive, setIsDraftActive] = useState(false);
-
-   const handleDiscardDraft = useCallback(() => setIsDraftActive(false), []);
-
-   const handleAddCard = useCallback(
-      async (data: Record<string, string | string[]>) => {
-         const name = String(data.name ?? "").trim();
-         const closingDay = parseInt(String(data.closingDay ?? ""), 10);
-         const dueDay = parseInt(String(data.dueDay ?? ""), 10);
-         const bankAccountId = String(data.bankAccountId ?? "").trim();
-         if (!name || !closingDay || !dueDay || !bankAccountId) return;
-         await createMutation.mutateAsync({
-            name,
-            closingDay,
-            dueDay,
-            bankAccountId,
-            color: "#6366f1",
-            creditLimit: "0",
-         });
-         setIsDraftActive(false);
-      },
-      [createMutation],
-   );
+   const handleOpenCreate = useCallback(() => {
+      openSheet({ renderChildren: () => <CreditCardFormSheet /> });
+   }, [openSheet]);
 
    const importConfig: DataTableImportConfig = useMemo(
       () => ({
@@ -271,9 +247,6 @@ function CreditCardsList() {
                   replace: true,
                });
             }}
-            isDraftRowActive={isDraftActive}
-            onAddRow={handleAddCard}
-            onDiscardAddRow={handleDiscardDraft}
             renderExpandedRow={(props) => (
                <CreditCardFaturaRow creditCardId={props.row.original.id} />
             )}
@@ -291,7 +264,7 @@ function CreditCardsList() {
             <DataTableToolbar>
                <DataTableImportButton importConfig={importConfig} />
                <Button
-                  onClick={() => setIsDraftActive(true)}
+                  onClick={handleOpenCreate}
                   size="icon-sm"
                   tooltip="Novo Cartão"
                   variant="outline"

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards.tsx
@@ -15,6 +15,7 @@ import { z } from "zod";
 import { DefaultHeader } from "../-layout/default-header";
 import { QueryBoundary } from "@/components/query-boundary";
 import { useSheet } from "@/hooks/use-sheet";
+import { LogoDevAttribution } from "@/components/logo-dev-attribution";
 import { CreditCardFormSheet } from "./-credit-cards/credit-card-form-sheet";
 import {
    DataTableBulkActions,
@@ -98,6 +99,7 @@ function CreditCardsList() {
    const { columnFilters, page, pageSize, search, status } = Route.useSearch();
    const { openAlertDialog } = useAlertDialog();
    const { openSheet } = useSheet();
+   const { publicEnv } = Route.useRouteContext();
    const { parse: parseCsv } = useCsvFile();
    const { parse: parseXlsx } = useXlsxFile();
 
@@ -220,8 +222,9 @@ function CreditCardsList() {
                bankCode: b.bankCode,
                color: b.color,
             })),
+            logoDevToken: publicEnv?.LOGO_DEV_TOKEN,
          }),
-      [bankAccounts],
+      [bankAccounts, publicEnv?.LOGO_DEV_TOKEN],
    );
 
    return (
@@ -334,6 +337,7 @@ function CreditCardsList() {
                }
             />
          </DataTableRoot>
+         <LogoDevAttribution />
       </div>
    );
 }

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards.tsx
@@ -162,6 +162,9 @@ function CreditCardsList() {
             id: `__import_${i}`,
             name: String(row.name ?? "").trim(),
             brand: String(row.brand ?? "") || null,
+            last4: String(row.last4 ?? row.final ?? "")
+               .replace(/\D/g, "")
+               .slice(0, 4),
             color: "#6366f1",
             creditLimit: String(row.creditLimit ?? row.limite ?? "0"),
             closingDay:
@@ -188,6 +191,7 @@ function CreditCardsList() {
                   bankAccountId: firstBankAccountId,
                   color: "#6366f1",
                   creditLimit: String(r.creditLimit ?? "0"),
+                  last4: String(r.last4 ?? "") || null,
                })),
             });
          },

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards.tsx
@@ -15,7 +15,6 @@ import { z } from "zod";
 import { DefaultHeader } from "../-layout/default-header";
 import { QueryBoundary } from "@/components/query-boundary";
 import { useSheet } from "@/hooks/use-sheet";
-import { LogoDevAttribution } from "@/components/logo-dev-attribution";
 import { CreditCardFormSheet } from "./-credit-cards/credit-card-form-sheet";
 import {
    DataTableBulkActions,
@@ -340,7 +339,6 @@ function CreditCardsList() {
                }
             />
          </DataTableRoot>
-         <LogoDevAttribution />
       </div>
    );
 }

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards.tsx
@@ -48,8 +48,7 @@ const creditCardsSearchSchema = z.object({
       .default([]),
    search: z.string().max(100).catch("").default(""),
    status: z
-      .enum(["active", "blocked", "cancelled"])
-      .optional()
+      .union([z.enum(["active", "blocked", "cancelled"]), z.undefined()])
       .catch(undefined),
    page: z.number().int().min(1).catch(1).default(1),
    pageSize: z.number().int().catch(20).default(20),

--- a/core/database/__tests__/schemas/credit-cards-validators.test.ts
+++ b/core/database/__tests__/schemas/credit-cards-validators.test.ts
@@ -47,6 +47,14 @@ describe("createCreditCardSchema", () => {
       expectPass({ ...validCard, brand: null });
    });
 
+   it("accepts card with last4", () => {
+      expectPass({ ...validCard, last4: "1234" });
+   });
+
+   it("rejects invalid last4", () => {
+      expectFail({ ...validCard, last4: "123" }, "last4");
+   });
+
    it("rejects name shorter than 2 characters", () => {
       expectFail({ ...validCard, name: "A" }, "name");
    });
@@ -146,6 +154,14 @@ describe("updateCreditCardSchema", () => {
 
    it("accepts valid brand on update", () => {
       expect(parse({ brand: "mastercard" }).success).toBe(true);
+   });
+
+   it("accepts valid last4 on update", () => {
+      expect(parse({ last4: "9876" }).success).toBe(true);
+   });
+
+   it("rejects invalid last4 on update", () => {
+      expect(parse({ last4: "abcd" }).success).toBe(false);
    });
 
    it("rejects closingDay out of range on update", () => {

--- a/core/database/src/schemas/credit-cards.ts
+++ b/core/database/src/schemas/credit-cards.ts
@@ -40,6 +40,7 @@ export const creditCards = financeSchema.table(
       creditLimit: numeric("credit_limit", { precision: 12, scale: 2 })
          .notNull()
          .default("0"),
+      last4: text("last4"),
       closingDay: integer("closing_day").notNull(),
       dueDay: integer("due_day").notNull(),
       bankAccountId: uuid("bank_account_id")
@@ -89,6 +90,12 @@ const colorSchema = z
    .string()
    .regex(HEX_COLOR_REGEX, "Cor inválida. Use formato hex (#RRGGBB).");
 
+const last4Schema = z
+   .string()
+   .regex(/^\d{4}$/, "Final do cartão deve ter 4 dígitos.")
+   .nullable()
+   .optional();
+
 const daySchema = z
    .number()
    .int("Dia deve ser um número inteiro.")
@@ -100,6 +107,7 @@ const baseCreditCardSchema = createInsertSchema(creditCards).pick({
    color: true,
    iconUrl: true,
    creditLimit: true,
+   last4: true,
    closingDay: true,
    dueDay: true,
    bankAccountId: true,
@@ -110,6 +118,7 @@ export const createCreditCardSchema = baseCreditCardSchema.extend({
    name: nameSchema,
    color: colorSchema.default("#6366f1"),
    creditLimit: creditLimitSchema.default("0"),
+   last4: last4Schema,
    closingDay: daySchema,
    dueDay: daySchema,
    bankAccountId: z.string().uuid("Conta vinculada inválida."),
@@ -124,6 +133,7 @@ export const updateCreditCardSchema = baseCreditCardSchema
       name: nameSchema.optional(),
       color: colorSchema.optional(),
       creditLimit: creditLimitSchema.optional(),
+      last4: last4Schema,
       closingDay: daySchema.optional(),
       dueDay: daySchema.optional(),
       bankAccountId: z.string().uuid("Conta vinculada inválida.").optional(),

--- a/modules/finance/src/router/credit-cards.ts
+++ b/modules/finance/src/router/credit-cards.ts
@@ -196,6 +196,11 @@ const bulkCreateSchema = z.object({
          z.object({
             name: z.string().min(2).max(80),
             creditLimit: z.string(),
+            last4: z
+               .string()
+               .regex(/^\d{4}$/)
+               .nullable()
+               .optional(),
             closingDay: z.number().int().min(1).max(31),
             dueDay: z.number().int().min(1).max(31),
             bankAccountId: z.string().uuid(),
@@ -247,6 +252,7 @@ export const bulkCreate = protectedProcedure
          teamId: context.teamId,
          name: c.name,
          creditLimit: c.creditLimit,
+         last4: c.last4,
          closingDay: c.closingDay,
          dueDay: c.dueDay,
          color: c.color ?? "#6366f1",

--- a/packages/ui/src/components/autocomplete.tsx
+++ b/packages/ui/src/components/autocomplete.tsx
@@ -13,6 +13,7 @@ import { Command as CommandPrimitive } from "cmdk";
 import { Check } from "lucide-react";
 import {
    type KeyboardEvent,
+   type ReactNode,
    useCallback,
    useMemo,
    useRef,
@@ -31,6 +32,7 @@ interface AutocompleteProps {
    disabled?: boolean;
    placeholder?: string;
    onBlur?: () => void;
+   renderOption?: (option: AutocompleteOption) => ReactNode;
 }
 
 export function Autocomplete({
@@ -42,6 +44,7 @@ export function Autocomplete({
    disabled,
    isLoading = false,
    onBlur,
+   renderOption,
 }: AutocompleteProps) {
    const inputRef = useRef<HTMLInputElement>(null);
    const [parentNode, setParentNode] = useState<HTMLDivElement | null>(null);
@@ -237,9 +240,13 @@ export function Autocomplete({
                                              {isSelected ? (
                                                 <Check className="w-4 shrink-0 mt-0.5" />
                                              ) : null}
-                                             <span className="break-words">
-                                                {option.label}
-                                             </span>
+                                             {renderOption ? (
+                                                renderOption(option)
+                                             ) : (
+                                                <span className="break-words">
+                                                   {option.label}
+                                                </span>
+                                             )}
                                           </CommandItem>
                                        );
                                     })}

--- a/packages/ui/src/components/field.tsx
+++ b/packages/ui/src/components/field.tsx
@@ -110,8 +110,10 @@ function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
 
 function FieldLabel({
    className,
+   children,
+   required,
    ...props
-}: React.ComponentProps<typeof Label>) {
+}: React.ComponentProps<typeof Label> & { required?: boolean }) {
    return (
       <Label
          className={cn(
@@ -122,7 +124,14 @@ function FieldLabel({
          )}
          data-slot="field-label"
          {...props}
-      />
+      >
+         {children}
+         {required ? (
+            <span aria-hidden="true" className="text-destructive">
+               *
+            </span>
+         ) : null}
+      </Label>
    );
 }
 


### PR DESCRIPTION
## Summary
- Migra criação de cartões de crédito do draft row inline para side sheet com TanStack Form (`CreditCardFormSheet`), alinhando com Contas Bancárias e Categorias
- Form com campos: nome, conta vinculada (select), bandeira (opcional), limite (MoneyInput), dia de fechamento e vencimento
- Edição inline célula a célula preservada
- E2E coverage: `apps/web-e2e/tests/credit-cards-create.spec.ts` + helpers `findCreditCardByName`, `deleteCreditCardById`, `findAnyBankAccount`, `insertBankAccount`

Closes MON-943

## Test plan
- [ ] Abrir `/credit-cards`, clicar `+` → side sheet abre
- [ ] Validar erro de nome curto, conta obrigatória, submit desabilitado até form válido
- [ ] Criar cartão → toast sucesso, sheet fecha, linha aparece
- [ ] Cancelar fecha sheet sem criar
- [ ] Edição inline do nome continua funcionando
- [ ] `bun nx run web-e2e:e2e --grep "credit-cards-create"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)