### PR TITLE
MON-957: Localiza exportação de cartões de crédito

### DIFF
--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-cards-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-cards-columns.tsx
@@ -121,7 +121,11 @@ export function buildCreditCardColumns(options?: {
                </div>
             );
          },
-         meta: { label: "Bandeira" },
+         meta: {
+            label: "Bandeira",
+            exportValue: (row) =>
+               row.brand ? (BRAND_LABEL[row.brand] ?? row.brand) : "",
+         },
       },
       {
          accessorKey: "creditLimit",
@@ -136,7 +140,10 @@ export function buildCreditCardColumns(options?: {
                </AnnouncementTitle>
             </Announcement>
          ),
-         meta: { label: "Limite" },
+         meta: {
+            label: "Limite",
+            exportValue: (row) => formatBRL(row.creditLimit),
+         },
       },
       {
          accessorKey: "closingDay",
@@ -155,6 +162,7 @@ export function buildCreditCardColumns(options?: {
             label: "Fechamento",
             cellComponent: "text" as const,
             editSchema: z.coerce.number().int().min(1).max(31),
+            exportValue: (row) => `Dia ${row.closingDay}`,
          },
       },
       {
@@ -172,6 +180,7 @@ export function buildCreditCardColumns(options?: {
             label: "Vencimento",
             cellComponent: "text" as const,
             editSchema: z.coerce.number().int().min(1).max(31),
+            exportValue: (row) => `Dia ${row.dueDay}`,
          },
       },
       {
@@ -219,6 +228,12 @@ export function buildCreditCardColumns(options?: {
                value: a.id,
                label: a.name,
             })),
+            exportValue: (row) => {
+               const account = bankAccountsById.get(row.bankAccountId);
+               if (!account) return "";
+               const issuer = account.bankName?.trim() || account.name;
+               return formatBankIssuerName(issuer);
+            },
          },
       },
       {
@@ -232,7 +247,11 @@ export function buildCreditCardColumns(options?: {
                </Badge>
             );
          },
-         meta: { label: "Status", filterVariant: "select" },
+         meta: {
+            label: "Status",
+            filterVariant: "select",
+            exportValue: (row) => STATUS_LABEL[row.status] ?? row.status,
+         },
       },
    ];
 }

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards.tsx
@@ -234,6 +234,8 @@ function CreditCardsList() {
          <DataTableRoot
             columns={columns}
             data={result.data}
+            exportDateFormat="DD-MM-YYYY"
+            exportFileBase="cartoes-de-credito"
             getRowId={(row) => row.id}
             storageKey="montte:datatable:credit-cards"
             columnFilters={columnFilters}


### PR DESCRIPTION
## Resumo
- define nome de arquivo em português para exportação de cartões de crédito
- aplica data do arquivo no formato DD-MM-YYYY
- exporta valores em pt-BR para bandeira, limite, dias, conta bancária e status

## Verificações
- bun nx run web:typecheck
- bun nx run web:check
- bunx oxfmt --check apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards.tsx apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-cards-columns.tsx