### PR TITLE
fix(transactions): substituir "marcar como pagas" por "ignorar lançamentos" (MON-946)

### DIFF
--- a/apps/web-e2e/helpers/db.ts
+++ b/apps/web-e2e/helpers/db.ts
@@ -249,10 +249,37 @@ export async function insertBankAccount(
    return row;
 }
 
+export async function findTransactionById(teamId: string, id: string) {
+   return db().query.transactions.findFirst({
+      where: (f, { and, eq }) => and(eq(f.teamId, teamId), eq(f.id, id)),
+   });
+}
+
 export async function findTransactionByName(teamId: string, name: string) {
    return db().query.transactions.findFirst({
       where: (f, { and, eq }) => and(eq(f.teamId, teamId), eq(f.name, name)),
    });
+}
+
+export async function insertExpenseTransaction(
+   teamId: string,
+   bankAccountId: string,
+   name: string,
+   status: "pending" | "paid" | "cancelled" = "pending",
+) {
+   const [row] = await db()
+      .insert(transactions)
+      .values({
+         teamId,
+         name,
+         type: "expense",
+         amount: "10.00",
+         date: new Date().toISOString().slice(0, 10),
+         bankAccountId,
+         status,
+      })
+      .returning();
+   return row;
 }
 
 export async function deleteTransactionById(teamId: string, id: string) {

--- a/apps/web-e2e/helpers/db.ts
+++ b/apps/web-e2e/helpers/db.ts
@@ -279,6 +279,7 @@ export async function insertExpenseTransaction(
          status,
       })
       .returning();
+   if (!row) throw new Error("Failed to insert transaction");
    return row;
 }
 

--- a/apps/web-e2e/tests/transactions-bulk-actions.spec.ts
+++ b/apps/web-e2e/tests/transactions-bulk-actions.spec.ts
@@ -33,6 +33,7 @@ async function setupTwoTransactions(session: E2ESession) {
 
    const accountName = `Bulk Conta ${stamp()}`;
    const account = await insertBankAccount(team.id, accountName);
+   if (!account) throw new Error("failed to create bank account");
    createdAccountIds.push(account.id);
 
    const tag = `Bulk ${stamp()}`;

--- a/apps/web-e2e/tests/transactions-bulk-actions.spec.ts
+++ b/apps/web-e2e/tests/transactions-bulk-actions.spec.ts
@@ -1,0 +1,116 @@
+import type { Page } from "@playwright/test";
+import { expect, test, type E2ESession } from "../fixtures";
+import {
+   deleteBankAccountById,
+   deleteTransactionById,
+   findTeamByOrgAndSlug,
+   findTransactionById,
+   findTransactionByName,
+   insertBankAccount,
+   insertExpenseTransaction,
+} from "../helpers/db";
+
+const stamp = () => `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+const createdTxIds: string[] = [];
+const createdAccountIds: string[] = [];
+
+async function gotoTransactions(
+   page: Page,
+   session: E2ESession,
+   search: string,
+) {
+   await page.goto(
+      `/${session.orgSlug}/${session.teamSlug}/transactions?search=${encodeURIComponent(search)}`,
+   );
+   await expect(
+      page.getByRole("heading", { name: "Lançamentos" }),
+   ).toBeVisible();
+}
+
+async function setupTwoTransactions(session: E2ESession) {
+   const team = await findTeamByOrgAndSlug(session.orgSlug, session.teamSlug);
+   if (!team) throw new Error("team não encontrado");
+
+   const accountName = `Bulk Conta ${stamp()}`;
+   const account = await insertBankAccount(team.id, accountName);
+   createdAccountIds.push(account.id);
+
+   const tag = `Bulk ${stamp()}`;
+   const txA = await insertExpenseTransaction(
+      team.id,
+      account.id,
+      `${tag} A`,
+      "pending",
+   );
+   const txB = await insertExpenseTransaction(
+      team.id,
+      account.id,
+      `${tag} B`,
+      "pending",
+   );
+   createdTxIds.push(txA.id, txB.id);
+
+   return { team, tag, txAId: txA.id, txBId: txB.id };
+}
+
+test.afterEach(async ({ e2eSession }) => {
+   const team = await findTeamByOrgAndSlug(
+      e2eSession.orgSlug,
+      e2eSession.teamSlug,
+   );
+   if (!team) return;
+   for (const id of createdTxIds.splice(0)) {
+      await deleteTransactionById(team.id, id);
+   }
+   for (const id of createdAccountIds.splice(0)) {
+      await deleteBankAccountById(team.id, id);
+   }
+});
+
+test("ação em massa 'Ignorar lançamentos' cancela seleção", async ({
+   page,
+   e2eSession,
+}) => {
+   const { team, tag, txAId, txBId } = await setupTwoTransactions(e2eSession);
+
+   await gotoTransactions(page, e2eSession, tag);
+   await expect(page.getByRole("cell", { name: `${tag} A` })).toBeVisible();
+   await expect(page.getByRole("cell", { name: `${tag} B` })).toBeVisible();
+
+   await page.getByRole("checkbox", { name: "Selecionar todos" }).click();
+
+   const ignoreBtn = page.getByRole("button", { name: "Ignorar lançamentos" });
+   await expect(ignoreBtn).toBeVisible();
+   await expect(
+      page.getByRole("button", { name: "Marcar como pagas" }),
+   ).toHaveCount(0);
+
+   await ignoreBtn.click();
+   const dialog = page.getByRole("alertdialog");
+   await expect(dialog).toBeVisible();
+   await dialog.getByRole("button", { name: "Ignorar" }).click();
+   await expect(dialog).not.toBeVisible();
+
+   await expect
+      .poll(async () => (await findTransactionById(team.id, txAId))?.status)
+      .toBe("cancelled");
+   await expect
+      .poll(async () => (await findTransactionById(team.id, txBId))?.status)
+      .toBe("cancelled");
+});
+
+test("menu Status em massa não expõe 'Cancelado'", async ({
+   page,
+   e2eSession,
+}) => {
+   const { tag } = await setupTwoTransactions(e2eSession);
+
+   await gotoTransactions(page, e2eSession, tag);
+   await expect(page.getByRole("cell", { name: `${tag} A` })).toBeVisible();
+   await page.getByRole("checkbox", { name: "Selecionar todos" }).click();
+
+   await page.getByRole("button", { name: "Status" }).click();
+   await expect(page.getByRole("button", { name: "Pendente" })).toBeVisible();
+   await expect(page.getByRole("button", { name: "Efetivado" })).toBeVisible();
+   await expect(page.getByRole("button", { name: "Cancelado" })).toHaveCount(0);
+});

--- a/apps/web-e2e/tests/transactions-bulk-actions.spec.ts
+++ b/apps/web-e2e/tests/transactions-bulk-actions.spec.ts
@@ -91,6 +91,10 @@ test("ação em massa 'Ignorar lançamentos' cancela seleção", async ({
    await expect(dialog).toBeVisible();
    await dialog.getByRole("button", { name: "Ignorar" }).click();
    await expect(dialog).not.toBeVisible();
+   await expect(ignoreBtn).toHaveCount(0);
+   await expect(
+      page.getByRole("checkbox", { name: "Selecionar todos" }),
+   ).not.toBeChecked();
 
    await expect
       .poll(async () => (await findTransactionById(team.id, txAId))?.status)

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
@@ -603,22 +603,13 @@ export function TransactionsList() {
             <DataTableContent className="flex-1 overflow-auto min-h-0" />
             <DataTableBulkActions<TransactionRow>>
                {({ selectedRows, clearSelection }) => {
-                  const pendingIds = selectedRows
-                     .filter((r) => r.status === "pending")
-                     .map((r) => r.id);
                   const selectedIds = selectedRows.map((r) => r.id);
-                  const allPending =
-                     pendingIds.length === selectedIds.length &&
-                     selectedIds.length > 0;
                   return (
                      <>
-                        {allPending && (
-                           <BulkMarkPaidButton
-                              bankAccounts={bankAccounts}
-                              ids={selectedIds}
-                              onSuccess={clearSelection}
-                           />
-                        )}
+                        <BulkIgnoreButton
+                           ids={selectedIds}
+                           onSuccess={clearSelection}
+                        />
                         <BulkStatusButton
                            ids={selectedIds}
                            onSuccess={clearSelection}
@@ -678,73 +669,44 @@ export function TransactionsList() {
    );
 }
 
-function BulkMarkPaidButton({
+function BulkIgnoreButton({
    ids,
-   bankAccounts,
    onSuccess,
 }: {
    ids: string[];
-   bankAccounts: BankAccountOption[];
    onSuccess: () => void;
 }) {
-   const [open, setOpen] = useState(false);
-   const [date, setDate] = useState<Date>(() => dayjs().toDate());
-   const [bankAccountId, setBankAccountId] = useState("");
+   const { openAlertDialog } = useAlertDialog();
    const mutation = useMutation(
-      orpc.transactions.bulkMarkAsPaid.mutationOptions({
-         onError: (e) => toast.error(e.message || "Erro ao marcar como pago."),
+      orpc.transactions.update.mutationOptions({
+         onError: (e) =>
+            toast.error(e.message || "Erro ao ignorar lançamentos."),
       }),
    );
 
    return (
-      <Popover open={open} onOpenChange={setOpen}>
-         <PopoverTrigger asChild>
-            <SelectionActionButton icon={<CheckCircle2 />}>
-               Marcar como pagas
-            </SelectionActionButton>
-         </PopoverTrigger>
-         <PopoverContent
-            align="start"
-            className="w-auto flex flex-col gap-4 p-4"
-         >
-            <p className="text-sm font-medium">Data do pagamento</p>
-            <Calendar
-               mode="single"
-               selected={date}
-               onSelect={(d) => d && setDate(d)}
-            />
-            <Combobox
-               emptyMessage="Nenhuma conta."
-               options={bankAccounts.map((a) => ({
-                  value: a.id,
-                  label: a.name,
-               }))}
-               placeholder="Conta bancária (opcional)"
-               searchPlaceholder="Buscar conta..."
-               value={bankAccountId}
-               onValueChange={setBankAccountId}
-            />
-            <Button
-               disabled={mutation.isPending}
-               size="sm"
-               onClick={async () => {
-                  await mutation.mutateAsync({
-                     ids,
-                     paidDate: dayjs(date).format("YYYY-MM-DD"),
-                     bankAccountId: bankAccountId || null,
-                  });
-                  toast.success(
-                     `${ids.length} ${ids.length === 1 ? "lançamento marcado" : "lançamentos marcados"} como pago(s).`,
+      <SelectionActionButton
+         icon={<Ban />}
+         onClick={() =>
+            openAlertDialog({
+               title: `Ignorar ${ids.length} ${ids.length === 1 ? "lançamento" : "lançamentos"}`,
+               description:
+                  "Os lançamentos selecionados serão marcados como ignorados e não entrarão nos cálculos.",
+               actionLabel: "Ignorar",
+               cancelLabel: "Cancelar",
+               onAction: async () => {
+                  await Promise.allSettled(
+                     ids.map((id) =>
+                        mutation.mutateAsync({ id, status: "cancelled" }),
+                     ),
                   );
-                  setOpen(false);
-                  setBankAccountId("");
                   onSuccess();
-               }}
-            >
-               Confirmar pagamento
-            </Button>
-         </PopoverContent>
-      </Popover>
+               },
+            })
+         }
+      >
+         Ignorar lançamentos
+      </SelectionActionButton>
    );
 }
 
@@ -762,7 +724,7 @@ function BulkStatusButton({
       }),
    );
 
-   const apply = async (status: "pending" | "paid" | "cancelled") => {
+   const apply = async (status: "pending" | "paid") => {
       await Promise.allSettled(
          ids.map((id) => mutation.mutateAsync({ id, status })),
       );
@@ -773,7 +735,6 @@ function BulkStatusButton({
    const statusOptions = [
       { value: "pending" as const, label: "Pendente" },
       { value: "paid" as const, label: "Efetivado" },
-      { value: "cancelled" as const, label: "Cancelado" },
    ];
 
    return (

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
@@ -695,12 +695,14 @@ function BulkIgnoreButton({
                actionLabel: "Ignorar",
                cancelLabel: "Cancelar",
                onAction: async () => {
-                  await Promise.allSettled(
+                  const results = await Promise.allSettled(
                      ids.map((id) =>
                         mutation.mutateAsync({ id, status: "cancelled" }),
                      ),
                   );
-                  onSuccess();
+                  if (results.every((r) => r.status === "fulfilled")) {
+                     onSuccess();
+                  }
                },
             })
          }

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
@@ -727,11 +727,13 @@ function BulkStatusButton({
    );
 
    const apply = async (status: "pending" | "paid") => {
-      await Promise.allSettled(
+      const results = await Promise.allSettled(
          ids.map((id) => mutation.mutateAsync({ id, status })),
       );
       setOpen(false);
-      onSuccess();
+      if (results.every((r) => r.status === "fulfilled")) {
+         onSuccess();
+      }
    };
 
    const statusOptions = [


### PR DESCRIPTION
## Summary
- Remove ação em massa "Marcar como pagas" da toolbar de seleção em `/transactions`
- Adiciona ação em massa "Ignorar lançamentos" no lugar (confirma via alert dialog, marca status `cancelled`)
- Remove opção "Cancelado" do menu Status em massa (coberto pela nova ação)

## Test plan
- [ ] Selecionar múltiplos lançamentos → rodapé mostra "Ignorar lançamentos" (não "Marcar como pagas")
- [ ] Clicar "Ignorar lançamentos" → confirma → lançamentos ficam com status cancelado
- [ ] Abrir menu Status em massa → só "Pendente" e "Efetivado"

🤖 Generated with [Claude Code](https://claude.com/claude-code)