### PR TITLE
feat(transactions): hierarchical category picker (MON-947)

### DIFF
--- a/apps/web-e2e/helpers/db.ts
+++ b/apps/web-e2e/helpers/db.ts
@@ -286,6 +286,30 @@ export async function insertDefaultCategory(
    return row;
 }
 
+export async function insertCategory(
+   teamId: string,
+   input: {
+      name: string;
+      type: "income" | "expense" | "transfer";
+      parentId?: string;
+      level?: number;
+   },
+) {
+   const [row] = await db()
+      .insert(categories)
+      .values({
+         teamId,
+         name: input.name,
+         type: input.type,
+         parentId: input.parentId,
+         level: input.level ?? (input.parentId ? 2 : 1),
+         isDefault: false,
+         participatesDre: false,
+      })
+      .returning();
+   return row;
+}
+
 export async function deleteCategoryById(teamId: string, id: string) {
    await db()
       .delete(categories)

--- a/apps/web-e2e/helpers/db.ts
+++ b/apps/web-e2e/helpers/db.ts
@@ -292,7 +292,6 @@ export async function insertCategory(
       name: string;
       type: "income" | "expense" | "transfer";
       parentId?: string;
-      level?: number;
    },
 ) {
    const [row] = await db()
@@ -302,7 +301,7 @@ export async function insertCategory(
          name: input.name,
          type: input.type,
          parentId: input.parentId,
-         level: input.level ?? (input.parentId ? 2 : 1),
+         level: input.parentId ? 2 : 1,
          isDefault: false,
          participatesDre: false,
       })

--- a/apps/web-e2e/helpers/db.ts
+++ b/apps/web-e2e/helpers/db.ts
@@ -307,6 +307,7 @@ export async function insertCategory(
          participatesDre: false,
       })
       .returning();
+   if (!row) throw new Error(`Falha ao inserir categoria "${input.name}".`);
    return row;
 }
 

--- a/apps/web-e2e/tests/transactions-category-hierarchy.spec.ts
+++ b/apps/web-e2e/tests/transactions-category-hierarchy.spec.ts
@@ -1,0 +1,141 @@
+import type { Page } from "@playwright/test";
+import { expect, test, type E2ESession } from "../fixtures";
+import {
+   deleteBankAccountById,
+   deleteCategoryById,
+   findBankAccountByName,
+   findTeamByOrgAndSlug,
+   insertCategory,
+} from "../helpers/db";
+
+const stamp = () => `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+const createdAccountIds: string[] = [];
+const createdCategoryIds: string[] = [];
+
+async function gotoTransactions(page: Page, session: E2ESession) {
+   await page.goto(`/${session.orgSlug}/${session.teamSlug}/transactions`);
+   await expect(
+      page.getByRole("heading", { name: "Lançamentos" }),
+   ).toBeVisible();
+}
+
+async function ensureBankAccount(
+   page: Page,
+   session: E2ESession,
+   name: string,
+) {
+   const team = await findTeamByOrgAndSlug(session.orgSlug, session.teamSlug);
+   if (!team) throw new Error("team not found");
+   const existing = await findBankAccountByName(team.id, name);
+   if (existing) {
+      createdAccountIds.push(existing.id);
+      return;
+   }
+   await page.goto(`/${session.orgSlug}/${session.teamSlug}/bank-accounts`);
+   await expect(
+      page.getByRole("heading", { name: "Contas Bancárias" }),
+   ).toBeVisible();
+   await page.getByRole("button", { name: "Nova Conta" }).click();
+   const sheet = page.getByRole("dialog");
+   await sheet.getByLabel("Nome").fill(name);
+   await sheet.getByLabel("Tipo").click();
+   await page.getByRole("option", { name: "Caixa Físico" }).click();
+   await sheet.getByRole("button", { name: "Criar conta" }).click();
+   const created = await findBankAccountByName(team.id, name);
+   if (created) createdAccountIds.push(created.id);
+}
+
+test.afterEach(async ({ e2eSession }) => {
+   const team = await findTeamByOrgAndSlug(
+      e2eSession.orgSlug,
+      e2eSession.teamSlug,
+   );
+   if (!team) return;
+   for (const id of createdCategoryIds.splice(0)) {
+      await deleteCategoryById(team.id, id);
+   }
+   for (const id of createdAccountIds.splice(0)) {
+      await deleteBankAccountById(team.id, id);
+   }
+});
+
+test("category picker exibe hierarquia pai/filho respeitando tipo", async ({
+   page,
+   e2eSession,
+}) => {
+   const team = await findTeamByOrgAndSlug(
+      e2eSession.orgSlug,
+      e2eSession.teamSlug,
+   );
+   if (!team) throw new Error("team not found");
+
+   const suffix = stamp();
+   const expenseParent = await insertCategory(team.id, {
+      name: `Despesa Pai ${suffix}`,
+      type: "expense",
+   });
+   const expenseChild = await insertCategory(team.id, {
+      name: `Despesa Filha ${suffix}`,
+      type: "expense",
+      parentId: expenseParent.id,
+   });
+   const incomeParent = await insertCategory(team.id, {
+      name: `Receita Pai ${suffix}`,
+      type: "income",
+   });
+   createdCategoryIds.push(expenseChild.id, expenseParent.id, incomeParent.id);
+
+   const accountName = `Caixa Hierarquia ${suffix}`;
+   await ensureBankAccount(page, e2eSession, accountName);
+
+   await gotoTransactions(page, e2eSession);
+   await page.getByRole("button", { name: "Novo Lançamento" }).click();
+   const sheet = page.getByRole("dialog");
+
+   // Default = Despesa. Abre picker.
+   await sheet.getByRole("combobox", { name: "Categoria" }).click();
+   const listbox = page.getByRole("listbox");
+
+   // Receita Pai não aparece (tipo errado).
+   await expect(
+      listbox.getByRole("option", { name: incomeParent.name }),
+   ).toHaveCount(0);
+
+   // Despesa Pai visível; filha escondida até expandir.
+   await expect(
+      listbox.getByRole("option", { name: expenseParent.name }),
+   ).toBeVisible();
+   await expect(
+      listbox.getByRole("option", { name: expenseChild.name }),
+   ).toHaveCount(0);
+
+   // Expandir pai revela filha.
+   await listbox
+      .getByRole("option", { name: expenseParent.name })
+      .getByRole("button", { name: "Expandir" })
+      .click();
+   await expect(
+      listbox.getByRole("option", { name: expenseChild.name }),
+   ).toBeVisible();
+
+   // Seleciona filha → label mostra "Pai / Filha".
+   await listbox.getByRole("option", { name: expenseChild.name }).click();
+   await expect(
+      sheet.getByRole("combobox", { name: "Categoria" }),
+   ).toContainText(`${expenseParent.name} / ${expenseChild.name}`);
+
+   // Troca tipo → categoria reseta e lista mostra apenas receita.
+   await sheet.getByLabel("Tipo").click();
+   await page.getByRole("option", { name: "Receita" }).click();
+   await expect(
+      sheet.getByRole("combobox", { name: "Categoria" }),
+   ).toContainText("Selecionar categoria...");
+
+   await sheet.getByRole("combobox", { name: "Categoria" }).click();
+   await expect(
+      listbox.getByRole("option", { name: incomeParent.name }),
+   ).toBeVisible();
+   await expect(
+      listbox.getByRole("option", { name: expenseParent.name }),
+   ).toHaveCount(0);
+});

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-form-sheet.tsx
@@ -4,11 +4,24 @@ import {
    CollapsibleContent,
    CollapsibleTrigger,
 } from "@packages/ui/components/collapsible";
+import {
+   Command,
+   CommandEmpty,
+   CommandGroup,
+   CommandInput,
+   CommandItem,
+   CommandList,
+} from "@packages/ui/components/command";
 import { Combobox } from "@packages/ui/components/combobox";
 import { DatePicker } from "@packages/ui/components/date-picker";
 import { Field, FieldError, FieldLabel } from "@packages/ui/components/field";
 import { Input } from "@packages/ui/components/input";
 import { MoneyInput } from "@packages/ui/components/money-input";
+import {
+   Popover,
+   PopoverContent,
+   PopoverTrigger,
+} from "@packages/ui/components/popover";
 import {
    Select,
    SelectContent,
@@ -27,17 +40,28 @@ import { toast } from "@packages/ui/components/sonner";
 import { Textarea } from "@packages/ui/components/textarea";
 import { UploadDropzone } from "@packages/ui/components/upload-dropzone";
 import { UploadProgress } from "@packages/ui/components/upload-progress";
+import { cn } from "@packages/ui/lib/utils";
 import { useUploadFiles } from "@better-upload/client";
 import imageCompression from "browser-image-compression";
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import dayjs from "dayjs";
-import { ChevronDown, FileText } from "lucide-react";
+import {
+   CheckIcon,
+   ChevronDown,
+   ChevronRight,
+   ChevronsUpDownIcon,
+   FileText,
+} from "lucide-react";
 import { fromPromise } from "neverthrow";
+import * as React from "react";
 import { z } from "zod";
 import { QueryBoundary } from "@/components/query-boundary";
 import { useSheet } from "@/hooks/use-sheet";
 import { orpc } from "@/integrations/orpc/client";
+import type { Outputs } from "@/integrations/orpc/client";
+
+type CategoryNode = Outputs["categories"]["getAll"][number];
 
 const TRANSACTION_TYPES = ["income", "expense", "transfer"] as const;
 type TransactionType = (typeof TRANSACTION_TYPES)[number];
@@ -194,6 +218,193 @@ async function compressIfImage(files: File[]) {
    );
 }
 
+interface CategoryPickerProps {
+   categories: CategoryNode[];
+   value: string;
+   onValueChange: (value: string) => void;
+   onBlur?: React.FocusEventHandler<HTMLButtonElement>;
+   id?: string;
+}
+
+function CategoryPicker({
+   categories,
+   value,
+   onValueChange,
+   onBlur,
+   id,
+}: CategoryPickerProps) {
+   const [open, setOpen] = React.useState(false);
+   const [search, setSearch] = React.useState("");
+   const [expanded, setExpanded] = React.useState<Set<string>>(new Set());
+
+   const { roots, childrenByParent, byId } = React.useMemo(() => {
+      const byId = new Map<string, CategoryNode>();
+      const childrenByParent = new Map<string, CategoryNode[]>();
+      const roots: CategoryNode[] = [];
+      for (const c of categories) byId.set(c.id, c);
+      for (const c of categories) {
+         if (c.parentId) {
+            const list = childrenByParent.get(c.parentId) ?? [];
+            list.push(c);
+            childrenByParent.set(c.parentId, list);
+         } else {
+            roots.push(c);
+         }
+      }
+      return { roots, childrenByParent, byId };
+   }, [categories]);
+
+   const selected = value ? byId.get(value) : undefined;
+   const selectedLabel = selected
+      ? selected.parentId
+         ? `${byId.get(selected.parentId)?.name ?? ""} / ${selected.name}`
+         : selected.name
+      : null;
+
+   const term = search.trim().toLowerCase();
+
+   const visibleRoots = React.useMemo(() => {
+      if (!term) return roots;
+      return roots.filter((r) => {
+         if (r.name.toLowerCase().includes(term)) return true;
+         const kids = childrenByParent.get(r.id) ?? [];
+         return kids.some((k) => k.name.toLowerCase().includes(term));
+      });
+   }, [roots, childrenByParent, term]);
+
+   const isRootExpanded = (rootId: string) =>
+      term ? true : expanded.has(rootId);
+
+   const toggleExpanded = (rootId: string) => {
+      setExpanded((prev) => {
+         const next = new Set(prev);
+         if (next.has(rootId)) next.delete(rootId);
+         else next.add(rootId);
+         return next;
+      });
+   };
+
+   const handleSelect = (id: string) => {
+      onValueChange(id === value ? "" : id);
+      setOpen(false);
+      setSearch("");
+   };
+
+   return (
+      <Popover
+         onOpenChange={(o) => {
+            setOpen(o);
+            if (!o) setSearch("");
+         }}
+         open={open}
+      >
+         <PopoverTrigger asChild>
+            <Button
+               aria-expanded={open}
+               className="flex truncate items-center gap-2"
+               id={id}
+               onBlur={onBlur}
+               role="combobox"
+               variant="outline"
+            >
+               {selectedLabel ?? "Selecionar categoria..."}
+               <ChevronsUpDownIcon className="size-4" />
+            </Button>
+         </PopoverTrigger>
+         <PopoverContent className="p-0">
+            <Command shouldFilter={false}>
+               <CommandInput
+                  onValueChange={setSearch}
+                  placeholder="Buscar categoria..."
+                  value={search}
+               />
+               <CommandList>
+                  {visibleRoots.length === 0 ? (
+                     <CommandEmpty>Nenhuma categoria.</CommandEmpty>
+                  ) : null}
+                  <CommandGroup>
+                     {visibleRoots.map((root) => {
+                        const kids = childrenByParent.get(root.id) ?? [];
+                        const expandedNow = isRootExpanded(root.id);
+                        const visibleKids = term
+                           ? kids.filter(
+                                (k) =>
+                                   k.name.toLowerCase().includes(term) ||
+                                   root.name.toLowerCase().includes(term),
+                             )
+                           : kids;
+                        return (
+                           <React.Fragment key={root.id}>
+                              <CommandItem
+                                 value={root.id}
+                                 onSelect={() => handleSelect(root.id)}
+                                 className="gap-2"
+                              >
+                                 {kids.length > 0 ? (
+                                    <button
+                                       aria-label={
+                                          expandedNow ? "Recolher" : "Expandir"
+                                       }
+                                       className="flex size-4 items-center justify-center rounded hover:bg-accent"
+                                       onClick={(e) => {
+                                          e.stopPropagation();
+                                          toggleExpanded(root.id);
+                                       }}
+                                       type="button"
+                                    >
+                                       <ChevronRight
+                                          className={cn(
+                                             "size-3 transition-transform",
+                                             expandedNow && "rotate-90",
+                                          )}
+                                       />
+                                    </button>
+                                 ) : (
+                                    <span className="size-4" />
+                                 )}
+                                 <CheckIcon
+                                    className={cn(
+                                       "size-4",
+                                       value === root.id
+                                          ? "opacity-100"
+                                          : "opacity-0",
+                                    )}
+                                 />
+                                 <span className="truncate">{root.name}</span>
+                              </CommandItem>
+                              {expandedNow
+                                 ? visibleKids.map((child) => (
+                                      <CommandItem
+                                         key={child.id}
+                                         value={child.id}
+                                         onSelect={() => handleSelect(child.id)}
+                                         className="gap-2 pl-8"
+                                      >
+                                         <CheckIcon
+                                            className={cn(
+                                               "size-4",
+                                               value === child.id
+                                                  ? "opacity-100"
+                                                  : "opacity-0",
+                                            )}
+                                         />
+                                         <span className="truncate">
+                                            {child.name}
+                                         </span>
+                                      </CommandItem>
+                                   ))
+                                 : null}
+                           </React.Fragment>
+                        );
+                     })}
+                  </CommandGroup>
+               </CommandList>
+            </Command>
+         </PopoverContent>
+      </Popover>
+   );
+}
+
 export function TransactionFormSheet() {
    return (
       <QueryBoundary
@@ -342,6 +553,7 @@ function TransactionFormSheetContent() {
                            const parsed = parseTransactionType(v);
                            if (!parsed) return;
                            field.handleChange(parsed);
+                           form.setFieldValue("categoryId", "");
                         }}
                      >
                         <SelectTrigger id={field.name} name={field.name}>
@@ -361,15 +573,13 @@ function TransactionFormSheetContent() {
 
             <form.Subscribe selector={(s) => s.values.type}>
                {(type) => {
-                  const categoryOptions = categoriesResult
-                     .filter((c) =>
-                        type === "transfer"
-                           ? false
-                           : type === "income"
-                             ? c.type === "income"
-                             : c.type === "expense",
-                     )
-                     .map((c) => ({ value: c.id, label: c.name }));
+                  const filteredCategories = categoriesResult.filter((c) =>
+                     type === "transfer"
+                        ? false
+                        : type === "income"
+                          ? c.type === "income"
+                          : c.type === "expense",
+                  );
                   return (
                      <div className="flex flex-col gap-4">
                         <form.Field name="bankAccountId">
@@ -443,12 +653,9 @@ function TransactionFormSheetContent() {
                                     <FieldLabel htmlFor={field.name}>
                                        Categoria
                                     </FieldLabel>
-                                    <Combobox
-                                       emptyMessage="Nenhuma categoria."
+                                    <CategoryPicker
+                                       categories={filteredCategories}
                                        id={field.name}
-                                       options={categoryOptions}
-                                       placeholder="Selecionar categoria..."
-                                       searchPlaceholder="Buscar categoria..."
                                        value={field.state.value}
                                        onBlur={field.handleBlur}
                                        onValueChange={(v) =>


### PR DESCRIPTION
## Summary

- Substitui o Combobox plano da categoria no sheet de novo lançamento por um picker hierárquico (pai → filhos), respeitando o tipo (`income`/`expense`) selecionado.
- Categorias pai aparecem primeiro; chevron expande/recolhe os filhos com indentação. Busca expande a árvore automaticamente.
- Trocar o tipo do lançamento reseta o `categoryId` para evitar seleção inconsistente.

## Test plan

- [ ] `bunx nx run web:typecheck`
- [ ] `bunx nx run web:check`
- [ ] `bunx nx run web-e2e:e2e --testFile=transactions-category-hierarchy.spec.ts`
- [ ] Abrir Novo Lançamento → trocar entre Despesa/Receita/Transferência e verificar lista correta de categorias.
- [ ] Selecionar subcategoria → label mostra `Pai / Filha`.

Linear: MON-947

🤖 Generated with [Claude Code](https://claude.com/claude-code)