### PR TITLE
MON-952: adiciona atalho para lançamentos da conta

### DIFF
--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
@@ -70,8 +70,16 @@ const routeApi = getRouteApi(
 
 export function TransactionsList() {
    const navigate = routeApi.useNavigate();
-   const { page, pageSize, view, overdueOnly, status, search, contactId } =
-      routeApi.useSearch();
+   const {
+      page,
+      pageSize,
+      view,
+      overdueOnly,
+      status,
+      search,
+      contactId,
+      bankId,
+   } = routeApi.useSearch();
 
    const { openAlertDialog } = useAlertDialog();
    const { openSheet } = useSheet();
@@ -94,6 +102,17 @@ export function TransactionsList() {
       (checked: boolean) => {
          navigate({
             search: (prev) => ({ ...prev, overdueOnly: checked, page: 1 }),
+            replace: true,
+         });
+      },
+      [navigate],
+   );
+
+   const handleBankFilterToggle = useCallback(
+      (active: boolean) => {
+         if (active) return;
+         navigate({
+            search: (prev) => ({ ...prev, bankId: "", page: 1 }),
             replace: true,
          });
       },
@@ -130,12 +149,18 @@ export function TransactionsList() {
             page,
             pageSize,
             contactId: contactId || undefined,
+            bankAccountId: bankId || undefined,
          },
       }),
    );
 
    const { data: bankAccounts } = useSuspenseQuery(
       orpc.bankAccounts.getAll.queryOptions({}),
+   );
+
+   const selectedBankAccount = useMemo(
+      () => bankAccounts.find((account) => account.id === bankId),
+      [bankAccounts, bankId],
    );
 
    const { data: contacts } = useSuspenseQuery(
@@ -561,6 +586,16 @@ export function TransactionsList() {
             }}
             storageKey="montte:datatable:transactions"
          >
+            {bankId ? (
+               <DataTableExternalFilter
+                  id="bankId"
+                  label={selectedBankAccount?.name ?? "Conta selecionada"}
+                  group="Conta"
+                  active
+                  renderIcon={() => <Landmark className="size-4" />}
+                  onToggle={handleBankFilterToggle}
+               />
+            ) : null}
             <DataTableExternalFilter
                id="overdueOnly"
                label="Somente vencidos"
@@ -593,7 +628,7 @@ export function TransactionsList() {
                      </EmptyMedia>
                      <EmptyTitle>Nenhum lançamento</EmptyTitle>
                      <EmptyDescription>
-                        {search
+                        {search || bankId
                            ? "Nenhum lançamento encontrado para os filtros aplicados."
                            : "Registre um novo lançamento para começar a controlar suas finanças."}
                      </EmptyDescription>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/bank-accounts.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/bank-accounts.tsx
@@ -34,6 +34,7 @@ import { DataTableSkeleton } from "@/components/data-table/data-table-skeleton";
 import { DataTableToolbar } from "@/components/data-table/data-table-toolbar";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import { useCsvFile } from "@/hooks/use-csv-file";
+import { useDashboardSlugs } from "@/hooks/use-dashboard-slugs";
 import { useSheet } from "@/hooks/use-sheet";
 import { useXlsxFile } from "@/hooks/use-xlsx-file";
 import { orpc } from "@/integrations/orpc/client";
@@ -115,7 +116,7 @@ function BankAccountsSkeleton() {
 
 function BankAccountsList() {
    const navigate = Route.useNavigate();
-   const { slug, teamSlug } = Route.useParams();
+   const { slug, teamSlug } = useDashboardSlugs();
    const { sorting, columnFilters, type, search, page, pageSize } =
       Route.useSearch();
    const { openAlertDialog } = useAlertDialog();

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/bank-accounts.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/bank-accounts.tsx
@@ -7,9 +7,9 @@ import {
    EmptyTitle,
 } from "@packages/ui/components/empty";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import dayjs from "dayjs";
-import { Landmark, Plus, Trash2 } from "lucide-react";
+import { Landmark, Plus, ReceiptText, Trash2 } from "lucide-react";
 import { useCallback, useMemo } from "react";
 import { toast } from "sonner";
 import { z } from "zod";
@@ -115,6 +115,7 @@ function BankAccountsSkeleton() {
 
 function BankAccountsList() {
    const navigate = Route.useNavigate();
+   const { slug, teamSlug } = Route.useParams();
    const { sorting, columnFilters, type, search, page, pageSize } =
       Route.useSearch();
    const { openAlertDialog } = useAlertDialog();
@@ -297,14 +298,42 @@ function BankAccountsList() {
                });
             }}
             renderActions={({ row }) => (
-               <Button
-                  className="text-destructive hover:text-destructive"
-                  onClick={() => handleDelete(row.original)}
-                  tooltip="Excluir"
-                  variant="outline"
-               >
-                  <Trash2 className="size-4" />
-               </Button>
+               <>
+                  <Button
+                     asChild
+                     size="icon"
+                     tooltip="Ver lançamentos"
+                     variant="outline"
+                  >
+                     <Link
+                        params={{ slug, teamSlug }}
+                        search={{
+                           bankId: row.original.id,
+                           contactId: "",
+                           overdueOnly: false,
+                           page: 1,
+                           pageSize: 20,
+                           search: "",
+                           status: [],
+                           view: "all",
+                        }}
+                        to="/$slug/$teamSlug/transactions"
+                     >
+                        <ReceiptText className="size-4" />
+                        <span className="sr-only">Ver lançamentos</span>
+                     </Link>
+                  </Button>
+                  <Button
+                     className="text-destructive hover:text-destructive"
+                     onClick={() => handleDelete(row.original)}
+                     size="icon"
+                     tooltip="Excluir"
+                     variant="outline"
+                  >
+                     <Trash2 className="size-4" />
+                     <span className="sr-only">Excluir</span>
+                  </Button>
+               </>
             )}
          >
             {TYPES.map((key) => (

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/transactions.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/transactions.tsx
@@ -25,6 +25,7 @@ const transactionsSearchSchema = z.object({
       .catch([])
       .default([]),
    contactId: z.string().catch("").default(""),
+   bankId: z.string().catch("").default(""),
 });
 
 export const Route = createFileRoute(
@@ -32,7 +33,16 @@ export const Route = createFileRoute(
 )({
    validateSearch: transactionsSearchSchema,
    loaderDeps: ({
-      search: { page, pageSize, view, overdueOnly, status, search, contactId },
+      search: {
+         page,
+         pageSize,
+         view,
+         overdueOnly,
+         status,
+         search,
+         contactId,
+         bankId,
+      },
    }) => ({
       page,
       pageSize,
@@ -41,6 +51,7 @@ export const Route = createFileRoute(
       status,
       search,
       contactId,
+      bankId,
    }),
    loader: ({ context, deps }) => {
       context.queryClient.prefetchQuery(
@@ -65,6 +76,7 @@ export const Route = createFileRoute(
                status: deps.status.length > 0 ? deps.status : undefined,
                search: deps.search || undefined,
                contactId: deps.contactId || undefined,
+               bankAccountId: deps.bankId || undefined,
             },
          }),
       );


### PR DESCRIPTION
## Resumo
- adiciona ação de ver lançamentos na listagem de contas bancárias
- navega para lançamentos usando bankId na URL
- aplica bankId como filtro de conta bancária e exibe filtro ativo na tabela

## Validação
- bun run nx run web:typecheck
- bun run nx run web:check