### PR TITLE
MON-958: revisar importações e criar modelos por entidade

### DIFF
--- a/apps/web-e2e/tests/import-templates.spec.ts
+++ b/apps/web-e2e/tests/import-templates.spec.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs";
+import type { Page } from "@playwright/test";
+import { expect, test, type E2ESession } from "../fixtures";
+
+type TemplateCase = {
+   path: string;
+   heading: string;
+   filename: string;
+   headers: string[];
+};
+
+const cases: TemplateCase[] = [
+   {
+      path: "categories",
+      heading: "Categorias",
+      filename: "modelo-categorias.csv",
+      headers: ["name", "type"],
+   },
+   {
+      path: "transactions",
+      heading: "Lançamentos",
+      filename: "modelo-lancamentos.csv",
+      headers: [
+         "date",
+         "name",
+         "type",
+         "amount",
+         "status",
+         "dueDate",
+         "bankAccountName",
+         "creditCardName",
+         "categoryName",
+         "contactName",
+      ],
+   },
+   {
+      path: "bank-accounts",
+      heading: "Contas Bancárias",
+      filename: "modelo-contas-bancarias.csv",
+      headers: ["name", "type", "initialBalance"],
+   },
+   {
+      path: "credit-cards",
+      heading: "Cartões de Crédito",
+      filename: "modelo-cartoes-credito.csv",
+      headers: [
+         "name",
+         "brand",
+         "last4",
+         "creditLimit",
+         "closingDay",
+         "dueDay",
+         "bankAccountId",
+         "status",
+      ],
+   },
+];
+
+async function gotoImportFlow(
+   page: Page,
+   session: E2ESession,
+   item: TemplateCase,
+) {
+   await page.goto(`/${session.orgSlug}/${session.teamSlug}/${item.path}`);
+   await expect(
+      page.getByRole("heading", { name: item.heading }),
+   ).toBeVisible();
+}
+
+test("MON-958: disponibiliza modelos CSV nos fluxos de importação", async ({
+   page,
+   e2eSession,
+}) => {
+   for (const item of cases) {
+      await gotoImportFlow(page, e2eSession, item);
+      await page.getByRole("button", { name: "Importar dados" }).click();
+
+      const downloadPromise = page.waitForEvent("download");
+      await page.getByRole("button", { name: "Baixar modelo CSV" }).click();
+      const download = await downloadPromise;
+
+      expect(download.suggestedFilename()).toBe(item.filename);
+      const filePath = await download.path();
+      expect(filePath).toBeTruthy();
+      const content = fs.readFileSync(filePath ?? "", "utf8");
+      const headerLine = content.split(/\r?\n/)[0] ?? "";
+      for (const header of item.headers) {
+         expect(headerLine).toContain(header);
+      }
+   }
+});

--- a/apps/web-e2e/tests/transactions-import-ofx.spec.ts
+++ b/apps/web-e2e/tests/transactions-import-ofx.spec.ts
@@ -43,6 +43,16 @@ OLDFILEUID:NONE
 NEWFILEUID:NONE
 
 <OFX>
+<SIGNONMSGSRSV1>
+<SONRS>
+<STATUS>
+<CODE>0
+<SEVERITY>INFO
+</STATUS>
+<DTSERVER>20260131120000
+<LANGUAGE>POR
+</SONRS>
+</SIGNONMSGSRSV1>
 <BANKMSGSRSV1>
 <STMTTRNRS>
 <TRNUID>1
@@ -173,14 +183,23 @@ test("MON-888: importa OFX selecionando conta em bulk salva lançamentos com toa
       });
 
    await expect(page.getByText("Importando")).toBeVisible();
-   await expect(page.getByRole("cell", { name: txA })).toBeVisible();
-   await expect(page.getByRole("cell", { name: txB })).toBeVisible();
+   await expect(page.getByRole("row").filter({ hasText: txA })).toBeVisible();
+   await expect(page.getByRole("row").filter({ hasText: txB })).toBeVisible();
 
-   await page.getByLabel("Selecionar todos").first().check();
+   await page
+      .getByRole("row")
+      .filter({ hasText: txA })
+      .getByLabel("Selecionar linha")
+      .click();
+   await page
+      .getByRole("row")
+      .filter({ hasText: txB })
+      .getByLabel("Selecionar linha")
+      .click();
    await page.getByRole("button", { name: "Definir conta" }).click();
    await page.getByRole("option", { name: accountName }).click();
 
-   await page.getByRole("button", { name: "Salvar importação" }).click();
+   await page.getByRole("button", { name: /Salvar 2 linha/ }).click();
    await page.getByRole("button", { name: "Salvar" }).click();
 
    await expect(
@@ -188,8 +207,8 @@ test("MON-888: importa OFX selecionando conta em bulk salva lançamentos com toa
    ).toBeVisible();
    await expect(page.getByText(/com erro/)).toHaveCount(0);
 
-   await expect(page.getByRole("cell", { name: txA })).toBeVisible();
-   await expect(page.getByRole("cell", { name: txB })).toBeVisible();
+   await expect(page.getByRole("row").filter({ hasText: txA })).toBeVisible();
+   await expect(page.getByRole("row").filter({ hasText: txB })).toBeVisible();
 
    await rememberTx(e2eSession, txA);
    await rememberTx(e2eSession, txB);
@@ -224,12 +243,16 @@ test("MON-888: importa OFX sem conta exibe erro e não dispara toast de sucesso"
          buffer: Buffer.from(ofx, "utf8"),
       });
 
-   await expect(page.getByRole("cell", { name: txA })).toBeVisible();
+   await expect(page.getByRole("row").filter({ hasText: txA })).toBeVisible();
 
-   await page.getByRole("button", { name: "Salvar importação" }).click();
+   await page.getByRole("button", { name: /Salvar 1 linha/ }).click();
    await page.getByRole("button", { name: "Salvar" }).click();
 
-   await expect(page.getByText(/com erro/)).toBeVisible();
+   await expect(
+      page.getByText(
+         "Nenhum lançamento válido para importar. Preencha data, valor e conta ou cartão.",
+      ),
+   ).toBeVisible();
    await expect(
       page.getByText(/linha\(s\) importada\(s\) com sucesso/),
    ).toHaveCount(0);

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-cards-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-cards-columns.tsx
@@ -223,7 +223,6 @@ export function buildCreditCardColumns(options?: {
          meta: {
             label: "Conta Bancária",
             cellComponent: "combobox" as const,
-            importIgnore: true,
             editOptions: options?.bankAccounts?.map((a) => ({
                value: a.id,
                label: a.name,

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
@@ -68,6 +68,84 @@ const routeApi = getRouteApi(
    "/_authenticated/$slug/$teamSlug/_dashboard/transactions",
 );
 
+type ImportLookupItem = { id: string; name: string };
+
+function normalizeImportLookup(value: unknown): string {
+   return String(value ?? "")
+      .trim()
+      .toLowerCase()
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "");
+}
+
+function resolveImportId(
+   options: ImportLookupItem[],
+   value: unknown,
+): string | null {
+   const normalized = normalizeImportLookup(value);
+   if (!normalized) return null;
+   const option = options.find(
+      (item) =>
+         normalizeImportLookup(item.id) === normalized ||
+         normalizeImportLookup(item.name) === normalized,
+   );
+   return option?.id ?? null;
+}
+
+function parseImportDate(value: unknown): string {
+   const raw = String(value ?? "").trim();
+   const match = raw.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+   if (!match) return raw;
+   return `${match[3]}-${match[2].padStart(2, "0")}-${match[1].padStart(2, "0")}`;
+}
+
+function parseImportAmount(value: unknown) {
+   const cleaned = String(value ?? "")
+      .replace(/[R$\s]/g, "")
+      .trim();
+   const raw = cleaned.includes(",")
+      ? cleaned.replace(/\./g, "").replace(",", ".")
+      : cleaned;
+   const parsed = Number.parseFloat(raw);
+   if (Number.isNaN(parsed)) return { amount: "", signedAmount: 0 };
+   return { amount: Math.abs(parsed).toFixed(2), signedAmount: parsed };
+}
+
+function parseImportType(
+   value: unknown,
+   signedAmount: number,
+): "income" | "expense" {
+   const normalized = normalizeImportLookup(value);
+   if (
+      normalized === "income" ||
+      normalized.includes("cred") ||
+      normalized.includes("entrada") ||
+      normalized.includes("receita")
+   ) {
+      return "income";
+   }
+   if (
+      normalized === "expense" ||
+      normalized.includes("deb") ||
+      normalized.includes("saida") ||
+      normalized.includes("despesa")
+   ) {
+      return "expense";
+   }
+   return signedAmount < 0 ? "expense" : "income";
+}
+
+function parseImportStatus(value: unknown): "pending" | "paid" | "cancelled" {
+   const normalized = normalizeImportLookup(value);
+   if (normalized === "paid" || normalized.includes("efetivado")) {
+      return "paid";
+   }
+   if (normalized === "cancelled" || normalized.includes("cancelado")) {
+      return "cancelled";
+   }
+   return "pending";
+}
+
 export function TransactionsList() {
    const navigate = routeApi.useNavigate();
    const {
@@ -84,7 +162,7 @@ export function TransactionsList() {
    const { openAlertDialog } = useAlertDialog();
    const { openSheet } = useSheet();
    const queryClient = useQueryClient();
-   const { parse: parseCsv } = useCsvFile();
+   const { parse: parseCsv, generate: generateCsv } = useCsvFile();
    const { parse: parseXlsx } = useXlsxFile();
    const { parse: parseOfx } = useOfxFile();
 
@@ -180,7 +258,7 @@ export function TransactionsList() {
    const totalPages = Math.max(1, Math.ceil(total / pageSize));
 
    const importMutation = useMutation(
-      orpc.transactions.create.mutationOptions({
+      orpc.transactions.importBulk.mutationOptions({
          meta: { skipGlobalInvalidation: true },
       }),
    );
@@ -371,121 +449,143 @@ export function TransactionsList() {
             return parseCsv(file);
          },
          mapRow: (row, i) => {
-            const rawDate = String(row.date ?? "").trim();
-            const rawAmount = String(row.amount ?? "").trim();
-            const rawType = String(row.type ?? "").trim();
-
-            const dateMatch = rawDate.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
-            const date = dateMatch
-               ? `${dateMatch[3]}-${dateMatch[2].padStart(2, "0")}-${dateMatch[1].padStart(2, "0")}`
-               : rawDate;
-
-            const amountNum = parseFloat(
-               rawAmount.replace(/[R$\s.]/g, "").replace(",", "."),
-            );
-            const amount = Number.isNaN(amountNum)
-               ? ""
-               : Math.abs(amountNum).toString();
-
-            const lower = rawType.toLowerCase();
-            let type: "income" | "expense" = "expense";
-            if (
-               lower.includes("créd") ||
-               lower.includes("cred") ||
-               lower === "c" ||
-               lower.includes("entrada") ||
-               lower.includes("receita")
-            ) {
-               type = "income";
-            } else if (
-               !(
-                  lower.includes("déb") ||
-                  lower.includes("deb") ||
-                  lower === "d" ||
-                  lower.includes("saíd") ||
-                  lower.includes("said") ||
-                  lower.includes("despesa")
-               )
-            ) {
-               type = amountNum < 0 ? "expense" : "income";
-            }
+            const parsedAmount = parseImportAmount(row.amount);
+            const type = parseImportType(row.type, parsedAmount.signedAmount);
 
             return {
                id: `__import_${i}`,
-               date,
-               amount,
+               date: parseImportDate(row.date),
+               amount: parsedAmount.amount,
                type,
                name: String(row.name ?? "").trim() || null,
-               status: "pending",
-               dueDate: null,
-               bankAccountName: null,
-               bankAccountId: null,
-               contactName: null,
-               categoryName: null,
-               creditCardName: null,
+               status: parseImportStatus(row.status),
+               dueDate: row.dueDate ? parseImportDate(row.dueDate) : null,
+               bankAccountName: String(row.bankAccountName ?? "").trim(),
+               bankAccountId: resolveImportId(
+                  bankAccounts,
+                  row.bankAccountName,
+               ),
+               contactName: String(row.contactName ?? "").trim(),
+               contactId: resolveImportId(contacts, row.contactName),
+               categoryName: String(row.categoryName ?? "").trim(),
+               categoryId: resolveImportId(categoriesResult, row.categoryName),
+               creditCardName: String(row.creditCardName ?? "").trim(),
+               creditCardId: resolveImportId(
+                  creditCardsResult.data,
+                  row.creditCardName,
+               ),
                suggestedCategoryId: null,
                suggestedCategoryName: null,
             };
          },
+         template: {
+            filename: "modelo-lancamentos.csv",
+            label: "Baixar modelo CSV",
+            description:
+               "Inclui date, name, type, amount, status e referências por nome ou ID.",
+            createBlob: () =>
+               generateCsv(
+                  [
+                     {
+                        date: dayjs().format("YYYY-MM-DD"),
+                        name: "Venda recebida",
+                        type: "income",
+                        amount: "1500.00",
+                        status: "paid",
+                        dueDate: "",
+                        bankAccountName: bankAccounts[0]?.name ?? "",
+                        creditCardName: "",
+                        categoryName: categoriesResult[0]?.name ?? "",
+                        contactName: contacts[0]?.name ?? "",
+                     },
+                     {
+                        date: dayjs().format("YYYY-MM-DD"),
+                        name: "Compra no cartão",
+                        type: "expense",
+                        amount: "250.00",
+                        status: "pending",
+                        dueDate: dayjs().add(7, "day").format("YYYY-MM-DD"),
+                        bankAccountName: "",
+                        creditCardName: creditCardsResult.data[0]?.name ?? "",
+                        categoryName: categoriesResult[0]?.name ?? "",
+                        contactName: contacts[0]?.name ?? "",
+                     },
+                  ],
+                  [
+                     "date",
+                     "name",
+                     "type",
+                     "amount",
+                     "status",
+                     "dueDate",
+                     "bankAccountName",
+                     "creditCardName",
+                     "categoryName",
+                     "contactName",
+                  ],
+               ),
+         },
          onImport: async (rows) => {
-            const results = await Promise.allSettled(
-               rows.map((r) => {
-                  const date = String(r.date ?? "");
-                  const amount = String(r.amount ?? "");
-                  if (!date || !amount)
-                     return Promise.reject(new Error("skip"));
-                  const bankAccountId = r.bankAccountId
-                     ? String(r.bankAccountId)
-                     : r.bankAccountName
-                       ? String(r.bankAccountName)
-                       : null;
-                  const creditCardId = r.creditCardId
-                     ? String(r.creditCardId)
-                     : r.creditCardName
-                       ? String(r.creditCardName)
-                       : null;
-                  if (!bankAccountId && !creditCardId)
-                     return Promise.reject(
-                        new Error("Selecione conta ou cartão."),
-                     );
-                  return importMutation.mutateAsync({
-                     type: (r.type as "income" | "expense") ?? "expense",
+            const transactions = rows.flatMap((r) => {
+               const date = String(r.date ?? "");
+               const amount = String(r.amount ?? "");
+               if (!date || !amount) return [];
+               const bankAccountId =
+                  resolveImportId(bankAccounts, r.bankAccountId) ??
+                  resolveImportId(bankAccounts, r.bankAccountName);
+               const creditCardId =
+                  resolveImportId(creditCardsResult.data, r.creditCardId) ??
+                  resolveImportId(creditCardsResult.data, r.creditCardName);
+               if (!bankAccountId && !creditCardId) return [];
+               return [
+                  {
+                     type: parseImportType(r.type, 1),
                      amount,
                      date,
                      name: r.name ? String(r.name) : null,
                      bankAccountId,
                      destinationBankAccountId: null,
-                     categoryId: null,
+                     categoryId:
+                        resolveImportId(categoriesResult, r.categoryId) ??
+                        resolveImportId(categoriesResult, r.categoryName),
                      attachments: [],
                      description: null,
-                     contactId: null,
+                     contactId:
+                        resolveImportId(contacts, r.contactId) ??
+                        resolveImportId(contacts, r.contactName),
                      creditCardId,
                      paymentMethod: null,
-                     status: "pending",
-                     dueDate: null,
-                     autoCategorize: true,
-                  });
-               }),
-            );
-            const ok = results.filter((r) => r.status === "fulfilled").length;
-            const failed = results.filter(
-               (r) =>
-                  r.status === "rejected" &&
-                  (r.reason as Error)?.message !== "skip",
-            ).length;
+                     status: parseImportStatus(r.status),
+                     dueDate: r.dueDate ? String(r.dueDate) : null,
+                  },
+               ];
+            });
+            if (transactions.length === 0) {
+               throw new Error(
+                  "Nenhum lançamento válido para importar. Preencha data, valor e conta ou cartão.",
+               );
+            }
+            await importMutation.mutateAsync({
+               transactions,
+               autoCategorize: true,
+            });
             await queryClient.invalidateQueries({
                queryKey: orpc.transactions.getAll.queryKey(),
             });
-            if (failed > 0) {
-               throw new Error(
-                  ok > 0
-                     ? `${ok} importado(s), ${failed} com erro.`
-                     : `${failed} lançamento(s) com erro. Defina conta bancária ou cartão.`,
-               );
-            }
          },
       }),
-      [parseCsv, parseXlsx, parseOfx, importMutation, queryClient],
+      [
+         parseCsv,
+         parseXlsx,
+         parseOfx,
+         generateCsv,
+         bankAccounts,
+         categoriesResult,
+         contacts,
+         creditCardsResult.data,
+         importMutation,
+         queryClient,
+      ],
    );
 
    const columns = useMemo(

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards.tsx
@@ -55,6 +55,69 @@ const creditCardsSearchSchema = z.object({
 
 const skeletonColumns = buildCreditCardColumns();
 
+type CreditCardBrand =
+   | "visa"
+   | "mastercard"
+   | "elo"
+   | "amex"
+   | "hipercard"
+   | "other";
+
+type CreditCardStatus = "active" | "blocked" | "cancelled";
+
+function normalizeImportLookup(value: unknown): string {
+   return String(value ?? "")
+      .trim()
+      .toLowerCase()
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "");
+}
+
+function resolveBankAccountId(
+   bankAccounts: Array<{ id: string; name: string }>,
+   value: unknown,
+): string | null {
+   const normalized = normalizeImportLookup(value);
+   if (!normalized) return null;
+   const bankAccount = bankAccounts.find(
+      (item) =>
+         normalizeImportLookup(item.id) === normalized ||
+         normalizeImportLookup(item.name) === normalized,
+   );
+   return bankAccount?.id ?? null;
+}
+
+function parseCreditCardBrand(value: unknown): CreditCardBrand | undefined {
+   const normalized = normalizeImportLookup(value);
+   if (normalized === "visa") return "visa";
+   if (normalized === "mastercard") return "mastercard";
+   if (normalized === "elo") return "elo";
+   if (normalized === "amex") return "amex";
+   if (normalized === "hipercard") return "hipercard";
+   if (normalized === "other") return "other";
+   return undefined;
+}
+
+function parseCreditCardStatus(value: unknown): CreditCardStatus {
+   const normalized = normalizeImportLookup(value);
+   if (normalized === "blocked") return "blocked";
+   if (normalized === "cancelled") return "cancelled";
+   return "active";
+}
+
+function parseImportDay(value: unknown, fallback: number): number {
+   const parsed = Number.parseInt(String(value ?? ""), 10);
+   if (Number.isNaN(parsed) || parsed < 1 || parsed > 31) return fallback;
+   return parsed;
+}
+
+function normalizeLast4(value: unknown): string | null {
+   const digits = String(value ?? "")
+      .replace(/\D/g, "")
+      .slice(0, 4);
+   return digits.length === 4 ? digits : null;
+}
+
 export const Route = createFileRoute(
    "/_authenticated/$slug/$teamSlug/_dashboard/credit-cards",
 )({
@@ -98,7 +161,7 @@ function CreditCardsList() {
    const { openAlertDialog } = useAlertDialog();
    const { openSheet } = useSheet();
    const { publicEnv } = Route.useRouteContext();
-   const { parse: parseCsv } = useCsvFile();
+   const { parse: parseCsv, generate: generateCsv } = useCsvFile();
    const { parse: parseXlsx } = useXlsxFile();
 
    const [{ data: result }, { data: bankAccounts }] = useSuspenseQueries({
@@ -160,19 +223,49 @@ function CreditCardsList() {
          mapRow: (row, i): Record<string, unknown> => ({
             id: `__import_${i}`,
             name: String(row.name ?? "").trim(),
-            brand: String(row.brand ?? "") || null,
-            last4: String(row.last4 ?? row.final ?? "")
-               .replace(/\D/g, "")
-               .slice(0, 4),
+            brand: parseCreditCardBrand(row.brand),
+            last4: normalizeLast4(row.last4 ?? row.final),
             color: "#6366f1",
             creditLimit: String(row.creditLimit ?? row.limite ?? "0"),
-            closingDay:
-               parseInt(String(row.closingDay ?? row.fechamento ?? "1"), 10) ||
-               1,
-            dueDay:
-               parseInt(String(row.dueDay ?? row.vencimento ?? "1"), 10) || 1,
-            status: "active",
+            closingDay: parseImportDay(row.closingDay ?? row.fechamento, 1),
+            dueDay: parseImportDay(row.dueDay ?? row.vencimento, 1),
+            bankAccountId: resolveBankAccountId(
+               bankAccounts ?? [],
+               row.bankAccountId,
+            ),
+            status: parseCreditCardStatus(row.status),
          }),
+         template: {
+            filename: "modelo-cartoes-credito.csv",
+            label: "Baixar modelo CSV",
+            description:
+               "Inclui name, brand, last4, creditLimit, closingDay, dueDay, bankAccountId e status.",
+            createBlob: () =>
+               generateCsv(
+                  [
+                     {
+                        name: "Cartão Principal",
+                        brand: "visa",
+                        last4: "1234",
+                        creditLimit: "5000.00",
+                        closingDay: "10",
+                        dueDay: "20",
+                        bankAccountId: bankAccounts?.[0]?.name ?? "",
+                        status: "active",
+                     },
+                  ],
+                  [
+                     "name",
+                     "brand",
+                     "last4",
+                     "creditLimit",
+                     "closingDay",
+                     "dueDay",
+                     "bankAccountId",
+                     "status",
+                  ],
+               ),
+         },
          onImport: async (rows) => {
             const firstBankAccountId = bankAccounts?.[0]?.id;
             if (!firstBankAccountId) {
@@ -187,15 +280,21 @@ function CreditCardsList() {
                   closingDay:
                      typeof r.closingDay === "number" ? r.closingDay : 1,
                   dueDay: typeof r.dueDay === "number" ? r.dueDay : 1,
-                  bankAccountId: firstBankAccountId,
+                  bankAccountId:
+                     resolveBankAccountId(
+                        bankAccounts ?? [],
+                        r.bankAccountId,
+                     ) ?? firstBankAccountId,
                   color: "#6366f1",
                   creditLimit: String(r.creditLimit ?? "0"),
-                  last4: String(r.last4 ?? "") || null,
+                  last4: normalizeLast4(r.last4),
+                  brand: parseCreditCardBrand(r.brand),
+                  status: parseCreditCardStatus(r.status),
                })),
             });
          },
       }),
-      [bulkCreateMutation, parseCsv, parseXlsx, bankAccounts],
+      [bulkCreateMutation, generateCsv, parseCsv, parseXlsx, bankAccounts],
    );
 
    const handleDelete = useCallback(


### PR DESCRIPTION
## Resumo
- adiciona modelo CSV nos fluxos de categorias, lançamentos, contas bancárias e cartões de crédito
- revisa importação de lançamentos para usar importação em bulk e resolver referências por nome/ID
- revisa importação de cartões para normalizar bandeira, status, final, dias e conta bancária
- adiciona cobertura E2E para download dos modelos e ajusta o teste OFX para o fluxo atual

## Testes
- bun nx run web:typecheck --skipSync
- bun nx run web:check --skipSync
- E2E_BASE_URL=http://localhost:3007 bunx playwright test -c apps/web-e2e/playwright.config.ts apps/web-e2e/tests/import-templates.spec.ts apps/web-e2e/tests/transactions-import-ofx.spec.ts