### PR TITLE
MON-951: adicionar opção de arquivar categorias

### DIFF
--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/categories.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/categories.tsx
@@ -377,11 +377,9 @@ function CategoriesList() {
                   );
                }
 
-               const isSub = row.original.parentId !== null;
-
                return (
                   <>
-                     {!isSub && (
+                     {row.original.parentId === null && (
                         <Button
                            disabled={regenerateKeywordsMutation.isPending}
                            onClick={() =>
@@ -395,7 +393,7 @@ function CategoriesList() {
                            <RefreshCw />
                         </Button>
                      )}
-                     {!isDefault && !isSub && (
+                     {!isDefault && (
                         <Button
                            onClick={() => handleArchive(row.original)}
                            tooltip="Arquivar"

--- a/modules/classification/__tests__/router/categories.test.ts
+++ b/modules/classification/__tests__/router/categories.test.ts
@@ -553,6 +553,65 @@ describe("categories router", () => {
       expect(result.map((r) => r.name).sort()).toEqual(["A1", "A2"]);
    });
 
+   it("getAll hides archived categories and subcategories by default", async () => {
+      const { teamId } = await seedTeam(testDb.db);
+      const active = await makeCategory(testDb.db, teamId, {
+         name: "Ativa",
+      });
+      await makeCategory(testDb.db, teamId, {
+         name: "Sub ativa",
+         parentId: active.id,
+         level: 2,
+      });
+      await makeCategory(testDb.db, teamId, {
+         name: "Arquivada",
+         isArchived: true,
+      });
+      await makeCategory(testDb.db, teamId, {
+         name: "Sub arquivada",
+         parentId: active.id,
+         level: 2,
+         isArchived: true,
+      });
+
+      const ctx = createTestContext(testDb.db, { teamId });
+      const result = await call(categoriesRouter.getAll, undefined, {
+         context: ctx,
+      });
+
+      expect(result.map((r) => r.name).sort()).toEqual(["Ativa", "Sub ativa"]);
+   });
+
+   it("getAll includes archived categories and subcategories when requested", async () => {
+      const { teamId } = await seedTeam(testDb.db);
+      const active = await makeCategory(testDb.db, teamId, {
+         name: "Ativa include",
+      });
+      await makeCategory(testDb.db, teamId, {
+         name: "Sub arquivada include",
+         parentId: active.id,
+         level: 2,
+         isArchived: true,
+      });
+      await makeCategory(testDb.db, teamId, {
+         name: "Arquivada include",
+         isArchived: true,
+      });
+
+      const ctx = createTestContext(testDb.db, { teamId });
+      const result = await call(
+         categoriesRouter.getAll,
+         { includeArchived: true },
+         { context: ctx },
+      );
+
+      expect(result.map((r) => r.name).sort()).toEqual([
+         "Arquivada include",
+         "Ativa include",
+         "Sub arquivada include",
+      ]);
+   });
+
    it("exportAll returns all team categories including archived", async () => {
       const { teamId } = await seedTeam(testDb.db);
       await makeCategory(testDb.db, teamId, { name: "Active" });

--- a/modules/finance/__tests__/router/middlewares.test.ts
+++ b/modules/finance/__tests__/router/middlewares.test.ts
@@ -1,0 +1,33 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { setupTestDb } from "@core/database/testing/setup-test-db";
+import { seedTeam } from "@core/database/testing/factories";
+import { requireValidFinancialReferences } from "../../src/router/middlewares";
+import { makeCategory } from "../../../classification/__tests__/helpers/classification-factories";
+
+let testDb: Awaited<ReturnType<typeof setupTestDb>>;
+
+beforeAll(async () => {
+   testDb = await setupTestDb();
+}, 30_000);
+
+afterAll(async () => {
+   await testDb.cleanup();
+});
+
+describe("finance router middlewares", () => {
+   it("rejects archived categories in financial references", async () => {
+      const { teamId } = await seedTeam(testDb.db);
+      const category = await makeCategory(testDb.db, teamId, {
+         isArchived: true,
+      });
+
+      await expect(
+         requireValidFinancialReferences(testDb.db, teamId, {
+            categoryId: category.id,
+         }),
+      ).rejects.toMatchObject({
+         code: "BAD_REQUEST",
+         message: "Categoria arquivada.",
+      });
+   });
+});

--- a/modules/finance/src/router/middlewares.ts
+++ b/modules/finance/src/router/middlewares.ts
@@ -155,6 +155,9 @@ export async function requireValidFinancialReferences(
       if (!cat || cat.teamId !== teamId) {
          throw WebAppError.badRequest("Categoria inválida.");
       }
+      if (cat.isArchived) {
+         throw WebAppError.badRequest("Categoria arquivada.");
+      }
    }
 
    if (refs.tagId) {


### PR DESCRIPTION
## Resumo
- permite arquivar subcategorias diretamente na lista de categorias
- mantém categorias e subcategorias arquivadas fora de getAll por padrão
- bloqueia o uso de categoria arquivada em referências financeiras enviadas para lançamentos

## Testes
- BUN_TMPDIR=/tmp bun --filter @modules/classification test __tests__/router/categories.test.ts
- BUN_TMPDIR=/tmp bun --filter @modules/finance test __tests__/router/middlewares.test.ts