### PR TITLE
MON-963: Implementar lançamentos ignorados

### DIFF
--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-form-sheet.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@packages/ui/components/button";
+import { Checkbox } from "@packages/ui/components/checkbox";
 import {
    Collapsible,
    CollapsibleContent,
@@ -79,7 +80,7 @@ const TYPE_OPTIONS: { value: TransactionType; label: string }[] = [
 const STATUS_OPTIONS = [
    { value: "paid" as const, label: "Efetivado" },
    { value: "pending" as const, label: "Pendente" },
-   { value: "cancelled" as const, label: "Cancelado" },
+   { value: "cancelled" as const, label: "Ignorado" },
 ];
 
 const ATTACHMENT_MAX_FILES = 5;
@@ -111,6 +112,7 @@ const formSchema = z
          .positive("Valor deve ser maior que zero."),
       date: z.string().min(1, "Data é obrigatória."),
       status: z.enum(["pending", "paid", "cancelled"]),
+      ignored: z.boolean(),
       dueDate: z.string(),
       bankAccountId: z.string(),
       destinationBankAccountId: z.string(),
@@ -189,6 +191,7 @@ const DEFAULT_VALUES: FormValues = {
    amount: 0,
    date: dayjs().format("YYYY-MM-DD"),
    status: "paid",
+   ignored: false,
    dueDate: "",
    bankAccountId: "",
    destinationBankAccountId: "",
@@ -463,6 +466,7 @@ function TransactionFormSheetContent() {
                amount: String(value.amount),
                date: value.date,
                status: value.status,
+               ignored: value.ignored,
                dueDate: value.dueDate || null,
                bankAccountId: value.bankAccountId || null,
                destinationBankAccountId:
@@ -825,6 +829,26 @@ function TransactionFormSheetContent() {
                                  ))}
                               </SelectContent>
                            </Select>
+                        </Field>
+                     )}
+                  </form.Field>
+
+                  <form.Field name="ignored">
+                     {(field) => (
+                        <Field className="flex flex-row items-center gap-2 rounded-md border p-4">
+                           <Checkbox
+                              aria-invalid={isFieldInvalid(field)}
+                              checked={field.state.value}
+                              id={field.name}
+                              name={field.name}
+                              onBlur={field.handleBlur}
+                              onCheckedChange={(checked) =>
+                                 field.handleChange(checked === true)
+                              }
+                           />
+                           <FieldLabel htmlFor={field.name}>
+                              Ignorar lançamento
+                           </FieldLabel>
                         </Field>
                      )}
                   </form.Field>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-form-sheet.tsx
@@ -77,17 +77,18 @@ const TYPE_OPTIONS: { value: TransactionType; label: string }[] = [
    { value: "transfer", label: "Transferência" },
 ];
 
-const STATUS_OPTIONS = [
-   { value: "paid" as const, label: "Efetivado" },
-   { value: "pending" as const, label: "Pendente" },
-   { value: "cancelled" as const, label: "Ignorado" },
+type TransactionStatus = "paid" | "pending" | "cancelled";
+type StatusOption = { value: TransactionStatus; label: string };
+
+const STATUS_OPTIONS: StatusOption[] = [
+   { value: "paid", label: "Efetivado" },
+   { value: "pending", label: "Pendente" },
+   { value: "cancelled", label: "Ignorado" },
 ];
 
 const ATTACHMENT_MAX_FILES = 5;
 
-function parseStatus(
-   value: string,
-): "pending" | "paid" | "cancelled" | undefined {
+function parseStatus(value: string): TransactionStatus | undefined {
    return STATUS_OPTIONS.find((s) => s.value === value)?.value;
 }
 

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-columns.tsx
@@ -89,7 +89,16 @@ function SuggestedCategoryCell({
    );
 }
 
-function StatusBadge({ status }: { status: "pending" | "paid" | "cancelled" }) {
+function StatusBadge({
+   ignored,
+   status,
+}: {
+   ignored: boolean;
+   status: "pending" | "paid" | "cancelled";
+}) {
+   if (ignored) {
+      return <Badge variant="secondary">Ignorado</Badge>;
+   }
    if (status === "pending") {
       return (
          <Badge
@@ -101,7 +110,7 @@ function StatusBadge({ status }: { status: "pending" | "paid" | "cancelled" }) {
       );
    }
    if (status === "cancelled") {
-      return <Badge variant="secondary">Cancelado</Badge>;
+      return <Badge variant="secondary">Ignorado</Badge>;
    }
    return (
       <Badge
@@ -138,13 +147,18 @@ export function buildTransactionColumns(options?: {
             editOptions: [
                { value: "pending", label: "Pendente" },
                { value: "paid", label: "Efetivado" },
-               { value: "cancelled", label: "Cancelado" },
+               { value: "cancelled", label: "Ignorado" },
             ],
             onSave: async (rowId, value) => {
                await options?.onUpdate?.(rowId, { status: value });
             },
          },
-         cell: ({ row }) => <StatusBadge status={row.original.status} />,
+         cell: ({ row }) => (
+            <StatusBadge
+               ignored={row.original.ignored}
+               status={row.original.status}
+            />
+         ),
       },
       {
          accessorKey: "date",

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-columns.tsx
@@ -150,7 +150,10 @@ export function buildTransactionColumns(options?: {
                { value: "cancelled", label: "Ignorado" },
             ],
             onSave: async (rowId, value) => {
-               await options?.onUpdate?.(rowId, { status: value });
+               await options?.onUpdate?.(rowId, {
+                  ignored: value === "cancelled",
+                  status: value,
+               });
             },
          },
          cell: ({ row }) => (

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
@@ -218,9 +218,9 @@ export function TransactionsList() {
 
    const cancelMutation = useMutation(
       orpc.transactions.cancel.mutationOptions({
-         onSuccess: () => toast.success("Lançamento cancelado."),
+         onSuccess: () => toast.success("Lançamento ignorado."),
          onError: (error) =>
-            toast.error(error.message || "Erro ao cancelar lançamento."),
+            toast.error(error.message || "Erro ao ignorar lançamento."),
       }),
    );
 
@@ -334,10 +334,10 @@ export function TransactionsList() {
    const handleCancel = useCallback(
       (tx: TransactionRow) => {
          openAlertDialog({
-            title: "Cancelar lançamento",
+            title: "Ignorar lançamento",
             description:
-               "Tem certeza que deseja cancelar este lançamento? Ele ficará marcado como cancelado.",
-            actionLabel: "Cancelar lançamento",
+               "Tem certeza que deseja ignorar este lançamento? Ele não entrará nos cálculos financeiros.",
+            actionLabel: "Ignorar lançamento",
             cancelLabel: "Voltar",
             variant: "destructive",
             onAction: async () => {
@@ -566,11 +566,11 @@ export function TransactionsList() {
                         <Button
                            onClick={() => handleCancel(tx)}
                            size="icon"
-                           tooltip="Ignorar transação"
+                           tooltip="Ignorar lançamento"
                            variant="ghost"
                         >
                            <Ban className="size-4" />
-                           <span className="sr-only">Ignorar transação</span>
+                           <span className="sr-only">Ignorar lançamento</span>
                         </Button>
                      )}
                      <Button
@@ -734,7 +734,11 @@ function BulkIgnoreButton({
                onAction: async () => {
                   const results = await Promise.allSettled(
                      ids.map((id) =>
-                        mutation.mutateAsync({ id, status: "cancelled" }),
+                        mutation.mutateAsync({
+                           id,
+                           ignored: true,
+                           status: "cancelled",
+                        }),
                      ),
                   );
                   if (results.every((r) => r.status === "fulfilled")) {

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/transactions.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/transactions.tsx
@@ -129,7 +129,7 @@ function TransactionsPage() {
                <TabsTrigger value="payable">A Pagar</TabsTrigger>
                <TabsTrigger value="receivable">A Receber</TabsTrigger>
                <TabsTrigger value="settled">Efetivados</TabsTrigger>
-               <TabsTrigger value="cancelled">Cancelados</TabsTrigger>
+               <TabsTrigger value="cancelled">Ignorados</TabsTrigger>
             </TabsList>
          </Tabs>
          <div className="flex flex-1 flex-col min-h-0">

--- a/core/database/src/repositories/contacts-repository.ts
+++ b/core/database/src/repositories/contacts-repository.ts
@@ -296,6 +296,7 @@ export function getContactTransactions(
          const where = and(
             eq(transactions.contactId, contactId),
             eq(transactions.teamId, teamId),
+            eq(transactions.ignored, false),
          );
          const [totalResult] = await db
             .select({ value: count() })

--- a/core/database/src/repositories/contacts-repository.ts
+++ b/core/database/src/repositories/contacts-repository.ts
@@ -329,6 +329,7 @@ export function getContactTransactionStats(
          const where = and(
             eq(transactions.contactId, contactId),
             eq(transactions.teamId, teamId),
+            eq(transactions.ignored, false),
          );
          const [incomeResult] = await db
             .select({ total: sum(transactions.amount) })

--- a/core/database/src/schemas/credit-card-statement-totals.ts
+++ b/core/database/src/schemas/credit-card-statement-totals.ts
@@ -18,6 +18,8 @@ export const creditCardStatementTotals = financeSchema
             ),
          })
          .from(transactions)
-         .where(sql`${transactions.creditCardId} IS NOT NULL`)
+         .where(
+            sql`${transactions.creditCardId} IS NOT NULL AND ${transactions.ignored} = false`,
+         )
          .groupBy(transactions.creditCardId, transactions.statementPeriod),
    );

--- a/core/database/src/schemas/transactions.ts
+++ b/core/database/src/schemas/transactions.ts
@@ -1,6 +1,7 @@
 import { sql } from "drizzle-orm";
 import { createInsertSchema, createSelectSchema } from "drizzle-zod";
 import {
+   boolean,
    date,
    index,
    jsonb,
@@ -83,6 +84,7 @@ export const transactions = financeSchema.table(
       attachments: jsonb("attachments").$type<Attachment[]>(),
       paymentMethod: paymentMethodEnum("payment_method"),
       status: transactionStatusEnum("status").notNull().default("paid"),
+      ignored: boolean("ignored").notNull().default(false),
       dueDate: date("due_date"),
       paidAt: timestamp("paid_at", { withTimezone: true }),
       statementPeriod: text("statement_period"),
@@ -120,6 +122,7 @@ export const transactions = financeSchema.table(
       index("transactions_tag_id_idx").on(table.tagId),
       index("transactions_suggested_tag_id_idx").on(table.suggestedTagId),
       index("transactions_status_idx").on(table.status),
+      index("transactions_ignored_idx").on(table.ignored),
       index("transactions_due_date_idx").on(table.dueDate),
       index("transactions_status_type_idx").on(table.status, table.type),
    ],
@@ -182,6 +185,7 @@ const baseTransactionSchema = createInsertSchema(transactions).pick({
    attachments: true,
    statementPeriod: true,
    status: true,
+   ignored: true,
    dueDate: true,
    paidAt: true,
 });
@@ -216,6 +220,7 @@ export const createTransactionSchema = baseTransactionSchema
          .enum(["pending", "paid", "cancelled"])
          .optional()
          .default("paid"),
+      ignored: z.boolean().optional().default(false),
       dueDate: dateSchema.nullable().optional(),
       paidAt: z.date().nullable().optional(),
    })
@@ -293,6 +298,7 @@ export const updateTransactionSchema = baseTransactionSchema
       contactId: z.string().uuid().nullable().optional(),
       attachments: z.array(attachmentSchema).nullable().optional(),
       status: z.enum(["pending", "paid", "cancelled"]).optional(),
+      ignored: z.boolean().optional(),
       dueDate: dateSchema.nullable().optional(),
       paidAt: z.date().nullable().optional(),
    })

--- a/modules/billing/src/router/contacts.ts
+++ b/modules/billing/src/router/contacts.ts
@@ -342,6 +342,7 @@ export const getTransactions = protectedProcedure
          const where = and(
             eq(transactions.contactId, contact.id),
             eq(transactions.teamId, context.teamId),
+            eq(transactions.ignored, false),
          );
          const data = yield* fromPromise(
             Promise.all([

--- a/modules/billing/src/router/contacts.ts
+++ b/modules/billing/src/router/contacts.ts
@@ -297,6 +297,7 @@ export const getStats = protectedProcedure
          const where = and(
             eq(transactions.contactId, contact.id),
             eq(transactions.teamId, context.teamId),
+            eq(transactions.ignored, false),
          );
          const stats = yield* fromPromise(
             Promise.all([

--- a/modules/classification/src/workflows/classification-workflow.ts
+++ b/modules/classification/src/workflows/classification-workflow.ts
@@ -87,6 +87,7 @@ const stepLoadInputs = (input: ClassifyTransactionsBatchInput) =>
                   where: (f, { and, eq, inArray, isNull }) =>
                      and(
                         eq(f.teamId, input.teamId),
+                        eq(f.ignored, false),
                         inArray(f.id, input.transactionIds),
                         isNull(f.categoryId),
                         isNull(f.suggestedCategoryId),
@@ -180,6 +181,7 @@ const stepWrite = (writes: ClassificationWrite[], teamId: string) =>
                         and(
                            eq(transactions.id, w.transactionId),
                            eq(transactions.teamId, teamId),
+                           eq(transactions.ignored, false),
                            isNull(transactions.categoryId),
                            isNull(transactions.suggestedCategoryId),
                         ),

--- a/modules/finance/src/router/transactions-bulk.ts
+++ b/modules/finance/src/router/transactions-bulk.ts
@@ -141,6 +141,7 @@ export const checkDuplicates = protectedProcedure
             and(
                eq(f.bankAccountId, input.bankAccountId),
                eq(f.teamId, context.teamId),
+               eq(f.ignored, false),
                inArray(
                   f.date,
                   input.transactions.map((t) => t.date),
@@ -231,12 +232,15 @@ export const importBulk = protectedProcedure
             tagId,
             date: data.date,
          });
+         const ignored = data.ignored || data.status === "cancelled";
          const inserted = await fromPromise(
             context.db.transaction(async (tx) =>
                tx
                   .insert(transactions)
                   .values({
                      ...data,
+                     status: ignored ? "cancelled" : data.status,
+                     ignored,
                      teamId: context.teamId,
                      tagId: tagId ?? null,
                   })
@@ -249,6 +253,7 @@ export const importBulk = protectedProcedure
          if (
             input.autoCategorize &&
             row &&
+            !ignored &&
             !data.categoryId &&
             (data.type === "income" || data.type === "expense")
          ) {

--- a/modules/finance/src/router/transactions-list.ts
+++ b/modules/finance/src/router/transactions-list.ts
@@ -95,7 +95,15 @@ export const getAll = protectedProcedure
 export const getSummary = protectedProcedure
    .input(filterSchema)
    .handler(async ({ context, input }) => {
-      const filter: TransactionFilter = { teamId: context.teamId, ...input };
+      const filtersIgnored =
+         input?.view === "cancelled" ||
+         input?.status === "cancelled" ||
+         (Array.isArray(input?.status) && input.status.includes("cancelled"));
+      const filter: TransactionFilter = {
+         teamId: context.teamId,
+         ...input,
+         includeIgnored: filtersIgnored,
+      };
       const where = buildTransactionWhere(filter, false);
       const t = transactions;
       const [row] = await context.db

--- a/modules/finance/src/router/transactions-list.ts
+++ b/modules/finance/src/router/transactions-list.ts
@@ -45,7 +45,15 @@ const filterSchema = z
 export const getAll = protectedProcedure
    .input(filterSchema)
    .handler(async ({ context, input }) => {
-      const filter: TransactionFilter = { teamId: context.teamId, ...input };
+      const filtersIgnored =
+         input?.view === "cancelled" ||
+         input?.status === "cancelled" ||
+         (Array.isArray(input?.status) && input.status.includes("cancelled"));
+      const filter: TransactionFilter = {
+         teamId: context.teamId,
+         ...input,
+         includeIgnored: filtersIgnored,
+      };
       const page = filter.page ?? 1;
       const pageSize = filter.pageSize ?? 50;
       const where = buildTransactionWhere(filter, true);

--- a/modules/finance/src/router/transactions-status.ts
+++ b/modules/finance/src/router/transactions-status.ts
@@ -25,13 +25,11 @@ export const markAsPaid = protectedProcedure
    .use(requireTransaction, (input) => input.id)
    .handler(async ({ context, input }) => {
       const existing = context.transaction;
-      if (existing.status === "paid") {
+      if (existing.status === "paid" && !existing.ignored) {
          throw WebAppError.conflict("Lançamento já está pago.");
       }
-      if (existing.status === "cancelled") {
-         throw WebAppError.badRequest(
-            "Lançamento cancelado não pode ser pago.",
-         );
+      if (existing.status === "cancelled" || existing.ignored) {
+         throw WebAppError.badRequest("Lançamento ignorado não pode ser pago.");
       }
       if (typeof input.bankAccountId === "string") {
          const account = await fromPromise(
@@ -53,6 +51,7 @@ export const markAsPaid = protectedProcedure
                .update(transactions)
                .set({
                   status: "paid",
+                  ignored: false,
                   paidAt: dayjs().toDate(),
                   date: paidDate,
                   ...(input.bankAccountId !== undefined
@@ -74,7 +73,10 @@ export const markAsUnpaid = protectedProcedure
    .input(idSchema)
    .use(requireTransaction, (input) => input.id)
    .handler(async ({ context, input }) => {
-      if (context.transaction.status !== "paid") {
+      if (
+         context.transaction.status !== "paid" ||
+         context.transaction.ignored
+      ) {
          throw WebAppError.conflict(
             "Apenas lançamentos pagos podem ser desmarcados.",
          );
@@ -83,7 +85,7 @@ export const markAsUnpaid = protectedProcedure
          context.db.transaction(async (tx) =>
             tx
                .update(transactions)
-               .set({ status: "pending", paidAt: null })
+               .set({ status: "pending", ignored: false, paidAt: null })
                .where(eq(transactions.id, input.id))
                .returning(),
          ),
@@ -99,18 +101,21 @@ export const cancel = protectedProcedure
    .input(idSchema)
    .use(requireTransaction, (input) => input.id)
    .handler(async ({ context, input }) => {
-      if (context.transaction.status === "cancelled") {
-         throw WebAppError.conflict("Lançamento já está cancelado.");
+      if (
+         context.transaction.status === "cancelled" ||
+         context.transaction.ignored
+      ) {
+         throw WebAppError.conflict("Lançamento já está ignorado.");
       }
       const result = await fromPromise(
          context.db.transaction(async (tx) =>
             tx
                .update(transactions)
-               .set({ status: "cancelled" })
+               .set({ status: "cancelled", ignored: true })
                .where(eq(transactions.id, input.id))
                .returning(),
          ),
-         () => WebAppError.internal("Falha ao cancelar lançamento."),
+         () => WebAppError.internal("Falha ao ignorar lançamento."),
       );
       if (result.isErr()) throw result.error;
       const [row] = result.value;
@@ -122,9 +127,12 @@ export const reactivate = protectedProcedure
    .input(z.object({ id: z.string().uuid(), paid: z.boolean().default(false) }))
    .use(requireTransaction, (input) => input.id)
    .handler(async ({ context, input }) => {
-      if (context.transaction.status !== "cancelled") {
+      if (
+         context.transaction.status !== "cancelled" &&
+         !context.transaction.ignored
+      ) {
          throw WebAppError.conflict(
-            "Apenas lançamentos cancelados podem ser reativados.",
+            "Apenas lançamentos ignorados podem ser reativados.",
          );
       }
       const result = await fromPromise(
@@ -133,6 +141,7 @@ export const reactivate = protectedProcedure
                .update(transactions)
                .set({
                   status: input.paid ? "paid" : "pending",
+                  ignored: false,
                   paidAt: input.paid ? dayjs().toDate() : null,
                })
                .where(eq(transactions.id, input.id))
@@ -176,6 +185,7 @@ export const bulkMarkAsPaid = protectedProcedure
                   .update(transactions)
                   .set({
                      status: "paid",
+                     ignored: false,
                      paidAt: dayjs().toDate(),
                      date: paidDate,
                      ...(input.bankAccountId !== undefined

--- a/modules/finance/src/router/transactions.ts
+++ b/modules/finance/src/router/transactions.ts
@@ -53,6 +53,8 @@ export const create = protectedProcedure
 
       const txData =
          data.type === "transfer" ? { ...data, categoryId: null } : data;
+      const ignored = txData.ignored || txData.status === "cancelled";
+      const status = ignored ? "cancelled" : txData.status;
 
       const created = await fromPromise(
          context.db.transaction(async (tx) => {
@@ -60,6 +62,8 @@ export const create = protectedProcedure
                .insert(transactions)
                .values({
                   ...txData,
+                  status,
+                  ignored,
                   teamId: context.teamId,
                   tagId: tagId ?? null,
                })
@@ -89,6 +93,7 @@ export const create = protectedProcedure
       if (
          autoCategorize &&
          !input.categoryId &&
+         !ignored &&
          (input.type === "income" || input.type === "expense")
       ) {
          await enqueueClassifyTransactionsBatchWorkflow(
@@ -149,6 +154,21 @@ export const update = protectedProcedure
          });
       }
       const { id, tagId, items, ...data } = input;
+      const ignored =
+         data.ignored === true || data.status === "cancelled"
+            ? true
+            : data.ignored === false ||
+                data.status === "pending" ||
+                data.status === "paid"
+              ? false
+              : undefined;
+      const status =
+         ignored === true
+            ? "cancelled"
+            : ignored === false
+              ? (data.status ??
+                (existing.status === "cancelled" ? "pending" : undefined))
+              : data.status;
 
       const updated = await fromPromise(
          context.db.transaction(async (tx) => {
@@ -156,6 +176,8 @@ export const update = protectedProcedure
                .update(transactions)
                .set({
                   ...data,
+                  ...(status !== undefined ? { status } : {}),
+                  ...(ignored !== undefined ? { ignored } : {}),
                   ...(tagId !== undefined
                      ? { tagId, suggestedTagId: null }
                      : {}),

--- a/modules/finance/src/services/bank-account-balance.ts
+++ b/modules/finance/src/services/bank-account-balance.ts
@@ -1,5 +1,5 @@
 import { of, toDecimal } from "@f-o-t/money";
-import { eq, inArray, or, sql } from "drizzle-orm";
+import { and, eq, inArray, or, sql } from "drizzle-orm";
 import type { DatabaseInstance } from "@core/database/client";
 import { bankAccounts } from "@core/database/schemas/bank-accounts";
 import { transactions } from "@core/database/schemas/transactions";
@@ -35,9 +35,12 @@ export async function computeBankAccountBalance(
       })
       .from(t)
       .where(
-         or(
-            eq(t.bankAccountId, accountId),
-            eq(t.destinationBankAccountId, accountId),
+         and(
+            or(
+               eq(t.bankAccountId, accountId),
+               eq(t.destinationBankAccountId, accountId),
+            ),
+            eq(t.ignored, false),
          ),
       );
 
@@ -97,7 +100,10 @@ export async function computeBankAccountBalances(
       .from(a)
       .leftJoin(
          t,
-         or(eq(t.bankAccountId, a.id), eq(t.destinationBankAccountId, a.id)),
+         and(
+            or(eq(t.bankAccountId, a.id), eq(t.destinationBankAccountId, a.id)),
+            eq(t.ignored, false),
+         ),
       )
       .where(inArray(a.id, ids))
       .groupBy(a.id, a.initialBalance);

--- a/modules/finance/src/services/transactions-where.ts
+++ b/modules/finance/src/services/transactions-where.ts
@@ -41,6 +41,7 @@ export interface TransactionFilter {
    dueDateTo?: string;
    overdueOnly?: boolean;
    view?: "all" | "payable" | "receivable" | "settled" | "cancelled";
+   includeIgnored?: boolean;
 }
 
 const t = transactions;
@@ -101,6 +102,7 @@ export function buildTransactionWhere(
    includeContactSearch: boolean,
 ): SQL {
    const c: SQL[] = [eq(t.teamId, f.teamId)];
+   if (!f.includeIgnored) c.push(eq(t.ignored, false));
    if (f.type) c.push(eq(t.type, f.type));
    if (f.bankAccountId) c.push(eq(t.bankAccountId, f.bankAccountId));
    if (f.categoryId) c.push(eq(t.categoryId, f.categoryId));

--- a/modules/inbox/src/services/sources/due-payments.ts
+++ b/modules/inbox/src/services/sources/due-payments.ts
@@ -39,6 +39,7 @@ export function fetchDuePayments(db: DatabaseInstance, teamId: string) {
          .where(
             and(
                eq(transactions.teamId, teamId),
+               eq(transactions.ignored, false),
                eq(transactions.status, "pending"),
                lte(transactions.dueDate, horizon),
             ),

--- a/modules/inbox/src/services/sources/uncategorized-tx.ts
+++ b/modules/inbox/src/services/sources/uncategorized-tx.ts
@@ -14,6 +14,7 @@ export function fetchUncategorized(db: DatabaseInstance, teamId: string) {
          .where(
             and(
                eq(transactions.teamId, teamId),
+               eq(transactions.ignored, false),
                isNull(transactions.categoryId),
             ),
          ),

--- a/modules/insights/src/compute-kpi.ts
+++ b/modules/insights/src/compute-kpi.ts
@@ -89,6 +89,7 @@ export function buildConditions(
 
    const conditions = [
       eq(transactions.teamId, teamId),
+      eq(transactions.ignored, false),
       gte(transactions.date, startStr),
       lte(transactions.date, endStr),
    ];


### PR DESCRIPTION
## Resumo
- adiciona o campo real `ignored` no modelo de lançamentos e aceita o campo nos schemas de criação/atualização
- persiste lançamentos ignorados com `ignored = true` e status coerente, sem depender de short-circuit no frontend
- exclui lançamentos ignorados de listagens padrão, totais, saldos, faturas, inbox, duplicidade e classificação automática
- atualiza a drawer/lista para exibir "Ignorar lançamento" e labels em pt-BR

## Verificações
- `bun run typecheck`
- `bun run check` (0 erros; warnings preexistentes)
- `bun run check-boundaries`