### PR TITLE
Permitir arquivar categorias padrão

### DIFF
--- a/apps/web-e2e/tests/categories-default.spec.ts
+++ b/apps/web-e2e/tests/categories-default.spec.ts
@@ -104,19 +104,19 @@ test("permite excluir categoria padrão", async ({
    defaultCategoryIds.length = 0;
 });
 
-test("categoria padrão não exibe botão Arquivar", async ({
+test("categoria padrão exibe botão Arquivar", async ({
    page,
    e2eSession,
    defaultCategoryIds,
 }) => {
-   const name = `Padrão Sem Arquivar ${stamp()}`;
+   const name = `Padrão Arquivar ${stamp()}`;
    await seedDefault(e2eSession, defaultCategoryIds, name);
 
    await gotoCategories(page, e2eSession);
    await searchFor(page, name);
 
    const row = page.getByRole("row").filter({ hasText: name });
-   await expect(row.getByRole("button", { name: "Arquivar" })).toHaveCount(0);
+   await expect(row.getByRole("button", { name: "Arquivar" })).toBeVisible();
    await expect(row.getByRole("button", { name: "Excluir" })).toBeVisible();
 });
 

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/categories.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/categories.tsx
@@ -352,7 +352,6 @@ function CategoriesList() {
                       : "Outros"
             }
             renderActions={({ row }) => {
-               const isDefault = row.original.isDefault;
                const isArchived = row.original.isArchived;
 
                if (isArchived) {
@@ -393,15 +392,13 @@ function CategoriesList() {
                            <RefreshCw />
                         </Button>
                      )}
-                     {!isDefault && (
-                        <Button
-                           onClick={() => handleArchive(row.original)}
-                           tooltip="Arquivar"
-                           variant="outline"
-                        >
-                           <Archive />
-                        </Button>
-                     )}
+                     <Button
+                        onClick={() => handleArchive(row.original)}
+                        tooltip="Arquivar"
+                        variant="outline"
+                     >
+                        <Archive />
+                     </Button>
                      <Button
                         className="text-destructive hover:text-destructive"
                         onClick={() => handleDelete(row.original)}
@@ -535,7 +532,7 @@ function CategoriesList() {
             <DataTableBulkActions<CategoryRow>>
                {({ selectedRows, clearSelection }) => {
                   const archivableIds = selectedRows
-                     .filter((r) => !r.isDefault && !r.isArchived)
+                     .filter((r) => !r.isArchived)
                      .map((r) => r.id);
                   const deletableIds = selectedRows.map((r) => r.id);
                   return (

--- a/modules/classification/__tests__/router/categories.test.ts
+++ b/modules/classification/__tests__/router/categories.test.ts
@@ -381,16 +381,18 @@ describe("categories router", () => {
       expect(childRow?.isArchived).toBe(true);
    });
 
-   it("archive on default category throws CONFLICT", async () => {
+   it("archive allows default category", async () => {
       const { teamId } = await seedTeam(testDb.db);
       const cat = await makeCategory(testDb.db, teamId, { isDefault: true });
       const ctx = createTestContext(testDb.db, { teamId });
 
-      await expect(
-         call(categoriesRouter.archive, { id: cat.id }, { context: ctx }),
-      ).rejects.toSatisfy(
-         (e: Error & { code?: string }) => e.code === "CONFLICT",
+      const result = await call(
+         categoriesRouter.archive,
+         { id: cat.id },
+         { context: ctx },
       );
+      expect(result.isDefault).toBe(true);
+      expect(result.isArchived).toBe(true);
    });
 
    it("unarchive sets isArchived to false", async () => {
@@ -406,10 +408,13 @@ describe("categories router", () => {
       expect(result.isArchived).toBe(false);
    });
 
-   it("bulkArchive archives all selected non-default categories", async () => {
+   it("bulkArchive archives all selected categories", async () => {
       const { teamId } = await seedTeam(testDb.db);
       const a = await makeCategory(testDb.db, teamId, { name: "A" });
-      const b = await makeCategory(testDb.db, teamId, { name: "B" });
+      const b = await makeCategory(testDb.db, teamId, {
+         name: "B",
+         isDefault: true,
+      });
       const c = await makeCategory(testDb.db, teamId, { name: "C" });
 
       const ctx = createTestContext(testDb.db, { teamId });
@@ -425,26 +430,6 @@ describe("categories router", () => {
          .from(categories)
          .where(eq(categories.teamId, teamId));
       expect(rows.every((r) => r.isArchived)).toBe(true);
-   });
-
-   it("bulkArchive throws CONFLICT when any selected is default", async () => {
-      const { teamId } = await seedTeam(testDb.db);
-      const a = await makeCategory(testDb.db, teamId, { name: "A" });
-      const b = await makeCategory(testDb.db, teamId, {
-         name: "B",
-         isDefault: true,
-      });
-
-      const ctx = createTestContext(testDb.db, { teamId });
-      await expect(
-         call(
-            categoriesBulkRouter.bulkArchive,
-            { ids: [a.id, b.id] },
-            { context: ctx },
-         ),
-      ).rejects.toSatisfy(
-         (e: Error & { code?: string }) => e.code === "CONFLICT",
-      );
    });
 
    it("bulkRemove deletes selected categories including default ones without transactions", async () => {

--- a/modules/classification/src/router/categories-bulk.ts
+++ b/modules/classification/src/router/categories-bulk.ts
@@ -10,7 +10,6 @@ import {
 import { WebAppError } from "@core/logging/errors";
 import { protectedProcedure } from "@core/orpc/server";
 import {
-   blockDefaultCategories,
    requireNoTransactionsForExpandedIds,
    requireOwnedCategoryIds,
    withExpandedCategoryIds,
@@ -125,10 +124,6 @@ export const bulkRemove = protectedProcedure
 export const bulkArchive = protectedProcedure
    .input(idsSchema)
    .use(requireOwnedCategoryIds, (input) => input.ids)
-   .use(
-      blockDefaultCategories,
-      () => "Categorias padrão não podem ser arquivadas.",
-   )
    .use(withExpandedCategoryIds, (input) => input.ids)
    .handler(async ({ context }) => {
       const result = await fromPromise(

--- a/modules/classification/src/router/categories.ts
+++ b/modules/classification/src/router/categories.ts
@@ -396,11 +396,6 @@ export const archive = protectedProcedure
    .use(requireCategory, (input) => input.id)
    .use(withCategoryDescendants, (input) => input.id)
    .handler(async ({ context, input }) => {
-      if (context.category.isDefault)
-         throw WebAppError.conflict(
-            "Categorias padrão não podem ser arquivadas.",
-         );
-
       const allIds = [input.id, ...context.descendantCategoryIds];
       const result = await fromPromise(
          (async () => {


### PR DESCRIPTION
## Resumo
- remove o bloqueio de arquivamento para categorias padrão
- exibe a ação Arquivar para categorias padrão na tabela
- inclui categorias padrão no arquivamento em massa
- atualiza testes de router e E2E para o novo comportamento

## Testes
- BUN_TMPDIR=/tmp bun --filter @modules/classification test __tests__/router/categories.test.ts