### PR TITLE
MON-953 Exibir logo do banco na listagem de contas

### DIFF
--- a/apps/web-e2e/tests/bank-accounts-logos.spec.ts
+++ b/apps/web-e2e/tests/bank-accounts-logos.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "../fixtures";
+import {
+   deleteBankAccountById,
+   findTeamByOrgAndSlug,
+   insertBankAccount,
+} from "../helpers/db";
+
+const stamp = () => `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+const createdBankAccountIds: string[] = [];
+
+test.afterEach(async ({ e2eSession }) => {
+   const team = await findTeamByOrgAndSlug(
+      e2eSession.orgSlug,
+      e2eSession.teamSlug,
+   );
+   if (!team) return;
+   for (const id of createdBankAccountIds.splice(0)) {
+      await deleteBankAccountById(team.id, id);
+   }
+});
+
+test("exibe logo do banco antes do nome da conta na listagem", async ({
+   page,
+   e2eSession,
+}) => {
+   const team = await findTeamByOrgAndSlug(
+      e2eSession.orgSlug,
+      e2eSession.teamSlug,
+   );
+   if (!team) throw new Error("team not found");
+
+   const accountName = `Conta Itaú Logo ${stamp()}`;
+   const account = await insertBankAccount(team.id, accountName, {
+      bankCode: "341",
+      bankName: "Itaú",
+   });
+   if (!account) throw new Error("failed to create bank account");
+   createdBankAccountIds.push(account.id);
+
+   await page.goto(
+      `/${e2eSession.orgSlug}/${e2eSession.teamSlug}/bank-accounts?search=${encodeURIComponent(accountName)}`,
+   );
+
+   const row = page.getByRole("row").filter({ hasText: accountName });
+   await expect(row).toBeVisible();
+   await expect(row.getByText("IT", { exact: true })).toBeVisible();
+   await expect(row.getByText(accountName)).toBeVisible();
+});

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-bank-accounts/bank-accounts-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-bank-accounts/bank-accounts-columns.tsx
@@ -5,6 +5,11 @@ import {
    AnnouncementTitle,
 } from "@/components/blocks/announcement";
 import {
+   Avatar,
+   AvatarFallback,
+   AvatarImage,
+} from "@packages/ui/components/avatar";
+import {
    Tooltip,
    TooltipContent,
    TooltipProvider,
@@ -23,6 +28,7 @@ import {
 } from "lucide-react";
 import type { ReactNode } from "react";
 import { z } from "zod";
+import { bankInitials, bankLogoUrl } from "@/lib/logos";
 
 export type BankAccountRow = {
    id: string;
@@ -31,6 +37,8 @@ export type BankAccountRow = {
    type: "checking" | "savings" | "investment" | "payment" | "cash";
    color: string;
    iconUrl?: string | null;
+   bankCode?: string | null;
+   bankName?: string | null;
    initialBalance: string;
    currentBalance: string;
    projectedBalance: string;
@@ -66,6 +74,7 @@ function formatBRL(value: string | number): string {
 }
 
 interface BuildBankAccountColumnsOptions {
+   logoDevToken?: string;
    onRenameAccount?: (id: string, name: string) => Promise<void>;
 }
 
@@ -73,6 +82,7 @@ export function buildBankAccountColumns(
    options?: BuildBankAccountColumnsOptions,
 ): ColumnDef<BankAccountRow>[] {
    const canRenameAccount = Boolean(options?.onRenameAccount);
+   const logoDevToken = options?.logoDevToken;
    return [
       {
          accessorKey: "name",
@@ -91,9 +101,35 @@ export function buildBankAccountColumns(
                await options.onRenameAccount(rowId, String(value).trim());
             },
          },
-         cell: ({ row }) => (
-            <span className="font-medium truncate">{row.original.name}</span>
-         ),
+         cell: ({ row }) => {
+            const account = row.original;
+            const issuer = account.bankName?.trim() || account.name;
+            const logo = bankLogoUrl(account.bankCode, logoDevToken);
+            return (
+               <div className="flex min-w-0 items-center gap-2">
+                  <Avatar className="size-4 shrink-0 rounded-lg bg-white ring-1 ring-border">
+                     {logo ? (
+                        <AvatarImage
+                           alt={issuer}
+                           className="object-contain"
+                           src={logo}
+                        />
+                     ) : null}
+                     <AvatarFallback
+                        className="rounded-lg text-xs font-semibold text-white"
+                        style={{ backgroundColor: account.color }}
+                     >
+                        {account.bankName ? (
+                           bankInitials(account.bankName)
+                        ) : (
+                           <Landmark className="size-2" />
+                        )}
+                     </AvatarFallback>
+                  </Avatar>
+                  <span className="font-medium truncate">{account.name}</span>
+               </div>
+            );
+         },
       },
       {
          accessorKey: "currentBalance",

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/bank-accounts.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/bank-accounts.tsx
@@ -121,6 +121,7 @@ function BankAccountsList() {
       Route.useSearch();
    const { openAlertDialog } = useAlertDialog();
    const { openSheet } = useSheet();
+   const { publicEnv } = Route.useRouteContext();
    const { parse: parseCsv, generate: generateCsv } = useCsvFile();
    const { parse: parseXlsx } = useXlsxFile();
 
@@ -190,6 +191,8 @@ function BankAccountsList() {
             type: resolveType(row.type),
             color: "#6366f1",
             iconUrl: null,
+            bankCode: null,
+            bankName: null,
             initialBalance: String(row.initialBalance ?? "0"),
             currentBalance: "0",
             projectedBalance: "0",
@@ -267,8 +270,12 @@ function BankAccountsList() {
    );
 
    const columns = useMemo(
-      () => buildBankAccountColumns({ onRenameAccount: handleRenameAccount }),
-      [handleRenameAccount],
+      () =>
+         buildBankAccountColumns({
+            logoDevToken: publicEnv?.LOGO_DEV_TOKEN,
+            onRenameAccount: handleRenameAccount,
+         }),
+      [handleRenameAccount, publicEnv?.LOGO_DEV_TOKEN],
    );
 
    return (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,44 +3,44 @@
    "files": [],
    "exclude": [".worktrees", "node_modules", "dist"],
    "references": [
-      {
-         "path": "./core/transactional"
-      },
-      {
-         "path": "./core/environment"
-      },
-      {
-         "path": "./core/database"
-      },
-      {
-         "path": "./core/logging"
-      },
-      {
-         "path": "./core/posthog"
-      },
-      {
-         "path": "./packages/ui"
-      },
-      {
-         "path": "./core/files"
-      },
-      {
-         "path": "./core/redis"
-      },
-      {
-         "path": "./core/sse"
-      },
-      {
-         "path": "./core/utils"
-      },
-      {
-         "path": "./core/ai"
-      },
-      {
-         "path": "./core/dbos"
-      },
-      {
-         "path": "./apps/web-e2e"
-      }
-   ]
+    {
+      "path": "./core/transactional"
+    },
+    {
+      "path": "./core/environment"
+    },
+    {
+      "path": "./core/database"
+    },
+    {
+      "path": "./core/logging"
+    },
+    {
+      "path": "./core/posthog"
+    },
+    {
+      "path": "./packages/ui"
+    },
+    {
+      "path": "./core/files"
+    },
+    {
+      "path": "./core/redis"
+    },
+    {
+      "path": "./core/sse"
+    },
+    {
+      "path": "./core/utils"
+    },
+    {
+      "path": "./core/ai"
+    },
+    {
+      "path": "./core/dbos"
+    },
+    {
+      "path": "./apps/web-e2e"
+    }
+  ]
 }


### PR DESCRIPTION
## Contexto

Na listagem de contas bancárias, o nome da conta deve exibir um ícone antes do texto que faça referência ao banco.

## Implementação

- Exibe um avatar antes do nome da conta na tabela de contas bancárias.
- Usa o helper existente de Logo.dev para resolver o logo pelo código do banco.
- Mantém fallback por iniciais do banco quando o logo externo não carrega.
- Adiciona cobertura E2E para conta com banco Itaú na listagem.

## Critérios de Aceite

- Cada conta bancária exibe um ícone antes do nome da conta.
- O ícone faz referência ao banco da conta bancária.
- Os ícones são obtidos por meio da integração existente com Logo.dev.

## Validação

- bun run check
- bun run typecheck
- E2E_BASE_URL=http://localhost:3007 bunx playwright test -c apps/web-e2e/playwright.config.ts apps/web-e2e/tests/bank-accounts-logos.spec.ts