### PR TITLE
MON-958: padronizar modelos de importação CSV e XLSX

### DIFF
--- a/apps/web-e2e/tests/import-templates.spec.ts
+++ b/apps/web-e2e/tests/import-templates.spec.ts
@@ -1,11 +1,12 @@
 import fs from "node:fs";
 import type { Page } from "@playwright/test";
+import { read as readXlsx, utils as xlsxUtils } from "xlsx";
 import { expect, test, type E2ESession } from "../fixtures";
 
 type TemplateCase = {
    path: string;
    heading: string;
-   filename: string;
+   filenameBase: string;
    headers: string[];
 };
 
@@ -13,45 +14,45 @@ const cases: TemplateCase[] = [
    {
       path: "categories",
       heading: "Categorias",
-      filename: "modelo-categorias.csv",
-      headers: ["name", "type"],
+      filenameBase: "modelo-categorias",
+      headers: ["Nome", "Tipo"],
    },
    {
       path: "transactions",
       heading: "Lançamentos",
-      filename: "modelo-lancamentos.csv",
+      filenameBase: "modelo-lancamentos",
       headers: [
-         "date",
-         "name",
-         "type",
-         "amount",
-         "status",
-         "dueDate",
-         "bankAccountName",
-         "creditCardName",
-         "categoryName",
-         "contactName",
+         "Data",
+         "Nome",
+         "Tipo",
+         "Valor",
+         "Status",
+         "Vencimento",
+         "Conta",
+         "Cartão",
+         "Categoria",
+         "Fornecedor/Cliente",
       ],
    },
    {
       path: "bank-accounts",
       heading: "Contas Bancárias",
-      filename: "modelo-contas-bancarias.csv",
-      headers: ["name", "type", "initialBalance"],
+      filenameBase: "modelo-contas-bancarias",
+      headers: ["Nome", "Tipo", "Saldo Inicial"],
    },
    {
       path: "credit-cards",
       heading: "Cartões de Crédito",
-      filename: "modelo-cartoes-credito.csv",
+      filenameBase: "modelo-cartoes-credito",
       headers: [
-         "name",
-         "brand",
-         "last4",
-         "creditLimit",
-         "closingDay",
-         "dueDay",
-         "bankAccountId",
-         "status",
+         "Nome",
+         "Bandeira",
+         "Final",
+         "Limite",
+         "Fechamento",
+         "Vencimento",
+         "Conta Bancária",
+         "Status",
       ],
    },
 ];
@@ -67,7 +68,49 @@ async function gotoImportFlow(
    ).toBeVisible();
 }
 
-test("MON-958: disponibiliza modelos CSV nos fluxos de importação", async ({
+async function downloadTemplate(page: Page, label: "CSV" | "XLSX") {
+   const downloadPromise = page.waitForEvent("download");
+   await page.getByRole("button", { exact: true, name: label }).click();
+   return downloadPromise;
+}
+
+async function expectCsvTemplate(page: Page, item: TemplateCase) {
+   const download = await downloadTemplate(page, "CSV");
+   expect(download.suggestedFilename()).toBe(`${item.filenameBase}.csv`);
+   const filePath = await download.path();
+   expect(filePath).toBeTruthy();
+   if (!filePath) throw new Error("Download CSV sem arquivo temporário.");
+   const content = fs.readFileSync(filePath, "utf8");
+   const headerLine = content.split(/\r?\n/)[0] ?? "";
+   for (const header of item.headers) {
+      expect(headerLine).toContain(header);
+   }
+}
+
+async function expectXlsxTemplate(page: Page, item: TemplateCase) {
+   const download = await downloadTemplate(page, "XLSX");
+   expect(download.suggestedFilename()).toBe(`${item.filenameBase}.xlsx`);
+   const filePath = await download.path();
+   expect(filePath).toBeTruthy();
+   if (!filePath) throw new Error("Download XLSX sem arquivo temporário.");
+   const workbook = readXlsx(fs.readFileSync(filePath), { type: "buffer" });
+   const firstSheetName = workbook.SheetNames[0];
+   expect(firstSheetName).toBeTruthy();
+   const worksheet = firstSheetName ? workbook.Sheets[firstSheetName] : null;
+   expect(worksheet).toBeTruthy();
+   if (!worksheet) throw new Error("Modelo XLSX sem planilha.");
+   const rows = xlsxUtils.sheet_to_json<unknown[]>(worksheet, {
+      header: 1,
+      defval: "",
+   });
+   const firstRow = rows[0];
+   const headerRow = Array.isArray(firstRow) ? firstRow.map(String) : [];
+   for (const header of item.headers) {
+      expect(headerRow).toContain(header);
+   }
+}
+
+test("MON-958: disponibiliza modelos CSV e XLSX nos fluxos de importação", async ({
    page,
    e2eSession,
 }) => {
@@ -75,17 +118,7 @@ test("MON-958: disponibiliza modelos CSV nos fluxos de importação", async ({
       await gotoImportFlow(page, e2eSession, item);
       await page.getByRole("button", { name: "Importar dados" }).click();
 
-      const downloadPromise = page.waitForEvent("download");
-      await page.getByRole("button", { name: "Baixar modelo CSV" }).click();
-      const download = await downloadPromise;
-
-      expect(download.suggestedFilename()).toBe(item.filename);
-      const filePath = await download.path();
-      expect(filePath).toBeTruthy();
-      const content = fs.readFileSync(filePath ?? "", "utf8");
-      const headerLine = content.split(/\r?\n/)[0] ?? "";
-      for (const header of item.headers) {
-         expect(headerLine).toContain(header);
-      }
+      await expectCsvTemplate(page, item);
+      await expectXlsxTemplate(page, item);
    }
 });

--- a/apps/web/src/components/data-table/data-table-import.tsx
+++ b/apps/web/src/components/data-table/data-table-import.tsx
@@ -1,6 +1,6 @@
 import { fromPromise } from "neverthrow";
 import { useCallback, useState, useTransition } from "react";
-import { Download, FileDown, FileSpreadsheet, Loader2 } from "lucide-react";
+import { Download, FileSpreadsheet, Loader2 } from "lucide-react";
 import {
    Popover,
    PopoverContent,
@@ -21,19 +21,27 @@ export type RawImportData = {
    rows: string[][];
 };
 
+type DataTableImportTemplateFile = {
+   filename: string;
+   label: string;
+   createBlob: () => Blob;
+};
+
 export interface DataTableImportConfig {
    accept?: Record<string, string[]>;
    parseFile: (file: File) => Promise<RawImportData>;
+   importColumns?: Array<{ key: string; label: string }>;
    mapRow?: (
       row: Record<string, string>,
       index: number,
    ) => Record<string, unknown>;
    onImport: (rows: Record<string, unknown>[]) => Promise<void>;
    template?: {
-      filename: string;
       label?: string;
       description?: string;
-      createBlob: () => Blob;
+      filename?: string;
+      createBlob?: () => Blob;
+      formats?: DataTableImportTemplateFile[];
    };
 }
 
@@ -44,9 +52,14 @@ const DEFAULT_ACCEPT = {
    ],
    "application/vnd.ms-excel": [".xls"],
 };
+const TEMPLATE_FORMAT_LABELS = new Set(["CSV", "XLSX"]);
 
 function normalize(s: string) {
-   return s.toLowerCase().replace(/[^a-z0-9]/g, "");
+   return s
+      .toLowerCase()
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .replace(/[^a-z0-9]/g, "");
 }
 
 function autoMatch(
@@ -79,32 +92,47 @@ export function DataTableImportButton({
    const { table, store } = useDataTable();
    const { download } = useFileDownload();
 
-   const importableColumns = table
-      .getAllColumns()
-      .filter(
-         (col) =>
-            col.id !== "__select" &&
-            col.id !== "__actions" &&
-            !col.columnDef.meta?.importIgnore,
-      )
-      .map((col) => {
-         const def = col.columnDef;
-         const rawKey =
-            "accessorKey" in def && def.accessorKey != null
-               ? String(def.accessorKey)
-               : col.id;
-         return { key: rawKey, label: col.columnDef.meta?.label ?? col.id };
-      });
+   const importableColumns = [
+      ...table
+         .getAllColumns()
+         .filter(
+            (col) =>
+               col.id !== "__select" &&
+               col.id !== "__actions" &&
+               !col.columnDef.meta?.importIgnore,
+         )
+         .map((col) => {
+            const def = col.columnDef;
+            const rawKey =
+               "accessorKey" in def && def.accessorKey != null
+                  ? String(def.accessorKey)
+                  : col.id;
+            return { key: rawKey, label: col.columnDef.meta?.label ?? col.id };
+         }),
+      ...(importConfig.importColumns ?? []),
+   ];
 
    const [open, setOpen] = useState(false);
    const [isParsing, startParsing] = useTransition();
    const [selectedFile, setSelectedFile] = useState<File>();
+   const templateFormats =
+      importConfig.template?.formats ??
+      (importConfig.template?.filename && importConfig.template.createBlob
+         ? [
+              {
+                 filename: importConfig.template.filename,
+                 label: importConfig.template.label ?? "Baixar modelo",
+                 createBlob: importConfig.template.createBlob,
+              },
+           ]
+         : []);
 
-   const handleDownloadTemplate = useCallback(() => {
-      const template = importConfig.template;
-      if (!template) return;
-      download(template.createBlob(), template.filename);
-   }, [download, importConfig.template]);
+   const handleDownloadTemplate = useCallback(
+      (template: DataTableImportTemplateFile) => {
+         download(template.createBlob(), template.filename);
+      },
+      [download],
+   );
 
    function handleDrop([file]: File[]) {
       if (!file) return;
@@ -171,24 +199,25 @@ export function DataTableImportButton({
                   Selecione um arquivo para começar
                </p>
             </div>
-            {importConfig.template && (
-               <Button
-                  className="justify-start h-auto"
-                  onClick={handleDownloadTemplate}
-                  type="button"
-                  variant="outline"
-               >
-                  <FileDown data-icon="inline-start" />
-                  <span className="flex flex-col items-start gap-2 text-left">
-                     <span className="text-sm font-medium">
-                        {importConfig.template.label ?? "Baixar modelo"}
-                     </span>
-                     <span className="text-xs text-muted-foreground">
-                        {importConfig.template.description ??
-                           "Use o arquivo modelo para conferir as colunas esperadas."}
-                     </span>
+            {importConfig.template && templateFormats.length > 0 && (
+               <div className="flex flex-wrap items-center gap-2 text-xs">
+                  <span className="text-muted-foreground">
+                     Precisa de um modelo?
                   </span>
-               </Button>
+                  {templateFormats.map((template) => (
+                     <Button
+                        className="h-auto p-0 text-xs"
+                        key={template.filename}
+                        onClick={() => handleDownloadTemplate(template)}
+                        type="button"
+                        variant="link"
+                     >
+                        {TEMPLATE_FORMAT_LABELS.has(template.label)
+                           ? template.label
+                           : `Baixar modelo ${template.label}`}
+                     </Button>
+                  ))}
+               </div>
             )}
             <Dropzone
                accept={importConfig.accept ?? DEFAULT_ACCEPT}

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-bank-accounts/bank-accounts-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-bank-accounts/bank-accounts-columns.tsx
@@ -233,6 +233,7 @@ export function buildBankAccountColumns(
       {
          accessorKey: "initialBalance",
          header: "Saldo Inicial",
+         meta: { label: "Saldo Inicial" },
          cell: ({ row }) => (
             <Announcement>
                <AnnouncementTag className="flex items-center text-muted-foreground">

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
@@ -163,7 +163,7 @@ export function TransactionsList() {
    const { openSheet } = useSheet();
    const queryClient = useQueryClient();
    const { parse: parseCsv, generate: generateCsv } = useCsvFile();
-   const { parse: parseXlsx } = useXlsxFile();
+   const { parse: parseXlsx, generate: generateXlsx } = useXlsxFile();
    const { parse: parseOfx } = useOfxFile();
 
    const handleSearch = useCallback(
@@ -479,51 +479,105 @@ export function TransactionsList() {
             };
          },
          template: {
-            filename: "modelo-lancamentos.csv",
-            label: "Baixar modelo CSV",
+            label: "Baixar modelo",
             description:
-               "Inclui date, name, type, amount, status e referências por nome ou ID.",
-            createBlob: () =>
-               generateCsv(
-                  [
-                     {
-                        date: dayjs().format("YYYY-MM-DD"),
-                        name: "Venda recebida",
-                        type: "income",
-                        amount: "1500.00",
-                        status: "paid",
-                        dueDate: "",
-                        bankAccountName: bankAccounts[0]?.name ?? "",
-                        creditCardName: "",
-                        categoryName: categoriesResult[0]?.name ?? "",
-                        contactName: contacts[0]?.name ?? "",
-                     },
-                     {
-                        date: dayjs().format("YYYY-MM-DD"),
-                        name: "Compra no cartão",
-                        type: "expense",
-                        amount: "250.00",
-                        status: "pending",
-                        dueDate: dayjs().add(7, "day").format("YYYY-MM-DD"),
-                        bankAccountName: "",
-                        creditCardName: creditCardsResult.data[0]?.name ?? "",
-                        categoryName: categoriesResult[0]?.name ?? "",
-                        contactName: contacts[0]?.name ?? "",
-                     },
-                  ],
-                  [
-                     "date",
-                     "name",
-                     "type",
-                     "amount",
-                     "status",
-                     "dueDate",
-                     "bankAccountName",
-                     "creditCardName",
-                     "categoryName",
-                     "contactName",
-                  ],
-               ),
+               "Inclui Data, Nome, Tipo, Valor, Status e referências por nome.",
+            formats: [
+               {
+                  filename: "modelo-lancamentos.csv",
+                  label: "CSV",
+                  createBlob: () =>
+                     generateCsv(
+                        [
+                           {
+                              Data: dayjs().format("YYYY-MM-DD"),
+                              Nome: "Venda recebida",
+                              Tipo: "Receita",
+                              Valor: "1500.00",
+                              Status: "Efetivado",
+                              Vencimento: "",
+                              Conta: bankAccounts[0]?.name ?? "",
+                              Cartão: "",
+                              Categoria: categoriesResult[0]?.name ?? "",
+                              "Fornecedor/Cliente": contacts[0]?.name ?? "",
+                           },
+                           {
+                              Data: dayjs().format("YYYY-MM-DD"),
+                              Nome: "Compra no cartão",
+                              Tipo: "Despesa",
+                              Valor: "250.00",
+                              Status: "Pendente",
+                              Vencimento: dayjs()
+                                 .add(7, "day")
+                                 .format("YYYY-MM-DD"),
+                              Conta: "",
+                              Cartão: creditCardsResult.data[0]?.name ?? "",
+                              Categoria: categoriesResult[0]?.name ?? "",
+                              "Fornecedor/Cliente": contacts[0]?.name ?? "",
+                           },
+                        ],
+                        [
+                           "Data",
+                           "Nome",
+                           "Tipo",
+                           "Valor",
+                           "Status",
+                           "Vencimento",
+                           "Conta",
+                           "Cartão",
+                           "Categoria",
+                           "Fornecedor/Cliente",
+                        ],
+                     ),
+               },
+               {
+                  filename: "modelo-lancamentos.xlsx",
+                  label: "XLSX",
+                  createBlob: () =>
+                     generateXlsx(
+                        [
+                           {
+                              Data: dayjs().format("YYYY-MM-DD"),
+                              Nome: "Venda recebida",
+                              Tipo: "Receita",
+                              Valor: "1500.00",
+                              Status: "Efetivado",
+                              Vencimento: "",
+                              Conta: bankAccounts[0]?.name ?? "",
+                              Cartão: "",
+                              Categoria: categoriesResult[0]?.name ?? "",
+                              "Fornecedor/Cliente": contacts[0]?.name ?? "",
+                           },
+                           {
+                              Data: dayjs().format("YYYY-MM-DD"),
+                              Nome: "Compra no cartão",
+                              Tipo: "Despesa",
+                              Valor: "250.00",
+                              Status: "Pendente",
+                              Vencimento: dayjs()
+                                 .add(7, "day")
+                                 .format("YYYY-MM-DD"),
+                              Conta: "",
+                              Cartão: creditCardsResult.data[0]?.name ?? "",
+                              Categoria: categoriesResult[0]?.name ?? "",
+                              "Fornecedor/Cliente": contacts[0]?.name ?? "",
+                           },
+                        ],
+                        [
+                           "Data",
+                           "Nome",
+                           "Tipo",
+                           "Valor",
+                           "Status",
+                           "Vencimento",
+                           "Conta",
+                           "Cartão",
+                           "Categoria",
+                           "Fornecedor/Cliente",
+                        ],
+                     ),
+               },
+            ],
          },
          onImport: async (rows) => {
             const transactions = rows.flatMap((r) => {
@@ -579,6 +633,7 @@ export function TransactionsList() {
          parseXlsx,
          parseOfx,
          generateCsv,
+         generateXlsx,
          bankAccounts,
          categoriesResult,
          contacts,

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/bank-accounts.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/bank-accounts.tsx
@@ -55,12 +55,28 @@ const TYPE_LABELS: Record<(typeof TYPES)[number], string> = {
    cash: "Caixa Físico",
 };
 
+function normalizeImportLabel(raw: unknown): string {
+   return String(raw ?? "")
+      .trim()
+      .toLowerCase()
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "");
+}
+
 function resolveType(raw: unknown): BankAccountRow["type"] | undefined {
    if (raw === null || raw === undefined || raw === "") return "checking";
-   const str = String(raw).trim();
+   const str = normalizeImportLabel(raw);
    if (!str) return "checking";
    const parsed = typeSchema.safeParse(str);
-   return parsed.success ? parsed.data : undefined;
+   if (parsed.success) return parsed.data;
+   if (normalizeImportLabel(TYPE_LABELS.checking) === str) return "checking";
+   if (normalizeImportLabel(TYPE_LABELS.savings) === str) return "savings";
+   if (normalizeImportLabel(TYPE_LABELS.investment) === str) {
+      return "investment";
+   }
+   if (normalizeImportLabel(TYPE_LABELS.payment) === str) return "payment";
+   if (normalizeImportLabel(TYPE_LABELS.cash) === str) return "cash";
+   return undefined;
 }
 
 const searchSchema = z.object({
@@ -123,7 +139,7 @@ function BankAccountsList() {
    const { openSheet } = useSheet();
    const { publicEnv } = Route.useRouteContext();
    const { parse: parseCsv, generate: generateCsv } = useCsvFile();
-   const { parse: parseXlsx } = useXlsxFile();
+   const { parse: parseXlsx, generate: generateXlsx } = useXlsxFile();
 
    const { data: result } = useSuspenseQuery(
       orpc.bankAccounts.list.queryOptions({
@@ -200,37 +216,67 @@ function BankAccountsList() {
             updatedAt: dayjs().toISOString(),
          }),
          template: {
-            filename: "modelo-contas-bancarias.csv",
-            label: "Baixar modelo CSV",
+            label: "Baixar modelo",
             description:
-               "Inclui name, type e initialBalance. Use type como checking, savings, investment, payment ou cash.",
-            createBlob: () =>
-               generateCsv(
-                  [
-                     {
-                        name: "Conta Corrente Principal",
-                        type: "checking",
-                        initialBalance: "1500.00",
-                     },
-                     {
-                        name: "Reserva de Emergência",
-                        type: "savings",
-                        initialBalance: "2500.00",
-                     },
-                     {
-                        name: "Caixa da Loja",
-                        type: "cash",
-                        initialBalance: "300.00",
-                     },
-                  ],
-                  ["name", "type", "initialBalance"],
-               ),
+               "Inclui Nome, Tipo e Saldo Inicial. Use Tipo como Conta Corrente, Conta Poupança, Conta Investimento, Conta Pagamento ou Caixa Físico.",
+            formats: [
+               {
+                  filename: "modelo-contas-bancarias.csv",
+                  label: "CSV",
+                  createBlob: () =>
+                     generateCsv(
+                        [
+                           {
+                              Nome: "Conta Corrente Principal",
+                              Tipo: "Conta Corrente",
+                              "Saldo Inicial": "1500.00",
+                           },
+                           {
+                              Nome: "Reserva de Emergência",
+                              Tipo: "Conta Poupança",
+                              "Saldo Inicial": "2500.00",
+                           },
+                           {
+                              Nome: "Caixa da Loja",
+                              Tipo: "Caixa Físico",
+                              "Saldo Inicial": "300.00",
+                           },
+                        ],
+                        ["Nome", "Tipo", "Saldo Inicial"],
+                     ),
+               },
+               {
+                  filename: "modelo-contas-bancarias.xlsx",
+                  label: "XLSX",
+                  createBlob: () =>
+                     generateXlsx(
+                        [
+                           {
+                              Nome: "Conta Corrente Principal",
+                              Tipo: "Conta Corrente",
+                              "Saldo Inicial": "1500.00",
+                           },
+                           {
+                              Nome: "Reserva de Emergência",
+                              Tipo: "Conta Poupança",
+                              "Saldo Inicial": "2500.00",
+                           },
+                           {
+                              Nome: "Caixa da Loja",
+                              Tipo: "Caixa Físico",
+                              "Saldo Inicial": "300.00",
+                           },
+                        ],
+                        ["Nome", "Tipo", "Saldo Inicial"],
+                     ),
+               },
+            ],
          },
          onImport: async (rows) => {
             const invalidType = rows.some((r) => !resolveType(r.type));
             if (invalidType) {
                throw new Error(
-                  "Arquivo contém tipo de conta inválido. Use checking, savings, investment, payment ou cash.",
+                  "Arquivo contém tipo de conta inválido. Use Conta Corrente, Conta Poupança, Conta Investimento, Conta Pagamento ou Caixa Físico.",
                );
             }
             const accounts = rows.flatMap((r) => {
@@ -250,7 +296,7 @@ function BankAccountsList() {
             });
          },
       }),
-      [bulkCreateMutation, generateCsv, parseCsv, parseXlsx],
+      [bulkCreateMutation, generateCsv, generateXlsx, parseCsv, parseXlsx],
    );
 
    const handleDelete = useCallback(

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/categories.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/categories.tsx
@@ -72,8 +72,15 @@ const categoriesSearchSchema = z.object({
 });
 
 function parseCategoryType(raw: unknown): "income" | "expense" | "transfer" {
-   const str = String(raw ?? "").toLowerCase();
+   const str = String(raw ?? "")
+      .trim()
+      .toLowerCase()
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "");
    if (str === "income" || str === "expense" || str === "transfer") return str;
+   if (str === "receita") return "income";
+   if (str === "despesa") return "expense";
+   if (str === "transferencia") return "transfer";
    return "expense";
 }
 
@@ -127,7 +134,7 @@ function CategoriesList() {
    const { search, type, includeArchived, groupBy, page, pageSize } =
       Route.useSearch();
    const { parse: parseCsv, generate: generateCsv } = useCsvFile();
-   const { parse: parseXlsx } = useXlsxFile();
+   const { parse: parseXlsx, generate: generateXlsx } = useXlsxFile();
 
    const [{ data: result }, { data: categoryOptions }] = useSuspenseQueries({
       queries: [
@@ -251,19 +258,43 @@ function CategoriesList() {
             type: parseCategoryType(row.type),
          }),
          template: {
-            filename: "modelo-categorias.csv",
-            label: "Baixar modelo CSV",
+            label: "Baixar modelo",
             description:
-               "Inclui name e type. Use type como income, expense ou transfer.",
-            createBlob: () =>
-               generateCsv(
-                  [
-                     { name: "Vendas", type: "income" },
-                     { name: "Aluguel", type: "expense" },
-                     { name: "Transferência entre contas", type: "transfer" },
-                  ],
-                  ["name", "type"],
-               ),
+               "Inclui Nome e Tipo. Use Tipo como Receita, Despesa ou Transferência.",
+            formats: [
+               {
+                  filename: "modelo-categorias.csv",
+                  label: "CSV",
+                  createBlob: () =>
+                     generateCsv(
+                        [
+                           { Nome: "Vendas", Tipo: "Receita" },
+                           { Nome: "Aluguel", Tipo: "Despesa" },
+                           {
+                              Nome: "Transferência entre contas",
+                              Tipo: "Transferência",
+                           },
+                        ],
+                        ["Nome", "Tipo"],
+                     ),
+               },
+               {
+                  filename: "modelo-categorias.xlsx",
+                  label: "XLSX",
+                  createBlob: () =>
+                     generateXlsx(
+                        [
+                           { Nome: "Vendas", Tipo: "Receita" },
+                           { Nome: "Aluguel", Tipo: "Despesa" },
+                           {
+                              Nome: "Transferência entre contas",
+                              Tipo: "Transferência",
+                           },
+                        ],
+                        ["Nome", "Tipo"],
+                     ),
+               },
+            ],
          },
          onImport: async (importedRows) => {
             await importBatchMutation.mutateAsync({
@@ -275,7 +306,7 @@ function CategoriesList() {
             });
          },
       }),
-      [importBatchMutation, generateCsv, parseCsv, parseXlsx],
+      [importBatchMutation, generateCsv, generateXlsx, parseCsv, parseXlsx],
    );
 
    const handleDelete = useCallback(

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards.tsx
@@ -100,8 +100,12 @@ function parseCreditCardBrand(value: unknown): CreditCardBrand | undefined {
 
 function parseCreditCardStatus(value: unknown): CreditCardStatus {
    const normalized = normalizeImportLookup(value);
-   if (normalized === "blocked") return "blocked";
-   if (normalized === "cancelled") return "cancelled";
+   if (normalized === "blocked" || normalized === "bloqueado") {
+      return "blocked";
+   }
+   if (normalized === "cancelled" || normalized === "cancelado") {
+      return "cancelled";
+   }
    return "active";
 }
 
@@ -162,7 +166,7 @@ function CreditCardsList() {
    const { openSheet } = useSheet();
    const { publicEnv } = Route.useRouteContext();
    const { parse: parseCsv, generate: generateCsv } = useCsvFile();
-   const { parse: parseXlsx } = useXlsxFile();
+   const { parse: parseXlsx, generate: generateXlsx } = useXlsxFile();
 
    const [{ data: result }, { data: bankAccounts }] = useSuspenseQueries({
       queries: [
@@ -220,6 +224,7 @@ function CreditCardsList() {
             if (ext === "xlsx" || ext === "xls") return parseXlsx(file);
             return parseCsv(file);
          },
+         importColumns: [{ key: "last4", label: "Final" }],
          mapRow: (row, i): Record<string, unknown> => ({
             id: `__import_${i}`,
             name: String(row.name ?? "").trim(),
@@ -236,35 +241,69 @@ function CreditCardsList() {
             status: parseCreditCardStatus(row.status),
          }),
          template: {
-            filename: "modelo-cartoes-credito.csv",
-            label: "Baixar modelo CSV",
+            label: "Baixar modelo",
             description:
-               "Inclui name, brand, last4, creditLimit, closingDay, dueDay, bankAccountId e status.",
-            createBlob: () =>
-               generateCsv(
-                  [
-                     {
-                        name: "Cartão Principal",
-                        brand: "visa",
-                        last4: "1234",
-                        creditLimit: "5000.00",
-                        closingDay: "10",
-                        dueDay: "20",
-                        bankAccountId: bankAccounts?.[0]?.name ?? "",
-                        status: "active",
-                     },
-                  ],
-                  [
-                     "name",
-                     "brand",
-                     "last4",
-                     "creditLimit",
-                     "closingDay",
-                     "dueDay",
-                     "bankAccountId",
-                     "status",
-                  ],
-               ),
+               "Inclui Nome, Bandeira, Final, Limite, Fechamento, Vencimento, Conta Bancária e Status.",
+            formats: [
+               {
+                  filename: "modelo-cartoes-credito.csv",
+                  label: "CSV",
+                  createBlob: () =>
+                     generateCsv(
+                        [
+                           {
+                              Nome: "Cartão Principal",
+                              Bandeira: "visa",
+                              Final: "1234",
+                              Limite: "5000.00",
+                              Fechamento: "10",
+                              Vencimento: "20",
+                              "Conta Bancária": bankAccounts?.[0]?.name ?? "",
+                              Status: "Ativo",
+                           },
+                        ],
+                        [
+                           "Nome",
+                           "Bandeira",
+                           "Final",
+                           "Limite",
+                           "Fechamento",
+                           "Vencimento",
+                           "Conta Bancária",
+                           "Status",
+                        ],
+                     ),
+               },
+               {
+                  filename: "modelo-cartoes-credito.xlsx",
+                  label: "XLSX",
+                  createBlob: () =>
+                     generateXlsx(
+                        [
+                           {
+                              Nome: "Cartão Principal",
+                              Bandeira: "visa",
+                              Final: "1234",
+                              Limite: "5000.00",
+                              Fechamento: "10",
+                              Vencimento: "20",
+                              "Conta Bancária": bankAccounts?.[0]?.name ?? "",
+                              Status: "Ativo",
+                           },
+                        ],
+                        [
+                           "Nome",
+                           "Bandeira",
+                           "Final",
+                           "Limite",
+                           "Fechamento",
+                           "Vencimento",
+                           "Conta Bancária",
+                           "Status",
+                        ],
+                     ),
+               },
+            ],
          },
          onImport: async (rows) => {
             const firstBankAccountId = bankAccounts?.[0]?.id;
@@ -294,7 +333,14 @@ function CreditCardsList() {
             });
          },
       }),
-      [bulkCreateMutation, generateCsv, parseCsv, parseXlsx, bankAccounts],
+      [
+         bulkCreateMutation,
+         generateCsv,
+         generateXlsx,
+         parseCsv,
+         parseXlsx,
+         bankAccounts,
+      ],
    );
 
    const handleDelete = useCallback(


### PR DESCRIPTION
## Resumo
- adiciona modelos de importação em CSV e XLSX no componente compartilhado de importação
- padroniza os cabeçalhos dos modelos em pt-BR, alinhados aos rótulos das tabelas
- mantém auto-mapeamento aceitando rótulos pt-BR com acentos e campos auxiliares
- atualiza o E2E para validar os dois formatos em categorias, lançamentos, contas bancárias e cartões de crédito

## Testes
- bun nx run web:typecheck --skipSync
- bun nx run web:check --skipSync
- E2E_BASE_URL=http://localhost:3008 bunx playwright test -c apps/web-e2e/playwright.config.ts apps/web-e2e/tests/import-templates.spec.ts