### PR TITLE
fix(transactions): allow type in update schema

### DIFF
--- a/core/database/src/schemas/transactions.ts
+++ b/core/database/src/schemas/transactions.ts
@@ -274,8 +274,8 @@ export const createTransactionSchema = baseTransactionSchema
    });
 
 export const updateTransactionSchema = baseTransactionSchema
-   .omit({ type: true })
    .extend({
+      type: z.enum(["income", "expense", "transfer"]).optional(),
       name: z
          .string()
          .min(2, "Nome deve ter no mínimo 2 caracteres.")


### PR DESCRIPTION
## Summary
- Edição inline da coluna "Tipo" retornava 500 (`Falha ao atualizar lançamento.`).
- `updateTransactionSchema` fazia `.omit({ type: true })`, Zod descartava o campo e o `set()` do Drizzle ficava vazio.
- Schema agora aceita `type` opcional.

## Test plan
- [ ] Editar tipo de um lançamento inline (income ↔ expense)
- [ ] Validar que update sem `type` continua funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)