### PR TITLE
Add fixed id toast hook

### DIFF
--- a/apps/web/src/routes/auth/email-verification.tsx
+++ b/apps/web/src/routes/auth/email-verification.tsx
@@ -11,10 +11,10 @@ import {
    InputOTPSlot,
 } from "@packages/ui/components/input-otp";
 import { Spinner } from "@packages/ui/components/spinner";
+import { useToastActions } from "@packages/ui/hooks/use-toast";
 import { useForm } from "@tanstack/react-form";
 import { createFileRoute, useRouter } from "@tanstack/react-router";
 import { type FormEvent, useCallback } from "react";
-import { toast } from "sonner";
 import z from "zod";
 import { authClient } from "@/integrations/better-auth/auth-client";
 
@@ -38,23 +38,25 @@ const emailVerificationSchema = z.object({
 function EmailVerificationPage() {
    const { email, redirect: redirectTo } = Route.useSearch();
    const router = useRouter();
+   const resendEmailToast = useToastActions("email-verification-resend");
+   const verifyEmailToast = useToastActions("email-verification-verify");
 
    const handleResendEmail = useCallback(async () => {
       await authClient.emailOtp.sendVerificationOtp(
          { email, type: "email-verification" },
          {
             onError: ({ error }) => {
-               toast.error(error.message);
+               resendEmailToast.error(error.message);
             },
             onRequest: () => {
-               toast.loading("Processando...");
+               resendEmailToast.loading("Processando...");
             },
             onSuccess: () => {
-               toast.success("Email reenviado!");
+               resendEmailToast.success("Email reenviado!");
             },
          },
       );
-   }, [email]);
+   }, [email, resendEmailToast]);
 
    const handleVerifyEmail = useCallback(
       async (otp: string) => {
@@ -62,19 +64,19 @@ function EmailVerificationPage() {
             { email, otp },
             {
                onError: ({ error }) => {
-                  toast.error(error.message);
+                  verifyEmailToast.error(error.message);
                },
                onRequest: () => {
-                  toast.loading("Verificando...");
+                  verifyEmailToast.loading("Verificando...");
                },
                onSuccess: () => {
-                  toast.success("Email verificado!");
+                  verifyEmailToast.success("Email verificado!");
                   router.navigate({ to: redirectTo ?? "/auth/callback" });
                },
             },
          );
       },
-      [email, redirectTo, router],
+      [email, redirectTo, router, verifyEmailToast],
    );
 
    const form = useForm({

--- a/apps/web/src/routes/auth/forgot-password.tsx
+++ b/apps/web/src/routes/auth/forgot-password.tsx
@@ -15,11 +15,11 @@ import {
 import { PasswordInput } from "@packages/ui/components/password-input";
 import { Spinner } from "@packages/ui/components/spinner";
 import { defineStepper } from "@packages/ui/components/stepper";
+import { useToastActions } from "@packages/ui/hooks/use-toast";
 import { useForm } from "@tanstack/react-form";
 import { createFileRoute, Link, useRouter } from "@tanstack/react-router";
 import { ArrowLeft } from "lucide-react";
 import { createContext, useCallback, useContext } from "react";
-import { toast } from "sonner";
 import z from "zod";
 import { authClient } from "@/integrations/better-auth/auth-client";
 
@@ -223,26 +223,29 @@ function PasswordStep() {
 
 function ForgotPasswordPage() {
    const router = useRouter();
+   const sendOtpToast = useToastActions("forgot-password-send-otp");
+   const resetPasswordToast = useToastActions("forgot-password-reset");
 
-   const handleSendOtp = useCallback(async (email: string) => {
-      let success = false;
-      await authClient.emailOtp.sendVerificationOtp(
-         { email, type: "forget-password" },
-         {
-            onError: ({ error }) => {
-               toast.error(error.message);
+   const handleSendOtp = useCallback(
+      async (email: string) => {
+         const result = await authClient.emailOtp.sendVerificationOtp(
+            { email, type: "forget-password" },
+            {
+               onError: ({ error }) => {
+                  sendOtpToast.error(error.message);
+               },
+               onRequest: () => {
+                  sendOtpToast.loading("Processando...");
+               },
+               onSuccess: () => {
+                  sendOtpToast.success("Código enviado!");
+               },
             },
-            onRequest: () => {
-               toast.loading("Processando...");
-            },
-            onSuccess: () => {
-               toast.success("Código enviado!");
-               success = true;
-            },
-         },
-      );
-      return success;
-   }, []);
+         );
+         return !result.error;
+      },
+      [sendOtpToast],
+   );
 
    const handleResetPassword = useCallback(
       async (email: string, otp: string, password: string) => {
@@ -250,13 +253,13 @@ function ForgotPasswordPage() {
             { email, otp, password },
             {
                onError: ({ error }) => {
-                  toast.error(error.message);
+                  resetPasswordToast.error(error.message);
                },
                onRequest: () => {
-                  toast.loading("Redefinindo...");
+                  resetPasswordToast.loading("Redefinindo...");
                },
                onSuccess: () => {
-                  toast.success("Senha redefinida!");
+                  resetPasswordToast.success("Senha redefinida!");
                   router.navigate({
                      search: { redirect: undefined },
                      to: "/auth/sign-in",
@@ -265,7 +268,7 @@ function ForgotPasswordPage() {
             },
          );
       },
-      [router],
+      [resetPasswordToast, router],
    );
 
    const form = useForm({

--- a/apps/web/src/routes/auth/magic-link.tsx
+++ b/apps/web/src/routes/auth/magic-link.tsx
@@ -8,12 +8,12 @@ import {
 } from "@packages/ui/components/field";
 import { Input } from "@packages/ui/components/input";
 import { Spinner } from "@packages/ui/components/spinner";
+import { useToastActions } from "@packages/ui/hooks/use-toast";
 import { useForm } from "@tanstack/react-form";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { ArrowLeft, Mail } from "lucide-react";
 import { ResultAsync } from "neverthrow";
-import { type FormEvent, useCallback, useState } from "react";
-import { toast } from "sonner";
+import { type FormEvent, useCallback } from "react";
 import { z } from "zod";
 import { authClient } from "@/integrations/better-auth/auth-client";
 
@@ -21,6 +21,7 @@ const magicLinkSearchSchema = z.object({
    redirect: z
       .union([z.string().startsWith("/"), z.undefined()])
       .catch(undefined),
+   sent: z.boolean().catch(false).default(false),
 });
 
 export const Route = createFileRoute("/auth/magic-link")({
@@ -34,8 +35,22 @@ const magicLinkSchema = z.object({
 });
 
 function MagicLinkPage() {
-   const { redirect: redirectTo } = Route.useSearch();
-   const [isSent, setIsSent] = useState(false);
+   const { redirect: redirectTo, sent } = Route.useSearch();
+   const navigate = Route.useNavigate();
+   const magicLinkToast = useToastActions("magic-link");
+
+   const setSent = useCallback(
+      (nextSent: boolean) => {
+         navigate({
+            replace: true,
+            search: (prev) => ({
+               ...prev,
+               sent: nextSent,
+            }),
+         });
+      },
+      [navigate],
+   );
 
    const handleMagicLinkSignIn = useCallback(
       async (email: string) => {
@@ -46,10 +61,10 @@ function MagicLinkPage() {
             },
             {
                onError: ({ error }) => {
-                  toast.error(error.message);
+                  magicLinkToast.error(error.message);
                },
                onRequest: () => {
-                  toast.loading("Enviando link de acesso...");
+                  magicLinkToast.loading("Enviando link de acesso...");
                },
                onSuccess: async () => {
                   const result = await ResultAsync.fromPromise(
@@ -62,8 +77,10 @@ function MagicLinkPage() {
                   );
 
                   if (result.isErr()) {
-                     toast.error("Endpoint de desenvolvimento indisponível.");
-                     setIsSent(true);
+                     magicLinkToast.error(
+                        "Endpoint de desenvolvimento indisponível.",
+                     );
+                     setSent(true);
                      return;
                   }
 
@@ -78,13 +95,13 @@ function MagicLinkPage() {
                      return;
                   }
 
-                  setIsSent(true);
-                  toast.success("Link enviado! Verifique seu e-mail.");
+                  setSent(true);
+                  magicLinkToast.success("Link enviado! Verifique seu e-mail.");
                },
             },
          );
       },
-      [redirectTo],
+      [magicLinkToast, redirectTo, setSent],
    );
 
    const form = useForm({
@@ -108,7 +125,7 @@ function MagicLinkPage() {
       [form],
    );
 
-   if (isSent) {
+   if (sent) {
       return (
          <div className="flex w-full flex-col gap-6">
             <div className="flex items-center justify-center">
@@ -128,7 +145,7 @@ function MagicLinkPage() {
             <div className="flex flex-col gap-2">
                <Button
                   className="h-10"
-                  onClick={() => setIsSent(false)}
+                  onClick={() => setSent(false)}
                   variant="outline"
                >
                   Usar outro email

--- a/apps/web/src/routes/auth/sign-in/email.tsx
+++ b/apps/web/src/routes/auth/sign-in/email.tsx
@@ -8,11 +8,11 @@ import {
 import { Input } from "@packages/ui/components/input";
 import { PasswordInput } from "@packages/ui/components/password-input";
 import { Spinner } from "@packages/ui/components/spinner";
+import { useToastActions } from "@packages/ui/hooks/use-toast";
 import { useForm } from "@tanstack/react-form";
 import { createFileRoute, Link, useRouter } from "@tanstack/react-router";
 import { ArrowLeft } from "lucide-react";
 import { type FormEvent, useCallback } from "react";
-import { toast } from "sonner";
 import { z } from "zod";
 import { authClient } from "@/integrations/better-auth/auth-client";
 
@@ -36,6 +36,7 @@ export const Route = createFileRoute("/auth/sign-in/email")({
 function SignInEmailPage() {
    const router = useRouter();
    const { redirect: redirectTo } = Route.useSearch();
+   const signInToast = useToastActions("sign-in-email");
 
    const handleSignIn = useCallback(
       async (email: string, password: string) => {
@@ -43,15 +44,13 @@ function SignInEmailPage() {
             { email, password },
             {
                onError: ({ error }) => {
-                  toast.error(error.message);
+                  signInToast.error(error.message);
                },
                onRequest: () => {
-                  toast.loading("Entrando na sua conta...", {
-                     id: "sign-in-email",
-                  });
+                  signInToast.loading("Entrando na sua conta...");
                },
                onSuccess: () => {
-                  toast.success("Bem-vindo de volta!", { id: "sign-in-email" });
+                  signInToast.success("Bem-vindo de volta!");
                   router.navigate({
                      search: { redirect: redirectTo },
                      to: "/auth/callback",
@@ -60,7 +59,7 @@ function SignInEmailPage() {
             },
          );
       },
-      [redirectTo, router],
+      [redirectTo, router, signInToast],
    );
 
    const form = useForm({

--- a/apps/web/src/routes/auth/sign-up.tsx
+++ b/apps/web/src/routes/auth/sign-up.tsx
@@ -9,16 +9,10 @@ import { Input } from "@packages/ui/components/input";
 import { PasswordInput } from "@packages/ui/components/password-input";
 import { Spinner } from "@packages/ui/components/spinner";
 import { defineStepper } from "@packages/ui/components/stepper";
+import { useToastActions } from "@packages/ui/hooks/use-toast";
 import { useForm } from "@tanstack/react-form";
 import { createFileRoute, Link, useRouter } from "@tanstack/react-router";
-import {
-   createContext,
-   type FormEvent,
-   useCallback,
-   useContext,
-   useTransition,
-} from "react";
-import { toast } from "sonner";
+import { createContext, type FormEvent, useCallback, useContext } from "react";
 import z from "zod";
 import { authClient } from "@/integrations/better-auth/auth-client";
 import { PasswordStrengthCard } from "./-auth/password-strength-card";
@@ -205,7 +199,7 @@ function PasswordStep() {
 function SignUpPage() {
    const router = useRouter();
    const { redirect: redirectTo } = Route.useSearch();
-   const [isPending, startTransition] = useTransition();
+   const signUpToast = useToastActions("sign-up-email");
 
    const handleSignUp = useCallback(
       async (email: string, name: string, password: string) => {
@@ -213,13 +207,13 @@ function SignUpPage() {
             { email, name, password },
             {
                onError: ({ error }) => {
-                  toast.error(error.message);
+                  signUpToast.error(error.message);
                },
                onRequest: () => {
-                  toast.loading("Criando sua conta...");
+                  signUpToast.loading("Criando sua conta...");
                },
                onSuccess: ({ data }) => {
-                  toast.success("Conta criada com sucesso!");
+                  signUpToast.success("Conta criada com sucesso!");
                   if (data?.token) {
                      router.navigate({ to: redirectTo ?? "/auth/callback" });
                      return;
@@ -232,7 +226,7 @@ function SignUpPage() {
             },
          );
       },
-      [redirectTo, router],
+      [redirectTo, router, signUpToast],
    );
 
    const form = useForm({
@@ -255,11 +249,9 @@ function SignUpPage() {
       (e: FormEvent) => {
          e.preventDefault();
          e.stopPropagation();
-         startTransition(async () => {
-            await form.handleSubmit();
-         });
+         form.handleSubmit();
       },
-      [form, startTransition],
+      [form],
    );
 
    return (
@@ -312,14 +304,10 @@ function SignUpPage() {
                               <div className="flex flex-col gap-2">
                                  <Button
                                     className="h-10"
-                                    disabled={isSubmitting || isPending}
+                                    disabled={isSubmitting}
                                     type="submit"
                                  >
-                                    {isPending || isSubmitting ? (
-                                       <Spinner />
-                                    ) : (
-                                       "Criar conta"
-                                    )}
+                                    {isSubmitting ? <Spinner /> : "Criar conta"}
                                  </Button>
                                  <Button
                                     className="h-10"

--- a/packages/ui/src/hooks/use-toast.ts
+++ b/packages/ui/src/hooks/use-toast.ts
@@ -1,0 +1,84 @@
+"use client";
+
+import { useCallback } from "foxact/use-typescript-happy-callback";
+import { useMemo, type ReactElement, type ReactNode } from "react";
+import { type ExternalToast, toast } from "sonner";
+
+type ToastId = NonNullable<ExternalToast["id"]>;
+type ToastMessage = ReactNode | (() => ReactNode);
+type ToastOptions = Omit<ExternalToast, "id">;
+
+export function useToastActions(id: ToastId) {
+   const withToastId = useCallback(
+      (options?: ToastOptions): ExternalToast => ({
+         ...options,
+         id,
+      }),
+      [id],
+   );
+
+   const show = useCallback(
+      (message: ToastMessage, options?: ToastOptions) =>
+         toast(message, withToastId(options)),
+      [withToastId],
+   );
+
+   const success = useCallback(
+      (message: ToastMessage, options?: ToastOptions) =>
+         toast.success(message, withToastId(options)),
+      [withToastId],
+   );
+
+   const info = useCallback(
+      (message: ToastMessage, options?: ToastOptions) =>
+         toast.info(message, withToastId(options)),
+      [withToastId],
+   );
+
+   const warning = useCallback(
+      (message: ToastMessage, options?: ToastOptions) =>
+         toast.warning(message, withToastId(options)),
+      [withToastId],
+   );
+
+   const error = useCallback(
+      (message: ToastMessage, options?: ToastOptions) =>
+         toast.error(message, withToastId(options)),
+      [withToastId],
+   );
+
+   const loading = useCallback(
+      (message: ToastMessage, options?: ToastOptions) =>
+         toast.loading(message, withToastId(options)),
+      [withToastId],
+   );
+
+   const message = useCallback(
+      (message: ToastMessage, options?: ToastOptions) =>
+         toast.message(message, withToastId(options)),
+      [withToastId],
+   );
+
+   const custom = useCallback(
+      (jsx: (id: ToastId) => ReactElement, options?: ToastOptions) =>
+         toast.custom(jsx, withToastId(options)),
+      [withToastId],
+   );
+
+   const dismiss = useCallback(() => toast.dismiss(id), [id]);
+
+   return useMemo(
+      () => ({
+         custom,
+         dismiss,
+         error,
+         info,
+         loading,
+         message,
+         success,
+         toast: show,
+         warning,
+      }),
+      [custom, dismiss, error, info, loading, message, show, success, warning],
+   );
+}


### PR DESCRIPTION
## Summary
- Add a shared useToast hook that wraps Sonner calls with a fixed toast id
- Use the wrapper in auth request flows so loading/success/error update the same toast
- Replace local magic-link sent state with a TanStack Router search param and remove unnecessary sign-up transition state

## Validation
- bun --filter @packages/ui typecheck
- bun --filter @packages/ui build
- bun --filter web check

Note: Nx task execution was blocked in the worktree by Nx plugin worker startup failures. Full web typecheck was also blocked by missing dependent package dist declarations in the fresh worktree.