### PR TITLE
feat(finance): add installment support for transactions

### DIFF
--- a/apps/landing/src/blocks/footer-block.astro
+++ b/apps/landing/src/blocks/footer-block.astro
@@ -29,8 +29,14 @@ const year = dayjs().year();
          </p>
          <nav
             class="flex items-center justify-center gap-4 pt-2 text-sm"
-            aria-label="Links legais"
+            aria-label="Links do rodapé"
          >
+            <a
+               href="/blog"
+               class="text-foreground/80 transition-colors hover:text-foreground"
+            >
+               Blog
+            </a>
             <a
                href="/privacidade"
                class="text-foreground/80 transition-colors hover:text-foreground"

--- a/apps/landing/src/pages/blog/[...slug].astro
+++ b/apps/landing/src/pages/blog/[...slug].astro
@@ -30,7 +30,10 @@ const canonical = new URL(`/blog/${post.id}`, siteUrl).toString();
 const generatedOgPath = `/open-graph/${post.id}.png`;
 const ogImagePath = post.data.ogImage?.src ?? generatedOgPath;
 const ogImageUrl = new URL(ogImagePath, siteUrl).toString();
-const computedReading = readingTime(post.body ?? "", 220, "pt-br");
+const computedReading = readingTime(post.body ?? "", {
+   wordsPerMinute: 220,
+   language: "pt-br",
+});
 const readingMinutes =
    post.data.readingMinutes ?? Math.max(1, computedReading.minutes);
 

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-form-sheet.tsx
@@ -44,6 +44,7 @@ import { UploadProgress } from "@packages/ui/components/upload-progress";
 import { cn } from "@packages/ui/lib/utils";
 import { useUploadFiles } from "@better-upload/client";
 import imageCompression from "browser-image-compression";
+import { format, of } from "@f-o-t/money";
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import dayjs from "dayjs";
@@ -62,6 +63,7 @@ import { QueryBoundary } from "@/components/query-boundary";
 import { useSheet } from "@/hooks/use-sheet";
 import { orpc } from "@/integrations/orpc/client";
 import type { Outputs } from "@/integrations/orpc/client";
+import { buildInstallmentPreview } from "@/utils/finance/installments";
 import { CATEGORY_ICON_MAP } from "../-categories/category-icons";
 
 type CategoryNode = Outputs["categories"]["getAll"][number];
@@ -115,6 +117,10 @@ const formSchema = z
       date: z.string().min(1, "Data é obrigatória."),
       status: z.enum(["pending", "paid"]),
       ignored: z.boolean(),
+      isInstallment: z.boolean(),
+      installmentCount: z
+         .number({ message: "Número de parcelas é obrigatório." })
+         .optional(),
       dueDate: z.string(),
       bankAccountId: z.string(),
       destinationBankAccountId: z.string(),
@@ -190,6 +196,73 @@ const formSchema = z
             message: "Categoria é obrigatória.",
          });
       }
+      if (v.type === "transfer" && v.isInstallment) {
+         ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["isInstallment"],
+            message: "Transferências não podem ser parceladas.",
+         });
+      }
+      if (v.isInstallment && !v.installmentCount) {
+         ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["installmentCount"],
+            message: "Número de parcelas é obrigatório.",
+         });
+      }
+      if (
+         v.isInstallment &&
+         v.installmentCount !== undefined &&
+         !Number.isInteger(v.installmentCount)
+      ) {
+         ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["installmentCount"],
+            message: "Número de parcelas deve ser inteiro.",
+         });
+      }
+      if (
+         v.isInstallment &&
+         v.installmentCount !== undefined &&
+         v.installmentCount < 2
+      ) {
+         ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["installmentCount"],
+            message: "Número de parcelas deve ser maior que 1.",
+         });
+      }
+      if (
+         v.isInstallment &&
+         v.installmentCount !== undefined &&
+         v.installmentCount > 120
+      ) {
+         ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["installmentCount"],
+            message: "Número de parcelas deve ser menor ou igual a 120.",
+         });
+      }
+      if (
+         v.isInstallment &&
+         v.amount > 0 &&
+         v.installmentCount !== undefined &&
+         v.installmentCount >= 2
+      ) {
+         const preview = buildInstallmentPreview({
+            amount: String(v.amount),
+            count: v.installmentCount,
+            date: v.date,
+            dueDate: v.dueDate || null,
+         });
+         if (preview.isErr()) {
+            ctx.addIssue({
+               code: z.ZodIssueCode.custom,
+               path: ["installmentCount"],
+               message: preview.error,
+            });
+         }
+      }
    });
 
 type FormValues = z.input<typeof formSchema>;
@@ -201,6 +274,8 @@ const DEFAULT_VALUES: FormValues = {
    date: dayjs().format("YYYY-MM-DD"),
    status: "paid",
    ignored: false,
+   isInstallment: false,
+   installmentCount: 2,
    dueDate: "",
    bankAccountId: "",
    destinationBankAccountId: "",
@@ -214,6 +289,10 @@ function isFieldInvalid(field: {
    state: { meta: { isTouched: boolean; errors: unknown[] } };
 }) {
    return field.state.meta.isTouched && field.state.meta.errors.length > 0;
+}
+
+function formatMoney(value: string) {
+   return format(of(value, "BRL"), "pt-BR");
 }
 
 async function compressIfImage(files: File[]) {
@@ -581,6 +660,12 @@ function TransactionFormSheetContent() {
                date: value.date,
                status: value.status,
                ignored: value.ignored,
+               isInstallment:
+                  value.type !== "transfer" ? value.isInstallment : false,
+               installmentCount:
+                  value.type !== "transfer" && value.isInstallment
+                     ? value.installmentCount
+                     : undefined,
                dueDate: value.dueDate || null,
                bankAccountId: value.bankAccountId || null,
                destinationBankAccountId:
@@ -672,6 +757,9 @@ function TransactionFormSheetContent() {
                            if (!parsed) return;
                            field.handleChange(parsed);
                            form.setFieldValue("categoryId", "");
+                           if (parsed === "transfer") {
+                              form.setFieldValue("isInstallment", false);
+                           }
                         }}
                      >
                         <SelectTrigger id={field.name} name={field.name}>
@@ -874,6 +962,141 @@ function TransactionFormSheetContent() {
                   </Field>
                )}
             </form.Field>
+
+            <form.Subscribe
+               selector={(s) => ({
+                  amount: s.values.amount,
+                  date: s.values.date,
+                  dueDate: s.values.dueDate,
+                  installmentCount: s.values.installmentCount,
+                  isInstallment: s.values.isInstallment,
+                  type: s.values.type,
+               })}
+            >
+               {({
+                  amount,
+                  date,
+                  dueDate,
+                  installmentCount,
+                  isInstallment,
+                  type,
+               }) => {
+                  if (type === "transfer") return null;
+                  const canPreview =
+                     isInstallment &&
+                     amount > 0 &&
+                     installmentCount !== undefined &&
+                     installmentCount >= 2;
+                  const preview = canPreview
+                     ? buildInstallmentPreview({
+                          amount: String(amount),
+                          count: installmentCount,
+                          date,
+                          dueDate: dueDate || null,
+                       })
+                     : null;
+
+                  return (
+                     <div className="flex flex-col gap-4 rounded-md border p-4">
+                        <form.Field name="isInstallment">
+                           {(field) => (
+                              <Field
+                                 data-invalid={
+                                    isFieldInvalid(field) || undefined
+                                 }
+                                 orientation="horizontal"
+                              >
+                                 <Checkbox
+                                    aria-invalid={isFieldInvalid(field)}
+                                    checked={field.state.value}
+                                    id={field.name}
+                                    name={field.name}
+                                    onBlur={field.handleBlur}
+                                    onCheckedChange={(checked) =>
+                                       field.handleChange(checked === true)
+                                    }
+                                 />
+                                 <FieldLabel htmlFor={field.name}>
+                                    Parcelar lançamento
+                                 </FieldLabel>
+                                 {isFieldInvalid(field) ? (
+                                    <FieldError>
+                                       {field.state.meta.errors[0]?.message}
+                                    </FieldError>
+                                 ) : null}
+                              </Field>
+                           )}
+                        </form.Field>
+
+                        {isInstallment ? (
+                           <>
+                              <form.Field name="installmentCount">
+                                 {(field) => (
+                                    <Field
+                                       data-invalid={
+                                          isFieldInvalid(field) || undefined
+                                       }
+                                    >
+                                       <FieldLabel
+                                          htmlFor={field.name}
+                                          required
+                                       >
+                                          Número de parcelas
+                                       </FieldLabel>
+                                       <Input
+                                          aria-invalid={isFieldInvalid(field)}
+                                          id={field.name}
+                                          min={2}
+                                          name={field.name}
+                                          type="number"
+                                          value={field.state.value}
+                                          onBlur={field.handleBlur}
+                                          onChange={(e) =>
+                                             field.handleChange(
+                                                Number(e.target.value),
+                                             )
+                                          }
+                                       />
+                                       {isFieldInvalid(field) ? (
+                                          <FieldError>
+                                             {
+                                                field.state.meta.errors[0]
+                                                   ?.message
+                                             }
+                                          </FieldError>
+                                       ) : null}
+                                    </Field>
+                                 )}
+                              </form.Field>
+
+                              {preview?.isOk() ? (
+                                 <div className="flex flex-col gap-2 rounded-md bg-muted p-4 text-sm">
+                                    {preview.value.map((installment) => (
+                                       <div
+                                          className="flex items-center justify-between gap-4"
+                                          key={`installment-${installment.number}`}
+                                       >
+                                          <span>
+                                             {installment.number}/
+                                             {installment.count} -{" "}
+                                             {dayjs(
+                                                installment.dueDate ??
+                                                   installment.date,
+                                             ).format("DD/MM/YYYY")}
+                                          </span>
+                                          <strong>
+                                             {formatMoney(installment.amount)}
+                                          </strong>
+                                       </div>
+                                    ))}
+                                 </div>
+                              ) : null}
+                           </>
+                        ) : null}
+                     </div>
+                  );
+               }}
+            </form.Subscribe>
 
             <form.Field name="name">
                {(field) => (

--- a/apps/web/src/utils/finance/installments.ts
+++ b/apps/web/src/utils/finance/installments.ts
@@ -1,0 +1,93 @@
+import dayjs from "dayjs";
+import { err, ok, type Result } from "neverthrow";
+
+export type InstallmentInput = {
+   amount: string;
+   date: string;
+   dueDate?: string | null;
+   count: number;
+};
+
+export type InstallmentPreview = {
+   number: number;
+   count: number;
+   amount: string;
+   date: string;
+   dueDate: string | null;
+};
+
+const DECIMAL_REGEX = /^(\d+)(?:\.(\d+))?$/;
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+function parseMoneyToCents(value: string): Result<number, string> {
+   const normalized = value.trim();
+   const match = DECIMAL_REGEX.exec(normalized);
+   if (!match) return err("Valor deve ser um número válido maior que zero.");
+
+   const [, majorRaw, minorRaw = ""] = match;
+   if (!majorRaw) return err("Valor deve ser um número válido maior que zero.");
+
+   const major = Number(majorRaw);
+   const centsText = minorRaw.padEnd(3, "0");
+   const centsBase = Number(centsText.slice(0, 2));
+   const shouldRound = Number(centsText.slice(2, 3)) >= 5;
+   const cents = major * 100 + centsBase + (shouldRound ? 1 : 0);
+
+   if (!Number.isSafeInteger(cents) || cents <= 0) {
+      return err("Valor deve ser um número válido maior que zero.");
+   }
+
+   return ok(cents);
+}
+
+function formatCents(cents: number) {
+   const major = Math.floor(cents / 100);
+   const minor = String(cents % 100).padStart(2, "0");
+   return `${major}.${minor}`;
+}
+
+function isValidIsoDate(value: string) {
+   if (!ISO_DATE_REGEX.test(value)) return false;
+   const parsed = dayjs(value);
+   return parsed.isValid() && parsed.format("YYYY-MM-DD") === value;
+}
+
+export function buildInstallmentPreview(
+   input: InstallmentInput,
+): Result<InstallmentPreview[], string> {
+   if (!Number.isInteger(input.count) || input.count < 2) {
+      return err("Número de parcelas deve ser maior que 1.");
+   }
+   if (!isValidIsoDate(input.date)) {
+      return err("Data deve estar no formato YYYY-MM-DD.");
+   }
+   if (input.dueDate && !isValidIsoDate(input.dueDate)) {
+      return err("Vencimento deve estar no formato YYYY-MM-DD.");
+   }
+
+   const parsed = parseMoneyToCents(input.amount);
+   if (parsed.isErr()) return err(parsed.error);
+
+   const baseAmount = Math.floor(parsed.value / input.count);
+   const remainder = parsed.value % input.count;
+
+   if (baseAmount <= 0) {
+      return err("Valor total é baixo demais para o número de parcelas.");
+   }
+
+   return ok(
+      Array.from({ length: input.count }, (_, index) => {
+         const number = index + 1;
+         const amount = baseAmount + (index < remainder ? 1 : 0);
+         return {
+            number,
+            count: input.count,
+            amount: formatCents(amount),
+            date: dayjs(input.date).add(index, "month").format("YYYY-MM-DD"),
+            dueDate: input.dueDate
+               ? dayjs(input.dueDate).add(index, "month").format("YYYY-MM-DD")
+               : null,
+         };
+      }),
+   );
+}

--- a/core/database/src/schemas/transactions.ts
+++ b/core/database/src/schemas/transactions.ts
@@ -4,6 +4,7 @@ import {
    boolean,
    date,
    index,
+   integer,
    jsonb,
    numeric,
    text,
@@ -86,6 +87,9 @@ export const transactions = financeSchema.table(
       status: transactionStatusEnum("status").notNull().default("paid"),
       ignored: boolean("ignored").notNull().default(false),
       dueDate: date("due_date"),
+      installmentGroupId: uuid("installment_group_id"),
+      installmentNumber: integer("installment_number"),
+      installmentCount: integer("installment_count"),
       paidAt: timestamp("paid_at", { withTimezone: true }),
       statementPeriod: text("statement_period"),
       contactId: uuid("contact_id").references(() => contacts.id, {
@@ -124,6 +128,9 @@ export const transactions = financeSchema.table(
       index("transactions_status_idx").on(table.status),
       index("transactions_ignored_idx").on(table.ignored),
       index("transactions_due_date_idx").on(table.dueDate),
+      index("transactions_installment_group_id_idx").on(
+         table.installmentGroupId,
+      ),
       index("transactions_status_type_idx").on(table.status, table.type),
    ],
 );

--- a/modules/finance/__tests__/router/transactions.test.ts
+++ b/modules/finance/__tests__/router/transactions.test.ts
@@ -1,0 +1,137 @@
+import { call } from "@orpc/server";
+import { asc, eq } from "drizzle-orm";
+import {
+   beforeAll,
+   afterAll,
+   beforeEach,
+   describe,
+   expect,
+   it,
+   vi,
+} from "vitest";
+import { setupTestDb } from "@core/database/testing/setup-test-db";
+import { seedTeam } from "@core/database/testing/factories";
+import { createTestContext } from "@core/orpc/testing/create-test-context";
+import { bankAccounts } from "@core/database/schemas/bank-accounts";
+import { transactions } from "@core/database/schemas/transactions";
+
+const { enqueueClassifyTransactionsBatchWorkflowSpy } = vi.hoisted(() => ({
+   enqueueClassifyTransactionsBatchWorkflowSpy: vi
+      .fn()
+      .mockResolvedValue(undefined),
+}));
+
+vi.mock("@modules/classification/workflows/classification-workflow", () => ({
+   enqueueClassifyTransactionsBatchWorkflow:
+      enqueueClassifyTransactionsBatchWorkflowSpy,
+}));
+
+vi.mock("@core/orpc/server", async () =>
+   (await import("@core/orpc/testing/mock-server")).createMockServerModule(),
+);
+
+import * as transactionsRouter from "../../src/router/transactions";
+
+let testDb: Awaited<ReturnType<typeof setupTestDb>>;
+
+beforeAll(async () => {
+   testDb = await setupTestDb();
+}, 30_000);
+
+afterAll(async () => {
+   await testDb.cleanup();
+});
+
+beforeEach(() => {
+   vi.clearAllMocks();
+});
+
+describe("transactions router", () => {
+   it("create persiste parcelas vinculadas com valores e datas determinísticos", async () => {
+      const { teamId, organizationId } = await seedTeam(testDb.db);
+      const ctx = createTestContext(testDb.db, { teamId, organizationId });
+      const [account] = await testDb.db
+         .insert(bankAccounts)
+         .values({
+            teamId,
+            name: "Conta Parcelas",
+            type: "checking",
+            initialBalance: "0",
+            status: "active",
+         })
+         .returning();
+
+      await call(
+         transactionsRouter.create,
+         {
+            type: "expense",
+            name: "Compra parcelada",
+            amount: "100.00",
+            date: "2026-05-15",
+            dueDate: "2026-05-20",
+            status: "pending",
+            ignored: false,
+            bankAccountId: account.id,
+            categoryId: null,
+            isInstallment: true,
+            installmentCount: 3,
+         },
+         { context: ctx },
+      );
+
+      const rows = await testDb.db
+         .select()
+         .from(transactions)
+         .where(eq(transactions.teamId, teamId))
+         .orderBy(asc(transactions.installmentNumber));
+
+      expect(rows).toHaveLength(3);
+      expect(rows.map((row) => row.amount)).toEqual([
+         "33.34",
+         "33.33",
+         "33.33",
+      ]);
+      expect(rows.map((row) => row.date)).toEqual([
+         "2026-05-15",
+         "2026-06-15",
+         "2026-07-15",
+      ]);
+      expect(rows.map((row) => row.dueDate)).toEqual([
+         "2026-05-20",
+         "2026-06-20",
+         "2026-07-20",
+      ]);
+      expect(rows.map((row) => row.installmentNumber)).toEqual([1, 2, 3]);
+      expect(rows.map((row) => row.installmentCount)).toEqual([3, 3, 3]);
+      expect(rows[0]?.installmentGroupId).not.toBeNull();
+      expect(
+         rows.every(
+            (row) => row.installmentGroupId === rows[0]?.installmentGroupId,
+         ),
+      ).toBe(true);
+   });
+
+   it("create rejeita transferência parcelada em pt-BR", async () => {
+      const { teamId, organizationId } = await seedTeam(testDb.db);
+      const ctx = createTestContext(testDb.db, { teamId, organizationId });
+
+      await expect(
+         call(
+            transactionsRouter.create,
+            {
+               type: "transfer",
+               name: "Transferência parcelada",
+               amount: "100.00",
+               date: "2026-05-15",
+               status: "paid",
+               ignored: false,
+               bankAccountId: crypto.randomUUID(),
+               destinationBankAccountId: crypto.randomUUID(),
+               isInstallment: true,
+               installmentCount: 2,
+            },
+            { context: ctx },
+         ),
+      ).rejects.toThrow("Transferências não podem ser parceladas.");
+   });
+});

--- a/modules/finance/__tests__/services/installments.test.ts
+++ b/modules/finance/__tests__/services/installments.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { buildInstallmentPreview } from "../../src/services/installments";
+
+describe("installments", () => {
+   it("distribui centavos restantes nas primeiras parcelas", () => {
+      const result = buildInstallmentPreview({
+         amount: "100.00",
+         count: 3,
+         date: "2026-05-15",
+         dueDate: "2026-05-20",
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) return;
+
+      expect(result.value.map((p) => p.amount)).toEqual([
+         "33.34",
+         "33.33",
+         "33.33",
+      ]);
+      expect(result.value.map((p) => p.date)).toEqual([
+         "2026-05-15",
+         "2026-06-15",
+         "2026-07-15",
+      ]);
+      expect(result.value.map((p) => p.dueDate)).toEqual([
+         "2026-05-20",
+         "2026-06-20",
+         "2026-07-20",
+      ]);
+   });
+
+   it("rejeita total baixo demais para a quantidade de parcelas", () => {
+      const result = buildInstallmentPreview({
+         amount: "0.01",
+         count: 2,
+         date: "2026-05-15",
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isOk()) return;
+      expect(result.error).toBe(
+         "Valor total é baixo demais para o número de parcelas.",
+      );
+   });
+
+   it("rejeita datas inválidas com mensagem em pt-BR", () => {
+      const result = buildInstallmentPreview({
+         amount: "100.00",
+         count: 2,
+         date: "2026-02-31",
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isOk()) return;
+      expect(result.error).toBe("Data deve estar no formato YYYY-MM-DD.");
+   });
+});

--- a/modules/finance/src/router/transactions.ts
+++ b/modules/finance/src/router/transactions.ts
@@ -15,6 +15,7 @@ import {
    requireTransaction,
    requireValidFinancialReferences,
 } from "@modules/finance/router/middlewares";
+import { buildInstallmentPreview } from "@modules/finance/services/installments";
 
 const idSchema = z.object({ id: z.string().uuid() });
 
@@ -33,41 +34,122 @@ const tagAndItemsSchema = z.object({
       .default([]),
 });
 
+const installmentSchema = z
+   .object({
+      isInstallment: z.boolean().optional().default(false),
+      installmentCount: z
+         .number({ message: "Número de parcelas é obrigatório." })
+         .int("Número de parcelas deve ser inteiro.")
+         .min(2, "Número de parcelas deve ser maior que 1.")
+         .max(120, "Número de parcelas deve ser menor ou igual a 120.")
+         .optional(),
+   })
+   .superRefine((data, ctx) => {
+      if (data.isInstallment && !data.installmentCount) {
+         ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Número de parcelas é obrigatório.",
+            path: ["installmentCount"],
+         });
+      }
+   });
+
 export const create = protectedProcedure
    .input(
       createTransactionSchema
          .merge(tagAndItemsSchema)
+         .merge(installmentSchema)
          .merge(z.object({ autoCategorize: z.boolean().default(false) })),
    )
    .use(enforceCostCenterPolicy, (input) => input.tagId)
    .handler(async ({ context, input }) => {
-      const { tagId, items, autoCategorize, ...data } = input;
-      await requireValidFinancialReferences(context.db, context.teamId, {
-         bankAccountId: data.bankAccountId,
-         destinationBankAccountId: data.destinationBankAccountId,
-         categoryId: data.type === "transfer" ? null : data.categoryId,
+      const {
          tagId,
-         contactId: data.contactId,
-         date: data.date,
+         items,
+         autoCategorize,
+         isInstallment,
+         installmentCount: rawInstallmentCount,
+         ...transactionData
+      } = input;
+      const installmentCount = rawInstallmentCount ?? 1;
+      const installmentPreview =
+         isInstallment && installmentCount > 1
+            ? buildInstallmentPreview({
+                 amount: transactionData.amount,
+                 count: installmentCount,
+                 date: transactionData.date,
+                 dueDate: transactionData.dueDate,
+              })
+            : null;
+
+      if (isInstallment && transactionData.type === "transfer") {
+         throw WebAppError.badRequest(
+            "Transferências não podem ser parceladas.",
+         );
+      }
+      if (installmentPreview?.isErr()) {
+         throw WebAppError.badRequest(installmentPreview.error);
+      }
+
+      await requireValidFinancialReferences(context.db, context.teamId, {
+         bankAccountId: transactionData.bankAccountId,
+         destinationBankAccountId: transactionData.destinationBankAccountId,
+         categoryId:
+            transactionData.type === "transfer"
+               ? null
+               : transactionData.categoryId,
+         tagId,
+         contactId: transactionData.contactId,
+         date: transactionData.date,
       });
 
       const txData =
-         data.type === "transfer" ? { ...data, categoryId: null } : data;
+         transactionData.type === "transfer"
+            ? { ...transactionData, categoryId: null }
+            : transactionData;
       const ignored = txData.ignored ?? false;
       const status = txData.status;
+      const installments = installmentPreview?.isOk()
+         ? installmentPreview.value
+         : [
+              {
+                 number: 1,
+                 count: 1,
+                 amount: txData.amount,
+                 date: txData.date,
+                 dueDate: txData.dueDate ?? null,
+              },
+           ];
+      const installmentGroupId =
+         installments.length > 1 ? crypto.randomUUID() : null;
 
       const created = await fromPromise(
          context.db.transaction(async (tx) => {
-            const [row] = await tx
+            const rows = await tx
                .insert(transactions)
-               .values({
-                  ...txData,
-                  status,
-                  ignored,
-                  teamId: context.teamId,
-                  tagId: tagId ?? null,
-               })
+               .values(
+                  installments.map((installment) => ({
+                     ...txData,
+                     amount: installment.amount,
+                     date: installment.date,
+                     dueDate: installment.dueDate,
+                     name:
+                        installment.count > 1 && txData.name
+                           ? `${txData.name} (${installment.number}/${installment.count})`
+                           : txData.name,
+                     status,
+                     ignored,
+                     teamId: context.teamId,
+                     tagId: tagId ?? null,
+                     installmentGroupId,
+                     installmentNumber:
+                        installment.count > 1 ? installment.number : null,
+                     installmentCount:
+                        installment.count > 1 ? installment.count : null,
+                  })),
+               )
                .returning();
+            const [row] = rows;
             if (!row) throw WebAppError.internal("Falha ao criar lançamento.");
             if (items.length > 0) {
                await tx.insert(transactionItems).values(
@@ -96,12 +178,24 @@ export const create = protectedProcedure
          !ignored &&
          (input.type === "income" || input.type === "expense")
       ) {
+         const transactionIds = created.value.installmentGroupId
+            ? await context.db
+                 .select({ id: transactions.id })
+                 .from(transactions)
+                 .where(
+                    eq(
+                       transactions.installmentGroupId,
+                       created.value.installmentGroupId,
+                    ),
+                 )
+                 .then((rows) => rows.map((row) => row.id))
+            : [created.value.id];
          await enqueueClassifyTransactionsBatchWorkflow(
             context.workflowClient,
             {
                organizationId: context.organizationId,
                teamId: context.teamId,
-               transactionIds: [created.value.id],
+               transactionIds,
             },
          );
       }

--- a/modules/finance/src/services/installments.ts
+++ b/modules/finance/src/services/installments.ts
@@ -1,0 +1,93 @@
+import dayjs from "dayjs";
+import { err, ok, type Result } from "neverthrow";
+
+export type InstallmentInput = {
+   amount: string;
+   date: string;
+   dueDate?: string | null;
+   count: number;
+};
+
+export type InstallmentPreview = {
+   number: number;
+   count: number;
+   amount: string;
+   date: string;
+   dueDate: string | null;
+};
+
+const DECIMAL_REGEX = /^(\d+)(?:\.(\d+))?$/;
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+function parseMoneyToCents(value: string): Result<number, string> {
+   const normalized = value.trim();
+   const match = DECIMAL_REGEX.exec(normalized);
+   if (!match) return err("Valor deve ser um número válido maior que zero.");
+
+   const [, majorRaw, minorRaw = ""] = match;
+   if (!majorRaw) return err("Valor deve ser um número válido maior que zero.");
+
+   const major = Number(majorRaw);
+   const centsText = minorRaw.padEnd(3, "0");
+   const centsBase = Number(centsText.slice(0, 2));
+   const shouldRound = Number(centsText.slice(2, 3)) >= 5;
+   const cents = major * 100 + centsBase + (shouldRound ? 1 : 0);
+
+   if (!Number.isSafeInteger(cents) || cents <= 0) {
+      return err("Valor deve ser um número válido maior que zero.");
+   }
+
+   return ok(cents);
+}
+
+function formatCents(cents: number) {
+   const major = Math.floor(cents / 100);
+   const minor = String(cents % 100).padStart(2, "0");
+   return `${major}.${minor}`;
+}
+
+function isValidIsoDate(value: string) {
+   if (!ISO_DATE_REGEX.test(value)) return false;
+   const parsed = dayjs(value);
+   return parsed.isValid() && parsed.format("YYYY-MM-DD") === value;
+}
+
+export function buildInstallmentPreview(
+   input: InstallmentInput,
+): Result<InstallmentPreview[], string> {
+   if (!Number.isInteger(input.count) || input.count < 2) {
+      return err("Número de parcelas deve ser maior que 1.");
+   }
+   if (!isValidIsoDate(input.date)) {
+      return err("Data deve estar no formato YYYY-MM-DD.");
+   }
+   if (input.dueDate && !isValidIsoDate(input.dueDate)) {
+      return err("Vencimento deve estar no formato YYYY-MM-DD.");
+   }
+
+   const parsed = parseMoneyToCents(input.amount);
+   if (parsed.isErr()) return err(parsed.error);
+
+   const baseAmount = Math.floor(parsed.value / input.count);
+   const remainder = parsed.value % input.count;
+
+   if (baseAmount <= 0) {
+      return err("Valor total é baixo demais para o número de parcelas.");
+   }
+
+   return ok(
+      Array.from({ length: input.count }, (_, index) => {
+         const number = index + 1;
+         const amount = baseAmount + (index < remainder ? 1 : 0);
+         return {
+            number,
+            count: input.count,
+            amount: formatCents(amount),
+            date: dayjs(input.date).add(index, "month").format("YYYY-MM-DD"),
+            dueDate: input.dueDate
+               ? dayjs(input.dueDate).add(index, "month").format("YYYY-MM-DD")
+               : null,
+         };
+      }),
+   );
+}


### PR DESCRIPTION
## Summary
- adds installment metadata to manual transactions so related installments can be identified together
- shares the installment calculation rule between the form preview and backend creation boundary without importing backend code into the client
- creates monthly installment transactions with deterministic cent rounding and pt-BR validation errors
- keeps the footer Blog link in the PR and updates the landing blog reading-time call for the current package API
- covers calculation and router persistence with focused tests

## Validation
- bun --filter @core/database build
- bun --filter @core/database typecheck
- bun --filter @modules/finance typecheck
- bun --filter @modules/finance test -- __tests__/services/installments.test.ts __tests__/router/transactions.test.ts
- bun --filter web typecheck
- bun --filter @modules/finance check
- bun --filter web check (passes with pre-existing warnings outside the touched feature files)
- bun nx run landing:typecheck
- bun run check-boundaries
- bun nx affected -t typecheck --base=origin/master --head=HEAD --parallel=8
- bun nx affected -t check --base=origin/master --head=HEAD --parallel=8
- git diff --check