### PR TITLE
MON-961: Implementar lançamentos recorrentes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Skills live in `.agents/skills/<name>/SKILL.md`. Open the SKILL.md before writin
 
 Domain → skill map (open before coding):
 
-- oRPC handlers/errors → `neverthrow`. Schema/queries → `postgres-drizzle`. Search/BM25 → `paradedb-skill`. Redis → `redis-best-practices`.
+- New Payments/Vault/domain errors → `better-result`. Legacy oRPC handlers/errors still using `neverthrow` → `neverthrow`. Schema/queries → `postgres-drizzle`. Search/BM25 → `paradedb-skill`. Redis → `redis-best-practices`.
 - Client data → `tanstack-query`. Forms → `tanstack-form`. Tables → `tanstack-table` (+ `tanstack-virtual` for long lists). Routes → `tanstack-router`. Stores → `tanstack-store` (+ `tanstack-db`). SSR/server fns → `tanstack-start` (+ `tanstack-devtools`).
 - AI agents → `tanstack-ai`. Durable workflows → `dbos-typescript`.
 - Auth → `better-auth-best-practices` (sub-skills exist for email/2FA/orgs/scaffolding).
@@ -250,7 +250,7 @@ Routers tag cost-incurring procedures with `billableProcedure` + `.meta({ billab
 ## Code Style
 
 - TypeScript: **never `as`** in any form (including `[] as string[]`) — fix the source type. No redundant return types Claude can infer. No unused params (delete; no `_foo`). No JSDoc / section comments / inline rationale. No barrel files. No relative imports in `core/` — `@core/<pkg>/*`. No dynamic imports.
-- Errors: **no `try/catch`** — use `neverthrow` (`fromPromise`, `fromThrowable`, `ok`, `err`, `Result`, `ResultAsync`, `safeTry`). Patterns: early return on `isErr`, `andThen` chains, no `match(v=>v, e=>throw)`, no `Promise.reject` inside `match`, fire-and-forget uses `.catch(log)`. Exception: tests and scripts.
+- Errors: **no `try/catch`** — for new Payments/Vault/domain code use `better-result` with tagged expected errors, Zod at contract edges, no `unknown` leakage, and serialization across workflow/API boundaries when needed. Legacy modules still on `neverthrow` may keep `fromPromise`, `fromThrowable`, `ok`, `err`, `Result`, `ResultAsync`, `safeTry`; do not mix both libraries inside one module. Exception: tests and scripts.
 - Control flow: early returns, never `else` after `return`. Minimize `useEffect` — derive state or use event handlers; `useEffect` only for external sync. Use `useCallback`, never `useStableHandler`.
 - Dates: always `dayjs`. Never `new Date()` (exceptions: Drizzle `.$onUpdate()`, test fixtures). `.toDate()` for Drizzle, `.toISOString()` for ISO, `.format("YYYY-MM-DD")` for date strings.
 - Naming: files kebab-case. Components PascalCase `[Feature][Action][Type]`. Hooks `use[Feature][Action]`.

--- a/apps/web-e2e/helpers/db.ts
+++ b/apps/web-e2e/helpers/db.ts
@@ -18,7 +18,10 @@ import { bankAccounts } from "@core/database/schemas/bank-accounts";
 import { creditCards } from "@core/database/schemas/credit-cards";
 import { categories } from "@core/database/schemas/categories";
 import { tags } from "@core/database/schemas/tags";
-import { transactions } from "@core/database/schemas/transactions";
+import {
+   transactionRecurrences,
+   transactions,
+} from "@core/database/schemas/transactions";
 
 loadEnv({
    path: path.join(import.meta.dirname, "..", "..", "web", ".env.local"),
@@ -260,6 +263,54 @@ export async function findTransactionByName(teamId: string, name: string) {
    return db().query.transactions.findFirst({
       where: (f, { and, eq }) => and(eq(f.teamId, teamId), eq(f.name, name)),
    });
+}
+
+export async function findTransactionsByName(teamId: string, name: string) {
+   return db().query.transactions.findMany({
+      where: (f, { and, eq }) => and(eq(f.teamId, teamId), eq(f.name, name)),
+      orderBy: (f, { asc }) => [
+         asc(f.recurrenceOccurrenceNumber),
+         asc(f.installmentNumber),
+         asc(f.createdAt),
+      ],
+   });
+}
+
+export async function findTransactionsByInstallmentGroupId(
+   teamId: string,
+   installmentGroupId: string,
+) {
+   return db().query.transactions.findMany({
+      where: (f, { and, eq }) =>
+         and(
+            eq(f.teamId, teamId),
+            eq(f.installmentGroupId, installmentGroupId),
+         ),
+      orderBy: (f, { asc }) => [asc(f.installmentNumber)],
+   });
+}
+
+export async function findTransactionRecurrenceById(
+   teamId: string,
+   id: string,
+) {
+   return db().query.transactionRecurrences.findFirst({
+      where: (f, { and, eq }) => and(eq(f.teamId, teamId), eq(f.id, id)),
+   });
+}
+
+export async function deleteTransactionRecurrenceById(
+   teamId: string,
+   id: string,
+) {
+   await db()
+      .delete(transactionRecurrences)
+      .where(
+         and(
+            eq(transactionRecurrences.teamId, teamId),
+            eq(transactionRecurrences.id, id),
+         ),
+      );
 }
 
 export async function insertExpenseTransaction(

--- a/apps/web-e2e/tests/transactions-create.spec.ts
+++ b/apps/web-e2e/tests/transactions-create.spec.ts
@@ -15,6 +15,8 @@ import {
    insertCategory,
 } from "../helpers/db";
 
+test.describe.configure({ mode: "serial" });
+
 const stamp = () => `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
 const createdTxIds: string[] = [];
 const createdAccountIds: string[] = [];
@@ -220,7 +222,9 @@ test("cria despesa parcelada", async ({ page, e2eSession }) => {
       team.id,
       `${txName} (1/3)`,
    );
-   if (!firstInstallment?.installmentGroupId) return;
+   if (!firstInstallment?.installmentGroupId) {
+      throw new Error("Parcelamento não criou grupo de parcelas.");
+   }
    const rows = await findTransactionsByInstallmentGroupId(
       team.id,
       firstInstallment.installmentGroupId,

--- a/apps/web-e2e/tests/transactions-create.spec.ts
+++ b/apps/web-e2e/tests/transactions-create.spec.ts
@@ -2,27 +2,29 @@ import type { Page } from "@playwright/test";
 import { expect, test, type E2ESession } from "../fixtures";
 import {
    deleteBankAccountById,
+   deleteCategoryById,
+   deleteTransactionRecurrenceById,
    deleteTransactionById,
    findBankAccountByName,
+   findTransactionRecurrenceById,
    findTeamByOrgAndSlug,
    findTransactionByName,
+   findTransactionsByInstallmentGroupId,
+   findTransactionsByName,
+   insertBankAccount,
+   insertCategory,
 } from "../helpers/db";
 
 const stamp = () => `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
 const createdTxIds: string[] = [];
 const createdAccountIds: string[] = [];
+const createdCategoryIds: string[] = [];
+const createdRecurrenceIds: string[] = [];
 
 async function gotoTransactions(page: Page, session: E2ESession) {
    await page.goto(`/${session.orgSlug}/${session.teamSlug}/transactions`);
    await expect(
       page.getByRole("heading", { name: "Lançamentos" }),
-   ).toBeVisible();
-}
-
-async function gotoBankAccounts(page: Page, session: E2ESession) {
-   await page.goto(`/${session.orgSlug}/${session.teamSlug}/bank-accounts`);
-   await expect(
-      page.getByRole("heading", { name: "Contas Bancárias" }),
    ).toBeVisible();
 }
 
@@ -40,11 +42,6 @@ async function rememberCreatedAccount(session: E2ESession, name: string) {
    const account = await findBankAccountByName(team.id, name);
    if (!account) return;
    createdAccountIds.push(account.id);
-}
-
-async function expectBankAccountRowVisible(page: Page, name: string) {
-   await page.getByPlaceholder("Buscar conta por nome...").fill(name);
-   await expect(page.getByRole("row").filter({ hasText: name })).toBeVisible();
 }
 
 async function expectTransactionRowVisible(session: E2ESession, name: string) {
@@ -65,11 +62,17 @@ async function selectComboboxOption(
    await page.getByRole("option", { name: optionName }).click();
 }
 
-async function ensureBankAccount(
+async function selectCategoryOption(
    page: Page,
-   session: E2ESession,
-   name: string,
+   label: string,
+   optionName: string,
 ) {
+   await page.getByRole("combobox", { name: label }).click();
+   await page.getByPlaceholder("Buscar categoria...").fill(optionName);
+   await page.getByRole("option", { name: optionName }).click();
+}
+
+async function ensureBankAccount(session: E2ESession, name: string) {
    const team = await findTeamByOrgAndSlug(session.orgSlug, session.teamSlug);
    if (!team) return;
    const existing = await findBankAccountByName(team.id, name);
@@ -77,15 +80,8 @@ async function ensureBankAccount(
       createdAccountIds.push(existing.id);
       return;
    }
-   await gotoBankAccounts(page, session);
-   await page.getByRole("button", { name: "Nova Conta" }).click();
-   const sheet = page.getByRole("dialog");
-   await sheet.getByLabel("Nome").fill(name);
-   await sheet.getByLabel("Tipo").click();
-   await page.getByRole("option", { name: "Caixa Físico" }).click();
-   await sheet.getByRole("button", { name: "Criar conta" }).click();
+   await insertBankAccount(team.id, name);
    await rememberCreatedAccount(session, name);
-   await expectBankAccountRowVisible(page, name);
 }
 
 test.afterEach(async ({ e2eSession }) => {
@@ -94,8 +90,14 @@ test.afterEach(async ({ e2eSession }) => {
       e2eSession.teamSlug,
    );
    if (!team) return;
+   for (const id of createdRecurrenceIds.splice(0)) {
+      await deleteTransactionRecurrenceById(team.id, id);
+   }
    for (const id of createdTxIds.splice(0)) {
       await deleteTransactionById(team.id, id);
+   }
+   for (const id of createdCategoryIds.splice(0)) {
+      await deleteCategoryById(team.id, id);
    }
    for (const id of createdAccountIds.splice(0)) {
       await deleteBankAccountById(team.id, id);
@@ -104,9 +106,21 @@ test.afterEach(async ({ e2eSession }) => {
 
 test("cria receita com conta bancária", async ({ page, e2eSession }) => {
    const accountName = `Caixa Receita ${stamp()}`;
+   const categoryName = `Categoria Receita ${stamp()}`;
    const txName = `Receita E2E ${stamp()}`;
+   const team = await findTeamByOrgAndSlug(
+      e2eSession.orgSlug,
+      e2eSession.teamSlug,
+   );
+   expect(team).not.toBeNull();
+   if (!team) return;
+   const category = await insertCategory(team.id, {
+      name: categoryName,
+      type: "income",
+   });
+   createdCategoryIds.push(category.id);
 
-   await ensureBankAccount(page, e2eSession, accountName);
+   await ensureBankAccount(e2eSession, accountName);
    await gotoTransactions(page, e2eSession);
    await page.getByRole("button", { name: "Novo Lançamento" }).click();
 
@@ -120,6 +134,7 @@ test("cria receita com conta bancária", async ({ page, e2eSession }) => {
    await sheet.getByLabel("Valor").fill("123,45");
 
    await selectComboboxOption(page, "Conta bancária", accountName);
+   await selectCategoryOption(page, "Categoria", categoryName);
 
    await expect(submit).toBeEnabled();
    await submit.click();
@@ -130,9 +145,21 @@ test("cria receita com conta bancária", async ({ page, e2eSession }) => {
 
 test("cria despesa com conta bancária", async ({ page, e2eSession }) => {
    const accountName = `Caixa Despesa ${stamp()}`;
+   const categoryName = `Categoria Despesa ${stamp()}`;
    const txName = `Despesa E2E ${stamp()}`;
+   const team = await findTeamByOrgAndSlug(
+      e2eSession.orgSlug,
+      e2eSession.teamSlug,
+   );
+   expect(team).not.toBeNull();
+   if (!team) return;
+   const category = await insertCategory(team.id, {
+      name: categoryName,
+      type: "expense",
+   });
+   createdCategoryIds.push(category.id);
 
-   await ensureBankAccount(page, e2eSession, accountName);
+   await ensureBankAccount(e2eSession, accountName);
    await gotoTransactions(page, e2eSession);
    await page.getByRole("button", { name: "Novo Lançamento" }).click();
 
@@ -143,6 +170,7 @@ test("cria despesa com conta bancária", async ({ page, e2eSession }) => {
    await sheet.getByLabel("Valor").fill("99,90");
 
    await selectComboboxOption(page, "Conta bancária", accountName);
+   await selectCategoryOption(page, "Categoria", categoryName);
 
    await sheet.getByRole("button", { name: "Criar lançamento" }).click();
    await expect(page.getByText("Lançamento criado com sucesso.")).toBeVisible();
@@ -150,13 +178,127 @@ test("cria despesa com conta bancária", async ({ page, e2eSession }) => {
    await expectTransactionRowVisible(e2eSession, txName);
 });
 
+test("cria despesa parcelada", async ({ page, e2eSession }) => {
+   const accountName = `Caixa Parcelado ${stamp()}`;
+   const categoryName = `Categoria Parcelado ${stamp()}`;
+   const txName = `Parcelado E2E ${stamp()}`;
+   const team = await findTeamByOrgAndSlug(
+      e2eSession.orgSlug,
+      e2eSession.teamSlug,
+   );
+   expect(team).not.toBeNull();
+   if (!team) return;
+   const category = await insertCategory(team.id, {
+      name: categoryName,
+      type: "expense",
+   });
+   createdCategoryIds.push(category.id);
+
+   await ensureBankAccount(e2eSession, accountName);
+   await gotoTransactions(page, e2eSession);
+   await page.getByRole("button", { name: "Novo Lançamento" }).click();
+
+   const sheet = page.getByRole("dialog");
+   await sheet.getByLabel("Nome").fill(txName);
+   await sheet.getByLabel("Valor").fill("120,00");
+   await selectComboboxOption(page, "Conta bancária", accountName);
+   await selectCategoryOption(page, "Categoria", categoryName);
+   await sheet.getByLabel("Parcelar lançamento").check();
+   await sheet.getByLabel("Número de parcelas").fill("3");
+
+   await sheet.getByRole("button", { name: "Criar lançamento" }).click();
+   await expect(page.getByText("Lançamento criado com sucesso.")).toBeVisible();
+
+   await expect
+      .poll(
+         async () =>
+            (await findTransactionByName(team.id, `${txName} (1/3)`))?.id ??
+            null,
+      )
+      .not.toBeNull();
+   const firstInstallment = await findTransactionByName(
+      team.id,
+      `${txName} (1/3)`,
+   );
+   if (!firstInstallment?.installmentGroupId) return;
+   const rows = await findTransactionsByInstallmentGroupId(
+      team.id,
+      firstInstallment.installmentGroupId,
+   );
+   createdTxIds.push(...rows.map((row) => row.id));
+
+   expect(rows).toHaveLength(3);
+   expect(rows.map((row) => row.name)).toEqual([
+      `${txName} (1/3)`,
+      `${txName} (2/3)`,
+      `${txName} (3/3)`,
+   ]);
+   expect(rows.map((row) => row.amount)).toEqual(["40.00", "40.00", "40.00"]);
+   expect(rows.map((row) => row.installmentNumber)).toEqual([1, 2, 3]);
+   expect(rows.map((row) => row.installmentCount)).toEqual([3, 3, 3]);
+});
+
+test("cria despesa recorrente", async ({ page, e2eSession }) => {
+   const accountName = `Caixa Recorrente ${stamp()}`;
+   const categoryName = `Categoria Recorrente ${stamp()}`;
+   const txName = `Recorrente E2E ${stamp()}`;
+   const team = await findTeamByOrgAndSlug(
+      e2eSession.orgSlug,
+      e2eSession.teamSlug,
+   );
+   expect(team).not.toBeNull();
+   if (!team) return;
+   const category = await insertCategory(team.id, {
+      name: categoryName,
+      type: "expense",
+   });
+   createdCategoryIds.push(category.id);
+
+   await ensureBankAccount(e2eSession, accountName);
+   await gotoTransactions(page, e2eSession);
+   await page.getByRole("button", { name: "Novo Lançamento" }).click();
+
+   const sheet = page.getByRole("dialog");
+   await sheet.getByLabel("Nome").fill(txName);
+   await sheet.getByLabel("Valor").fill("80,00");
+   await selectComboboxOption(page, "Conta bancária", accountName);
+   await selectCategoryOption(page, "Categoria", categoryName);
+   await sheet.getByLabel("Lançamento recorrente").check();
+   await sheet.getByLabel("Periodicidade").click();
+   await page.getByRole("option", { name: "Mensal" }).click();
+
+   await sheet.getByRole("button", { name: "Criar lançamento" }).click();
+   await expect(page.getByText("Lançamento criado com sucesso.")).toBeVisible();
+
+   await expect
+      .poll(async () => (await findTransactionsByName(team.id, txName)).length)
+      .toBe(2);
+   const rows = await findTransactionsByName(team.id, txName);
+   const recurrenceId = rows[0]?.recurrenceId;
+   expect(recurrenceId).not.toBeNull();
+   if (!recurrenceId) return;
+   createdRecurrenceIds.push(recurrenceId);
+   createdTxIds.push(...rows.map((row) => row.id));
+
+   expect(rows.every((row) => row.recurrenceId === recurrenceId)).toBe(true);
+   expect(rows.map((row) => row.amount)).toEqual(["80.00", "80.00"]);
+   expect(rows.map((row) => row.recurrenceOccurrenceNumber)).toEqual([1, 2]);
+
+   const recurrence = await findTransactionRecurrenceById(
+      team.id,
+      recurrenceId,
+   );
+   expect(recurrence?.frequency).toBe("monthly");
+   expect(recurrence?.status).toBe("active");
+});
+
 test("cria transferência entre contas", async ({ page, e2eSession }) => {
    const fromName = `Origem ${stamp()}`;
    const toName = `Destino ${stamp()}`;
    const txName = `Transferência E2E ${stamp()}`;
 
-   await ensureBankAccount(page, e2eSession, fromName);
-   await ensureBankAccount(page, e2eSession, toName);
+   await ensureBankAccount(e2eSession, fromName);
+   await ensureBankAccount(e2eSession, toName);
 
    await gotoTransactions(page, e2eSession);
    await page.getByRole("button", { name: "Novo Lançamento" }).click();

--- a/apps/web/src/blocks/data-table/data-table-body.tsx
+++ b/apps/web/src/blocks/data-table/data-table-body.tsx
@@ -25,6 +25,7 @@ function getPinStyles<TData>(column: Column<TData>): React.CSSProperties {
 
 interface DataTableBodyProps<TData> {
    table: Table<TData>;
+   getRowClassName?: (props: { row: Row<TData> }) => string | undefined;
    renderRow?: (props: { row: Row<TData> }) => React.ReactNode;
    renderExpandedRow?: (props: { row: Row<TData> }) => React.ReactNode;
    renderGroupLabel?: (props: { row: Row<TData> }) => React.ReactNode;
@@ -61,6 +62,7 @@ function defaultGroupLabel<TData>(row: Row<TData>): React.ReactNode {
 
 export function DataTableBody<TData>({
    table,
+   getRowClassName,
    renderRow,
    renderExpandedRow,
    renderGroupLabel,
@@ -106,6 +108,7 @@ export function DataTableBody<TData>({
                renderRow({ row })
             ) : (
                <TableRow
+                  className={getRowClassName?.({ row })}
                   data-selected={row.getIsSelected()}
                   data-state={row.getIsSelected() ? "selected" : undefined}
                   key={row.id}

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-form-sheet.tsx
@@ -83,16 +83,33 @@ const TYPE_OPTIONS: { value: TransactionType; label: string }[] = [
 
 type TransactionStatus = "paid" | "pending";
 type StatusOption = { value: TransactionStatus; label: string };
+type RecurrenceFrequency = "daily" | "weekly" | "biweekly" | "monthly";
 
 const STATUS_OPTIONS: StatusOption[] = [
    { value: "paid", label: "Efetivado" },
    { value: "pending", label: "Pendente" },
 ];
 
+const RECURRENCE_OPTIONS: {
+   value: RecurrenceFrequency;
+   label: string;
+}[] = [
+   { value: "daily", label: "Diário" },
+   { value: "weekly", label: "Semanal" },
+   { value: "biweekly", label: "Quinzenal" },
+   { value: "monthly", label: "Mensal" },
+];
+
 const ATTACHMENT_MAX_FILES = 5;
 
 function parseStatus(value: string): TransactionStatus | undefined {
    return STATUS_OPTIONS.find((s) => s.value === value)?.value;
+}
+
+function parseRecurrenceFrequency(
+   value: string,
+): RecurrenceFrequency | undefined {
+   return RECURRENCE_OPTIONS.find((o) => o.value === value)?.value;
 }
 
 function extractPublicUrls(metadata: unknown): Record<string, string> {
@@ -121,6 +138,8 @@ const formSchema = z
       installmentCount: z
          .number({ message: "Número de parcelas é obrigatório." })
          .optional(),
+      isRecurring: z.boolean(),
+      recurrenceFrequency: z.enum(["daily", "weekly", "biweekly", "monthly"]),
       dueDate: z.string(),
       bankAccountId: z.string(),
       destinationBankAccountId: z.string(),
@@ -203,6 +222,13 @@ const formSchema = z
             message: "Transferências não podem ser parceladas.",
          });
       }
+      if (v.isRecurring && v.isInstallment) {
+         ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["isRecurring"],
+            message: "Lançamento recorrente não pode ser parcelado.",
+         });
+      }
       if (v.isInstallment && !v.installmentCount) {
          ctx.addIssue({
             code: z.ZodIssueCode.custom,
@@ -276,6 +302,8 @@ const DEFAULT_VALUES: FormValues = {
    ignored: false,
    isInstallment: false,
    installmentCount: 2,
+   isRecurring: false,
+   recurrenceFrequency: "monthly",
    dueDate: "",
    bankAccountId: "",
    destinationBankAccountId: "",
@@ -661,11 +689,19 @@ function TransactionFormSheetContent() {
                status: value.status,
                ignored: value.ignored,
                isInstallment:
-                  value.type !== "transfer" ? value.isInstallment : false,
+                  value.type !== "transfer" && !value.isRecurring
+                     ? value.isInstallment
+                     : false,
                installmentCount:
-                  value.type !== "transfer" && value.isInstallment
+                  value.type !== "transfer" &&
+                  !value.isRecurring &&
+                  value.isInstallment
                      ? value.installmentCount
                      : undefined,
+               isRecurring: value.isRecurring,
+               recurrenceFrequency: value.isRecurring
+                  ? value.recurrenceFrequency
+                  : undefined,
                dueDate: value.dueDate || null,
                bankAccountId: value.bankAccountId || null,
                destinationBankAccountId:
@@ -970,6 +1006,7 @@ function TransactionFormSheetContent() {
                   dueDate: s.values.dueDate,
                   installmentCount: s.values.installmentCount,
                   isInstallment: s.values.isInstallment,
+                  isRecurring: s.values.isRecurring,
                   type: s.values.type,
                })}
             >
@@ -979,11 +1016,13 @@ function TransactionFormSheetContent() {
                   dueDate,
                   installmentCount,
                   isInstallment,
+                  isRecurring,
                   type,
                }) => {
                   if (type === "transfer") return null;
                   const canPreview =
                      isInstallment &&
+                     !isRecurring &&
                      amount > 0 &&
                      installmentCount !== undefined &&
                      installmentCount >= 2;
@@ -1012,9 +1051,16 @@ function TransactionFormSheetContent() {
                                     id={field.name}
                                     name={field.name}
                                     onBlur={field.handleBlur}
-                                    onCheckedChange={(checked) =>
-                                       field.handleChange(checked === true)
-                                    }
+                                    onCheckedChange={(checked) => {
+                                       const next = checked === true;
+                                       field.handleChange(next);
+                                       if (next) {
+                                          form.setFieldValue(
+                                             "isRecurring",
+                                             false,
+                                          );
+                                       }
+                                    }}
                                  />
                                  <FieldLabel htmlFor={field.name}>
                                     Parcelar lançamento
@@ -1097,6 +1143,91 @@ function TransactionFormSheetContent() {
                   );
                }}
             </form.Subscribe>
+
+            <div className="flex flex-col gap-4 rounded-md border p-4">
+               <form.Field name="isRecurring">
+                  {(field) => (
+                     <Field
+                        data-invalid={isFieldInvalid(field) || undefined}
+                        orientation="horizontal"
+                     >
+                        <Checkbox
+                           aria-invalid={isFieldInvalid(field)}
+                           checked={field.state.value}
+                           id={field.name}
+                           name={field.name}
+                           onBlur={field.handleBlur}
+                           onCheckedChange={(checked) => {
+                              const next = checked === true;
+                              field.handleChange(next);
+                              if (next) {
+                                 form.setFieldValue("isInstallment", false);
+                              }
+                           }}
+                        />
+                        <FieldLabel htmlFor={field.name}>
+                           Lançamento recorrente
+                        </FieldLabel>
+                        {isFieldInvalid(field) ? (
+                           <FieldError>
+                              {field.state.meta.errors[0]?.message}
+                           </FieldError>
+                        ) : null}
+                     </Field>
+                  )}
+               </form.Field>
+
+               <form.Subscribe selector={(s) => s.values.isRecurring}>
+                  {(isRecurring) =>
+                     isRecurring ? (
+                        <form.Field name="recurrenceFrequency">
+                           {(field) => (
+                              <Field
+                                 data-invalid={
+                                    isFieldInvalid(field) || undefined
+                                 }
+                              >
+                                 <FieldLabel htmlFor={field.name} required>
+                                    Periodicidade
+                                 </FieldLabel>
+                                 <Select
+                                    value={field.state.value}
+                                    onValueChange={(value) => {
+                                       const parsed =
+                                          parseRecurrenceFrequency(value);
+                                       if (!parsed) return;
+                                       field.handleChange(parsed);
+                                    }}
+                                 >
+                                    <SelectTrigger
+                                       id={field.name}
+                                       name={field.name}
+                                    >
+                                       <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                       {RECURRENCE_OPTIONS.map((option) => (
+                                          <SelectItem
+                                             key={option.value}
+                                             value={option.value}
+                                          >
+                                             {option.label}
+                                          </SelectItem>
+                                       ))}
+                                    </SelectContent>
+                                 </Select>
+                                 {isFieldInvalid(field) ? (
+                                    <FieldError>
+                                       {field.state.meta.errors[0]?.message}
+                                    </FieldError>
+                                 ) : null}
+                              </Field>
+                           )}
+                        </form.Field>
+                     ) : null
+                  }
+               </form.Subscribe>
+            </div>
 
             <form.Field name="name">
                {(field) => (

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-form-sheet.tsx
@@ -1199,6 +1199,7 @@ function TransactionFormSheetContent() {
                                     }}
                                  >
                                     <SelectTrigger
+                                       aria-invalid={isFieldInvalid(field)}
                                        id={field.name}
                                        name={field.name}
                                     >

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-form-sheet.tsx
@@ -18,6 +18,7 @@ import { DatePicker } from "@packages/ui/components/date-picker";
 import { Field, FieldError, FieldLabel } from "@packages/ui/components/field";
 import { Input } from "@packages/ui/components/input";
 import { MoneyInput } from "@packages/ui/components/money-input";
+import { NumberInput } from "@packages/ui/components/number-input";
 import {
    Popover,
    PopoverContent,
@@ -1089,18 +1090,16 @@ function TransactionFormSheetContent() {
                                        >
                                           Número de parcelas
                                        </FieldLabel>
-                                       <Input
+                                       <NumberInput
                                           aria-invalid={isFieldInvalid(field)}
                                           id={field.name}
+                                          max={120}
                                           min={2}
                                           name={field.name}
-                                          type="number"
                                           value={field.state.value}
                                           onBlur={field.handleBlur}
-                                          onChange={(e) =>
-                                             field.handleChange(
-                                                Number(e.target.value),
-                                             )
+                                          onChange={(value) =>
+                                             field.handleChange(value)
                                           }
                                        />
                                        {isFieldInvalid(field) ? (

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-columns.tsx
@@ -477,23 +477,25 @@ export function buildTransactionColumns(options?: {
             ) : null;
 
             return (
-               <InlineEditCombobox
-                  ariaLabel="Conta"
-                  className="w-auto justify-center border-0 bg-transparent p-0 shadow-none hover:bg-transparent [&>svg]:hidden [&>span]:flex-none"
-                  onCreate={options?.onCreateBankAccount}
-                  onSave={async (value) => {
-                     await options?.onUpdate?.(row.original.id, {
-                        bankAccountId: value || null,
-                     });
-                  }}
-                  options={bankOptions}
-                  renderSelected={() =>
-                     accountLogo ?? (
-                        <span className="text-muted-foreground">—</span>
-                     )
-                  }
-                  value={accountId ?? ""}
-               />
+               <div className="flex justify-center">
+                  <InlineEditCombobox
+                     ariaLabel="Conta"
+                     className="w-auto justify-center border-0 bg-transparent p-0 shadow-none hover:bg-transparent [&>svg]:hidden [&>span]:flex-none"
+                     onCreate={options?.onCreateBankAccount}
+                     onSave={async (value) => {
+                        await options?.onUpdate?.(row.original.id, {
+                           bankAccountId: value || null,
+                        });
+                     }}
+                     options={bankOptions}
+                     renderSelected={() =>
+                        accountLogo ?? (
+                           <span className="text-muted-foreground">—</span>
+                        )
+                     }
+                     value={accountId ?? ""}
+                  />
+               </div>
             );
          },
       },

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-columns.tsx
@@ -179,6 +179,9 @@ export function buildTransactionColumns(options?: {
             editOptions: statusOptions,
          },
          cell: ({ row }) => {
+            if (row.original.ignored) {
+               return <Badge variant="outline">Ignorado</Badge>;
+            }
             const status =
                row.original.status === "cancelled"
                   ? "pending"

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-columns.tsx
@@ -179,13 +179,6 @@ export function buildTransactionColumns(options?: {
             editOptions: statusOptions,
          },
          cell: ({ row }) => {
-            if (row.original.ignored) {
-               return (
-                  <Badge className="text-xs" variant="secondary">
-                     Ignorado
-                  </Badge>
-               );
-            }
             const status =
                row.original.status === "cancelled"
                   ? "pending"

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
@@ -62,6 +62,7 @@ import { useTableUrlState } from "@/blocks/data-table/use-table-url-state";
 import { DataImportButton } from "@/blocks/data-table/data-import/data-import-button";
 import { DataImportSection } from "@/blocks/data-table/data-import/data-import-section";
 import { ExportButton } from "@/components/export-button/export-button";
+import { cn } from "@packages/ui/lib/utils";
 import { useDataImport } from "@/blocks/data-table/data-import/use-data-import";
 import type { DataImportConfig } from "@/blocks/data-table/data-import/use-data-import";
 import { PageFilters } from "@/components/page-filters/page-filters";
@@ -1027,7 +1028,15 @@ export function TransactionsList() {
                <ScrollArea className="flex-1 min-h-0 rounded-md border bg-card">
                   <Table>
                      <DataTableHeader table={table} />
-                     <DataTableBody<TransactionRow> table={table} />
+                     <DataTableBody<TransactionRow>
+                        getRowClassName={({ row }) =>
+                           cn(
+                              row.original.ignored &&
+                                 "bg-muted/20 text-muted-foreground opacity-60",
+                           )
+                        }
+                        table={table}
+                     />
                      <DataImportSection
                         api={importApi}
                         config={importConfig}

--- a/core/database/src/relations.ts
+++ b/core/database/src/relations.ts
@@ -316,6 +316,7 @@ export const transactionsRelations = relations(
       recurrence: one(transactionRecurrences, {
          fields: [transactions.recurrenceId],
          references: [transactionRecurrences.id],
+         relationName: "transaction_recurrence",
       }),
       items: many(transactionItems),
    }),
@@ -327,6 +328,7 @@ export const transactionRecurrencesRelations = relations(
       sourceTransaction: one(transactions, {
          fields: [transactionRecurrences.sourceTransactionId],
          references: [transactions.id],
+         relationName: "source_transaction_recurrence",
       }),
       transactions: many(transactions),
    }),

--- a/core/database/src/relations.ts
+++ b/core/database/src/relations.ts
@@ -28,6 +28,7 @@ import { subscriptionItems } from "@core/database/schemas/subscription-items";
 import { contactSubscriptions } from "@core/database/schemas/subscriptions";
 import { tags } from "@core/database/schemas/tags";
 import {
+   transactionRecurrences,
    transactionItems,
    transactions,
 } from "@core/database/schemas/transactions";
@@ -312,7 +313,22 @@ export const transactionsRelations = relations(
          fields: [transactions.tagId],
          references: [tags.id],
       }),
+      recurrence: one(transactionRecurrences, {
+         fields: [transactions.recurrenceId],
+         references: [transactionRecurrences.id],
+      }),
       items: many(transactionItems),
+   }),
+);
+
+export const transactionRecurrencesRelations = relations(
+   transactionRecurrences,
+   ({ one, many }) => ({
+      sourceTransaction: one(transactions, {
+         fields: [transactionRecurrences.sourceTransactionId],
+         references: [transactions.id],
+      }),
+      transactions: many(transactions),
    }),
 );
 

--- a/core/database/src/schemas/transactions.ts
+++ b/core/database/src/schemas/transactions.ts
@@ -53,6 +53,16 @@ export const transactionStatusEnum = financeSchema.enum("transaction_status", [
    "cancelled",
 ]);
 
+export const transactionRecurrenceFrequencyEnum = financeSchema.enum(
+   "transaction_recurrence_frequency",
+   ["daily", "weekly", "biweekly", "monthly"],
+);
+
+export const transactionRecurrenceStatusEnum = financeSchema.enum(
+   "transaction_recurrence_status",
+   ["active", "stopped"],
+);
+
 export const transactions = financeSchema.table(
    "transactions",
    {
@@ -90,6 +100,8 @@ export const transactions = financeSchema.table(
       installmentGroupId: uuid("installment_group_id"),
       installmentNumber: integer("installment_number"),
       installmentCount: integer("installment_count"),
+      recurrenceId: uuid("recurrence_id"),
+      recurrenceOccurrenceNumber: integer("recurrence_occurrence_number"),
       paidAt: timestamp("paid_at", { withTimezone: true }),
       statementPeriod: text("statement_period"),
       contactId: uuid("contact_id").references(() => contacts.id, {
@@ -131,7 +143,45 @@ export const transactions = financeSchema.table(
       index("transactions_installment_group_id_idx").on(
          table.installmentGroupId,
       ),
+      index("transactions_recurrence_id_idx").on(table.recurrenceId),
       index("transactions_status_type_idx").on(table.status, table.type),
+   ],
+);
+
+export const transactionRecurrences = financeSchema.table(
+   "transaction_recurrences",
+   {
+      id: uuid("id")
+         .default(sql`pg_catalog.gen_random_uuid()`)
+         .primaryKey(),
+      teamId: uuid("team_id").notNull(),
+      sourceTransactionId: uuid("source_transaction_id")
+         .notNull()
+         .references(() => transactions.id, { onDelete: "restrict" }),
+      frequency: transactionRecurrenceFrequencyEnum("frequency").notNull(),
+      status: transactionRecurrenceStatusEnum("status")
+         .notNull()
+         .default("active"),
+      startedAt: date("started_at").notNull(),
+      nextOccurrenceDate: date("next_occurrence_date").notNull(),
+      stoppedAt: timestamp("stopped_at", { withTimezone: true }),
+      createdAt: timestamp("created_at", { withTimezone: true })
+         .notNull()
+         .defaultNow(),
+      updatedAt: timestamp("updated_at", { withTimezone: true })
+         .notNull()
+         .defaultNow()
+         .$onUpdate(() => new Date()),
+   },
+   (table) => [
+      index("transaction_recurrences_team_id_idx").on(table.teamId),
+      index("transaction_recurrences_source_transaction_id_idx").on(
+         table.sourceTransactionId,
+      ),
+      index("transaction_recurrences_status_idx").on(table.status),
+      index("transaction_recurrences_next_occurrence_date_idx").on(
+         table.nextOccurrenceDate,
+      ),
    ],
 );
 
@@ -159,12 +209,20 @@ export const transactionItems = financeSchema.table("transaction_items", {
 });
 
 export const transactionSchema = createSelectSchema(transactions);
+export const transactionRecurrenceSchema = createSelectSchema(
+   transactionRecurrences,
+);
 export const transactionItemSchema = createSelectSchema(transactionItems);
 export type Transaction = z.infer<typeof transactionSchema>;
+export type TransactionRecurrence = z.infer<typeof transactionRecurrenceSchema>;
 export type TransactionItem = z.infer<typeof transactionItemSchema>;
 export type TransactionType = (typeof transactionTypeEnum.enumValues)[number];
 export type TransactionStatus =
    (typeof transactionStatusEnum.enumValues)[number];
+export type TransactionRecurrenceFrequency =
+   (typeof transactionRecurrenceFrequencyEnum.enumValues)[number];
+export type TransactionRecurrenceStatus =
+   (typeof transactionRecurrenceStatusEnum.enumValues)[number];
 
 const numericPositive = (msg: string) =>
    z.string().refine((v) => !Number.isNaN(Number(v)) && Number(v) > 0, {

--- a/modules/finance/__tests__/router/transactions.test.ts
+++ b/modules/finance/__tests__/router/transactions.test.ts
@@ -227,7 +227,7 @@ describe("transactions router", () => {
       ).toBe(true);
    });
 
-   it("permite interromper e editar recorrência sem alterar lançamentos gerados", async () => {
+   it("permite interromper e editar recorrência recalculando próxima ocorrência sem alterar lançamentos gerados", async () => {
       const { teamId, organizationId } = await seedTeam(testDb.db);
       const ctx = createTestContext(testDb.db, { teamId, organizationId });
       const [account] = await testDb.db
@@ -288,6 +288,7 @@ describe("transactions router", () => {
       expect(updatedRecurrence?.frequency).toBe("biweekly");
       expect(updatedRecurrence?.status).toBe("stopped");
       expect(updatedRecurrence?.stoppedAt).not.toBeNull();
+      expect(updatedRecurrence?.nextOccurrenceDate).toBe("2026-06-05");
       expect(rows.map((row) => row.date)).toEqual(["2026-05-15", "2026-05-22"]);
    });
 

--- a/modules/finance/__tests__/router/transactions.test.ts
+++ b/modules/finance/__tests__/router/transactions.test.ts
@@ -13,7 +13,12 @@ import { setupTestDb } from "@core/database/testing/setup-test-db";
 import { seedTeam } from "@core/database/testing/factories";
 import { createTestContext } from "@core/orpc/testing/create-test-context";
 import { bankAccounts } from "@core/database/schemas/bank-accounts";
-import { transactions } from "@core/database/schemas/transactions";
+import { categories } from "@core/database/schemas/categories";
+import { contacts } from "@core/database/schemas/contacts";
+import {
+   transactionRecurrences,
+   transactions,
+} from "@core/database/schemas/transactions";
 
 const { enqueueClassifyTransactionsBatchWorkflowSpy } = vi.hoisted(() => ({
    enqueueClassifyTransactionsBatchWorkflowSpy: vi
@@ -133,5 +138,192 @@ describe("transactions router", () => {
             { context: ctx },
          ),
       ).rejects.toThrow("Transferências não podem ser parceladas.");
+   });
+
+   it("create persiste recorrência e materializa a próxima ocorrência preservando dados principais", async () => {
+      const { teamId, organizationId } = await seedTeam(testDb.db);
+      const ctx = createTestContext(testDb.db, { teamId, organizationId });
+      const [account] = await testDb.db
+         .insert(bankAccounts)
+         .values({
+            teamId,
+            name: "Conta Recorrência",
+            type: "checking",
+            initialBalance: "0",
+            status: "active",
+         })
+         .returning();
+      const [category] = await testDb.db
+         .insert(categories)
+         .values({
+            teamId,
+            name: "Assinaturas",
+            type: "expense",
+            level: 1,
+         })
+         .returning();
+      const [contact] = await testDb.db
+         .insert(contacts)
+         .values({
+            teamId,
+            name: "Fornecedor Recorrente",
+            type: "fornecedor",
+         })
+         .returning();
+
+      await call(
+         transactionsRouter.create,
+         {
+            type: "expense",
+            name: "Assinatura",
+            amount: "80.00",
+            date: "2026-05-15",
+            dueDate: "2026-05-20",
+            status: "pending",
+            ignored: false,
+            bankAccountId: account.id,
+            categoryId: category.id,
+            contactId: contact.id,
+            description: "Plano mensal",
+            isRecurring: true,
+            recurrenceFrequency: "monthly",
+         },
+         { context: ctx },
+      );
+
+      const rows = await testDb.db
+         .select()
+         .from(transactions)
+         .where(eq(transactions.teamId, teamId))
+         .orderBy(asc(transactions.recurrenceOccurrenceNumber));
+      const recurrences = await testDb.db
+         .select()
+         .from(transactionRecurrences)
+         .where(eq(transactionRecurrences.teamId, teamId));
+
+      expect(rows).toHaveLength(2);
+      expect(recurrences).toHaveLength(1);
+      expect(recurrences[0]?.frequency).toBe("monthly");
+      expect(recurrences[0]?.status).toBe("active");
+      expect(recurrences[0]?.startedAt).toBe("2026-05-15");
+      expect(recurrences[0]?.nextOccurrenceDate).toBe("2026-07-15");
+      expect(rows.map((row) => row.date)).toEqual(["2026-05-15", "2026-06-15"]);
+      expect(rows.map((row) => row.dueDate)).toEqual([
+         "2026-05-20",
+         "2026-06-20",
+      ]);
+      expect(rows.map((row) => row.amount)).toEqual(["80.00", "80.00"]);
+      expect(rows.every((row) => row.name === "Assinatura")).toBe(true);
+      expect(rows.every((row) => row.status === "pending")).toBe(true);
+      expect(rows.every((row) => row.description === "Plano mensal")).toBe(
+         true,
+      );
+      expect(rows.every((row) => row.bankAccountId === account.id)).toBe(true);
+      expect(rows.every((row) => row.categoryId === category.id)).toBe(true);
+      expect(rows.every((row) => row.contactId === contact.id)).toBe(true);
+      expect(rows[0]?.recurrenceId).not.toBeNull();
+      expect(
+         rows.every((row) => row.recurrenceId === rows[0]?.recurrenceId),
+      ).toBe(true);
+   });
+
+   it("permite interromper e editar recorrência sem alterar lançamentos gerados", async () => {
+      const { teamId, organizationId } = await seedTeam(testDb.db);
+      const ctx = createTestContext(testDb.db, { teamId, organizationId });
+      const [account] = await testDb.db
+         .insert(bankAccounts)
+         .values({
+            teamId,
+            name: "Conta Série",
+            type: "checking",
+            initialBalance: "0",
+            status: "active",
+         })
+         .returning();
+
+      await call(
+         transactionsRouter.create,
+         {
+            type: "income",
+            name: "Receita recorrente",
+            amount: "150.00",
+            date: "2026-05-15",
+            status: "pending",
+            ignored: false,
+            bankAccountId: account.id,
+            isRecurring: true,
+            recurrenceFrequency: "weekly",
+         },
+         { context: ctx },
+      );
+
+      const [recurrence] = await testDb.db
+         .select()
+         .from(transactionRecurrences)
+         .where(eq(transactionRecurrences.teamId, teamId));
+      expect(recurrence).toBeDefined();
+      if (!recurrence) return;
+
+      await call(
+         transactionsRouter.updateRecurrence,
+         { id: recurrence.id, frequency: "biweekly" },
+         { context: ctx },
+      );
+      await call(
+         transactionsRouter.stopRecurrence,
+         { id: recurrence.id },
+         { context: ctx },
+      );
+
+      const [updatedRecurrence] = await testDb.db
+         .select()
+         .from(transactionRecurrences)
+         .where(eq(transactionRecurrences.id, recurrence.id));
+      const rows = await testDb.db
+         .select()
+         .from(transactions)
+         .where(eq(transactions.teamId, teamId))
+         .orderBy(asc(transactions.recurrenceOccurrenceNumber));
+
+      expect(updatedRecurrence?.frequency).toBe("biweekly");
+      expect(updatedRecurrence?.status).toBe("stopped");
+      expect(updatedRecurrence?.stoppedAt).not.toBeNull();
+      expect(rows.map((row) => row.date)).toEqual(["2026-05-15", "2026-05-22"]);
+   });
+
+   it("create rejeita recorrência parcelada em pt-BR", async () => {
+      const { teamId, organizationId } = await seedTeam(testDb.db);
+      const ctx = createTestContext(testDb.db, { teamId, organizationId });
+      const [account] = await testDb.db
+         .insert(bankAccounts)
+         .values({
+            teamId,
+            name: "Conta Rejeição",
+            type: "checking",
+            initialBalance: "0",
+            status: "active",
+         })
+         .returning();
+
+      await expect(
+         call(
+            transactionsRouter.create,
+            {
+               type: "expense",
+               name: "Conflito",
+               amount: "100.00",
+               date: "2026-05-15",
+               status: "pending",
+               ignored: false,
+               bankAccountId: account.id,
+               categoryId: null,
+               isInstallment: true,
+               installmentCount: 2,
+               isRecurring: true,
+               recurrenceFrequency: "monthly",
+            },
+            { context: ctx },
+         ),
+      ).rejects.toThrow("Lançamento recorrente não pode ser parcelado.");
    });
 });

--- a/modules/finance/__tests__/services/recurrences.test.ts
+++ b/modules/finance/__tests__/services/recurrences.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { buildRecurrenceOccurrences } from "../../src/services/recurrences";
+
+describe("recurrences", () => {
+   it("calcula próximas ocorrências nas periodicidades suportadas", () => {
+      const daily = buildRecurrenceOccurrences({
+         date: "2026-05-15",
+         dueDate: "2026-05-20",
+         frequency: "daily",
+      });
+      const weekly = buildRecurrenceOccurrences({
+         date: "2026-05-15",
+         dueDate: "2026-05-20",
+         frequency: "weekly",
+      });
+      const biweekly = buildRecurrenceOccurrences({
+         date: "2026-05-15",
+         dueDate: "2026-05-20",
+         frequency: "biweekly",
+      });
+      const monthly = buildRecurrenceOccurrences({
+         date: "2026-05-15",
+         dueDate: "2026-05-20",
+         frequency: "monthly",
+      });
+
+      expect(daily.isOk()).toBe(true);
+      expect(weekly.isOk()).toBe(true);
+      expect(biweekly.isOk()).toBe(true);
+      expect(monthly.isOk()).toBe(true);
+      if (
+         daily.isErr() ||
+         weekly.isErr() ||
+         biweekly.isErr() ||
+         monthly.isErr()
+      ) {
+         return;
+      }
+      expect(daily.value[1]?.date).toBe("2026-05-16");
+      expect(weekly.value[1]?.date).toBe("2026-05-22");
+      expect(biweekly.value[1]?.date).toBe("2026-05-29");
+      expect(monthly.value[1]?.date).toBe("2026-06-15");
+   });
+
+   it("rejeita data inválida em pt-BR", () => {
+      const result = buildRecurrenceOccurrences({
+         date: "15/05/2026",
+         frequency: "monthly",
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isOk()) return;
+      expect(result.error).toBe("Data deve estar no formato YYYY-MM-DD.");
+   });
+});

--- a/modules/finance/src/router/middlewares.ts
+++ b/modules/finance/src/router/middlewares.ts
@@ -4,10 +4,7 @@ import { err, fromPromise, ok } from "neverthrow";
 import { os } from "@orpc/server";
 import { WebAppError } from "@core/logging/errors";
 import type { ORPCContextWithOrganization } from "@core/orpc/context";
-import {
-   transactionRecurrences,
-   transactions,
-} from "@core/database/schemas/transactions";
+import { transactions } from "@core/database/schemas/transactions";
 const base = os.$context<ORPCContextWithOrganization>();
 
 export const requireBankAccount = base.middleware(

--- a/modules/finance/src/router/middlewares.ts
+++ b/modules/finance/src/router/middlewares.ts
@@ -4,7 +4,10 @@ import { err, fromPromise, ok } from "neverthrow";
 import { os } from "@orpc/server";
 import { WebAppError } from "@core/logging/errors";
 import type { ORPCContextWithOrganization } from "@core/orpc/context";
-import { transactions } from "@core/database/schemas/transactions";
+import {
+   transactionRecurrences,
+   transactions,
+} from "@core/database/schemas/transactions";
 const base = os.$context<ORPCContextWithOrganization>();
 
 export const requireBankAccount = base.middleware(
@@ -55,6 +58,23 @@ export const requireTransaction = base.middleware(
       );
       if (result.isErr()) throw result.error;
       return next({ context: { transaction: result.value } });
+   },
+);
+
+export const requireTransactionRecurrence = base.middleware(
+   async ({ context, next }, id: string) => {
+      const result = await fromPromise(
+         context.db.query.transactionRecurrences.findFirst({
+            where: (f, { eq }) => eq(f.id, id),
+         }),
+         () => WebAppError.internal("Falha ao verificar recorrência."),
+      ).andThen((recurrence) =>
+         !recurrence || recurrence.teamId !== context.teamId
+            ? err(WebAppError.notFound("Recorrência não encontrada."))
+            : ok(recurrence),
+      );
+      if (result.isErr()) throw result.error;
+      return next({ context: { recurrence: result.value } });
    },
 );
 

--- a/modules/finance/src/router/transactions.ts
+++ b/modules/finance/src/router/transactions.ts
@@ -1,8 +1,11 @@
-import { eq } from "drizzle-orm";
+import dayjs from "dayjs";
+import { and, eq } from "drizzle-orm";
 import { fromPromise } from "neverthrow";
 import { z } from "zod";
 import {
    createTransactionSchema,
+   transactionRecurrenceFrequencyEnum,
+   transactionRecurrences,
    transactionItems,
    transactions,
    updateTransactionSchema,
@@ -16,6 +19,10 @@ import {
    requireValidFinancialReferences,
 } from "@modules/finance/router/middlewares";
 import { buildInstallmentPreview } from "@modules/finance/services/installments";
+import {
+   addRecurrencePeriod,
+   buildRecurrenceOccurrences,
+} from "@modules/finance/services/recurrences";
 
 const idSchema = z.object({ id: z.string().uuid() });
 
@@ -54,11 +61,31 @@ const installmentSchema = z
       }
    });
 
+const recurrenceSchema = z
+   .object({
+      isRecurring: z.boolean().optional().default(false),
+      recurrenceFrequency: z
+         .enum(transactionRecurrenceFrequencyEnum.enumValues, {
+            message: "Periodicidade da recorrência é obrigatória.",
+         })
+         .optional(),
+   })
+   .superRefine((data, ctx) => {
+      if (data.isRecurring && !data.recurrenceFrequency) {
+         ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Periodicidade da recorrência é obrigatória.",
+            path: ["recurrenceFrequency"],
+         });
+      }
+   });
+
 export const create = protectedProcedure
    .input(
       createTransactionSchema
          .merge(tagAndItemsSchema)
          .merge(installmentSchema)
+         .merge(recurrenceSchema)
          .merge(z.object({ autoCategorize: z.boolean().default(false) })),
    )
    .use(enforceCostCenterPolicy, (input) => input.tagId)
@@ -69,6 +96,8 @@ export const create = protectedProcedure
          autoCategorize,
          isInstallment,
          installmentCount: rawInstallmentCount,
+         isRecurring,
+         recurrenceFrequency,
          ...transactionData
       } = input;
       const installmentCount = rawInstallmentCount ?? 1;
@@ -81,14 +110,30 @@ export const create = protectedProcedure
                  dueDate: transactionData.dueDate,
               })
             : null;
+      const recurrencePreview =
+         isRecurring && recurrenceFrequency
+            ? buildRecurrenceOccurrences({
+                 date: transactionData.date,
+                 dueDate: transactionData.dueDate,
+                 frequency: recurrenceFrequency,
+              })
+            : null;
 
       if (isInstallment && transactionData.type === "transfer") {
          throw WebAppError.badRequest(
             "Transferências não podem ser parceladas.",
          );
       }
+      if (isRecurring && isInstallment) {
+         throw WebAppError.badRequest(
+            "Lançamento recorrente não pode ser parcelado.",
+         );
+      }
       if (installmentPreview?.isErr()) {
          throw WebAppError.badRequest(installmentPreview.error);
+      }
+      if (recurrencePreview?.isErr()) {
+         throw WebAppError.badRequest(recurrencePreview.error);
       }
 
       await requireValidFinancialReferences(context.db, context.teamId, {
@@ -122,35 +167,70 @@ export const create = protectedProcedure
            ];
       const installmentGroupId =
          installments.length > 1 ? crypto.randomUUID() : null;
+      const recurrenceOccurrences = recurrencePreview?.isOk()
+         ? recurrencePreview.value
+         : null;
+      const recurrenceId = recurrenceOccurrences ? crypto.randomUUID() : null;
+      const transactionRows = recurrenceOccurrences
+         ? recurrenceOccurrences.map((occurrence) => ({
+              ...txData,
+              amount: txData.amount,
+              date: occurrence.date,
+              dueDate: occurrence.dueDate,
+              name: txData.name,
+              status,
+              ignored,
+              teamId: context.teamId,
+              tagId: tagId ?? null,
+              recurrenceId,
+              recurrenceOccurrenceNumber: occurrence.number,
+           }))
+         : installments.map((installment) => ({
+              ...txData,
+              amount: installment.amount,
+              date: installment.date,
+              dueDate: installment.dueDate,
+              name:
+                 installment.count > 1 && txData.name
+                    ? `${txData.name} (${installment.number}/${installment.count})`
+                    : txData.name,
+              status,
+              ignored,
+              teamId: context.teamId,
+              tagId: tagId ?? null,
+              installmentGroupId,
+              installmentNumber:
+                 installment.count > 1 ? installment.number : null,
+              installmentCount:
+                 installment.count > 1 ? installment.count : null,
+           }));
 
       const created = await fromPromise(
          context.db.transaction(async (tx) => {
             const rows = await tx
                .insert(transactions)
-               .values(
-                  installments.map((installment) => ({
-                     ...txData,
-                     amount: installment.amount,
-                     date: installment.date,
-                     dueDate: installment.dueDate,
-                     name:
-                        installment.count > 1 && txData.name
-                           ? `${txData.name} (${installment.number}/${installment.count})`
-                           : txData.name,
-                     status,
-                     ignored,
-                     teamId: context.teamId,
-                     tagId: tagId ?? null,
-                     installmentGroupId,
-                     installmentNumber:
-                        installment.count > 1 ? installment.number : null,
-                     installmentCount:
-                        installment.count > 1 ? installment.count : null,
-                  })),
-               )
+               .values(transactionRows)
                .returning();
             const [row] = rows;
             if (!row) throw WebAppError.internal("Falha ao criar lançamento.");
+            if (recurrenceId && recurrenceFrequency && recurrenceOccurrences) {
+               const lastOccurrence =
+                  recurrenceOccurrences[recurrenceOccurrences.length - 1];
+               if (!lastOccurrence) {
+                  throw WebAppError.internal("Falha ao criar recorrência.");
+               }
+               await tx.insert(transactionRecurrences).values({
+                  id: recurrenceId,
+                  teamId: context.teamId,
+                  sourceTransactionId: row.id,
+                  frequency: recurrenceFrequency,
+                  startedAt: row.date,
+                  nextOccurrenceDate: addRecurrencePeriod(
+                     lastOccurrence.date,
+                     recurrenceFrequency,
+                  ),
+               });
+            }
             if (items.length > 0) {
                await tx.insert(transactionItems).values(
                   items.map((item) => ({
@@ -201,6 +281,89 @@ export const create = protectedProcedure
       }
 
       return created.value;
+   });
+
+const recurrenceIdSchema = z.object({ id: z.string().uuid() });
+
+export const stopRecurrence = protectedProcedure
+   .input(recurrenceIdSchema)
+   .handler(async ({ context, input }) => {
+      const stopped = await fromPromise(
+         context.db
+            .update(transactionRecurrences)
+            .set({
+               status: "stopped",
+               stoppedAt: dayjs().toDate(),
+            })
+            .where(
+               and(
+                  eq(transactionRecurrences.id, input.id),
+                  eq(transactionRecurrences.teamId, context.teamId),
+               ),
+            )
+            .returning(),
+         () => WebAppError.internal("Falha ao interromper recorrência."),
+      );
+      if (stopped.isErr()) throw stopped.error;
+      const [row] = stopped.value;
+      if (!row) throw WebAppError.notFound("Recorrência não encontrada.");
+      return row;
+   });
+
+export const updateRecurrence = protectedProcedure
+   .input(
+      recurrenceIdSchema.merge(
+         z.object({
+            frequency: z
+               .enum(transactionRecurrenceFrequencyEnum.enumValues, {
+                  message: "Periodicidade da recorrência é obrigatória.",
+               })
+               .optional(),
+            status: z.enum(["active", "stopped"]).optional(),
+         }),
+      ),
+   )
+   .handler(async ({ context, input }) => {
+      const existing = await fromPromise(
+         context.db.query.transactionRecurrences.findFirst({
+            where: (f, { eq }) => eq(f.id, input.id),
+         }),
+         () => WebAppError.internal("Falha ao verificar recorrência."),
+      );
+      if (existing.isErr()) throw existing.error;
+      if (!existing.value || existing.value.teamId !== context.teamId) {
+         throw WebAppError.notFound("Recorrência não encontrada.");
+      }
+
+      const nextStatus = input.status ?? existing.value.status;
+      const nextFrequency = input.frequency ?? existing.value.frequency;
+      const updated = await fromPromise(
+         context.db
+            .update(transactionRecurrences)
+            .set({
+               frequency: nextFrequency,
+               status: nextStatus,
+               stoppedAt:
+                  nextStatus === "stopped"
+                     ? (existing.value.stoppedAt ?? dayjs().toDate())
+                     : null,
+               nextOccurrenceDate:
+                  input.frequency &&
+                  input.frequency !== existing.value.frequency
+                     ? addRecurrencePeriod(
+                          existing.value.nextOccurrenceDate,
+                          input.frequency,
+                       )
+                     : existing.value.nextOccurrenceDate,
+            })
+            .where(eq(transactionRecurrences.id, input.id))
+            .returning(),
+         () => WebAppError.internal("Falha ao atualizar recorrência."),
+      );
+      if (updated.isErr()) throw updated.error;
+      const [row] = updated.value;
+      if (!row) throw WebAppError.notFound("Recorrência não encontrada.");
+      return row;
    });
 
 export const getById = protectedProcedure

--- a/modules/finance/src/router/transactions.ts
+++ b/modules/finance/src/router/transactions.ts
@@ -15,6 +15,7 @@ import { protectedProcedure } from "@core/orpc/server";
 import { enqueueClassifyTransactionsBatchWorkflow } from "@modules/classification/workflows/classification-workflow";
 import {
    enforceCostCenterPolicy,
+   requireTransactionRecurrence,
    requireTransaction,
    requireValidFinancialReferences,
 } from "@modules/finance/router/middlewares";
@@ -258,18 +259,39 @@ export const create = protectedProcedure
          !ignored &&
          (input.type === "income" || input.type === "expense")
       ) {
-         const transactionIds = created.value.installmentGroupId
-            ? await context.db
-                 .select({ id: transactions.id })
-                 .from(transactions)
-                 .where(
-                    eq(
-                       transactions.installmentGroupId,
-                       created.value.installmentGroupId,
-                    ),
-                 )
-                 .then((rows) => rows.map((row) => row.id))
-            : [created.value.id];
+         const transactionIds = await (async () => {
+            if (created.value.installmentGroupId) {
+               return context.db
+                  .select({ id: transactions.id })
+                  .from(transactions)
+                  .where(
+                     and(
+                        eq(
+                           transactions.installmentGroupId,
+                           created.value.installmentGroupId,
+                        ),
+                        eq(transactions.teamId, context.teamId),
+                     ),
+                  )
+                  .then((rows) => rows.map((row) => row.id));
+            }
+            if (created.value.recurrenceId) {
+               return context.db
+                  .select({ id: transactions.id })
+                  .from(transactions)
+                  .where(
+                     and(
+                        eq(
+                           transactions.recurrenceId,
+                           created.value.recurrenceId,
+                        ),
+                        eq(transactions.teamId, context.teamId),
+                     ),
+                  )
+                  .then((rows) => rows.map((row) => row.id));
+            }
+            return [created.value.id];
+         })();
          await enqueueClassifyTransactionsBatchWorkflow(
             context.workflowClient,
             {
@@ -287,21 +309,19 @@ const recurrenceIdSchema = z.object({ id: z.string().uuid() });
 
 export const stopRecurrence = protectedProcedure
    .input(recurrenceIdSchema)
-   .handler(async ({ context, input }) => {
+   .use(requireTransactionRecurrence, (input) => input.id)
+   .handler(async ({ context }) => {
       const stopped = await fromPromise(
-         context.db
-            .update(transactionRecurrences)
-            .set({
-               status: "stopped",
-               stoppedAt: dayjs().toDate(),
-            })
-            .where(
-               and(
-                  eq(transactionRecurrences.id, input.id),
-                  eq(transactionRecurrences.teamId, context.teamId),
-               ),
-            )
-            .returning(),
+         context.db.transaction(async (tx) =>
+            tx
+               .update(transactionRecurrences)
+               .set({
+                  status: "stopped",
+                  stoppedAt: dayjs().toDate(),
+               })
+               .where(eq(transactionRecurrences.id, context.recurrence.id))
+               .returning(),
+         ),
          () => WebAppError.internal("Falha ao interromper recorrência."),
       );
       if (stopped.isErr()) throw stopped.error;
@@ -323,41 +343,55 @@ export const updateRecurrence = protectedProcedure
          }),
       ),
    )
+   .use(requireTransactionRecurrence, (input) => input.id)
    .handler(async ({ context, input }) => {
-      const existing = await fromPromise(
-         context.db.query.transactionRecurrences.findFirst({
-            where: (f, { eq }) => eq(f.id, input.id),
-         }),
-         () => WebAppError.internal("Falha ao verificar recorrência."),
-      );
-      if (existing.isErr()) throw existing.error;
-      if (!existing.value || existing.value.teamId !== context.teamId) {
-         throw WebAppError.notFound("Recorrência não encontrada.");
+      const existing = context.recurrence;
+      const nextStatus = input.status ?? existing.status;
+      const nextFrequency = input.frequency ?? existing.frequency;
+      let nextOccurrenceDate = existing.nextOccurrenceDate;
+      if (input.frequency && input.frequency !== existing.frequency) {
+         const latestOccurrence = await fromPromise(
+            context.db.query.transactions.findFirst({
+               where: (f, { and, eq }) =>
+                  and(
+                     eq(f.recurrenceId, existing.id),
+                     eq(f.teamId, context.teamId),
+                  ),
+               orderBy: (f, { desc }) => [
+                  desc(f.recurrenceOccurrenceNumber),
+                  desc(f.date),
+               ],
+            }),
+            () =>
+               WebAppError.internal("Falha ao verificar lançamentos gerados."),
+         );
+         if (latestOccurrence.isErr()) throw latestOccurrence.error;
+         if (!latestOccurrence.value) {
+            throw WebAppError.internal(
+               "Falha ao verificar lançamentos gerados.",
+            );
+         }
+         nextOccurrenceDate = addRecurrencePeriod(
+            latestOccurrence.value.date,
+            input.frequency,
+         );
       }
-
-      const nextStatus = input.status ?? existing.value.status;
-      const nextFrequency = input.frequency ?? existing.value.frequency;
       const updated = await fromPromise(
-         context.db
-            .update(transactionRecurrences)
-            .set({
-               frequency: nextFrequency,
-               status: nextStatus,
-               stoppedAt:
-                  nextStatus === "stopped"
-                     ? (existing.value.stoppedAt ?? dayjs().toDate())
-                     : null,
-               nextOccurrenceDate:
-                  input.frequency &&
-                  input.frequency !== existing.value.frequency
-                     ? addRecurrencePeriod(
-                          existing.value.nextOccurrenceDate,
-                          input.frequency,
-                       )
-                     : existing.value.nextOccurrenceDate,
-            })
-            .where(eq(transactionRecurrences.id, input.id))
-            .returning(),
+         context.db.transaction(async (tx) =>
+            tx
+               .update(transactionRecurrences)
+               .set({
+                  frequency: nextFrequency,
+                  status: nextStatus,
+                  stoppedAt:
+                     nextStatus === "stopped"
+                        ? (existing.stoppedAt ?? dayjs().toDate())
+                        : null,
+                  nextOccurrenceDate,
+               })
+               .where(eq(transactionRecurrences.id, existing.id))
+               .returning(),
+         ),
          () => WebAppError.internal("Falha ao atualizar recorrência."),
       );
       if (updated.isErr()) throw updated.error;

--- a/modules/finance/src/services/recurrences.ts
+++ b/modules/finance/src/services/recurrences.ts
@@ -1,0 +1,62 @@
+import dayjs from "dayjs";
+import { err, ok, type Result } from "neverthrow";
+import type { TransactionRecurrenceFrequency } from "@core/database/schemas/transactions";
+
+export type RecurrenceInput = {
+   date: string;
+   dueDate?: string | null;
+   frequency: TransactionRecurrenceFrequency;
+};
+
+export type RecurrenceOccurrence = {
+   number: number;
+   date: string;
+   dueDate: string | null;
+};
+
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+function isValidIsoDate(value: string) {
+   if (!ISO_DATE_REGEX.test(value)) return false;
+   const parsed = dayjs(value);
+   return parsed.isValid() && parsed.format("YYYY-MM-DD") === value;
+}
+
+export function addRecurrencePeriod(
+   date: string,
+   frequency: TransactionRecurrenceFrequency,
+) {
+   if (frequency === "daily") {
+      return dayjs(date).add(1, "day").format("YYYY-MM-DD");
+   }
+   if (frequency === "weekly") {
+      return dayjs(date).add(1, "week").format("YYYY-MM-DD");
+   }
+   if (frequency === "biweekly") {
+      return dayjs(date).add(2, "week").format("YYYY-MM-DD");
+   }
+   return dayjs(date).add(1, "month").format("YYYY-MM-DD");
+}
+
+export function buildRecurrenceOccurrences(
+   input: RecurrenceInput,
+): Result<RecurrenceOccurrence[], string> {
+   if (!isValidIsoDate(input.date)) {
+      return err("Data deve estar no formato YYYY-MM-DD.");
+   }
+   if (input.dueDate && !isValidIsoDate(input.dueDate)) {
+      return err("Vencimento deve estar no formato YYYY-MM-DD.");
+   }
+
+   const nextDate = addRecurrencePeriod(input.date, input.frequency);
+   return ok([
+      { number: 1, date: input.date, dueDate: input.dueDate ?? null },
+      {
+         number: 2,
+         date: nextDate,
+         dueDate: input.dueDate
+            ? addRecurrencePeriod(input.dueDate, input.frequency)
+            : null,
+      },
+   ]);
+}

--- a/package.json
+++ b/package.json
@@ -189,6 +189,7 @@
             "vaul": "^1.1.2"
          },
          "validation": {
+            "better-result": "^2.9.2",
             "neverthrow": "^8.1.1",
             "zod": "4.3.6"
          },


### PR DESCRIPTION
## Resumo
- adiciona modelo de recorrência para lançamentos com periodicidades diária, semanal, quinzenal e mensal
- persiste recorrência na criação manual e materializa o lançamento original mais a próxima ocorrência
- adiciona endpoints para editar ou interromper a recorrência sem alterar lançamentos já gerados
- conecta o formulário manual ao envio de recorrência e mantém validações em pt-BR

## Validação
- bun nx run @modules/finance:test
- bun nx run @modules/finance:typecheck
- bun nx run @core/database:typecheck
- bun nx run web:typecheck
- bun nx run @modules/finance:check
- git diff --check

Observação: web:check e @core/database:check foram executados e passaram com 0 erros, mas ainda exibem warnings preexistentes fora deste diff.