### PR TITLE
Fix auth loading toasts

### DIFF
--- a/apps/web/src/blocks/data-table/data-import/data-import-button.tsx
+++ b/apps/web/src/blocks/data-table/data-import/data-import-button.tsx
@@ -12,7 +12,7 @@ import {
 import { Download, FileSpreadsheet, Loader2 } from "lucide-react";
 import { fromPromise } from "neverthrow";
 import { useCallback, useState, useTransition } from "react";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { useFileDownload } from "@/hooks/use-file-download";
 import type { DataImportConfig, ImportTemplateFile } from "./use-data-import";
 import type { UseDataImportApi } from "./use-data-import";

--- a/apps/web/src/blocks/data-table/data-import/data-import-section.tsx
+++ b/apps/web/src/blocks/data-table/data-import/data-import-section.tsx
@@ -9,7 +9,7 @@ import { cn } from "@packages/ui/lib/utils";
 import { Check, Loader2, TriangleAlert, X } from "lucide-react";
 import { fromPromise } from "neverthrow";
 import { useCallback, useMemo, useState } from "react";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import type { DataImportConfig } from "./use-data-import";
 import type { UseDataImportApi } from "./use-data-import";

--- a/apps/web/src/blocks/data-table/data-import/use-data-import.tsx
+++ b/apps/web/src/blocks/data-table/data-import/use-data-import.tsx
@@ -3,7 +3,7 @@ import { SelectionActionButton } from "@packages/ui/components/selection-action-
 import { Check, EyeOff, RotateCcw, Trash2 } from "lucide-react";
 import { fromPromise } from "neverthrow";
 import { type ReactNode, useCallback, useMemo, useState } from "react";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { z } from "zod";
 import { useSelectionToolbar } from "@/hooks/use-selection-toolbar";
 import { DataImportBulkEdit } from "./data-import-bulk-edit";

--- a/apps/web/src/features/file-upload/lib/use-file-upload.ts
+++ b/apps/web/src/features/file-upload/lib/use-file-upload.ts
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 
 interface FileUploadOptions {
    /** Maximum file size in bytes (default: 5MB) */

--- a/apps/web/src/features/inbox/use-inbox-stream.ts
+++ b/apps/web/src/features/inbox/use-inbox-stream.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { z } from "zod";
 import { orpc } from "@/integrations/orpc/client";
 

--- a/apps/web/src/hooks/use-alert-dialog.tsx
+++ b/apps/web/src/hooks/use-alert-dialog.tsx
@@ -13,7 +13,7 @@ import { Spinner } from "@packages/ui/components/spinner";
 import { cn } from "@packages/ui/lib/utils";
 import { createStore, useStore, shallow } from "@tanstack/react-store";
 import { useTransition } from "react";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 
 interface AlertDialogState {
    isOpen: boolean;

--- a/apps/web/src/integrations/better-auth/auth-client.ts
+++ b/apps/web/src/integrations/better-auth/auth-client.ts
@@ -9,7 +9,7 @@ import {
 } from "better-auth/client/plugins";
 import { createAuthClient as createBetterAuthClient } from "better-auth/react";
 import type { AuthInstance } from "@core/authentication/server";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { invalidateAllQueries } from "./query-bridge";
 
 export const authClient = createBetterAuthClient({

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/-layout/-sidebar-scope-switcher/create-team-form.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/-layout/-sidebar-scope-switcher/create-team-form.tsx
@@ -18,7 +18,7 @@ import { getInitials } from "@core/utils/text";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
 import { useForm } from "@tanstack/react-form";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { z } from "zod";
 import { useActiveOrganization } from "@/hooks/use-active-organization";
 import { closeCredenza } from "@/hooks/use-credenza";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/-layout/sidebar-account-menu.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/-layout/sidebar-account-menu.tsx
@@ -26,7 +26,7 @@ import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import { useDashboardSlugs } from "@/hooks/use-dashboard-slugs";
 import { authClient } from "@/integrations/better-auth/auth-client";
 import { orpc } from "@/integrations/orpc/client";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { ThemeSwitcher } from "./theme-switcher";
 
 function SidebarAccountMenuSkeleton() {

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/-layout/sidebar-scope-switcher.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/-layout/sidebar-scope-switcher.tsx
@@ -25,7 +25,7 @@ import { Link, useLocation, useRouter } from "@tanstack/react-router";
 import { Check, ChevronsUpDown, Plus, Settings, UserPlus } from "lucide-react";
 import { fromPromise } from "neverthrow";
 import { useTransition } from "react";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { QueryBoundary } from "@/components/query-boundary";
 import { useActiveOrganization } from "@/hooks/use-active-organization";
 import { useActiveTeam } from "@/hooks/use-active-team";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/-montte-ai/chat-store.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/-montte-ai/chat-store.tsx
@@ -22,7 +22,7 @@ import {
 } from "lucide-react";
 import dayjs from "dayjs";
 import { fromPromise } from "neverthrow";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { createPersistedStore } from "@/lib/store";
 import { client } from "@/integrations/orpc/client";
 import {

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-bank-accounts/bank-account-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-bank-accounts/bank-account-form-sheet.tsx
@@ -20,7 +20,7 @@ import {
    SheetHeader,
    SheetTitle,
 } from "@packages/ui/components/sheet";
-import { toast } from "@packages/ui/components/sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-categories/category-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-categories/category-form-sheet.tsx
@@ -51,7 +51,7 @@ import {
    SheetHeader,
    SheetTitle,
 } from "@packages/ui/components/sheet";
-import { toast } from "@packages/ui/components/sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { useForm } from "@tanstack/react-form";
 import { useMutation } from "@tanstack/react-query";
 import { Check, ChevronDown, ChevronsUpDown } from "lucide-react";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-card-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-credit-cards/credit-card-form-sheet.tsx
@@ -18,7 +18,7 @@ import {
    SheetHeader,
    SheetTitle,
 } from "@packages/ui/components/sheet";
-import { toast } from "@packages/ui/components/sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-reports/report-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-reports/report-form-sheet.tsx
@@ -15,7 +15,7 @@ import {
    SheetHeader,
    SheetTitle,
 } from "@packages/ui/components/sheet";
-import { toast } from "@packages/ui/components/sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { useForm } from "@tanstack/react-form";
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-tags/tags-form-sheet.tsx
@@ -8,7 +8,7 @@ import {
    SheetHeader,
    SheetTitle,
 } from "@packages/ui/components/sheet";
-import { toast } from "@packages/ui/components/sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { Textarea } from "@packages/ui/components/textarea";
 import { useForm } from "@tanstack/react-form";
 import { useMutation } from "@tanstack/react-query";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-form-sheet.tsx
@@ -38,7 +38,7 @@ import {
    SheetHeader,
    SheetTitle,
 } from "@packages/ui/components/sheet";
-import { toast } from "@packages/ui/components/sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { Textarea } from "@packages/ui/components/textarea";
 import { UploadDropzone } from "@packages/ui/components/upload-dropzone";
 import { UploadProgress } from "@packages/ui/components/upload-progress";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
@@ -58,7 +58,7 @@ import {
    Undo2,
 } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { DataTableBody } from "@/blocks/data-table/data-table-body";
 import { DataTableColumnVisibility } from "@/blocks/data-table/data-table-column-visibility";
 import { DataTableHeader } from "@/blocks/data-table/data-table-header";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/bank-accounts.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/bank-accounts.tsx
@@ -25,7 +25,7 @@ import {
 import dayjs from "dayjs";
 import { Landmark, Plus, ReceiptText, Trash2 } from "lucide-react";
 import { useCallback, useMemo } from "react";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { z } from "zod";
 
 import { DataTableBody } from "@/blocks/data-table/data-table-body";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/categories.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/categories.tsx
@@ -39,7 +39,7 @@ import {
 } from "lucide-react";
 import { fromPromise } from "neverthrow";
 import { useCallback, useMemo, useState } from "react";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { z } from "zod";
 import { DefaultHeader } from "../-layout/default-header";
 import { DataTableBody } from "@/blocks/data-table/data-table-body";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/chat/-layout/chat-sidebar.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/chat/-layout/chat-sidebar.tsx
@@ -35,7 +35,7 @@ import dayjs from "dayjs";
 import { MoreHorizontal, Pencil, Plus, Trash2 } from "lucide-react";
 import { fromPromise } from "neverthrow";
 import { useState } from "react";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { z } from "zod";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import { useDashboardSlugs } from "@/hooks/use-dashboard-slugs";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/credit-cards.tsx
@@ -32,7 +32,7 @@ import {
    Trash2,
 } from "lucide-react";
 import { startTransition, useCallback, useMemo } from "react";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { z } from "zod";
 import { DefaultHeader } from "../-layout/default-header";
 import { DataTableBody } from "@/blocks/data-table/data-table-body";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/inbox/-inbox/inbox-card.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/inbox/-inbox/inbox-card.tsx
@@ -24,7 +24,7 @@ import {
    Info,
    MoreHorizontal,
 } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { orpc } from "@/integrations/orpc/client";
 import { useOrgSlug, useTeamSlug } from "@/hooks/use-dashboard-slugs";
 import type { InboxItem } from "./inbox-types";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/reports/index.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/reports/index.tsx
@@ -23,7 +23,7 @@ import {
 } from "@tanstack/react-table";
 import { Plus, ReceiptText, Trash2 } from "lucide-react";
 import { useCallback, useMemo } from "react";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { z } from "zod";
 import { DataTableBody } from "@/blocks/data-table/data-table-body";
 import { DataTableColumnVisibility } from "@/blocks/data-table/data-table-column-visibility";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/-settings/hooks/use-session-actions.ts
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/-settings/hooks/use-session-actions.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import { orpc } from "@/integrations/orpc/client";
 

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/-settings/ui/session-details-form.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/-settings/ui/session-details-form.tsx
@@ -19,7 +19,7 @@ import { formatDate } from "@core/utils/date";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ArrowRight, CheckCircle2, Monitor, Trash2 } from "lucide-react";
 import { useCallback, useMemo } from "react";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import { useCredenza } from "@/hooks/use-credenza";
 import { orpc } from "@/integrations/orpc/client";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/danger-zone.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/danger-zone.tsx
@@ -10,7 +10,7 @@ import {
 } from "@packages/ui/components/item";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Trash2 } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { authClient } from "@/integrations/better-auth/auth-client";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import { DefaultHeader } from "../../-layout/default-header";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/-members/invite-members-form.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/-members/invite-members-form.tsx
@@ -17,7 +17,7 @@ import { Textarea } from "@packages/ui/components/textarea";
 import { getInitials } from "@core/utils/text";
 import { useForm } from "@tanstack/react-form";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { z } from "zod";
 import { authClient } from "@/integrations/better-auth/auth-client";
 import { orpc } from "@/integrations/orpc/client";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/danger-zone.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/danger-zone.tsx
@@ -29,7 +29,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { AlertTriangle, Trash2 } from "lucide-react";
 import { useState, useTransition } from "react";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { authClient } from "@/integrations/better-auth/auth-client";
 import { orpc } from "@/integrations/orpc/client";
 import { DefaultHeader } from "../../../-layout/default-header";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/general.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/general.tsx
@@ -34,7 +34,7 @@ import {
 } from "lucide-react";
 import { Suspense, useState, useTransition } from "react";
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { useFileUpload } from "@/features/file-upload/lib/use-file-upload";
 import { authClient } from "@/integrations/better-auth/auth-client";
 import { orpc } from "@/integrations/orpc/client";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/members.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/members.tsx
@@ -30,7 +30,7 @@ import {
 import dayjs from "dayjs";
 import { Mail, Plus, RotateCw, ShieldCheck, Users, X } from "lucide-react";
 import { startTransition, useCallback, useMemo } from "react";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { z } from "zod";
 import { authClient } from "@/integrations/better-auth/auth-client";
 import { orpc } from "@/integrations/orpc/client";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/teams.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/organization/teams.tsx
@@ -40,7 +40,7 @@ import {
 import dayjs from "dayjs";
 import { Box, UserMinus, UserPlus } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { QueryBoundary } from "@/components/query-boundary";
 import { useSheet } from "@/hooks/use-sheet";
 import { authClient } from "@/integrations/better-auth/auth-client";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/profile.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/profile.tsx
@@ -32,7 +32,7 @@ import { QRCodeSVG } from "qrcode.react";
 import type React from "react";
 import { useCallback, useState, useTransition } from "react";
 import type { FallbackProps } from "react-error-boundary";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { z } from "zod";
 import { useUploadImage } from "@/hooks/use-upload-image";
 import { useFileUpload } from "@/features/file-upload/lib/use-file-upload";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/-api-keys/create-api-key-form.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/-api-keys/create-api-key-form.tsx
@@ -1,6 +1,6 @@
 import { useForm } from "@tanstack/react-form";
 import { useQueryClient } from "@tanstack/react-query";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { z } from "zod";
 import { Copy, KeyRound } from "lucide-react";
 import { Button } from "@packages/ui/components/button";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/api-keys.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/api-keys.tsx
@@ -2,7 +2,7 @@ import { useSuspenseQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { KeyRound, Plus, Trash2 } from "lucide-react";
 import { useCallback, useMemo } from "react";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { z } from "zod";
 import {
    getCoreRowModel,

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/danger-zone.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/danger-zone.tsx
@@ -11,7 +11,7 @@ import {
 } from "@packages/ui/components/item";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { ArrowRightLeft, Trash2 } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { authClient } from "@/integrations/better-auth/auth-client";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import { useActiveTeam } from "@/hooks/use-active-team";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/general.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/general.tsx
@@ -17,7 +17,7 @@ import "dayjs/locale/pt-br";
 import { Hash, Loader2, Settings2 } from "lucide-react";
 import { Suspense, useState, useTransition } from "react";
 import { ErrorBoundary, type FallbackProps } from "react-error-boundary";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { authClient } from "@/integrations/better-auth/auth-client";
 import { orpc } from "@/integrations/orpc/client";
 import { DefaultHeader } from "../../../-layout/default-header";

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/ai-agents.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/ai-agents.tsx
@@ -15,7 +15,7 @@ import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { Loader2 } from "lucide-react";
 import { Suspense, useCallback } from "react";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import type { Inputs } from "@/integrations/orpc/client";
 import { orpc } from "@/integrations/orpc/client";
 

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/financeiro.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/settings/project/products/financeiro.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from "@packages/ui/components/skeleton";
 import { Switch } from "@packages/ui/components/switch";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { QueryBoundary } from "@/components/query-boundary";
 import { orpc } from "@/integrations/orpc/client";
 

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/tags.tsx
@@ -30,7 +30,7 @@ import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { Archive, ArchiveRestore, Plus, Tag, Trash2 } from "lucide-react";
 import { useCallback, useMemo } from "react";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { z } from "zod";
 
 import { DataTableBody } from "@/blocks/data-table/data-table-body";

--- a/apps/web/src/routes/_authenticated/-onboarding/onboarding-wizard.tsx
+++ b/apps/web/src/routes/_authenticated/-onboarding/onboarding-wizard.tsx
@@ -16,7 +16,7 @@ import { fromPromise } from "neverthrow";
 import posthog from "posthog-js";
 import { Banknote, Check } from "lucide-react";
 import { type FormEvent, useCallback, useMemo } from "react";
-import { toast } from "sonner";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { z } from "zod";
 import { RouteTransition } from "@/components/route-transition";
 import {

--- a/packages/ui/src/components/sonner.tsx
+++ b/packages/ui/src/components/sonner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Toaster as Sonner, type ToasterProps, toast } from "sonner";
+import { Toaster as Sonner, type ToasterProps } from "sonner";
 import { useTheme } from "../lib/theme-provider";
 
 const Toaster = ({ ...props }: ToasterProps) => {
@@ -23,4 +23,4 @@ const Toaster = ({ ...props }: ToasterProps) => {
    );
 };
 
-export { Toaster, toast };
+export { Toaster };

--- a/packages/ui/src/hooks/use-toast.ts
+++ b/packages/ui/src/hooks/use-toast.ts
@@ -1,12 +1,26 @@
 "use client";
 
 import { useCallback } from "foxact/use-typescript-happy-callback";
-import { useMemo, type ReactElement, type ReactNode } from "react";
-import { type ExternalToast, toast } from "sonner";
+import { useId, useMemo, type ReactElement, type ReactNode } from "react";
+import { type ExternalToast, toast as sonnerToast } from "sonner";
 
 type ToastId = NonNullable<ExternalToast["id"]>;
 type ToastMessage = ReactNode | (() => ReactNode);
 type ToastOptions = Omit<ExternalToast, "id">;
+type ToastPromiseInput<Data> = Promise<Data> | (() => Promise<Data>);
+type ToastPromiseMessage<Data> =
+   | ReactNode
+   | ((data: Data) => ReactNode | Promise<ReactNode>);
+type ToastPromiseOptions<Data> = Omit<ToastOptions, "description"> & {
+   description?: ToastPromiseMessage<Data>;
+   error?: ReactNode | ((error: Error) => ReactNode | Promise<ReactNode>);
+   finally?: () => void | Promise<void>;
+   loading?: ReactNode;
+   success?: ToastPromiseMessage<Data>;
+};
+type ToastPromiseResult<Data> = {
+   unwrap: () => Promise<Data>;
+};
 
 export function useToastActions(id: ToastId) {
    const withToastId = useCallback(
@@ -19,53 +33,53 @@ export function useToastActions(id: ToastId) {
 
    const show = useCallback(
       (message: ToastMessage, options?: ToastOptions) =>
-         toast(message, withToastId(options)),
+         sonnerToast(message, withToastId(options)),
       [withToastId],
    );
 
    const success = useCallback(
       (message: ToastMessage, options?: ToastOptions) =>
-         toast.success(message, withToastId(options)),
+         sonnerToast.success(message, withToastId(options)),
       [withToastId],
    );
 
    const info = useCallback(
       (message: ToastMessage, options?: ToastOptions) =>
-         toast.info(message, withToastId(options)),
+         sonnerToast.info(message, withToastId(options)),
       [withToastId],
    );
 
    const warning = useCallback(
       (message: ToastMessage, options?: ToastOptions) =>
-         toast.warning(message, withToastId(options)),
+         sonnerToast.warning(message, withToastId(options)),
       [withToastId],
    );
 
    const error = useCallback(
       (message: ToastMessage, options?: ToastOptions) =>
-         toast.error(message, withToastId(options)),
+         sonnerToast.error(message, withToastId(options)),
       [withToastId],
    );
 
    const loading = useCallback(
       (message: ToastMessage, options?: ToastOptions) =>
-         toast.loading(message, withToastId(options)),
+         sonnerToast.loading(message, withToastId(options)),
       [withToastId],
    );
 
    const message = useCallback(
       (message: ToastMessage, options?: ToastOptions) =>
-         toast.message(message, withToastId(options)),
+         sonnerToast.message(message, withToastId(options)),
       [withToastId],
    );
 
    const custom = useCallback(
       (jsx: (id: ToastId) => ReactElement, options?: ToastOptions) =>
-         toast.custom(jsx, withToastId(options)),
+         sonnerToast.custom(jsx, withToastId(options)),
       [withToastId],
    );
 
-   const dismiss = useCallback(() => toast.dismiss(id), [id]);
+   const dismiss = useCallback(() => sonnerToast.dismiss(id), [id]);
 
    return useMemo(
       () => ({
@@ -82,3 +96,25 @@ export function useToastActions(id: ToastId) {
       [custom, dismiss, error, info, loading, message, show, success, warning],
    );
 }
+
+export function useToast() {
+   const id = useId();
+   return useToastActions(id);
+}
+
+export const toast = {
+   custom: sonnerToast.custom,
+   dismiss: sonnerToast.dismiss,
+   error: sonnerToast.error,
+   getHistory: sonnerToast.getHistory,
+   getToasts: sonnerToast.getToasts,
+   info: sonnerToast.info,
+   loading: sonnerToast.loading,
+   message: sonnerToast.message,
+   promise: <Data>(
+      promise: ToastPromiseInput<Data>,
+      data?: ToastPromiseOptions<Data>,
+   ): ToastPromiseResult<Data> => sonnerToast.promise(promise, data),
+   success: sonnerToast.success,
+   warning: sonnerToast.warning,
+};


### PR DESCRIPTION
## Summary
- centralize web toast usage through @packages/ui/hooks/use-toast
- keep auth loading/success/error flows on stable toast ids so loading toasts are replaced
- remove toast re-export from the Sonner toaster component

## Validation
- bun run typecheck
- bun run check
- git diff --check