### PR TITLE
refactor agents resultgen flows

### DIFF
--- a/modules/agents/src/jobs/generate-title-job.ts
+++ b/modules/agents/src/jobs/generate-title-job.ts
@@ -182,284 +182,283 @@ export async function handleGenerateThreadTitleJob(options: {
    prompts: Prompts;
    job: Job<GenerateThreadTitleJobInput>;
 }) {
-   const parsedInput = generateThreadTitleJobInputSchema.safeParse(
-      options.job.data,
-   );
-   if (!parsedInput.success) {
-      return Result.err(
-         new GenerateThreadTitleJobError({
-            error: generateTitleJobErrors.INVALID_PAYLOAD({
-               internal: { jobId: options.job.id },
+   return Result.gen(async function* () {
+      const parsedInput = generateThreadTitleJobInputSchema.safeParse(
+         options.job.data,
+      );
+      if (!parsedInput.success) {
+         return Result.err(
+            new GenerateThreadTitleJobError({
+               error: generateTitleJobErrors.INVALID_PAYLOAD({
+                  internal: { jobId: options.job.id },
+               }),
+               message: generateTitleJobErrors.INVALID_PAYLOAD({
+                  internal: { jobId: options.job.id },
+               }).message,
             }),
-            message: generateTitleJobErrors.INVALID_PAYLOAD({
-               internal: { jobId: options.job.id },
-            }).message,
+         );
+      }
+
+      const input = parsedInput.data;
+      log.info({
+         module: "agents.generate-title-job",
+         message: "running",
+         jobId: options.job.id,
+         threadId: input.threadId,
+         teamId: input.teamId,
+         organizationId: input.organizationId,
+      });
+
+      const loaded = yield* Result.await(
+         Result.tryPromise({
+            try: () =>
+               options.db.transaction(async (tx) => {
+                  const thread = await tx.query.threads.findFirst({
+                     where: (f, { and: andFn, eq: eqFn }) =>
+                        andFn(
+                           eqFn(f.id, input.threadId),
+                           eqFn(f.teamId, input.teamId),
+                           eqFn(f.organizationId, input.organizationId),
+                        ),
+                  });
+                  if (!thread) return null;
+                  if (thread.title)
+                     return { title: thread.title, recent: null };
+                  const recent = await tx
+                     .select({
+                        id: messages.id,
+                        role: messages.role,
+                        parts: messages.parts,
+                     })
+                     .from(messages)
+                     .innerJoin(threads, eq(threads.id, messages.threadId))
+                     .where(
+                        and(
+                           eq(messages.threadId, input.threadId),
+                           eq(threads.teamId, input.teamId),
+                           eq(threads.organizationId, input.organizationId),
+                        ),
+                     )
+                     .orderBy(asc(messages.createdAt))
+                     .limit(6);
+                  return { title: null, recent };
+               }),
+            catch: () =>
+               new GenerateThreadTitleJobError({
+                  error: generateTitleJobErrors.MESSAGES_LOAD_FAILED({
+                     internal: {
+                        jobId: options.job.id,
+                        threadId: input.threadId,
+                     },
+                  }),
+                  message: generateTitleJobErrors.MESSAGES_LOAD_FAILED({
+                     internal: {
+                        jobId: options.job.id,
+                        threadId: input.threadId,
+                     },
+                  }).message,
+                  threadId: input.threadId,
+               }),
          }),
       );
-   }
 
-   const input = parsedInput.data;
-   log.info({
-      module: "agents.generate-title-job",
-      message: "running",
-      jobId: options.job.id,
-      threadId: input.threadId,
-      teamId: input.teamId,
-      organizationId: input.organizationId,
-   });
-
-   const loaded = await Result.tryPromise({
-      try: () =>
-         options.db.transaction(async (tx) => {
-            const thread = await tx.query.threads.findFirst({
-               where: (f, { and: andFn, eq: eqFn }) =>
-                  andFn(
-                     eqFn(f.id, input.threadId),
-                     eqFn(f.teamId, input.teamId),
-                     eqFn(f.organizationId, input.organizationId),
-                  ),
-            });
-            if (!thread) return null;
-            if (thread.title) return { title: thread.title, recent: null };
-            const recent = await tx
-               .select({
-                  id: messages.id,
-                  role: messages.role,
-                  parts: messages.parts,
-               })
-               .from(messages)
-               .innerJoin(threads, eq(threads.id, messages.threadId))
-               .where(
-                  and(
-                     eq(messages.threadId, input.threadId),
-                     eq(threads.teamId, input.teamId),
-                     eq(threads.organizationId, input.organizationId),
-                  ),
-               )
-               .orderBy(asc(messages.createdAt))
-               .limit(6);
-            return { title: null, recent };
-         }),
-      catch: () =>
-         new GenerateThreadTitleJobError({
-            error: generateTitleJobErrors.MESSAGES_LOAD_FAILED({
-               internal: {
-                  jobId: options.job.id,
-                  threadId: input.threadId,
-               },
-            }),
-            message: generateTitleJobErrors.MESSAGES_LOAD_FAILED({
-               internal: {
-                  jobId: options.job.id,
-                  threadId: input.threadId,
-               },
-            }).message,
+      if (!loaded) {
+         log.info({
+            module: "agents.generate-title-job",
+            message: "skipping: thread not found in scope",
+            jobId: options.job.id,
             threadId: input.threadId,
-         }),
-   });
+         });
+         return Result.ok(undefined);
+      }
 
-   if (Result.isError(loaded)) {
-      return Result.err(loaded.error);
-   }
-   if (!loaded.value) {
-      log.info({
-         module: "agents.generate-title-job",
-         message: "skipping: thread not found in scope",
-         jobId: options.job.id,
-         threadId: input.threadId,
-      });
-      return Result.ok(undefined);
-   }
-   if (loaded.value.title) {
-      log.info({
-         module: "agents.generate-title-job",
-         message: "skipping: title already exists",
-         jobId: options.job.id,
-         threadId: input.threadId,
-      });
-      return Result.ok(undefined);
-   }
-   if (!loaded.value.recent || loaded.value.recent.length === 0) {
-      log.info({
-         module: "agents.generate-title-job",
-         message: "skipping: no messages",
-         jobId: options.job.id,
-         threadId: input.threadId,
-      });
-      return Result.ok(undefined);
-   }
-
-   const recent = loaded.value.recent;
-   const hasUser = recent.some((row) => row.role === "user");
-   const hasAssistant = recent.some((row) => row.role === "assistant");
-   if (!hasUser || !hasAssistant) {
-      log.info({
-         module: "agents.generate-title-job",
-         message: "skipping: conversation too shallow",
-         jobId: options.job.id,
-         threadId: input.threadId,
-      });
-      return Result.ok(undefined);
-   }
-
-   const prompt = await Result.tryPromise({
-      try: () =>
-         options.prompts.get(AGENT_PROMPTS.generateTitle, {
-            withMetadata: true,
-         }),
-      catch: () =>
-         new GenerateThreadTitleJobError({
-            error: generateTitleJobErrors.PROMPT_LOAD_FAILED({
-               internal: {
-                  jobId: options.job.id,
-                  threadId: input.threadId,
-               },
-            }),
-            message: generateTitleJobErrors.PROMPT_LOAD_FAILED({
-               internal: {
-                  jobId: options.job.id,
-                  threadId: input.threadId,
-               },
-            }).message,
+      if (loaded.title) {
+         log.info({
+            module: "agents.generate-title-job",
+            message: "skipping: title already exists",
+            jobId: options.job.id,
             threadId: input.threadId,
-         }),
-   });
+         });
+         return Result.ok(undefined);
+      }
 
-   if (Result.isError(prompt)) {
-      return Result.err(prompt.error);
-   }
+      if (!loaded.recent || loaded.recent.length === 0) {
+         log.info({
+            module: "agents.generate-title-job",
+            message: "skipping: no messages",
+            jobId: options.job.id,
+            threadId: input.threadId,
+         });
+         return Result.ok(undefined);
+      }
 
-   const titleResult = await Result.tryPromise({
-      try: () =>
-         chat({
-            adapter: flashModel,
-            messages: convertMessagesToModelMessages([
-               ...recent,
-               {
-                  id: `${options.job.id}-title-request`,
-                  role: "user",
-                  parts: [
-                     {
-                        type: "text",
-                        content: options.prompts.compile(prompt.value.prompt, {
-                           transcript:
-                              "A conversa recente está disponível nas mensagens anteriores.",
-                        }),
-                     },
-                  ],
-               },
-            ]),
-            stream: false,
-            conversationId: input.threadId,
-            middleware: [
-               otelMiddleware({
-                  tracer: getAiTracer(),
-                  captureContent: false,
-                  attributeEnricher: () =>
-                     aiTraceAttributes({
-                        distinctId: input.teamId,
-                        organizationId: input.organizationId,
-                        teamId: input.teamId,
-                        threadId: input.threadId,
-                        promptName: prompt.value.name,
-                        promptVersion: prompt.value.version,
-                        customProperties: {
-                           agent_role: "job",
-                           agent_workflow: "generate-title",
-                           agent_thread_id: input.threadId,
-                           pg_boss_job_id: options.job.id,
-                        },
-                     }),
+      const recent = loaded.recent;
+      const hasUser = recent.some((row) => row.role === "user");
+      const hasAssistant = recent.some((row) => row.role === "assistant");
+      if (!hasUser || !hasAssistant) {
+         log.info({
+            module: "agents.generate-title-job",
+            message: "skipping: conversation too shallow",
+            jobId: options.job.id,
+            threadId: input.threadId,
+         });
+         return Result.ok(undefined);
+      }
+
+      const prompt = yield* Result.await(
+         Result.tryPromise({
+            try: () =>
+               options.prompts.get(AGENT_PROMPTS.generateTitle, {
+                  withMetadata: true,
                }),
-            ],
+            catch: () =>
+               new GenerateThreadTitleJobError({
+                  error: generateTitleJobErrors.PROMPT_LOAD_FAILED({
+                     internal: {
+                        jobId: options.job.id,
+                        threadId: input.threadId,
+                     },
+                  }),
+                  message: generateTitleJobErrors.PROMPT_LOAD_FAILED({
+                     internal: {
+                        jobId: options.job.id,
+                        threadId: input.threadId,
+                     },
+                  }).message,
+                  threadId: input.threadId,
+               }),
          }),
-      catch: () =>
-         new GenerateThreadTitleJobError({
-            error: generateTitleJobErrors.AI_FAILED({
-               internal: {
-                  jobId: options.job.id,
+      );
+
+      const title = yield* Result.await(
+         Result.tryPromise({
+            try: () =>
+               chat({
+                  adapter: flashModel,
+                  messages: convertMessagesToModelMessages([
+                     ...recent,
+                     {
+                        id: `${options.job.id}-title-request`,
+                        role: "user",
+                        parts: [
+                           {
+                              type: "text",
+                              content: options.prompts.compile(prompt.prompt, {
+                                 transcript:
+                                    "A conversa recente está disponível nas mensagens anteriores.",
+                              }),
+                           },
+                        ],
+                     },
+                  ]),
+                  stream: false,
+                  conversationId: input.threadId,
+                  middleware: [
+                     otelMiddleware({
+                        tracer: getAiTracer(),
+                        captureContent: false,
+                        attributeEnricher: () =>
+                           aiTraceAttributes({
+                              distinctId: input.teamId,
+                              organizationId: input.organizationId,
+                              teamId: input.teamId,
+                              threadId: input.threadId,
+                              promptName: prompt.name,
+                              promptVersion: prompt.version,
+                              customProperties: {
+                                 agent_role: "job",
+                                 agent_workflow: "generate-title",
+                                 agent_thread_id: input.threadId,
+                                 pg_boss_job_id: options.job.id,
+                              },
+                           }),
+                     }),
+                  ],
+               }),
+            catch: () =>
+               new GenerateThreadTitleJobError({
+                  error: generateTitleJobErrors.AI_FAILED({
+                     internal: {
+                        jobId: options.job.id,
+                        threadId: input.threadId,
+                     },
+                  }),
+                  message: generateTitleJobErrors.AI_FAILED({
+                     internal: {
+                        jobId: options.job.id,
+                        threadId: input.threadId,
+                     },
+                  }).message,
                   threadId: input.threadId,
-               },
-            }),
-            message: generateTitleJobErrors.AI_FAILED({
-               internal: {
-                  jobId: options.job.id,
-                  threadId: input.threadId,
-               },
-            }).message,
+               }),
+         }),
+      );
+
+      const normalizedTitle = title.trim().slice(0, 80);
+      if (normalizedTitle.length === 0) {
+         log.warn({
+            module: "agents.generate-title-job",
+            message: "empty title generated: skipping",
+            jobId: options.job.id,
             threadId: input.threadId,
-         }),
-   });
+         });
+         return Result.ok(undefined);
+      }
 
-   if (Result.isError(titleResult)) {
-      return Result.err(titleResult.error);
-   }
-
-   const title = titleResult.value.trim().slice(0, 80);
-   if (title.length === 0) {
-      log.warn({
-         module: "agents.generate-title-job",
-         message: "empty title generated: skipping",
-         jobId: options.job.id,
-         threadId: input.threadId,
-      });
-      return Result.ok(undefined);
-   }
-
-   const write = await Result.tryPromise({
-      try: () =>
-         options.db.transaction(async (tx) => {
-            return tx
-               .update(threads)
-               .set({ title })
-               .where(
-                  and(
-                     eq(threads.id, input.threadId),
-                     eq(threads.teamId, input.teamId),
-                     eq(threads.organizationId, input.organizationId),
-                     isNull(threads.title),
-                  ),
-               )
-               .returning({ title: threads.title });
-         }),
-      catch: () =>
-         new GenerateThreadTitleJobError({
-            error: generateTitleJobErrors.WRITE_FAILED({
-               internal: {
-                  jobId: options.job.id,
+      const write = yield* Result.await(
+         Result.tryPromise({
+            try: () =>
+               options.db.transaction(async (tx) => {
+                  return tx
+                     .update(threads)
+                     .set({ title: normalizedTitle })
+                     .where(
+                        and(
+                           eq(threads.id, input.threadId),
+                           eq(threads.teamId, input.teamId),
+                           eq(threads.organizationId, input.organizationId),
+                           isNull(threads.title),
+                        ),
+                     )
+                     .returning({ title: threads.title });
+               }),
+            catch: () =>
+               new GenerateThreadTitleJobError({
+                  error: generateTitleJobErrors.WRITE_FAILED({
+                     internal: {
+                        jobId: options.job.id,
+                        threadId: input.threadId,
+                     },
+                  }),
+                  message: generateTitleJobErrors.WRITE_FAILED({
+                     internal: {
+                        jobId: options.job.id,
+                        threadId: input.threadId,
+                     },
+                  }).message,
                   threadId: input.threadId,
-               },
-            }),
-            message: generateTitleJobErrors.WRITE_FAILED({
-               internal: {
-                  jobId: options.job.id,
-                  threadId: input.threadId,
-               },
-            }).message,
+               }),
+         }),
+      );
+
+      const writtenTitle = write[0]?.title;
+      if (!writtenTitle) {
+         log.info({
+            module: "agents.generate-title-job",
+            message: "skipping: title already set concurrently",
+            jobId: options.job.id,
             threadId: input.threadId,
-         }),
-   });
+         });
+         return Result.ok(undefined);
+      }
 
-   if (Result.isError(write)) {
-      return Result.err(write.error);
-   }
-   const writtenTitle = write.value[0]?.title;
-   if (!writtenTitle) {
       log.info({
          module: "agents.generate-title-job",
-         message: "skipping: title already set concurrently",
+         message: "completed",
          jobId: options.job.id,
          threadId: input.threadId,
+         title: normalizedTitle,
       });
       return Result.ok(undefined);
-   }
-
-   log.info({
-      module: "agents.generate-title-job",
-      message: "completed",
-      jobId: options.job.id,
-      threadId: input.threadId,
-      title,
    });
-   return Result.ok(undefined);
 }

--- a/modules/agents/src/jobs/refresh-suggestions-job.ts
+++ b/modules/agents/src/jobs/refresh-suggestions-job.ts
@@ -193,230 +193,232 @@ export async function handleRefreshThreadSuggestionsJob(options: {
    prompts: Prompts;
    job: Job<RefreshThreadSuggestionsJobInput>;
 }) {
-   const parsedInput = refreshThreadSuggestionsJobInputSchema.safeParse(
-      options.job.data,
-   );
-   if (!parsedInput.success) {
-      return Result.err(
-         new RefreshThreadSuggestionsJobError({
-            error: refreshSuggestionsJobErrors.INVALID_PAYLOAD({
-               internal: { jobId: options.job.id },
+   return Result.gen(async function* () {
+      const parsedInput = refreshThreadSuggestionsJobInputSchema.safeParse(
+         options.job.data,
+      );
+      if (!parsedInput.success) {
+         return Result.err(
+            new RefreshThreadSuggestionsJobError({
+               error: refreshSuggestionsJobErrors.INVALID_PAYLOAD({
+                  internal: { jobId: options.job.id },
+               }),
+               message: refreshSuggestionsJobErrors.INVALID_PAYLOAD({
+                  internal: { jobId: options.job.id },
+               }).message,
             }),
-            message: refreshSuggestionsJobErrors.INVALID_PAYLOAD({
-               internal: { jobId: options.job.id },
-            }).message,
+         );
+      }
+
+      const input = parsedInput.data;
+      log.info({
+         module: "agents.refresh-suggestions-job",
+         message: "running",
+         jobId: options.job.id,
+         threadId: input.threadId,
+         teamId: input.teamId,
+         organizationId: input.organizationId,
+         messageCount: input.messageCount,
+      });
+
+      const recent = yield* Result.await(
+         Result.tryPromise({
+            try: () =>
+               options.db.transaction(async (tx) => {
+                  const recent = await tx
+                     .select({
+                        id: messages.id,
+                        role: messages.role,
+                        parts: messages.parts,
+                     })
+                     .from(messages)
+                     .innerJoin(threads, eq(threads.id, messages.threadId))
+                     .where(
+                        and(
+                           eq(messages.threadId, input.threadId),
+                           eq(threads.teamId, input.teamId),
+                           eq(threads.organizationId, input.organizationId),
+                        ),
+                     )
+                     .orderBy(desc(messages.createdAt))
+                     .limit(8);
+                  return recent.slice().reverse();
+               }),
+            catch: () =>
+               new RefreshThreadSuggestionsJobError({
+                  error: refreshSuggestionsJobErrors.MESSAGES_LOAD_FAILED({
+                     internal: {
+                        jobId: options.job.id,
+                        threadId: input.threadId,
+                     },
+                  }),
+                  message: refreshSuggestionsJobErrors.MESSAGES_LOAD_FAILED({
+                     internal: {
+                        jobId: options.job.id,
+                        threadId: input.threadId,
+                     },
+                  }).message,
+                  threadId: input.threadId,
+               }),
          }),
       );
-   }
 
-   const input = parsedInput.data;
-   log.info({
-      module: "agents.refresh-suggestions-job",
-      message: "running",
-      jobId: options.job.id,
-      threadId: input.threadId,
-      teamId: input.teamId,
-      organizationId: input.organizationId,
-      messageCount: input.messageCount,
-   });
-
-   const recentResult = await Result.tryPromise({
-      try: () =>
-         options.db.transaction(async (tx) => {
-            const recent = await tx
-               .select({
-                  id: messages.id,
-                  role: messages.role,
-                  parts: messages.parts,
-               })
-               .from(messages)
-               .innerJoin(threads, eq(threads.id, messages.threadId))
-               .where(
-                  and(
-                     eq(messages.threadId, input.threadId),
-                     eq(threads.teamId, input.teamId),
-                     eq(threads.organizationId, input.organizationId),
-                  ),
-               )
-               .orderBy(desc(messages.createdAt))
-               .limit(8);
-            return recent.slice().reverse();
-         }),
-      catch: () =>
-         new RefreshThreadSuggestionsJobError({
-            error: refreshSuggestionsJobErrors.MESSAGES_LOAD_FAILED({
-               internal: {
-                  jobId: options.job.id,
-                  threadId: input.threadId,
-               },
-            }),
-            message: refreshSuggestionsJobErrors.MESSAGES_LOAD_FAILED({
-               internal: {
-                  jobId: options.job.id,
-                  threadId: input.threadId,
-               },
-            }).message,
+      if (recent.length === 0) {
+         log.info({
+            module: "agents.refresh-suggestions-job",
+            message: "skipping: no messages",
+            jobId: options.job.id,
             threadId: input.threadId,
-         }),
-   });
+         });
+         return Result.ok(undefined);
+      }
 
-   if (Result.isError(recentResult)) return Result.err(recentResult.error);
-   const recent = recentResult.value;
-   if (recent.length === 0) {
-      log.info({
-         module: "agents.refresh-suggestions-job",
-         message: "skipping: no messages",
-         jobId: options.job.id,
-         threadId: input.threadId,
-      });
-      return Result.ok(undefined);
-   }
-
-   const hasUser = recent.some((row) => row.role === "user");
-   const hasAssistant = recent.some((row) => row.role === "assistant");
-   if (!hasUser || !hasAssistant) {
-      log.info({
-         module: "agents.refresh-suggestions-job",
-         message: "skipping: conversation too shallow",
-         jobId: options.job.id,
-         threadId: input.threadId,
-      });
-      return Result.ok(undefined);
-   }
-
-   const prompt = await Result.tryPromise({
-      try: () =>
-         options.prompts.get(AGENT_PROMPTS.refreshSuggestions, {
-            withMetadata: true,
-         }),
-      catch: () =>
-         new RefreshThreadSuggestionsJobError({
-            error: refreshSuggestionsJobErrors.PROMPT_LOAD_FAILED({
-               internal: {
-                  jobId: options.job.id,
-                  threadId: input.threadId,
-               },
-            }),
-            message: refreshSuggestionsJobErrors.PROMPT_LOAD_FAILED({
-               internal: {
-                  jobId: options.job.id,
-                  threadId: input.threadId,
-               },
-            }).message,
+      const hasUser = recent.some((row) => row.role === "user");
+      const hasAssistant = recent.some((row) => row.role === "assistant");
+      if (!hasUser || !hasAssistant) {
+         log.info({
+            module: "agents.refresh-suggestions-job",
+            message: "skipping: conversation too shallow",
+            jobId: options.job.id,
             threadId: input.threadId,
-         }),
-   });
-   if (Result.isError(prompt)) return Result.err(prompt.error);
+         });
+         return Result.ok(undefined);
+      }
 
-   const suggestionsResult = await Result.tryPromise({
-      try: () =>
-         chat({
-            adapter: flashModel,
-            outputSchema: suggestionsSchema,
-            messages: convertMessagesToModelMessages([
-               ...recent,
-               {
-                  id: `${options.job.id}-suggestions-request`,
-                  role: "user",
-                  parts: [
-                     {
-                        type: "text",
-                        content: options.prompts.compile(prompt.value.prompt, {
-                           transcript:
-                              "A conversa recente está disponível nas mensagens anteriores.",
-                        }),
-                     },
-                  ],
-               },
-            ]),
-            stream: false,
-            conversationId: input.threadId,
-            middleware: [
-               otelMiddleware({
-                  tracer: getAiTracer(),
-                  captureContent: false,
-                  attributeEnricher: () =>
-                     aiTraceAttributes({
-                        distinctId: input.teamId,
-                        organizationId: input.organizationId,
-                        teamId: input.teamId,
-                        threadId: input.threadId,
-                        promptName: prompt.value.name,
-                        promptVersion: prompt.value.version,
-                        customProperties: {
-                           agent_role: "job",
-                           agent_workflow: "refresh-suggestions",
-                           agent_thread_id: input.threadId,
-                           pg_boss_job_id: options.job.id,
-                        },
-                     }),
+      const prompt = yield* Result.await(
+         Result.tryPromise({
+            try: () =>
+               options.prompts.get(AGENT_PROMPTS.refreshSuggestions, {
+                  withMetadata: true,
                }),
-            ],
-         }),
-      catch: () =>
-         new RefreshThreadSuggestionsJobError({
-            error: refreshSuggestionsJobErrors.AI_FAILED({
-               internal: {
-                  jobId: options.job.id,
+            catch: () =>
+               new RefreshThreadSuggestionsJobError({
+                  error: refreshSuggestionsJobErrors.PROMPT_LOAD_FAILED({
+                     internal: {
+                        jobId: options.job.id,
+                        threadId: input.threadId,
+                     },
+                  }),
+                  message: refreshSuggestionsJobErrors.PROMPT_LOAD_FAILED({
+                     internal: {
+                        jobId: options.job.id,
+                        threadId: input.threadId,
+                     },
+                  }).message,
                   threadId: input.threadId,
-               },
-            }),
-            message: refreshSuggestionsJobErrors.AI_FAILED({
-               internal: {
-                  jobId: options.job.id,
-                  threadId: input.threadId,
-               },
-            }).message,
-            threadId: input.threadId,
+               }),
          }),
-   });
-   if (Result.isError(suggestionsResult)) {
-      return Result.err(suggestionsResult.error);
-   }
+      );
 
-   const suggestions = suggestionsResult.value;
-   const write = await Result.tryPromise({
-      try: () =>
-         options.db.transaction(async (tx) => {
-            await tx
-               .update(threads)
-               .set({
-                  suggestions,
-                  suggestionsUpdatedAt: dayjs().toDate(),
-               })
-               .where(
-                  and(
-                     eq(threads.id, input.threadId),
-                     eq(threads.teamId, input.teamId),
-                     eq(threads.organizationId, input.organizationId),
-                  ),
-               );
-         }),
-      catch: () =>
-         new RefreshThreadSuggestionsJobError({
-            error: refreshSuggestionsJobErrors.WRITE_FAILED({
-               internal: {
-                  jobId: options.job.id,
+      const suggestions = yield* Result.await(
+         Result.tryPromise({
+            try: () =>
+               chat({
+                  adapter: flashModel,
+                  outputSchema: suggestionsSchema,
+                  messages: convertMessagesToModelMessages([
+                     ...recent,
+                     {
+                        id: `${options.job.id}-suggestions-request`,
+                        role: "user",
+                        parts: [
+                           {
+                              type: "text",
+                              content: options.prompts.compile(prompt.prompt, {
+                                 transcript:
+                                    "A conversa recente está disponível nas mensagens anteriores.",
+                              }),
+                           },
+                        ],
+                     },
+                  ]),
+                  stream: false,
+                  conversationId: input.threadId,
+                  middleware: [
+                     otelMiddleware({
+                        tracer: getAiTracer(),
+                        captureContent: false,
+                        attributeEnricher: () =>
+                           aiTraceAttributes({
+                              distinctId: input.teamId,
+                              organizationId: input.organizationId,
+                              teamId: input.teamId,
+                              threadId: input.threadId,
+                              promptName: prompt.name,
+                              promptVersion: prompt.version,
+                              customProperties: {
+                                 agent_role: "job",
+                                 agent_workflow: "refresh-suggestions",
+                                 agent_thread_id: input.threadId,
+                                 pg_boss_job_id: options.job.id,
+                              },
+                           }),
+                     }),
+                  ],
+               }),
+            catch: () =>
+               new RefreshThreadSuggestionsJobError({
+                  error: refreshSuggestionsJobErrors.AI_FAILED({
+                     internal: {
+                        jobId: options.job.id,
+                        threadId: input.threadId,
+                     },
+                  }),
+                  message: refreshSuggestionsJobErrors.AI_FAILED({
+                     internal: {
+                        jobId: options.job.id,
+                        threadId: input.threadId,
+                     },
+                  }).message,
                   threadId: input.threadId,
-               },
-            }),
-            message: refreshSuggestionsJobErrors.WRITE_FAILED({
-               internal: {
-                  jobId: options.job.id,
-                  threadId: input.threadId,
-               },
-            }).message,
-            threadId: input.threadId,
+               }),
          }),
-   });
-   if (Result.isError(write)) return Result.err(write.error);
+      );
 
-   log.info({
-      module: "agents.refresh-suggestions-job",
-      message: "completed",
-      jobId: options.job.id,
-      threadId: input.threadId,
-      suggestionsCount: suggestions.length,
+      yield* Result.await(
+         Result.tryPromise({
+            try: () =>
+               options.db.transaction(async (tx) => {
+                  await tx
+                     .update(threads)
+                     .set({
+                        suggestions,
+                        suggestionsUpdatedAt: dayjs().toDate(),
+                     })
+                     .where(
+                        and(
+                           eq(threads.id, input.threadId),
+                           eq(threads.teamId, input.teamId),
+                           eq(threads.organizationId, input.organizationId),
+                        ),
+                     );
+               }),
+            catch: () =>
+               new RefreshThreadSuggestionsJobError({
+                  error: refreshSuggestionsJobErrors.WRITE_FAILED({
+                     internal: {
+                        jobId: options.job.id,
+                        threadId: input.threadId,
+                     },
+                  }),
+                  message: refreshSuggestionsJobErrors.WRITE_FAILED({
+                     internal: {
+                        jobId: options.job.id,
+                        threadId: input.threadId,
+                     },
+                  }).message,
+                  threadId: input.threadId,
+               }),
+         }),
+      );
+
+      log.info({
+         module: "agents.refresh-suggestions-job",
+         message: "completed",
+         jobId: options.job.id,
+         threadId: input.threadId,
+         suggestionsCount: suggestions.length,
+      });
+      return Result.ok(undefined);
    });
-   return Result.ok(undefined);
 }

--- a/modules/agents/src/runtime/middleware/create-agent-runtime-middlewares.ts
+++ b/modules/agents/src/runtime/middleware/create-agent-runtime-middlewares.ts
@@ -14,11 +14,11 @@ import { log } from "@core/logging";
 import type { PgBossClient } from "@core/pg-boss/client";
 import {
    enqueueGenerateThreadTitleJob,
-   type GenerateThreadTitleJobError,
+   GenerateThreadTitleJobError,
 } from "@modules/agents/jobs/generate-title-job";
 import {
    enqueueRefreshThreadSuggestionsJob,
-   type RefreshThreadSuggestionsJobError,
+   RefreshThreadSuggestionsJobError,
 } from "@modules/agents/jobs/refresh-suggestions-job";
 import { createAssistantStreamState } from "./assistant-stream-state";
 
@@ -167,57 +167,62 @@ async function persistAssistantMessages(options: {
    organizationId: string;
    streamState: ReturnType<typeof createAssistantStreamState>;
 }): Promise<ResultType<void, AgentRuntimeError>> {
-   const newAssistantMessages = options.streamState.newAssistantMessages();
+   return Result.gen(async function* () {
+      const newAssistantMessages = options.streamState.newAssistantMessages();
 
-   if (newAssistantMessages.length === 0) {
-      log.warn({
-         module: "agents.runtime",
-         message: "agent chat produced no assistant parts",
-         threadId: options.threadId,
-      });
-      return Result.ok(undefined);
-   }
-
-   const result = await Result.tryPromise({
-      try: () =>
-         options.db.transaction(async (tx) => {
-            for (const msg of newAssistantMessages) {
-               const metadata: MessageMetadata = messageMetadataSchema.parse({
-                  ...(options.streamState.traceId() && {
-                     traceId: options.streamState.traceId(),
-                  }),
-               });
-               await tx.insert(messages).values({
-                  threadId: options.threadId,
-                  role: "assistant",
-                  parts: msg.parts,
-                  metadata,
-               });
-            }
-            await tx
-               .update(threads)
-               .set({ lastMessageAt: dayjs().toDate() })
-               .where(
-                  and(
-                     eq(threads.id, options.threadId),
-                     eq(threads.teamId, options.teamId),
-                     eq(threads.organizationId, options.organizationId),
-                  ),
-               );
-         }),
-      catch: () =>
-         new AgentRuntimeError({
-            error: runtimeErrors.ASSISTANT_MESSAGE_PERSIST_FAILED({
-               internal: { threadId: options.threadId },
-            }),
-            message: runtimeErrors.ASSISTANT_MESSAGE_PERSIST_FAILED({
-               internal: { threadId: options.threadId },
-            }).message,
+      if (newAssistantMessages.length === 0) {
+         log.warn({
+            module: "agents.runtime",
+            message: "agent chat produced no assistant parts",
             threadId: options.threadId,
+         });
+         return Result.ok(undefined);
+      }
+
+      yield* Result.await(
+         Result.tryPromise({
+            try: () =>
+               options.db.transaction(async (tx) => {
+                  for (const msg of newAssistantMessages) {
+                     const metadata: MessageMetadata =
+                        messageMetadataSchema.parse({
+                           ...(options.streamState.traceId() && {
+                              traceId: options.streamState.traceId(),
+                           }),
+                        });
+                     await tx.insert(messages).values({
+                        threadId: options.threadId,
+                        role: "assistant",
+                        parts: msg.parts,
+                        metadata,
+                     });
+                  }
+                  await tx
+                     .update(threads)
+                     .set({ lastMessageAt: dayjs().toDate() })
+                     .where(
+                        and(
+                           eq(threads.id, options.threadId),
+                           eq(threads.teamId, options.teamId),
+                           eq(threads.organizationId, options.organizationId),
+                        ),
+                     );
+               }),
+            catch: () =>
+               new AgentRuntimeError({
+                  error: runtimeErrors.ASSISTANT_MESSAGE_PERSIST_FAILED({
+                     internal: { threadId: options.threadId },
+                  }),
+                  message: runtimeErrors.ASSISTANT_MESSAGE_PERSIST_FAILED({
+                     internal: { threadId: options.threadId },
+                  }).message,
+                  threadId: options.threadId,
+               }),
          }),
+      );
+
+      return Result.ok(undefined);
    });
-   if (Result.isError(result)) return Result.err(result.error);
-   return Result.ok(undefined);
 }
 
 async function enqueueThreadTitle(options: {
@@ -227,102 +232,111 @@ async function enqueueThreadTitle(options: {
    teamId: string;
    organizationId: string;
 }): Promise<ResultType<string | undefined, AgentRuntimeError>> {
-   const threadResult = await Result.tryPromise({
-      try: () =>
-         options.db
-            .select({ title: threads.title })
-            .from(threads)
-            .where(
-               and(
-                  eq(threads.id, options.threadId),
-                  eq(threads.teamId, options.teamId),
-                  eq(threads.organizationId, options.organizationId),
-                  isNull(threads.title),
-               ),
-            )
-            .limit(1),
-      catch: () =>
-         new AgentRuntimeError({
-            error: runtimeErrors.THREAD_TITLE_CHECK_FAILED({
-               internal: {
+   const result = await Result.gen(async function* () {
+      const thread = yield* Result.await(
+         Result.tryPromise({
+            try: () =>
+               options.db
+                  .select({ title: threads.title })
+                  .from(threads)
+                  .where(
+                     and(
+                        eq(threads.id, options.threadId),
+                        eq(threads.teamId, options.teamId),
+                        eq(threads.organizationId, options.organizationId),
+                        isNull(threads.title),
+                     ),
+                  )
+                  .limit(1),
+            catch: () =>
+               new AgentRuntimeError({
+                  error: runtimeErrors.THREAD_TITLE_CHECK_FAILED({
+                     internal: {
+                        threadId: options.threadId,
+                        teamId: options.teamId,
+                        organizationId: options.organizationId,
+                     },
+                  }),
+                  message: runtimeErrors.THREAD_TITLE_CHECK_FAILED({
+                     internal: {
+                        threadId: options.threadId,
+                        teamId: options.teamId,
+                        organizationId: options.organizationId,
+                     },
+                  }).message,
                   threadId: options.threadId,
                   teamId: options.teamId,
                   organizationId: options.organizationId,
-               },
-            }),
-            message: runtimeErrors.THREAD_TITLE_CHECK_FAILED({
-               internal: {
-                  threadId: options.threadId,
-                  teamId: options.teamId,
-                  organizationId: options.organizationId,
-               },
-            }).message,
-            threadId: options.threadId,
-            teamId: options.teamId,
-            organizationId: options.organizationId,
-         }),
-   });
-   if (Result.isError(threadResult)) return Result.err(threadResult.error);
-   if (!threadResult.value[0]) return Result.ok(undefined);
-
-   const bossResult = await Result.tryPromise({
-      try: () => options.pgBoss,
-      catch: () =>
-         new AgentRuntimeError({
-            error: runtimeErrors.THREAD_TITLE_ENQUEUE_FAILED({
-               internal: {
-                  threadId: options.threadId,
-                  teamId: options.teamId,
-                  organizationId: options.organizationId,
-               },
-            }),
-            message: runtimeErrors.THREAD_TITLE_ENQUEUE_FAILED({
-               internal: {
-                  threadId: options.threadId,
-                  teamId: options.teamId,
-                  organizationId: options.organizationId,
-               },
-            }).message,
-            threadId: options.threadId,
-            teamId: options.teamId,
-            organizationId: options.organizationId,
-         }),
-   });
-   if (Result.isError(bossResult)) return Result.err(bossResult.error);
-
-   const result = await enqueueGenerateThreadTitleJob({
-      boss: bossResult.value,
-      input: {
-         threadId: options.threadId,
-         teamId: options.teamId,
-         organizationId: options.organizationId,
-      },
-   });
-   if (Result.isError(result)) {
-      return Result.err(
-         new AgentRuntimeError({
-            error: runtimeErrors.THREAD_TITLE_ENQUEUE_FAILED({
-               internal: {
-                  threadId: options.threadId,
-                  teamId: options.teamId,
-                  organizationId: options.organizationId,
-               },
-            }),
-            message: runtimeErrors.THREAD_TITLE_ENQUEUE_FAILED({
-               internal: {
-                  threadId: options.threadId,
-                  teamId: options.teamId,
-                  organizationId: options.organizationId,
-               },
-            }).message,
-            threadId: options.threadId,
-            teamId: options.teamId,
-            organizationId: options.organizationId,
-            jobError: result.error,
+               }),
          }),
       );
-   }
-   return Result.ok(result.value);
+      if (!thread[0]) return Result.ok(undefined);
+
+      const boss = yield* Result.await(
+         Result.tryPromise({
+            try: () => options.pgBoss,
+            catch: () =>
+               new AgentRuntimeError({
+                  error: runtimeErrors.THREAD_TITLE_ENQUEUE_FAILED({
+                     internal: {
+                        threadId: options.threadId,
+                        teamId: options.teamId,
+                        organizationId: options.organizationId,
+                     },
+                  }),
+                  message: runtimeErrors.THREAD_TITLE_ENQUEUE_FAILED({
+                     internal: {
+                        threadId: options.threadId,
+                        teamId: options.teamId,
+                        organizationId: options.organizationId,
+                     },
+                  }).message,
+                  threadId: options.threadId,
+                  teamId: options.teamId,
+                  organizationId: options.organizationId,
+               }),
+         }),
+      );
+
+      const jobId = yield* Result.await(
+         enqueueGenerateThreadTitleJob({
+            boss,
+            input: {
+               threadId: options.threadId,
+               teamId: options.teamId,
+               organizationId: options.organizationId,
+            },
+         }),
+      );
+
+      return Result.ok(jobId);
+   });
+
+   return result.mapError((error) => {
+      if (error instanceof GenerateThreadTitleJobError) {
+         return new AgentRuntimeError({
+            error: runtimeErrors.THREAD_TITLE_ENQUEUE_FAILED({
+               internal: {
+                  threadId: options.threadId,
+                  teamId: options.teamId,
+                  organizationId: options.organizationId,
+               },
+            }),
+            message: runtimeErrors.THREAD_TITLE_ENQUEUE_FAILED({
+               internal: {
+                  threadId: options.threadId,
+                  teamId: options.teamId,
+                  organizationId: options.organizationId,
+               },
+            }).message,
+            threadId: options.threadId,
+            teamId: options.teamId,
+            organizationId: options.organizationId,
+            jobError: error,
+         });
+      }
+      return error;
+   });
 }
 
 async function enqueueThreadSuggestions(options: {
@@ -332,69 +346,77 @@ async function enqueueThreadSuggestions(options: {
    organizationId: string;
    messageCount: number;
 }): Promise<ResultType<string, AgentRuntimeError>> {
-   const bossResult = await Result.tryPromise({
-      try: () => options.pgBoss,
-      catch: () =>
-         new AgentRuntimeError({
-            error: runtimeErrors.THREAD_SUGGESTIONS_ENQUEUE_FAILED({
-               internal: {
+   const result = await Result.gen(async function* () {
+      const boss = yield* Result.await(
+         Result.tryPromise({
+            try: () => options.pgBoss,
+            catch: () =>
+               new AgentRuntimeError({
+                  error: runtimeErrors.THREAD_SUGGESTIONS_ENQUEUE_FAILED({
+                     internal: {
+                        threadId: options.threadId,
+                        teamId: options.teamId,
+                        organizationId: options.organizationId,
+                        messageCount: options.messageCount,
+                     },
+                  }),
+                  message: runtimeErrors.THREAD_SUGGESTIONS_ENQUEUE_FAILED({
+                     internal: {
+                        threadId: options.threadId,
+                        teamId: options.teamId,
+                        organizationId: options.organizationId,
+                        messageCount: options.messageCount,
+                     },
+                  }).message,
                   threadId: options.threadId,
                   teamId: options.teamId,
                   organizationId: options.organizationId,
                   messageCount: options.messageCount,
-               },
-            }),
-            message: runtimeErrors.THREAD_SUGGESTIONS_ENQUEUE_FAILED({
-               internal: {
-                  threadId: options.threadId,
-                  teamId: options.teamId,
-                  organizationId: options.organizationId,
-                  messageCount: options.messageCount,
-               },
-            }).message,
-            threadId: options.threadId,
-            teamId: options.teamId,
-            organizationId: options.organizationId,
-            messageCount: options.messageCount,
-         }),
-   });
-   if (Result.isError(bossResult)) return Result.err(bossResult.error);
-
-   const result = await enqueueRefreshThreadSuggestionsJob({
-      boss: bossResult.value,
-      input: {
-         threadId: options.threadId,
-         teamId: options.teamId,
-         organizationId: options.organizationId,
-         messageCount: options.messageCount,
-      },
-   });
-   if (Result.isError(result)) {
-      return Result.err(
-         new AgentRuntimeError({
-            error: runtimeErrors.THREAD_SUGGESTIONS_ENQUEUE_FAILED({
-               internal: {
-                  threadId: options.threadId,
-                  teamId: options.teamId,
-                  organizationId: options.organizationId,
-                  messageCount: options.messageCount,
-               },
-            }),
-            message: runtimeErrors.THREAD_SUGGESTIONS_ENQUEUE_FAILED({
-               internal: {
-                  threadId: options.threadId,
-                  teamId: options.teamId,
-                  organizationId: options.organizationId,
-                  messageCount: options.messageCount,
-               },
-            }).message,
-            threadId: options.threadId,
-            teamId: options.teamId,
-            organizationId: options.organizationId,
-            messageCount: options.messageCount,
-            jobError: result.error,
+               }),
          }),
       );
-   }
-   return Result.ok(result.value);
+
+      const jobId = yield* Result.await(
+         enqueueRefreshThreadSuggestionsJob({
+            boss,
+            input: {
+               threadId: options.threadId,
+               teamId: options.teamId,
+               organizationId: options.organizationId,
+               messageCount: options.messageCount,
+            },
+         }),
+      );
+
+      return Result.ok(jobId);
+   });
+
+   return result.mapError((error) => {
+      if (error instanceof RefreshThreadSuggestionsJobError) {
+         return new AgentRuntimeError({
+            error: runtimeErrors.THREAD_SUGGESTIONS_ENQUEUE_FAILED({
+               internal: {
+                  threadId: options.threadId,
+                  teamId: options.teamId,
+                  organizationId: options.organizationId,
+                  messageCount: options.messageCount,
+               },
+            }),
+            message: runtimeErrors.THREAD_SUGGESTIONS_ENQUEUE_FAILED({
+               internal: {
+                  threadId: options.threadId,
+                  teamId: options.teamId,
+                  organizationId: options.organizationId,
+                  messageCount: options.messageCount,
+               },
+            }).message,
+            threadId: options.threadId,
+            teamId: options.teamId,
+            organizationId: options.organizationId,
+            messageCount: options.messageCount,
+            jobError: error,
+         });
+      }
+      return error;
+   });
 }

--- a/modules/agents/src/tools/advisor.ts
+++ b/modules/agents/src/tools/advisor.ts
@@ -56,6 +56,11 @@ type AdvisorCatalogError =
 class AdvisorToolError extends TaggedError("AdvisorToolError")<{
    error: AdvisorCatalogError;
    message: string;
+   userId?: string;
+   organizationId?: string;
+   teamId?: string;
+   threadId?: string;
+   turnId?: string;
 }>() {}
 
 export interface AdvisorToolDeps {
@@ -93,6 +98,14 @@ const advisorConsultInputSchema = z.object({
 });
 
 export function buildAdvisorTool(deps: AdvisorToolDeps) {
+   const errorContext = {
+      userId: deps.userId,
+      organizationId: deps.organizationId,
+      teamId: deps.teamId,
+      threadId: deps.threadId,
+      turnId: deps.turnId,
+   };
+
    return toolDefinition({
       name: "advisor_consult",
       description:
@@ -118,6 +131,7 @@ export function buildAdvisorTool(deps: AdvisorToolDeps) {
                   new AdvisorToolError({
                      error: advisorErrors.PROMPT_LOAD_FAILED(),
                      message: advisorErrors.PROMPT_LOAD_FAILED().message,
+                     ...errorContext,
                   }),
             }),
          );
@@ -128,6 +142,7 @@ export function buildAdvisorTool(deps: AdvisorToolDeps) {
                new AdvisorToolError({
                   error: advisorErrors.PROMPT_COMPILE_FAILED(),
                   message: advisorErrors.PROMPT_COMPILE_FAILED().message,
+                  ...errorContext,
                }),
          });
 
@@ -196,6 +211,7 @@ export function buildAdvisorTool(deps: AdvisorToolDeps) {
                      new AdvisorToolError({
                         error: advisorErrors.RUN_FAILED(),
                         message: advisorErrors.RUN_FAILED().message,
+                        ...errorContext,
                      }),
                }),
             );
@@ -208,6 +224,7 @@ export function buildAdvisorTool(deps: AdvisorToolDeps) {
                new AdvisorToolError({
                   error: advisorErrors.EMPTY_RESPONSE(),
                   message: advisorErrors.EMPTY_RESPONSE().message,
+                  ...errorContext,
                }),
             );
 

--- a/modules/agents/src/tools/advisor.ts
+++ b/modules/agents/src/tools/advisor.ts
@@ -99,111 +99,125 @@ export function buildAdvisorTool(deps: AdvisorToolDeps) {
          "Consulte o advisor sênior antes de tomar decisões ambíguas dentro de uma skill ativa: tabela/dado confuso ou mesma operação falhou 2x. NÃO consulte para CRUD trivial, listagem, input claro ou pedidos sem skill ativa. Budget: até 3 consultas por turno.",
       inputSchema: advisorConsultInputSchema,
    }).server(async ({ situation, question, options }) => {
-      if (SKILLS.length === 0) {
-         return {
-            guidance:
-               "Nenhuma skill operacional está disponível no momento. Não é possível consultar o advisor para este pedido.",
-            fallback: true,
-         };
-      }
+      const result = await Result.gen(async function* () {
+         if (SKILLS.length === 0) {
+            return Result.ok({
+               guidance:
+                  "Nenhuma skill operacional está disponível no momento. Não é possível consultar o advisor para este pedido.",
+               fallback: true,
+            });
+         }
 
-      const templateResult = await Result.tryPromise({
-         try: () =>
-            deps.prompts.get(AGENT_PROMPTS.advisor, {
-               withMetadata: false,
-            }),
-         catch: () =>
-            new AdvisorToolError({
-               error: advisorErrors.PROMPT_LOAD_FAILED(),
-               message: advisorErrors.PROMPT_LOAD_FAILED().message,
-            }),
-      });
-      if (Result.isError(templateResult)) throw templateResult.error;
-
-      const systemPromptResult = Result.try({
-         try: () => deps.prompts.compile(templateResult.value, {}),
-         catch: () =>
-            new AdvisorToolError({
-               error: advisorErrors.PROMPT_COMPILE_FAILED(),
-               message: advisorErrors.PROMPT_COMPILE_FAILED().message,
-            }),
-      });
-      if (Result.isError(systemPromptResult)) throw systemPromptResult.error;
-      const systemPrompt = systemPromptResult.value;
-
-      const optionsBlock =
-         options && options.length > 0
-            ? `\nOpções consideradas:\n${options.map((o, i) => `${i + 1}. ${o}`).join("\n")}`
-            : "";
-
-      const userContent = `Situação:\n${situation}\n\nDecisão necessária:\n${question}${optionsBlock}`;
-
-      const advisorController = new AbortController();
-      const timeout = setTimeout(
-         () => advisorController.abort("advisor-timeout"),
-         ADVISOR_TIMEOUT_MS,
-      );
-
-      const result = await Result.tryPromise({
-         try: () =>
-            chat({
-               adapter: proModel,
-               systemPrompts: [systemPrompt],
-               messages: [
-                  {
-                     role: "user",
-                     content: [{ type: "text", content: userContent }],
-                  },
-               ],
-               stream: false,
-               abortController: advisorController,
-               middleware: [
-                  otelMiddleware({
-                     tracer: getAiTracer(),
-                     captureContent: false,
-                     attributeEnricher: () =>
-                        aiTraceAttributes({
-                           distinctId: deps.distinctId,
-                           userId: deps.userId,
-                           organizationId: deps.organizationId,
-                           teamId: deps.teamId,
-                           threadId: deps.threadId,
-                           promptName: AGENT_PROMPTS.advisor,
-                           customProperties: {
-                              agent_role: "advisor",
-                              ...(deps.organizationId && {
-                                 agent_organization_id: deps.organizationId,
-                              }),
-                              ...(deps.teamId && {
-                                 agent_team_id: deps.teamId,
-                              }),
-                              ...(deps.threadId && {
-                                 agent_thread_id: deps.threadId,
-                              }),
-                              ...(deps.turnId && {
-                                 agent_turn_id: deps.turnId,
-                              }),
-                           },
-                        }),
+         const template = yield* Result.await(
+            Result.tryPromise({
+               try: () =>
+                  deps.prompts.get(AGENT_PROMPTS.advisor, {
+                     withMetadata: false,
                   }),
-               ],
+               catch: () =>
+                  new AdvisorToolError({
+                     error: advisorErrors.PROMPT_LOAD_FAILED(),
+                     message: advisorErrors.PROMPT_LOAD_FAILED().message,
+                  }),
             }),
-         catch: () =>
-            new AdvisorToolError({
-               error: advisorErrors.RUN_FAILED(),
-               message: advisorErrors.RUN_FAILED().message,
-            }),
-      }).finally(() => clearTimeout(timeout));
+         );
+
+         const systemPrompt = yield* Result.try({
+            try: () => deps.prompts.compile(template, {}),
+            catch: () =>
+               new AdvisorToolError({
+                  error: advisorErrors.PROMPT_COMPILE_FAILED(),
+                  message: advisorErrors.PROMPT_COMPILE_FAILED().message,
+               }),
+         });
+
+         const optionsBlock =
+            options && options.length > 0
+               ? `\nOpções consideradas:\n${options.map((o, i) => `${i + 1}. ${o}`).join("\n")}`
+               : "";
+
+         const userContent = `Situação:\n${situation}\n\nDecisão necessária:\n${question}${optionsBlock}`;
+
+         const advisorController = new AbortController();
+         const timeout = setTimeout(
+            () => advisorController.abort("advisor-timeout"),
+            ADVISOR_TIMEOUT_MS,
+         );
+
+         let response: string | undefined;
+         try {
+            response = yield* Result.await(
+               Result.tryPromise({
+                  try: () =>
+                     chat({
+                        adapter: proModel,
+                        systemPrompts: [systemPrompt],
+                        messages: [
+                           {
+                              role: "user",
+                              content: [{ type: "text", content: userContent }],
+                           },
+                        ],
+                        stream: false,
+                        abortController: advisorController,
+                        middleware: [
+                           otelMiddleware({
+                              tracer: getAiTracer(),
+                              captureContent: false,
+                              attributeEnricher: () =>
+                                 aiTraceAttributes({
+                                    distinctId: deps.distinctId,
+                                    userId: deps.userId,
+                                    organizationId: deps.organizationId,
+                                    teamId: deps.teamId,
+                                    threadId: deps.threadId,
+                                    promptName: AGENT_PROMPTS.advisor,
+                                    customProperties: {
+                                       agent_role: "advisor",
+                                       ...(deps.organizationId && {
+                                          agent_organization_id:
+                                             deps.organizationId,
+                                       }),
+                                       ...(deps.teamId && {
+                                          agent_team_id: deps.teamId,
+                                       }),
+                                       ...(deps.threadId && {
+                                          agent_thread_id: deps.threadId,
+                                       }),
+                                       ...(deps.turnId && {
+                                          agent_turn_id: deps.turnId,
+                                       }),
+                                    },
+                                 }),
+                           }),
+                        ],
+                     }),
+                  catch: () =>
+                     new AdvisorToolError({
+                        error: advisorErrors.RUN_FAILED(),
+                        message: advisorErrors.RUN_FAILED().message,
+                     }),
+               }),
+            );
+         } finally {
+            clearTimeout(timeout);
+         }
+
+         if (!response)
+            return Result.err(
+               new AdvisorToolError({
+                  error: advisorErrors.EMPTY_RESPONSE(),
+                  message: advisorErrors.EMPTY_RESPONSE().message,
+               }),
+            );
+
+         return Result.ok({
+            guidance: response,
+            fallback: false,
+         });
+      });
 
       if (Result.isError(result)) throw result.error;
-      if (!result.value)
-         throw new AdvisorToolError({
-            error: advisorErrors.EMPTY_RESPONSE(),
-            message: advisorErrors.EMPTY_RESPONSE().message,
-         });
-      return {
-         guidance: result.value,
-         fallback: false,
-      };
+      return result.value;
    });
 }


### PR DESCRIPTION
## Resumo

- Refatorei fluxos longos de `modules/agents` para estilo funcional com `Result.gen(async function* ...)` + `yield* Result.await(...)`, conforme padrão do `classification`.
- Atualizei:
  - `handleGenerateThreadTitleJob`
  - `handleRefreshThreadSuggestionsJob`
  - `persistAssistantMessages`
  - `enqueueThreadTitle`
  - `enqueueThreadSuggestions`
- Também atualizei `buildAdvisorTool` (opcional) para o mesmo padrão.

## Comportamento e escopo

- Mantive inalterados: políticas de retry, DLQ, debounce, enfileiramento e logs essenciais.
- Não alterei contratos de fila nem payloads esperados.
- Não houve mudança de regras de negócio; foi apenas a estrutura de fluxo de `Result`.

## Validação

- `bun run typecheck`
