### PR TITLE
fix(agents): skip completed when thread update has no rows

### DIFF
--- a/modules/agents/src/jobs/refresh-suggestions-job.ts
+++ b/modules/agents/src/jobs/refresh-suggestions-job.ts
@@ -375,11 +375,11 @@ export async function handleRefreshThreadSuggestionsJob(options: {
          }),
       );
 
-      yield* Result.await(
+      const updatedThreads = yield* Result.await(
          Result.tryPromise({
             try: () =>
-               options.db.transaction(async (tx) => {
-                  await tx
+               options.db.transaction(async (tx) =>
+                  tx
                      .update(threads)
                      .set({
                         suggestions,
@@ -391,8 +391,9 @@ export async function handleRefreshThreadSuggestionsJob(options: {
                            eq(threads.teamId, input.teamId),
                            eq(threads.organizationId, input.organizationId),
                         ),
-                     );
-               }),
+                     )
+                     .returning({ id: threads.id }),
+               ),
             catch: () =>
                new RefreshThreadSuggestionsJobError({
                   error: refreshSuggestionsJobErrors.WRITE_FAILED({
@@ -411,6 +412,18 @@ export async function handleRefreshThreadSuggestionsJob(options: {
                }),
          }),
       );
+
+      if (updatedThreads.length === 0) {
+         log.info({
+            module: "agents.refresh-suggestions-job",
+            message: "skipping: thread not found in scope",
+            jobId: options.job.id,
+            threadId: input.threadId,
+            teamId: input.teamId,
+            organizationId: input.organizationId,
+         });
+         return Result.ok(undefined);
+      }
 
       log.info({
          module: "agents.refresh-suggestions-job",


### PR DESCRIPTION
## Resumo
- Atualiza o job de sugestões para usar `returning({ id: threads.id })` no update.
- Quando nenhuma linha for atualizada, registra log de skip (`thread not found in scope`) e encerra com sucesso.
- Mantém `WRITE_FAILED` apenas para falha real de escrita no banco.

## Critérios de aceite
- Job não reporta `completed` quando nenhuma thread é atualizada.
- Sem mudanças de schema.
- `bun run typecheck` passa.
