### PR TITLE
Decouple AgentRuntimeError from job error payloads

### DIFF
--- a/modules/agents/src/runtime/middleware/create-agent-runtime-middlewares.ts
+++ b/modules/agents/src/runtime/middleware/create-agent-runtime-middlewares.ts
@@ -70,35 +70,6 @@ class AgentRuntimeError extends TaggedError("AgentRuntimeError")<{
    jobErrorMessage?: string;
 }>() {}
 
-function mapJobErrorPayload(error: unknown) {
-   if (error instanceof Error) {
-      return {
-         jobErrorName: error.name,
-         jobErrorMessage: error.message,
-      };
-   }
-
-   if (typeof error === "object" && error !== null) {
-      const name =
-         typeof Reflect.get(error, "name") === "string"
-            ? Reflect.get(error, "name")
-            : undefined;
-      const message =
-         typeof Reflect.get(error, "message") === "string"
-            ? Reflect.get(error, "message")
-            : undefined;
-
-      return {
-         jobErrorName: name,
-         jobErrorMessage: message,
-      };
-   }
-
-   return {
-      jobErrorMessage: typeof error === "string" ? error : undefined,
-   };
-}
-
 const MIN_TITLE_MESSAGE_COUNT = 2;
 const MIN_SUGGESTION_MESSAGE_COUNT = 4;
 const SUGGESTION_MESSAGE_INTERVAL = 4;
@@ -338,7 +309,10 @@ async function enqueueThreadTitle(options: {
 
    return result.mapError((error) => {
       if (error instanceof AgentRuntimeError) return error;
-      const jobError = mapJobErrorPayload(error);
+
+      const jobErrorName = error instanceof Error ? error.name : undefined;
+      const jobErrorMessage =
+         error instanceof Error ? error.message : undefined;
 
       log.error({
          module: "agents.runtime",
@@ -346,8 +320,8 @@ async function enqueueThreadTitle(options: {
          threadId: options.threadId,
          teamId: options.teamId,
          organizationId: options.organizationId,
-         jobErrorName: jobError.jobErrorName,
-         jobErrorMessage: jobError.jobErrorMessage,
+         jobErrorName,
+         jobErrorMessage,
          err: error,
       });
 
@@ -369,7 +343,8 @@ async function enqueueThreadTitle(options: {
          threadId: options.threadId,
          teamId: options.teamId,
          organizationId: options.organizationId,
-         ...jobError,
+         jobErrorName,
+         jobErrorMessage,
       });
    });
 }
@@ -439,7 +414,10 @@ async function enqueueThreadSuggestions(options: {
 
    return result.mapError((error) => {
       if (error instanceof AgentRuntimeError) return error;
-      const jobError = mapJobErrorPayload(error);
+
+      const jobErrorName = error instanceof Error ? error.name : undefined;
+      const jobErrorMessage =
+         error instanceof Error ? error.message : undefined;
 
       log.error({
          module: "agents.runtime",
@@ -448,8 +426,8 @@ async function enqueueThreadSuggestions(options: {
          teamId: options.teamId,
          organizationId: options.organizationId,
          messageCount: options.messageCount,
-         jobErrorName: jobError.jobErrorName,
-         jobErrorMessage: jobError.jobErrorMessage,
+         jobErrorName,
+         jobErrorMessage,
          err: error,
       });
 
@@ -474,7 +452,8 @@ async function enqueueThreadSuggestions(options: {
          teamId: options.teamId,
          organizationId: options.organizationId,
          messageCount: options.messageCount,
-         ...jobError,
+         jobErrorName,
+         jobErrorMessage,
       });
    });
 }

--- a/modules/agents/src/runtime/middleware/create-agent-runtime-middlewares.ts
+++ b/modules/agents/src/runtime/middleware/create-agent-runtime-middlewares.ts
@@ -12,14 +12,8 @@ import {
 import { threads } from "@core/database/schemas/threads";
 import { log } from "@core/logging";
 import type { PgBossClient } from "@core/pg-boss/client";
-import {
-   enqueueGenerateThreadTitleJob,
-   GenerateThreadTitleJobError,
-} from "@modules/agents/jobs/generate-title-job";
-import {
-   enqueueRefreshThreadSuggestionsJob,
-   RefreshThreadSuggestionsJobError,
-} from "@modules/agents/jobs/refresh-suggestions-job";
+import { enqueueGenerateThreadTitleJob } from "@modules/agents/jobs/generate-title-job";
+import { enqueueRefreshThreadSuggestionsJob } from "@modules/agents/jobs/refresh-suggestions-job";
 import { createAssistantStreamState } from "./assistant-stream-state";
 
 const runtimeErrors = defineErrorCatalog("agents.runtime", {
@@ -72,8 +66,38 @@ class AgentRuntimeError extends TaggedError("AgentRuntimeError")<{
    teamId?: string;
    organizationId?: string;
    messageCount?: number;
-   jobError?: GenerateThreadTitleJobError | RefreshThreadSuggestionsJobError;
+   jobErrorName?: string;
+   jobErrorMessage?: string;
 }>() {}
+
+function mapJobErrorPayload(error: unknown) {
+   if (error instanceof Error) {
+      return {
+         jobErrorName: error.name,
+         jobErrorMessage: error.message,
+      };
+   }
+
+   if (typeof error === "object" && error !== null) {
+      const name =
+         typeof Reflect.get(error, "name") === "string"
+            ? Reflect.get(error, "name")
+            : undefined;
+      const message =
+         typeof Reflect.get(error, "message") === "string"
+            ? Reflect.get(error, "message")
+            : undefined;
+
+      return {
+         jobErrorName: name,
+         jobErrorMessage: message,
+      };
+   }
+
+   return {
+      jobErrorMessage: typeof error === "string" ? error : undefined,
+   };
+}
 
 const MIN_TITLE_MESSAGE_COUNT = 2;
 const MIN_SUGGESTION_MESSAGE_COUNT = 4;
@@ -124,12 +148,7 @@ export function createAgentRuntimeMiddlewares(
                      teamId: deps.teamId,
                      organizationId: deps.organizationId,
                   }).then((result) => {
-                     if (!Result.isError(result)) return;
-                     log.error({
-                        module: "agents.runtime",
-                        message: "failed enqueue generate-title",
-                        err: result.error,
-                     });
+                     if (Result.isError(result)) throw result.error;
                   }),
                );
             }
@@ -146,12 +165,7 @@ export function createAgentRuntimeMiddlewares(
                      organizationId: deps.organizationId,
                      messageCount,
                   }).then((result) => {
-                     if (!Result.isError(result)) return;
-                     log.error({
-                        module: "agents.runtime",
-                        message: "failed enqueue refresh-suggestions",
-                        err: result.error,
-                     });
+                     if (Result.isError(result)) throw result.error;
                   }),
                );
             }
@@ -275,8 +289,17 @@ async function enqueueThreadTitle(options: {
       const boss = yield* Result.await(
          Result.tryPromise({
             try: () => options.pgBoss,
-            catch: () =>
-               new AgentRuntimeError({
+            catch: (error) => {
+               log.error({
+                  module: "agents.runtime",
+                  message: "failed resolve pg-boss for thread title",
+                  threadId: options.threadId,
+                  teamId: options.teamId,
+                  organizationId: options.organizationId,
+                  err: error,
+               });
+
+               return new AgentRuntimeError({
                   error: runtimeErrors.THREAD_TITLE_ENQUEUE_FAILED({
                      internal: {
                         threadId: options.threadId,
@@ -294,7 +317,8 @@ async function enqueueThreadTitle(options: {
                   threadId: options.threadId,
                   teamId: options.teamId,
                   organizationId: options.organizationId,
-               }),
+               });
+            },
          }),
       );
 
@@ -313,29 +337,40 @@ async function enqueueThreadTitle(options: {
    });
 
    return result.mapError((error) => {
-      if (error instanceof GenerateThreadTitleJobError) {
-         return new AgentRuntimeError({
-            error: runtimeErrors.THREAD_TITLE_ENQUEUE_FAILED({
-               internal: {
-                  threadId: options.threadId,
-                  teamId: options.teamId,
-                  organizationId: options.organizationId,
-               },
-            }),
-            message: runtimeErrors.THREAD_TITLE_ENQUEUE_FAILED({
-               internal: {
-                  threadId: options.threadId,
-                  teamId: options.teamId,
-                  organizationId: options.organizationId,
-               },
-            }).message,
-            threadId: options.threadId,
-            teamId: options.teamId,
-            organizationId: options.organizationId,
-            jobError: error,
-         });
-      }
-      return error;
+      if (error instanceof AgentRuntimeError) return error;
+      const jobError = mapJobErrorPayload(error);
+
+      log.error({
+         module: "agents.runtime",
+         message: "failed enqueue generate-title",
+         threadId: options.threadId,
+         teamId: options.teamId,
+         organizationId: options.organizationId,
+         jobErrorName: jobError.jobErrorName,
+         jobErrorMessage: jobError.jobErrorMessage,
+         err: error,
+      });
+
+      return new AgentRuntimeError({
+         error: runtimeErrors.THREAD_TITLE_ENQUEUE_FAILED({
+            internal: {
+               threadId: options.threadId,
+               teamId: options.teamId,
+               organizationId: options.organizationId,
+            },
+         }),
+         message: runtimeErrors.THREAD_TITLE_ENQUEUE_FAILED({
+            internal: {
+               threadId: options.threadId,
+               teamId: options.teamId,
+               organizationId: options.organizationId,
+            },
+         }).message,
+         threadId: options.threadId,
+         teamId: options.teamId,
+         organizationId: options.organizationId,
+         ...jobError,
+      });
    });
 }
 
@@ -350,8 +385,18 @@ async function enqueueThreadSuggestions(options: {
       const boss = yield* Result.await(
          Result.tryPromise({
             try: () => options.pgBoss,
-            catch: () =>
-               new AgentRuntimeError({
+            catch: (error) => {
+               log.error({
+                  module: "agents.runtime",
+                  message: "failed resolve pg-boss for thread suggestions",
+                  threadId: options.threadId,
+                  teamId: options.teamId,
+                  organizationId: options.organizationId,
+                  messageCount: options.messageCount,
+                  err: error,
+               });
+
+               return new AgentRuntimeError({
                   error: runtimeErrors.THREAD_SUGGESTIONS_ENQUEUE_FAILED({
                      internal: {
                         threadId: options.threadId,
@@ -372,7 +417,8 @@ async function enqueueThreadSuggestions(options: {
                   teamId: options.teamId,
                   organizationId: options.organizationId,
                   messageCount: options.messageCount,
-               }),
+               });
+            },
          }),
       );
 
@@ -392,31 +438,43 @@ async function enqueueThreadSuggestions(options: {
    });
 
    return result.mapError((error) => {
-      if (error instanceof RefreshThreadSuggestionsJobError) {
-         return new AgentRuntimeError({
-            error: runtimeErrors.THREAD_SUGGESTIONS_ENQUEUE_FAILED({
-               internal: {
-                  threadId: options.threadId,
-                  teamId: options.teamId,
-                  organizationId: options.organizationId,
-                  messageCount: options.messageCount,
-               },
-            }),
-            message: runtimeErrors.THREAD_SUGGESTIONS_ENQUEUE_FAILED({
-               internal: {
-                  threadId: options.threadId,
-                  teamId: options.teamId,
-                  organizationId: options.organizationId,
-                  messageCount: options.messageCount,
-               },
-            }).message,
-            threadId: options.threadId,
-            teamId: options.teamId,
-            organizationId: options.organizationId,
-            messageCount: options.messageCount,
-            jobError: error,
-         });
-      }
-      return error;
+      if (error instanceof AgentRuntimeError) return error;
+      const jobError = mapJobErrorPayload(error);
+
+      log.error({
+         module: "agents.runtime",
+         message: "failed enqueue refresh-suggestions",
+         threadId: options.threadId,
+         teamId: options.teamId,
+         organizationId: options.organizationId,
+         messageCount: options.messageCount,
+         jobErrorName: jobError.jobErrorName,
+         jobErrorMessage: jobError.jobErrorMessage,
+         err: error,
+      });
+
+      return new AgentRuntimeError({
+         error: runtimeErrors.THREAD_SUGGESTIONS_ENQUEUE_FAILED({
+            internal: {
+               threadId: options.threadId,
+               teamId: options.teamId,
+               organizationId: options.organizationId,
+               messageCount: options.messageCount,
+            },
+         }),
+         message: runtimeErrors.THREAD_SUGGESTIONS_ENQUEUE_FAILED({
+            internal: {
+               threadId: options.threadId,
+               teamId: options.teamId,
+               organizationId: options.organizationId,
+               messageCount: options.messageCount,
+            },
+         }).message,
+         threadId: options.threadId,
+         teamId: options.teamId,
+         organizationId: options.organizationId,
+         messageCount: options.messageCount,
+         ...jobError,
+      });
    });
 }

--- a/modules/agents/src/runtime/middleware/create-agent-runtime-middlewares.ts
+++ b/modules/agents/src/runtime/middleware/create-agent-runtime-middlewares.ts
@@ -1,7 +1,7 @@
 import type { ChatMiddleware, UIMessage } from "@tanstack/ai";
 import dayjs from "dayjs";
 import { defineErrorCatalog } from "evlog";
-import { Result, TaggedError, type Result as ResultType } from "better-result";
+import { Result, TaggedError } from "better-result";
 import { and, eq, isNull } from "drizzle-orm";
 import type { DatabaseInstance } from "@core/database/client";
 import {
@@ -151,7 +151,7 @@ async function persistAssistantMessages(options: {
    teamId: string;
    organizationId: string;
    streamState: ReturnType<typeof createAssistantStreamState>;
-}): Promise<ResultType<void, AgentRuntimeError>> {
+}): Promise<Result<void, AgentRuntimeError>> {
    return Result.gen(async function* () {
       const newAssistantMessages = options.streamState.newAssistantMessages();
 
@@ -216,7 +216,7 @@ async function enqueueThreadTitle(options: {
    threadId: string;
    teamId: string;
    organizationId: string;
-}): Promise<ResultType<string | undefined, AgentRuntimeError>> {
+}): Promise<Result<string | undefined, AgentRuntimeError>> {
    const result = await Result.gen(async function* () {
       const thread = yield* Result.await(
          Result.tryPromise({
@@ -294,59 +294,56 @@ async function enqueueThreadTitle(options: {
       );
 
       const jobId = yield* Result.await(
-         enqueueGenerateThreadTitleJob({
-            boss,
-            input: {
-               threadId: options.threadId,
-               teamId: options.teamId,
-               organizationId: options.organizationId,
-            },
-         }),
+         (async () => {
+            const enqueueResult = await enqueueGenerateThreadTitleJob({
+               boss,
+               input: {
+                  threadId: options.threadId,
+                  teamId: options.teamId,
+                  organizationId: options.organizationId,
+               },
+            });
+
+            return Result.mapError(
+               enqueueResult,
+               (jobError: { name: string; message: string }) => {
+                  const error = runtimeErrors.THREAD_TITLE_ENQUEUE_FAILED({
+                     internal: {
+                        threadId: options.threadId,
+                        teamId: options.teamId,
+                        organizationId: options.organizationId,
+                     },
+                  });
+
+                  log.error({
+                     module: "agents.runtime",
+                     message: "failed enqueue generate-title",
+                     threadId: options.threadId,
+                     teamId: options.teamId,
+                     organizationId: options.organizationId,
+                     jobErrorName: jobError.name,
+                     jobErrorMessage: jobError.message,
+                     err: jobError,
+                  });
+
+                  return new AgentRuntimeError({
+                     error,
+                     message: error.message,
+                     threadId: options.threadId,
+                     teamId: options.teamId,
+                     organizationId: options.organizationId,
+                     jobErrorName: jobError.name,
+                     jobErrorMessage: jobError.message,
+                  });
+               },
+            );
+         })(),
       );
 
       return Result.ok(jobId);
    });
 
-   return result.mapError((error) => {
-      if (error instanceof AgentRuntimeError) return error;
-
-      const jobErrorName = error instanceof Error ? error.name : undefined;
-      const jobErrorMessage =
-         error instanceof Error ? error.message : undefined;
-
-      log.error({
-         module: "agents.runtime",
-         message: "failed enqueue generate-title",
-         threadId: options.threadId,
-         teamId: options.teamId,
-         organizationId: options.organizationId,
-         jobErrorName,
-         jobErrorMessage,
-         err: error,
-      });
-
-      return new AgentRuntimeError({
-         error: runtimeErrors.THREAD_TITLE_ENQUEUE_FAILED({
-            internal: {
-               threadId: options.threadId,
-               teamId: options.teamId,
-               organizationId: options.organizationId,
-            },
-         }),
-         message: runtimeErrors.THREAD_TITLE_ENQUEUE_FAILED({
-            internal: {
-               threadId: options.threadId,
-               teamId: options.teamId,
-               organizationId: options.organizationId,
-            },
-         }).message,
-         threadId: options.threadId,
-         teamId: options.teamId,
-         organizationId: options.organizationId,
-         jobErrorName,
-         jobErrorMessage,
-      });
-   });
+   return result;
 }
 
 async function enqueueThreadSuggestions(options: {
@@ -355,7 +352,7 @@ async function enqueueThreadSuggestions(options: {
    teamId: string;
    organizationId: string;
    messageCount: number;
-}): Promise<ResultType<string, AgentRuntimeError>> {
+}): Promise<Result<string, AgentRuntimeError>> {
    const result = await Result.gen(async function* () {
       const boss = yield* Result.await(
          Result.tryPromise({
@@ -398,62 +395,60 @@ async function enqueueThreadSuggestions(options: {
       );
 
       const jobId = yield* Result.await(
-         enqueueRefreshThreadSuggestionsJob({
-            boss,
-            input: {
-               threadId: options.threadId,
-               teamId: options.teamId,
-               organizationId: options.organizationId,
-               messageCount: options.messageCount,
-            },
-         }),
+         (async () => {
+            const enqueueResult = await enqueueRefreshThreadSuggestionsJob({
+               boss,
+               input: {
+                  threadId: options.threadId,
+                  teamId: options.teamId,
+                  organizationId: options.organizationId,
+                  messageCount: options.messageCount,
+               },
+            });
+
+            return Result.mapError(
+               enqueueResult,
+               (jobError: { name: string; message: string }) => {
+                  const error = runtimeErrors.THREAD_SUGGESTIONS_ENQUEUE_FAILED(
+                     {
+                        internal: {
+                           threadId: options.threadId,
+                           teamId: options.teamId,
+                           organizationId: options.organizationId,
+                           messageCount: options.messageCount,
+                        },
+                     },
+                  );
+
+                  log.error({
+                     module: "agents.runtime",
+                     message: "failed enqueue refresh-suggestions",
+                     threadId: options.threadId,
+                     teamId: options.teamId,
+                     organizationId: options.organizationId,
+                     messageCount: options.messageCount,
+                     jobErrorName: jobError.name,
+                     jobErrorMessage: jobError.message,
+                     err: jobError,
+                  });
+
+                  return new AgentRuntimeError({
+                     error,
+                     message: error.message,
+                     threadId: options.threadId,
+                     teamId: options.teamId,
+                     organizationId: options.organizationId,
+                     messageCount: options.messageCount,
+                     jobErrorName: jobError.name,
+                     jobErrorMessage: jobError.message,
+                  });
+               },
+            );
+         })(),
       );
 
       return Result.ok(jobId);
    });
 
-   return result.mapError((error) => {
-      if (error instanceof AgentRuntimeError) return error;
-
-      const jobErrorName = error instanceof Error ? error.name : undefined;
-      const jobErrorMessage =
-         error instanceof Error ? error.message : undefined;
-
-      log.error({
-         module: "agents.runtime",
-         message: "failed enqueue refresh-suggestions",
-         threadId: options.threadId,
-         teamId: options.teamId,
-         organizationId: options.organizationId,
-         messageCount: options.messageCount,
-         jobErrorName,
-         jobErrorMessage,
-         err: error,
-      });
-
-      return new AgentRuntimeError({
-         error: runtimeErrors.THREAD_SUGGESTIONS_ENQUEUE_FAILED({
-            internal: {
-               threadId: options.threadId,
-               teamId: options.teamId,
-               organizationId: options.organizationId,
-               messageCount: options.messageCount,
-            },
-         }),
-         message: runtimeErrors.THREAD_SUGGESTIONS_ENQUEUE_FAILED({
-            internal: {
-               threadId: options.threadId,
-               teamId: options.teamId,
-               organizationId: options.organizationId,
-               messageCount: options.messageCount,
-            },
-         }).message,
-         threadId: options.threadId,
-         teamId: options.teamId,
-         organizationId: options.organizationId,
-         messageCount: options.messageCount,
-         jobErrorName,
-         jobErrorMessage,
-      });
-   });
+   return result;
 }


### PR DESCRIPTION
## Resumo
- Removi dependências diretas de `GenerateThreadTitleJobError` e `RefreshThreadSuggestionsJobError` no middleware runtime.
- `AgentRuntimeError` agora transporta apenas `jobErrorName` e `jobErrorMessage`.
- Mantive logs estruturados com o erro original no ponto de falha (erro do job/pg-boss) e payload operacional mínimo no erro de runtime.
- `ctx.defer` agora reconverte `Result.err(...)` em rejeição para não esconder falhas de enqueue.

## Validação
- `bun run typecheck`
