### PR TITLE
feat(cards): add automatic statement closing pg-boss job

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -18,6 +18,7 @@
       "@core/redis": "workspace:*",
       "@dbos-inc/dbos-sdk": "catalog:workers",
       "@modules/agents": "workspace:*",
+      "@modules/cards": "workspace:*",
       "@modules/classification": "workspace:*",
       "better-result": "catalog:validation"
    },

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -18,6 +18,10 @@ import {
    classificationPgBossQueues,
    registerClassificationPgBossJobs,
 } from "@modules/classification/jobs/derive-keywords-job";
+import {
+   cardsPgBossQueues,
+   registerCardsPgBossJobs,
+} from "@modules/cards/jobs/close-statements-job";
 import { setupAgentsWorkflows } from "@modules/agents/workflows/setup";
 import { setupClassificationWorkflows } from "@modules/classification/workflows/setup";
 import { Result, TaggedError } from "better-result";
@@ -81,7 +85,11 @@ async function initWorker() {
 
    const pgBossWorker = await startPgBossWorker({
       connectionString: env.DATABASE_URL,
-      queues: [...agentPgBossQueues, ...classificationPgBossQueues],
+      queues: [
+         ...agentPgBossQueues,
+         ...classificationPgBossQueues,
+         ...cardsPgBossQueues,
+      ],
       register: async (boss) => {
          await registerClassificationPgBossJobs({
             boss,
@@ -92,6 +100,10 @@ async function initWorker() {
             boss,
             db: setup.value.db,
             prompts: setup.value.promptsClient,
+         });
+         await registerCardsPgBossJobs({
+            boss,
+            db: setup.value.db,
          });
       },
    });

--- a/modules/cards/__tests__/jobs/close-statements-job.test.ts
+++ b/modules/cards/__tests__/jobs/close-statements-job.test.ts
@@ -1,0 +1,220 @@
+import { Result } from "better-result";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { and, eq } from "drizzle-orm";
+import { bankAccounts } from "@core/database/schemas/bank-accounts";
+import { creditCards } from "@core/database/schemas/credit-cards";
+import {
+   creditCardStatements,
+   type CreditCardStatement,
+} from "@core/database/schemas/credit-card-statements";
+import { setupTestDb } from "@core/database/testing/setup-test-db";
+import { seedTeam } from "@core/database/testing/factories";
+import type { DatabaseInstance } from "@core/database/client";
+import type { PgBossClient } from "@core/pg-boss/client";
+
+import * as closeStatementsJob from "../../src/jobs/close-statements-job";
+
+type DbSetup = Awaited<ReturnType<typeof setupTestDb>>;
+
+type StatementData = {
+   statementPeriod: string;
+   closingDate: string;
+   dueDate: string;
+   status?: CreditCardStatement["status"];
+};
+
+function requireRow<T>(row: T | undefined, name: string) {
+   if (!row) {
+      throw new Error(`${name} não foi criado.`);
+   }
+   return row;
+}
+
+let testDb: DbSetup;
+
+async function createAccount(db: DatabaseInstance, teamId: string) {
+   const [account] = await db
+      .insert(bankAccounts)
+      .values({ teamId, name: "Conta principal" })
+      .returning({ id: bankAccounts.id });
+   return account;
+}
+
+async function createCard(
+   db: DatabaseInstance,
+   teamId: string,
+   bankAccountId: string,
+   closingDay = 20,
+) {
+   const [card] = await db
+      .insert(creditCards)
+      .values({
+         teamId,
+         name: "Cartão principal",
+         creditLimit: "1000",
+         closingDay,
+         dueDay: 10,
+         bankAccountId,
+      })
+      .returning({ id: creditCards.id });
+   return card;
+}
+
+async function createStatement(
+   db: DatabaseInstance,
+   creditCardId: string,
+   statement: StatementData,
+) {
+   const [row] = await db
+      .insert(creditCardStatements)
+      .values({
+         creditCardId,
+         statementPeriod: statement.statementPeriod,
+         closingDate: statement.closingDate,
+         dueDate: statement.dueDate,
+         status: statement.status,
+      })
+      .returning({
+         id: creditCardStatements.id,
+         statementPeriod: creditCardStatements.statementPeriod,
+      });
+   return row;
+}
+
+async function fetchStatus(db: DatabaseInstance, cardId: string) {
+   const rows: Pick<CreditCardStatement, "statementPeriod" | "status">[] =
+      await db
+         .select()
+         .from(creditCardStatements)
+         .where(eq(creditCardStatements.creditCardId, cardId));
+
+   const statusByPeriod: Record<string, CreditCardStatement["status"]> = {};
+   for (const row of rows) {
+      statusByPeriod[row.statementPeriod] = row.status;
+   }
+   return statusByPeriod;
+}
+
+beforeAll(async () => {
+   testDb = await setupTestDb();
+}, 30_000);
+
+afterAll(async () => {
+   await testDb.cleanup();
+});
+
+describe("cards close statements job", () => {
+   it("enfileira fechamento automático com payload válido", async () => {
+      const send = vi.fn().mockResolvedValue("close-statements-job-id");
+      const boss: Pick<PgBossClient, "send"> = { send };
+
+      const queued = await closeStatementsJob.enqueueCloseStatementsJob({
+         boss,
+         today: "2026-06-15",
+      });
+
+      expect(Result.isOk(queued)).toBe(true);
+      expect(queued.value).toBe("close-statements-job-id");
+      expect(send).toHaveBeenCalledTimes(1);
+      expect(send).toHaveBeenCalledWith(
+         closeStatementsJob.closeStatementsQueue.name,
+         { today: "2026-06-15" },
+         expect.objectContaining({
+            retryLimit: closeStatementsJob.closeStatementsQueue.retryLimit,
+            deadLetter: closeStatementsJob.closeStatementsQueue.deadLetter,
+         }),
+      );
+   });
+
+   it("fecha faturas com data de vencimento ou competência", async () => {
+      const { teamId } = await seedTeam(testDb.db);
+      const account = requireRow(
+         await createAccount(testDb.db, teamId),
+         "Conta bancária",
+      );
+      const card = requireRow(
+         await createCard(testDb.db, teamId, account.id, 20),
+         "Cartão",
+      );
+
+      await createStatement(testDb.db, card.id, {
+         statementPeriod: "2026-05",
+         closingDate: "2026-06-30",
+         dueDate: "2026-07-05",
+      });
+      await createStatement(testDb.db, card.id, {
+         statementPeriod: "2026-04",
+         closingDate: "2026-04-15",
+         dueDate: "2026-05-05",
+      });
+      await createStatement(testDb.db, card.id, {
+         statementPeriod: "2026-06",
+         closingDate: "2026-06-25",
+         dueDate: "2026-07-05",
+      });
+      await createStatement(testDb.db, card.id, {
+         statementPeriod: "2026-07",
+         closingDate: "2026-07-20",
+         dueDate: "2026-07-25",
+         status: "open",
+      });
+
+      const result = await closeStatementsJob.handleCloseStatementsJob({
+         db: testDb.db,
+         job: {
+            id: "job-close-statements",
+            data: {
+               today: "2026-06-15",
+            },
+         },
+      });
+
+      expect(Result.isOk(result)).toBe(true);
+      expect(result.value).toBe(2);
+
+      const statusByPeriod = await fetchStatus(testDb.db, card.id);
+      expect(statusByPeriod["2026-05"]).toBe("paid");
+      expect(statusByPeriod["2026-04"]).toBe("paid");
+      expect(statusByPeriod["2026-06"]).toBe("open");
+      expect(statusByPeriod["2026-07"]).toBe("open");
+
+      const futureClosing = await testDb.db
+         .select()
+         .from(creditCardStatements)
+         .where(
+            and(
+               eq(creditCardStatements.creditCardId, card.id),
+               eq(creditCardStatements.statementPeriod, "2026-07"),
+            ),
+         );
+      expect(futureClosing).toHaveLength(1);
+      expect(futureClosing[0]?.status).toBe("open");
+   });
+
+   it("rejeita payload inválido", async () => {
+      const sent = await closeStatementsJob.handleCloseStatementsJob({
+         db: testDb.db,
+         job: {
+            id: "job-invalid",
+            data: {
+               today: "2026-99-99",
+            },
+         },
+      });
+
+      expect(Result.isError(sent)).toBe(true);
+   });
+
+   it("rejeita enfileiramento com payload inválido", async () => {
+      const send = vi.fn().mockResolvedValue("close-statements-job-id");
+      const boss: Pick<PgBossClient, "send"> = { send };
+
+      const queued = await closeStatementsJob.enqueueCloseStatementsJob({
+         boss,
+         today: "2026-99-99",
+      });
+
+      expect(Result.isError(queued)).toBe(true);
+      expect(send).not.toHaveBeenCalled();
+   });
+});

--- a/modules/cards/package.json
+++ b/modules/cards/package.json
@@ -6,6 +6,7 @@
    "type": "module",
    "exports": {
       "./router/*": "./src/router/*.ts",
+      "./jobs/*": "./src/jobs/*.ts",
       "./*": "./src/*.ts"
    },
    "scripts": {
@@ -18,11 +19,14 @@
    "dependencies": {
       "@core/database": "workspace:*",
       "@core/orpc": "workspace:*",
+      "@core/pg-boss": "workspace:*",
+      "@core/utils": "workspace:*",
       "@orpc/server": "catalog:orpc",
       "better-result": "catalog:validation",
       "dayjs": "catalog:ui",
       "drizzle-orm": "catalog:database",
       "evlog": "catalog:logging",
+      "pg-boss": "catalog:workers",
       "zod": "catalog:validation"
    },
    "devDependencies": {

--- a/modules/cards/src/jobs/close-statements-job.ts
+++ b/modules/cards/src/jobs/close-statements-job.ts
@@ -1,0 +1,336 @@
+import { defineErrorCatalog } from "evlog";
+import { Result, TaggedError } from "better-result";
+import dayjs from "dayjs";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { creditCardStatements } from "@core/database/schemas/credit-card-statements";
+import { creditCards } from "@core/database/schemas/credit-cards";
+import { computeStatementPeriod } from "@core/database/helpers/credit-card-dates";
+import { isIsoDateString } from "@core/utils/dates";
+import { log } from "@core/logging";
+import { defaultPgBossWorkOptions } from "@core/pg-boss/worker";
+import type { PgBossClient } from "@core/pg-boss/client";
+import type { DatabaseInstance } from "@core/database/client";
+import type { SendOptions } from "pg-boss";
+import {
+   closeStatement,
+   type CloseStatementInput,
+} from "../operations/close-statement";
+
+const CLOSE_STATEMENTS_QUEUE = "cards/close-statements";
+const CLOSE_STATEMENTS_DEAD_LETTER_QUEUE = "cards/close-statements/dead-letter";
+
+export const closeStatementsQueue = {
+   name: CLOSE_STATEMENTS_QUEUE,
+   policy: "key_strict_fifo",
+   retryLimit: 5,
+   retryDelay: 10,
+   retryBackoff: true,
+   retryDelayMax: 300,
+   expireInSeconds: 600,
+   retentionSeconds: 2_592_000,
+   deleteAfterSeconds: 604_800,
+   heartbeatSeconds: 30,
+   warningQueueSize: 25,
+   deadLetter: CLOSE_STATEMENTS_DEAD_LETTER_QUEUE,
+};
+
+export const closeStatementsDeadLetterQueue = {
+   name: CLOSE_STATEMENTS_DEAD_LETTER_QUEUE,
+   retryLimit: 0,
+   expireInSeconds: 60,
+   retentionSeconds: 2_592_000,
+   deleteAfterSeconds: 2_592_000,
+   warningQueueSize: 1,
+};
+
+export const cardsPgBossQueues = [
+   closeStatementsDeadLetterQueue,
+   closeStatementsQueue,
+];
+
+export const closeStatementsJobInputSchema = z.object({
+   today: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/)
+      .refine((value) => isIsoDateString(value), {
+         message: "Data inválida.",
+      })
+      .default(() => dayjs().format("YYYY-MM-DD")),
+});
+
+const closeStatementsJobErrors = defineErrorCatalog(
+   "cards.job.close-statements",
+   {
+      INVALID_PAYLOAD: {
+         status: 400,
+         message: "Payload inválido para fechamento de faturas.",
+         tags: ["cards", "job", "close"],
+      },
+      QUERY_FAILED: {
+         status: 500,
+         message: "Falha ao localizar faturas para fechamento.",
+         tags: ["cards", "job", "close", "query"],
+      },
+   },
+);
+
+declare module "evlog" {
+   interface RegisteredErrorCatalogs {
+      "cards.job.close-statements": typeof closeStatementsJobErrors;
+   }
+}
+
+type CloseStatementsJobCatalogError =
+   | ReturnType<typeof closeStatementsJobErrors.INVALID_PAYLOAD>
+   | ReturnType<typeof closeStatementsJobErrors.QUERY_FAILED>;
+
+export class CloseStatementsJobError extends TaggedError(
+   "CloseStatementsJobError",
+)<{
+   error: CloseStatementsJobCatalogError;
+   message: string;
+   teamId?: string;
+   creditCardId?: string;
+   statementPeriod?: string;
+   jobId?: string;
+   jobPayload?: unknown;
+}>() {}
+
+export type CloseStatementsJobInput = z.infer<
+   typeof closeStatementsJobInputSchema
+>;
+
+type HandleCloseStatementsJobInput = {
+   db: DatabaseInstance;
+   job: { id: string; data: unknown };
+};
+
+export function enqueueCloseStatementsJob(options: {
+   boss: PgBossClient;
+   today?: string;
+}) {
+   const rawPayload = options.today ? { today: options.today } : {};
+   const parsedPayload = closeStatementsJobInputSchema.safeParse(rawPayload);
+   if (!parsedPayload.success) {
+      return Result.err(
+         new CloseStatementsJobError({
+            error: closeStatementsJobErrors.INVALID_PAYLOAD(),
+            message: "Payload inválido para fechamento de faturas.",
+            jobPayload: rawPayload,
+         }),
+      );
+   }
+
+   const payload = parsedPayload.data;
+   const sendOptions: SendOptions = {
+      retryLimit: closeStatementsQueue.retryLimit,
+      retryDelay: closeStatementsQueue.retryDelay,
+      retryBackoff: closeStatementsQueue.retryBackoff,
+      retryDelayMax: closeStatementsQueue.retryDelayMax,
+      expireInSeconds: closeStatementsQueue.expireInSeconds,
+      retentionSeconds: closeStatementsQueue.retentionSeconds,
+      deleteAfterSeconds: closeStatementsQueue.deleteAfterSeconds,
+      heartbeatSeconds: closeStatementsQueue.heartbeatSeconds,
+      deadLetter: closeStatementsQueue.deadLetter,
+   };
+
+   return Result.tryPromise({
+      try: () =>
+         options.boss.send(CLOSE_STATEMENTS_QUEUE, payload, sendOptions),
+      catch: () =>
+         new CloseStatementsJobError({
+            error: closeStatementsJobErrors.QUERY_FAILED(),
+            message: "Falha ao enfileirar fechamento de faturas.",
+            jobPayload: payload,
+         }),
+   });
+}
+
+export async function handleCloseStatementsJob({
+   db,
+   job,
+}: HandleCloseStatementsJobInput) {
+   const parsed = closeStatementsJobInputSchema.safeParse(job.data);
+   if (!parsed.success) {
+      return Result.err(
+         new CloseStatementsJobError({
+            error: closeStatementsJobErrors.INVALID_PAYLOAD(),
+            message: "Payload inválido para fechamento de faturas.",
+            jobId: job.id,
+            jobPayload: job.data,
+         }),
+      );
+   }
+
+   const payload = parsed.data;
+   const today = dayjs(payload.today, "YYYY-MM-DD", true);
+   const todayString = today.format("YYYY-MM-DD");
+   const statements = await Result.tryPromise({
+      try: () =>
+         db
+            .select({
+               creditCardId: creditCardStatements.creditCardId,
+               statementPeriod: creditCardStatements.statementPeriod,
+               closingDate: creditCardStatements.closingDate,
+               closingDay: creditCards.closingDay,
+               teamId: creditCards.teamId,
+            })
+            .from(creditCardStatements)
+            .innerJoin(
+               creditCards,
+               eq(creditCardStatements.creditCardId, creditCards.id),
+            )
+            .where(eq(creditCardStatements.status, "open")),
+      catch: () =>
+         new CloseStatementsJobError({
+            error: closeStatementsJobErrors.QUERY_FAILED(),
+            message: "Falha ao localizar faturas para fechamento.",
+            jobId: job.id,
+         }),
+   });
+
+   if (Result.isError(statements)) return Result.err(statements.error);
+
+   const closable = statements.value.filter((statement) => {
+      const closingDate = dayjs(statement.closingDate);
+      const byClosingDate =
+         closingDate.isSame(today, "day") || closingDate.isBefore(today, "day");
+      const currentPeriod = computeStatementPeriod(
+         todayString,
+         statement.closingDay,
+      );
+      const byCompetence = statement.statementPeriod < currentPeriod;
+      return byClosingDate || byCompetence;
+   });
+
+   if (closable.length === 0) {
+      log.info({
+         module: "cards.close-statements-job",
+         message: "Nenhuma fatura elegível para fechamento encontrada.",
+         jobId: job.id,
+         executedAt: todayString,
+      });
+      return Result.ok(0);
+   }
+
+   log.info({
+      module: "cards.close-statements-job",
+      message: "Fechando faturas em lote.",
+      jobId: job.id,
+      totalCandidates: closable.length,
+   });
+
+   const errors: Error[] = [];
+   const closeResults = await Promise.allSettled(
+      closable.map((statement) => {
+         const input: CloseStatementInput = {
+            db,
+            creditCardId: statement.creditCardId,
+            statementPeriod: statement.statementPeriod,
+            teamId: statement.teamId,
+         };
+         return closeStatement(input);
+      }),
+   );
+
+   closeResults.forEach((result, index) => {
+      const statement = closable[index];
+      if (!statement) return;
+
+      if (result.status === "rejected") {
+         const reason = result.reason;
+         const reasonError =
+            reason instanceof Error
+               ? reason
+               : new Error("Falha ao fechar fatura automática.", {
+                    cause: reason,
+                 });
+         errors.push(reasonError);
+         log.error({
+            module: "cards.close-statements-job",
+            message: "Falha ao fechar fatura automática",
+            jobId: job.id,
+            creditCardId: statement.creditCardId,
+            statementPeriod: statement.statementPeriod,
+            teamId: statement.teamId,
+            err: reasonError,
+         });
+         return;
+      }
+
+      if (Result.isError(result.value)) {
+         const closeError = result.value.error;
+         errors.push(closeError);
+         log.error({
+            module: "cards.close-statements-job",
+            message: "Falha ao fechar fatura automática",
+            jobId: job.id,
+            creditCardId: statement.creditCardId,
+            statementPeriod: statement.statementPeriod,
+            teamId: statement.teamId,
+            err: closeError,
+         });
+      }
+   });
+
+   if (errors.length > 0) {
+      return Result.err(new AggregateError(errors));
+   }
+
+   log.info({
+      module: "cards.close-statements-job",
+      message: "Fechamento de faturas concluído.",
+      jobId: job.id,
+      closedCount: closable.length,
+      executedAt: todayString,
+   });
+
+   return Result.ok(closable.length);
+}
+
+export async function registerCardsPgBossJobs(options: {
+   boss: PgBossClient;
+   db: DatabaseInstance;
+}) {
+   await options.boss.work(
+      closeStatementsQueue.name,
+      defaultPgBossWorkOptions,
+      async (jobs) => {
+         const errors: Error[] = [];
+         const handled = await Promise.allSettled(
+            jobs.map((job) =>
+               handleCloseStatementsJob({
+                  db: options.db,
+                  job: {
+                     id: job.id,
+                     data: job.data,
+                  },
+               }),
+            ),
+         );
+
+         for (const result of handled) {
+            if (result.status === "rejected") {
+               const reason = result.reason;
+               errors.push(
+                  reason instanceof Error
+                     ? reason
+                     : new Error("Falha ao processar job de fechamento.", {
+                          cause: reason,
+                       }),
+               );
+               continue;
+            }
+
+            if (result.value.isErr()) {
+               errors.push(result.value.error);
+            }
+         }
+
+         if (errors.length > 0) {
+            throw new AggregateError(errors);
+         }
+      },
+   );
+}

--- a/modules/cards/src/operations/close-statement.ts
+++ b/modules/cards/src/operations/close-statement.ts
@@ -1,0 +1,115 @@
+import dayjs from "dayjs";
+import { defineErrorCatalog } from "evlog";
+import { and, eq } from "drizzle-orm";
+import { Result, TaggedError } from "better-result";
+import { creditCardStatements } from "@core/database/schemas/credit-card-statements";
+import { creditCards } from "@core/database/schemas/credit-cards";
+import type { DatabaseInstance } from "@core/database/client";
+
+const cardsCloseStatementErrors = defineErrorCatalog("cards.close-statement", {
+   QUERY_FAILED: {
+      status: 500,
+      message: "Falha ao localizar fatura para fechamento.",
+      tags: ["cards", "statement", "close"],
+   },
+   UPDATE_FAILED: {
+      status: 500,
+      message: "Falha ao fechar fatura.",
+      tags: ["cards", "statement", "close"],
+   },
+});
+
+declare module "evlog" {
+   interface RegisteredErrorCatalogs {
+      "cards.close-statement": typeof cardsCloseStatementErrors;
+   }
+}
+
+type CardsCloseStatementCatalogError =
+   | ReturnType<typeof cardsCloseStatementErrors.QUERY_FAILED>
+   | ReturnType<typeof cardsCloseStatementErrors.UPDATE_FAILED>;
+
+export class CloseStatementError extends TaggedError("CloseStatementError")<{
+   error: CardsCloseStatementCatalogError;
+   message: string;
+   creditCardId: string;
+   statementPeriod: string;
+   teamId: string;
+}>() {}
+
+export type CloseStatementInput = {
+   db: DatabaseInstance;
+   creditCardId: string;
+   statementPeriod: string;
+   teamId: string;
+};
+
+export async function closeStatement(input: CloseStatementInput) {
+   const statement = await Result.tryPromise({
+      try: () =>
+         input.db
+            .select({
+               statementId: creditCardStatements.id,
+            })
+            .from(creditCardStatements)
+            .innerJoin(
+               creditCards,
+               eq(creditCardStatements.creditCardId, creditCards.id),
+            )
+            .where(
+               and(
+                  eq(creditCardStatements.creditCardId, input.creditCardId),
+                  eq(
+                     creditCardStatements.statementPeriod,
+                     input.statementPeriod,
+                  ),
+                  eq(creditCards.teamId, input.teamId),
+                  eq(creditCardStatements.status, "open"),
+               ),
+            )
+            .limit(1),
+      catch: () =>
+         new CloseStatementError({
+            error: cardsCloseStatementErrors.QUERY_FAILED(),
+            message: "Falha ao localizar fatura para fechamento.",
+            creditCardId: input.creditCardId,
+            statementPeriod: input.statementPeriod,
+            teamId: input.teamId,
+         }),
+   });
+
+   if (Result.isError(statement)) return Result.err(statement.error);
+   const row = statement.value[0];
+   if (!row) {
+      return Result.ok();
+   }
+
+   const updated = await Result.tryPromise({
+      try: () =>
+         input.db.transaction(async (tx) =>
+            tx
+               .update(creditCardStatements)
+               .set({
+                  status: "paid",
+                  paymentTransactionId: null,
+                  updatedAt: dayjs().toDate(),
+               })
+               .where(eq(creditCardStatements.id, row.statementId))
+               .returning({ id: creditCardStatements.id }),
+         ),
+      catch: () =>
+         new CloseStatementError({
+            error: cardsCloseStatementErrors.UPDATE_FAILED(),
+            message: "Falha ao fechar fatura.",
+            creditCardId: input.creditCardId,
+            statementPeriod: input.statementPeriod,
+            teamId: input.teamId,
+         }),
+   });
+   if (Result.isError(updated)) return Result.err(updated.error);
+   if (!updated.value[0]) {
+      return Result.ok();
+   }
+
+   return Result.ok();
+}

--- a/modules/cards/tsconfig.json
+++ b/modules/cards/tsconfig.json
@@ -11,13 +11,23 @@
          "@core/database": ["../../core/database/src/index.ts"],
          "@core/database/*": ["../../core/database/src/*"],
          "@core/orpc/*": ["../../core/orpc/src/*"],
+         "@core/utils/*": ["../../core/utils/src/*"],
          "@modules/cards/*": ["./src/*"]
       }
    },
    "include": ["src"],
    "references": [
       {
+         "path": "../../core/logging"
+      },
+      {
+         "path": "../../core/pg-boss"
+      },
+      {
          "path": "../../core/database"
+      },
+      {
+         "path": "../../core/utils"
       }
    ]
 }


### PR DESCRIPTION
## Resumo

- Implementa job pg-boss para fechamento automático de faturas no módulo cards.
- Centraliza a lógica de fechamento na operação de domínio (`closeStatement`) e reutiliza no job, sem duplicar regra de negócio.
- Adiciona fila + DLQ com políticas de retry e integração no worker.
- Inclui testes de enqueue/handler em lote e rejeição de payload inválido.

## Validação

- `bunx vitest run --root modules/cards --passWithNoTests modules/cards/__tests__/jobs/close-statements-job.test.ts`
- `bun run typecheck` (módulo/projeto)
- `bunx oxfmt --check` e `bunx oxlint` nos arquivos tocados.
