### PR TITLE
Migrate Montte AI chat to AG-UI runtime

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,7 +14,10 @@
       "check": "oxlint ."
    },
    "dependencies": {
+      "@ag-ui/client": "catalog:ui",
+      "@assistant-ui/core": "catalog:ui",
       "@assistant-ui/react": "catalog:ui",
+      "@assistant-ui/react-ag-ui": "catalog:ui",
       "@assistant-ui/react-streamdown": "catalog:ui",
       "@better-upload/client": "catalog:files",
       "@better-upload/server": "catalog:files",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
    },
    "dependencies": {
       "@ag-ui/client": "catalog:ui",
+      "@ag-ui/core": "catalog:ui",
       "@assistant-ui/core": "catalog:ui",
       "@assistant-ui/react": "catalog:ui",
       "@assistant-ui/react-ag-ui": "catalog:ui",

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/-montte-ai/chat-data.ts
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/-montte-ai/chat-data.ts
@@ -37,14 +37,14 @@ function getCollectionMap<T>(
 function createThreadsCollection(queryClient: QueryClient) {
    return createCollection(
       queryCollectionOptions({
-         id: "chat-threads",
-         queryClient,
-         queryKey: ["chat-threads"],
-         queryFn: async () => {
+         queryFn: async (): Promise<ChatThreadListItem[]> => {
             const data = await client.threads.list({ limit: 50 });
             return data.threads;
          },
          getKey: (thread) => thread.id,
+         id: "chat-threads",
+         queryClient,
+         queryKey: ["chat-threads"],
       }),
    );
 }
@@ -57,6 +57,7 @@ function createThreadCollection(threadId: string, queryClient: QueryClient) {
          queryKey: ["chat-thread", threadId],
          queryFn: async (): Promise<ChatThreadBundle[]> => {
             const data = await client.threads.getById({ threadId });
+            if (data.thread === null) return [];
             const thread = {
                ...data.thread,
                suggestions: data.thread.suggestions ?? [],

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/-montte-ai/chat-store.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/-montte-ai/chat-store.tsx
@@ -1,15 +1,22 @@
 import {
-   AssistantRuntimeProvider,
-   type AppendMessage,
    type ThreadMessageLike,
-   useExternalStoreRuntime,
+   useAui,
+   useAuiState,
 } from "@assistant-ui/react";
-import { fetchHttpStream, useChat } from "@tanstack/ai-react";
+import { AssistantRuntimeProvider } from "@assistant-ui/core/react";
+import { useAgUiRuntime } from "@assistant-ui/react-ag-ui";
+import type { AgUiAssistantRuntime } from "@assistant-ui/react-ag-ui";
+import {
+   HttpAgent,
+   RunAgentInputSchema,
+   type AgentSubscriber,
+   type RunAgentParameters,
+   type RunAgentResult,
+} from "@ag-ui/client";
 import { useLiveQuery } from "@tanstack/react-db";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { createStore } from "@tanstack/store";
 import { shallow, useStore } from "@tanstack/react-store";
-import type { UIMessage } from "@tanstack/ai-react";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { usePostHog } from "posthog-js/react";
 import {
@@ -21,6 +28,7 @@ import {
    type LucideIcon,
 } from "lucide-react";
 import dayjs from "dayjs";
+import { z } from "zod";
 import { toast } from "@packages/ui/hooks/use-toast";
 import { createPersistedStore } from "@/lib/store";
 import { client } from "@/integrations/orpc/client";
@@ -35,7 +43,6 @@ type ChatMessageMetadata = ChatMessage["metadata"];
 type ChatPageContext = NonNullable<
    NonNullable<ChatMessageMetadata>["pageContext"]
 >;
-type UiMessagePart = UIMessage["parts"][number];
 
 export type AgentScopeId =
    | "auto"
@@ -80,6 +87,13 @@ const scopeStore = createPersistedStore<{ id: AgentScopeId }>(
    { id: "auto" },
 );
 
+const suggestionsStore = createStore<{ suggestions: string[] }>({
+   suggestions: [],
+});
+
+const uuidSchema = z.string().uuid();
+const forwardedPropsSchema = z.record(z.string(), z.unknown()).catch({});
+
 export const setActiveThread = (threadId: string | null) =>
    chatStore.setState((s) => ({ ...s, activeThreadId: threadId }));
 
@@ -99,16 +113,13 @@ export const useSelectedScope = (): AgentScope => {
    return SCOPES.find((scope) => scope.id === id) ?? AUTO_SCOPE;
 };
 
+export const useMontteSuggestions = () =>
+   useStore(suggestionsStore, (s) => s.suggestions);
+
 function pickPageContext(): ChatPageContext | undefined {
    const scope = SCOPES.find((item) => item.id === scopeStore.state.id);
    return scope?.skillHint ? { skillHint: scope.skillHint } : undefined;
 }
-
-export type ChatTurnRequest = {
-   text?: string;
-   regenerate?: boolean;
-   replaceFromMessageId?: string;
-};
 
 interface MontteAssistantActions {
    startNewConversation: () => void;
@@ -161,135 +172,58 @@ export const useMontteActions = () =>
       shallow,
    );
 
-function toUiMessage(message: ChatMessage): UIMessage {
-   return {
-      id: message.id,
-      role: message.role,
-      parts: message.parts,
-      createdAt: dayjs(message.createdAt).toDate(),
-   };
-}
+class MontteHttpAgent extends HttpAgent {
+   constructor(private readonly queryClient: QueryClient) {
+      super({ url: "/api/chat" });
+   }
 
-function messageText(message: AppendMessage): string {
-   return message.content
-      .flatMap((part) => {
-         if (part.type !== "text") return [];
-         return [part.text];
-      })
-      .join("\n\n")
-      .trim();
-}
-
-function pendingApprovalIds(messages: UIMessage[]): string[] {
-   return messages.flatMap((message) => {
-      if (message.role !== "assistant") return [];
-      return message.parts.flatMap((part) => {
-         if (part.type !== "tool-call") return [];
-         if (part.state !== "approval-requested") return [];
-         if (part.approval === undefined) return [];
-         if (part.approval.approved !== undefined) return [];
-         return [part.approval.id];
-      });
-   });
-}
-
-function hasPendingToolWork(messages: UIMessage[]): boolean {
-   return messages.some((message) => {
-      if (message.role !== "assistant") return false;
-      const resultIds = new Set(
-         message.parts.flatMap((part) =>
-            part.type === "tool-result" ? [part.toolCallId] : [],
-         ),
+   override async runAgent(
+      parameters?: RunAgentParameters,
+      subscriber?: AgentSubscriber,
+   ): Promise<RunAgentResult> {
+      const input = RunAgentInputSchema.parse(parameters);
+      const threadId = await this.ensureThread();
+      const forwardedProps = forwardedPropsSchema.parse(input.forwardedProps);
+      this.threadId = threadId;
+      this.setMessages(input.messages);
+      this.setState(input.state);
+      return super.runAgent(
+         {
+            runId: input.runId,
+            tools: input.tools,
+            context: input.context,
+            forwardedProps: {
+               ...forwardedProps,
+               pageContext: pickPageContext(),
+            },
+         },
+         subscriber,
       );
-      return message.parts.some((part) => {
-         if (part.type !== "tool-call") return false;
-         if (
-            part.state === "approval-requested" &&
-            part.approval?.approved === undefined
-         )
-            return true;
-         return part.output === undefined && !resultIds.has(part.id);
-      });
-   });
-}
-
-function isNonEmptyThinkingPart(part: UiMessagePart): boolean {
-   return part.type === "thinking" && part.content.trim().length > 0;
-}
-
-function mergeStreamingMessage(
-   previous: UIMessage | undefined,
-   next: UIMessage,
-): UIMessage {
-   if (previous === undefined) return next;
-   if (next.role !== "assistant") return next;
-
-   const previousThinking = previous.parts.filter(isNonEmptyThinkingPart);
-   let changed = false;
-   const nextParts = next.parts.map((part, index) => {
-      if (part.type !== "thinking") return part;
-      const previousPart = previous.parts[index];
-      const shouldKeepPrevious =
-         previousPart?.type === "thinking" &&
-         previousPart.content.length > part.content.length;
-      if (shouldKeepPrevious) {
-         changed = true;
-         return previousPart;
-      }
-      return part;
-   });
-
-   if (nextParts.some(isNonEmptyThinkingPart)) {
-      if (!changed) return next;
-      return { ...next, parts: nextParts };
    }
-   if (previousThinking.length === 0) return next;
 
-   const firstTextIndex = nextParts.findIndex((part) => part.type === "text");
-   const insertAt = firstTextIndex === -1 ? nextParts.length : firstTextIndex;
+   private async ensureThread(): Promise<string> {
+      const activeThreadId = chatStore.state.activeThreadId;
+      const activeThread = uuidSchema.safeParse(activeThreadId);
+      if (activeThread.success) return activeThread.data;
 
-   return {
-      ...next,
-      parts: [
-         ...nextParts.slice(0, insertAt),
-         ...previousThinking,
-         ...nextParts.slice(insertAt),
-      ],
-   };
-}
-
-function mergeStreamingMessages(
-   previousMessages: UIMessage[],
-   nextMessages: UIMessage[],
-   activeTurn: boolean,
-): UIMessage[] {
-   if (!activeTurn) return nextMessages;
-
-   const previousById = new Map(
-      previousMessages.map((message) => [message.id, message]),
-   );
-   return nextMessages.map((message) =>
-      mergeStreamingMessage(previousById.get(message.id), message),
-   );
-}
-
-function collapseAdjacentAssistantMessages(messages: UIMessage[]): UIMessage[] {
-   const collapsed: UIMessage[] = [];
-   for (const message of messages) {
-      const previous = collapsed.at(-1);
-      if (previous?.role === "assistant" && message.role === "assistant") {
-         collapsed[collapsed.length - 1] = {
-            ...previous,
-            parts: [...previous.parts, ...message.parts],
-         };
-         continue;
+      const thread = await client.threads.create({}).catch(() => null);
+      if (thread === null) {
+         toast.error("Falha ao criar conversa.");
+         throw new Error("Falha ao criar conversa.");
       }
-      collapsed.push(message);
+
+      void refreshChatData(this.queryClient, thread.id);
+      setActiveThread(thread.id);
+      return thread.id;
    }
-   return collapsed;
 }
 
-function convertMessage(message: UIMessage): ThreadMessageLike {
+function jsonPartResult(value: unknown): unknown {
+   if (typeof value !== "string") return value;
+   return z.json().catch(value).parse(value);
+}
+
+function convertMessage(message: ChatMessage): ThreadMessageLike {
    const toolResults = new Map<string, { content: string; error?: string }>();
    for (const part of message.parts) {
       if (part.type !== "tool-result") continue;
@@ -321,7 +255,7 @@ function convertMessage(message: UIMessage): ThreadMessageLike {
          toolCallId: part.id,
          toolName: part.name,
          argsText: part.arguments,
-         result: part.output ?? result?.content,
+         result: part.output ?? jsonPartResult(result?.content),
          isError: result?.error !== undefined,
          artifact: {
             state: part.state,
@@ -335,54 +269,26 @@ function convertMessage(message: UIMessage): ThreadMessageLike {
       id: message.id,
       role: message.role,
       content,
-      createdAt: message.createdAt,
+      createdAt: dayjs(message.createdAt).toDate(),
    };
 }
 
-export function ChatSessionProvider({
-   children,
+function ChatRuntimeBridge({
+   queryClient,
+   runtime,
 }: {
-   children: React.ReactNode;
+   queryClient: QueryClient;
+   runtime: AgUiAssistantRuntime;
 }) {
-   const queryClient = useQueryClient();
-   const posthog = usePostHog();
+   const aui = useAui();
    const threadId = useActiveThreadId();
-   const pendingTurn = useRef<ChatTurnRequest | null>(null);
    const loadedSnapshotKey = useRef<string | null>(null);
-   const visibleMessages = useRef<UIMessage[]>([]);
-
-   const connection = useMemo(
-      () =>
-         fetchHttpStream("/api/chat", () => {
-            const turn = pendingTurn.current;
-            pendingTurn.current = null;
-            return {
-               credentials: "include",
-               body: {
-                  threadId: chatStore.state.activeThreadId ?? "",
-                  ...(turn?.text !== undefined && { text: turn.text }),
-                  ...(turn?.regenerate && { regenerate: true }),
-                  ...(turn?.replaceFromMessageId && {
-                     replaceFromMessageId: turn.replaceFromMessageId,
-                  }),
-                  pageContext: pickPageContext(),
-               },
-            };
-         }),
-      [],
-   );
-
-   const chat = useChat({
-      connection,
-      initialMessages: [],
-      onFinish: () => {
-         const id = chatStore.state.activeThreadId;
-         if (!id) return;
-         void refreshChatData(queryClient, id);
-      },
-      onError: () => toast.error("Falha no streaming da Montte AI."),
-   });
-
+   const wasRunning = useRef(false);
+   const messages = useAuiState((s) => s.thread.messages);
+   const isRunning = useAuiState((s) => s.thread.isRunning);
+   const pendingApprovalIds = runtime
+      .unstable_getPendingInterrupts()
+      .map((interrupt) => interrupt.id);
    const { data: threadBundles } = useLiveQuery(
       (q) => {
          if (threadId === null) return undefined;
@@ -392,105 +298,47 @@ export function ChatSessionProvider({
    );
    const threadBundle = threadBundles?.[0];
 
-   const status = chat.status;
-   const activeTurn =
-      chat.isLoading ||
-      chat.sessionGenerating ||
-      status === "submitted" ||
-      status === "streaming" ||
-      hasPendingToolWork(chat.messages);
-
    useEffect(() => {
       if (threadId === null) {
-         if (loadedSnapshotKey.current === null && chat.messages.length === 0)
-            return;
          loadedSnapshotKey.current = null;
-         chat.setMessages([]);
+         suggestionsStore.setState(() => ({ suggestions: [] }));
+         aui.thread().reset([]);
          return;
       }
-      if (activeTurn) return;
+      if (isRunning) return;
       if (threadBundles === undefined) return;
       if (threadBundle === undefined) return;
-      const messages = threadBundle.messages.map(toUiMessage);
-      const snapshotKey = `${threadId}:${messages
+
+      const importedMessages = threadBundle.messages.map(convertMessage);
+      const snapshotKey = `${threadId}:${importedMessages
          .map((message) => message.id)
          .join(":")}`;
       if (loadedSnapshotKey.current === snapshotKey) return;
       loadedSnapshotKey.current = snapshotKey;
-      chat.setMessages(messages);
-   }, [
-      activeTurn,
-      chat,
-      chat.messages.length,
-      threadBundle,
-      threadBundles,
-      threadId,
-   ]);
+      suggestionsStore.setState(() => ({
+         suggestions: threadBundle.thread.suggestions ?? [],
+      }));
+      aui.thread().reset(importedMessages);
+   }, [aui, isRunning, threadBundle, threadBundles, threadId]);
 
-   const messages = useMemo(() => {
-      const merged = mergeStreamingMessages(
-         visibleMessages.current,
-         chat.messages,
-         activeTurn,
-      );
-      const collapsed = collapseAdjacentAssistantMessages(merged);
-      visibleMessages.current = collapsed;
-      return collapsed;
-   }, [activeTurn, chat.messages]);
-   const approvalIds = useMemo(() => pendingApprovalIds(messages), [messages]);
-
-   const ensureThread = useCallback(async (): Promise<string | null> => {
-      const existing = chatStore.state.activeThreadId;
-      if (existing !== null) return existing;
-      const thread = await client.threads.create({}).catch(() => null);
-      if (thread === null) {
-         toast.error("Falha ao criar conversa.");
-         return null;
+   useEffect(() => {
+      if (isRunning) {
+         wasRunning.current = true;
+         return;
       }
-      void refreshChatData(queryClient);
-      setActiveThread(thread.id);
-      return thread.id;
-   }, [queryClient]);
-
-   const onNew = useCallback(
-      async (message: AppendMessage) => {
-         const text = messageText(message);
-         if (!text || activeTurn) return;
-         const id = await ensureThread();
-         if (id === null) return;
-         pendingTurn.current = { text };
-         await chat.sendMessage(text);
-      },
-      [activeTurn, chat, ensureThread],
-   );
-
-   const onEdit = useCallback(
-      async (message: AppendMessage) => {
-         const text = messageText(message);
-         if (!text || activeTurn) return;
-         const id = await ensureThread();
-         if (id === null) return;
-         pendingTurn.current = {
-            text,
-            replaceFromMessageId: message.sourceId ?? message.parentId ?? "",
-         };
-         await chat.sendMessage(text);
-      },
-      [activeTurn, chat, ensureThread],
-   );
-
-   const onReload = useCallback(async () => {
-      if (activeTurn) return;
-      pendingTurn.current = { regenerate: true };
-      await chat.reload();
-   }, [activeTurn, chat]);
+      if (!wasRunning.current) return;
+      wasRunning.current = false;
+      const id = chatStore.state.activeThreadId;
+      if (!id) return;
+      void refreshChatData(queryClient, id);
+   }, [isRunning, queryClient]);
 
    const startNewConversation = useCallback(() => {
-      chat.setMessages([]);
+      aui.thread().reset([]);
       setActiveThread(null);
-   }, [chat]);
+   }, [aui]);
 
-   const stop = useCallback(() => chat.stop(), [chat]);
+   const stop = useCallback(() => aui.thread().cancelRun(), [aui]);
 
    const deleteMessage = useCallback(
       async (messageId: string) => {
@@ -509,27 +357,63 @@ export function ChatSessionProvider({
    );
 
    const approveTool = useCallback(
-      (id: string) => chat.addToolApprovalResponse({ id, approved: true }),
-      [chat],
+      (id: string) =>
+         runtime.unstable_submitInterruptResponses([
+            {
+               interruptId: id,
+               status: "resolved",
+               payload: { approved: true },
+            },
+         ]),
+      [runtime],
    );
 
    const rejectTool = useCallback(
-      (id: string) => chat.addToolApprovalResponse({ id, approved: false }),
-      [chat],
+      (id: string) =>
+         runtime.unstable_submitInterruptResponses([
+            { interruptId: id, status: "cancelled" },
+         ]),
+      [runtime],
    );
 
-   const runtime = useExternalStoreRuntime<UIMessage>({
-      messages,
-      isRunning: activeTurn,
-      isDisabled: false,
-      suggestions: (threadBundle?.thread.suggestions ?? []).map((prompt) => ({
-         prompt,
-      })),
-      convertMessage,
-      onNew,
-      onEdit,
-      onReload,
-      onCancel: async () => chat.stop(),
+   useEffect(() => {
+      montteAssistantStore.setState((s) => ({
+         ...s,
+         messageCount: messages.length,
+         isRunning,
+         pendingApprovalIds,
+         startNewConversation,
+         stop,
+         deleteMessage,
+         approveTool,
+         rejectTool,
+      }));
+   }, [
+      approveTool,
+      deleteMessage,
+      isRunning,
+      messages.length,
+      pendingApprovalIds,
+      rejectTool,
+      startNewConversation,
+      stop,
+   ]);
+
+   return null;
+}
+
+export function ChatSessionProvider({
+   children,
+}: {
+   children: React.ReactNode;
+}) {
+   const queryClient = useQueryClient();
+   const posthog = usePostHog();
+   const agent = useMemo(() => new MontteHttpAgent(queryClient), [queryClient]);
+   const runtime = useAgUiRuntime({
+      agent,
+      showThinking: true,
+      onError: () => toast.error("Falha no streaming da Montte AI."),
       adapters: {
          feedback: {
             submit: ({ message, type }) => {
@@ -539,41 +423,16 @@ export function ChatSessionProvider({
                   message_id: message.id,
                   message_role: "assistant",
                   thread_id: chatStore.state.activeThreadId,
-                  content_part_count:
-                     typeof message.content === "string"
-                        ? 1
-                        : message.content.length,
+                  content_part_count: message.content.length,
                });
             },
          },
       },
    });
 
-   useEffect(() => {
-      montteAssistantStore.setState((s) => ({
-         ...s,
-         messageCount: messages.length,
-         isRunning: activeTurn,
-         pendingApprovalIds: approvalIds,
-         startNewConversation,
-         stop,
-         deleteMessage,
-         approveTool,
-         rejectTool,
-      }));
-   }, [
-      activeTurn,
-      approvalIds,
-      approveTool,
-      deleteMessage,
-      messages.length,
-      rejectTool,
-      startNewConversation,
-      stop,
-   ]);
-
    return (
       <AssistantRuntimeProvider runtime={runtime}>
+         <ChatRuntimeBridge queryClient={queryClient} runtime={runtime} />
          {children}
       </AssistantRuntimeProvider>
    );

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/-montte-ai/composer.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/-montte-ai/composer.tsx
@@ -12,7 +12,12 @@ import { useState } from "react";
 import { cn } from "@packages/ui/lib/utils";
 import { QueryBoundary } from "@/components/query-boundary";
 import { orpc } from "@/integrations/orpc/client";
-import { SCOPES, selectScope, useSelectedScope } from "./chat-store";
+import {
+   SCOPES,
+   selectScope,
+   useMontteSuggestions,
+   useSelectedScope,
+} from "./chat-store";
 
 type Effort = "high" | "xhigh";
 
@@ -35,26 +40,31 @@ export function Composer({
    className,
    placeholder = "Faça uma pergunta ou / para comandos",
 }: ComposerProps) {
+   const suggestions = useMontteSuggestions();
+
    return (
       <div className={cn("flex flex-col gap-2", className)}>
-         <ThreadPrimitive.Suggestions>
-            {({ suggestion }) => (
-               <ThreadPrimitive.Suggestion
-                  asChild
-                  prompt={suggestion.prompt}
-                  send
-               >
-                  <Button
-                     className="h-auto whitespace-normal rounded-full border-dashed p-2 text-left text-xs"
-                     size="sm"
-                     type="button"
-                     variant="outline"
+         {suggestions.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+               {suggestions.map((prompt) => (
+                  <ThreadPrimitive.Suggestion
+                     asChild
+                     key={prompt}
+                     prompt={prompt}
+                     send
                   >
-                     {suggestion.prompt}
-                  </Button>
-               </ThreadPrimitive.Suggestion>
-            )}
-         </ThreadPrimitive.Suggestions>
+                     <Button
+                        className="h-auto whitespace-normal rounded-full border-dashed p-2 text-left text-xs"
+                        size="sm"
+                        type="button"
+                        variant="outline"
+                     >
+                        {prompt}
+                     </Button>
+                  </ThreadPrimitive.Suggestion>
+               ))}
+            </div>
+         ) : null}
 
          <ComposerPrimitive.Root className="w-full rounded-lg border bg-background/95 shadow-sm">
             <ComposerPrimitive.Input

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
@@ -493,7 +493,7 @@ export function TransactionsList() {
 
    const handleReactivate = useCallback(
       (tx: TransactionRow) => {
-         reactivateMutation.mutate({ id: tx.id, paid: false });
+         reactivateMutation.mutate({ id: tx.id });
       },
       [reactivateMutation],
    );

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/chat/$threadId.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/chat/$threadId.tsx
@@ -47,7 +47,7 @@ function ChatThreadPage() {
    }, [threadId]);
 
    return (
-      <div className="flex h-[calc(100%-2rem)] w-full flex-col gap-4">
+      <div className="mx-auto flex h-[calc(100%-2rem)] w-full max-w-5xl flex-col gap-4">
          <div className="flex min-h-0 flex-1 flex-col">
             <MessageList />
          </div>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/chat/$threadId.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/chat/$threadId.tsx
@@ -47,7 +47,7 @@ function ChatThreadPage() {
    }, [threadId]);
 
    return (
-      <div className="flex h-full w-full max-w-5xl flex-col gap-4 p-4">
+      <div className="flex h-[calc(100%-2rem)] w-full flex-col gap-4">
          <div className="flex min-h-0 flex-1 flex-col">
             <MessageList />
          </div>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/chat/-layout/chat-layout.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/chat/-layout/chat-layout.tsx
@@ -58,8 +58,8 @@ function ChatLayoutDesktop({ children }: ChatLayoutProps) {
             </Sidebar>
          </SidebarManager>
          <SidebarInset className="flex-1 overflow-hidden">
-            <main className="flex h-full justify-center px-4 py-2">
-               <div className="flex h-full w-full max-w-5xl">
+            <main className="flex h-full px-4 py-2">
+               <div className="mx-auto flex h-full w-full max-w-5xl">
                   <RouteTransition>{children}</RouteTransition>
                </div>
             </main>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/chat/-layout/chat-layout.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/chat/-layout/chat-layout.tsx
@@ -58,8 +58,10 @@ function ChatLayoutDesktop({ children }: ChatLayoutProps) {
             </Sidebar>
          </SidebarManager>
          <SidebarInset className="flex-1 overflow-hidden">
-            <main className="flex h-full justify-center">
-               <RouteTransition>{children}</RouteTransition>
+            <main className="flex h-full justify-center px-4 py-2">
+               <div className="flex h-full w-full max-w-5xl">
+                  <RouteTransition>{children}</RouteTransition>
+               </div>
             </main>
          </SidebarInset>
       </SidebarProvider>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/chat/index.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/chat/index.tsx
@@ -37,7 +37,7 @@ function ChatIndexPage() {
    const hasConversation = messageCount > 0;
 
    return (
-      <div className="flex h-[calc(100%-2rem)] w-full flex-col gap-4">
+      <div className="mx-auto flex h-[calc(100%-2rem)] w-full max-w-5xl flex-col gap-4">
          <div className="flex min-h-0 flex-1 flex-col">
             {hasConversation ? <MessageList /> : <EmptyState variant="page" />}
          </div>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/chat/index.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/chat/index.tsx
@@ -37,7 +37,7 @@ function ChatIndexPage() {
    const hasConversation = messageCount > 0;
 
    return (
-      <div className="flex h-full w-full max-w-5xl flex-col gap-4 p-4">
+      <div className="flex h-[calc(100%-2rem)] w-full flex-col gap-4">
          <div className="flex min-h-0 flex-1 flex-col">
             {hasConversation ? <MessageList /> : <EmptyState variant="page" />}
          </div>

--- a/apps/web/src/routes/api/chat.ts
+++ b/apps/web/src/routes/api/chat.ts
@@ -1,17 +1,29 @@
 import "@/polyfill";
 
-import { toHttpResponse } from "@tanstack/ai";
+import { RunAgentInputSchema } from "@ag-ui/core";
+import { toServerSentEventsResponse } from "@tanstack/ai";
 import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
 import { buildWebContext } from "@core/orpc/server";
-import {
-   chatInputSchema,
-   createThreadChatStream,
-} from "@modules/agents/router/chat";
+import { createAgUiThreadChatStream } from "@modules/agents/router/chat";
 import { getRequestLog } from "@/integrations/evlog";
 
+const forwardedPropsSchema = z.record(z.string(), z.unknown()).catch({});
+
 async function handle({ request }: { request: Request }) {
-   const body = await request.json();
-   const input = chatInputSchema.parse(body);
+   const body = await request.json().catch(() => undefined);
+   const parsedBody = RunAgentInputSchema.safeParse(body);
+   if (!parsedBody.success) {
+      return new Response("Invalid AG-UI request body.", { status: 400 });
+   }
+   const params = {
+      messages: parsedBody.data.messages,
+      threadId: parsedBody.data.threadId,
+      runId: parsedBody.data.runId,
+      forwardedProps: forwardedPropsSchema.parse(
+         parsedBody.data.forwardedProps,
+      ),
+   };
    const abortController = new AbortController();
    request.signal.addEventListener("abort", () => abortController.abort(), {
       once: true,
@@ -22,15 +34,14 @@ async function handle({ request }: { request: Request }) {
       return new Response("Unauthorized", { status: 401 });
    }
 
-   const stream = await createThreadChatStream({
+   const stream = await createAgUiThreadChatStream({
       context,
-      input,
+      params,
       signal: abortController.signal,
    });
 
-   return toHttpResponse(stream, {
+   return toServerSentEventsResponse(stream, {
       abortController,
-      headers: { "Content-Type": "application/x-ndjson" },
    });
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -68,7 +68,10 @@
     "apps/web": {
       "name": "web",
       "dependencies": {
+        "@ag-ui/client": "catalog:ui",
+        "@assistant-ui/core": "catalog:ui",
         "@assistant-ui/react": "catalog:ui",
+        "@assistant-ui/react-ag-ui": "catalog:ui",
         "@assistant-ui/react-streamdown": "catalog:ui",
         "@better-upload/client": "catalog:files",
         "@better-upload/server": "catalog:files",
@@ -544,8 +547,10 @@
         "@f-o-t/money": "catalog:fot",
         "@modules/classification": "workspace:*",
         "@orpc/server": "catalog:orpc",
+        "better-result": "catalog:validation",
         "dayjs": "catalog:ui",
         "drizzle-orm": "catalog:database",
+        "evlog": "catalog:logging",
         "neverthrow": "catalog:validation",
         "zod": "catalog:validation",
       },
@@ -866,9 +871,9 @@
       "@tanstack/store": "^0.11.0",
     },
     "tanstack-ai": {
-      "@tanstack/ai": "0.15.0",
-      "@tanstack/ai-openrouter": "0.8.3",
-      "@tanstack/ai-react": "^0.8.1",
+      "@tanstack/ai": "0.18.0",
+      "@tanstack/ai-openrouter": "0.9.1",
+      "@tanstack/ai-react": "0.10.0",
     },
     "telemetry": {
       "@opentelemetry/api": "^1.9.0",
@@ -886,8 +891,11 @@
       "vitest": "^4.1.4",
     },
     "ui": {
-      "@assistant-ui/react": "^0.12.28",
-      "@assistant-ui/react-streamdown": "^0.1.11",
+      "@ag-ui/client": "0.0.53",
+      "@assistant-ui/core": "0.2.2",
+      "@assistant-ui/react": "0.14.5",
+      "@assistant-ui/react-ag-ui": "0.0.30",
+      "@assistant-ui/react-streamdown": "0.3.0",
       "@json-render/core": "^0.18.0",
       "@json-render/react": "^0.18.0",
       "@json-render/shadcn": "^0.18.0",
@@ -942,7 +950,13 @@
     },
   },
   "packages": {
-    "@ag-ui/core": ["@ag-ui/core@0.0.49", "", { "dependencies": { "zod": "^3.22.4" } }, "sha512-9ywypwjUGtIvTxJ2eKQjhPZgLnSFAfNK7vZUcT7Bz4ur4yAIB+lAFtzvu7VDYe6jsUx/6N/71Dh4R0zX5woNVw=="],
+    "@ag-ui/client": ["@ag-ui/client@0.0.53", "", { "dependencies": { "@ag-ui/core": "0.0.53", "@ag-ui/encoder": "0.0.53", "@ag-ui/proto": "0.0.53", "@types/uuid": "^10.0.0", "compare-versions": "^6.1.1", "fast-json-patch": "^3.1.1", "rxjs": "7.8.1", "untruncate-json": "^0.0.1", "uuid": "^11.1.0", "zod": "^3.22.4" } }, "sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ=="],
+
+    "@ag-ui/core": ["@ag-ui/core@0.0.52", "", { "dependencies": { "zod": "^3.22.4" } }, "sha512-Xo0bUaNV56EqylzcrAuhUkQX7et7+SZIrqZZtEByGwEq/I1EHny6ZMkWHLkKR7UNi0FJZwJyhKYmKJS3B2SEgA=="],
+
+    "@ag-ui/encoder": ["@ag-ui/encoder@0.0.53", "", { "dependencies": { "@ag-ui/core": "0.0.53", "@ag-ui/proto": "0.0.53" } }, "sha512-bAOcfVdm6U4H6G6tW+DZfwPEQm1w/snVBTwaFn9nJcEMW69M7/HZuwvEc/7Zo0rK1jRL32N/j60PwTAeky19fw=="],
+
+    "@ag-ui/proto": ["@ag-ui/proto@0.0.53", "", { "dependencies": { "@ag-ui/core": "0.0.53", "@bufbuild/protobuf": "^2.2.5", "@protobuf-ts/protoc": "^2.11.1" } }, "sha512-swjz22xWT8YUZt5OhmUwkARDQdwt8XM1hmGZbQrhRnNPXKwrKJX9ELlbnQ4iFUQIKkMWpphzE3vA3yNKs2bbKw=="],
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.53", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-QT3FEoNARMRlk8JJVR7L98exiK9C8AGfrEJVbRxBT1yIXKs/N19o/+PsjTRVsARgDJNcy9JbJp1FspKucEat0Q=="],
 
@@ -986,11 +1000,13 @@
 
     "@arcjet/transport": ["@arcjet/transport@1.4.0", "", { "dependencies": { "@bufbuild/protobuf": "2.11.0", "@connectrpc/connect": "2.1.1", "@connectrpc/connect-node": "2.1.1", "@connectrpc/connect-web": "2.1.1" } }, "sha512-EGCtY0sZwAJsYc21xbJlz6G+Cv++wPHA45WhzcKTAjJydDyhKSKgE9cM/+5EVmjGE5SHG6ctPwjqxEkV/jR4cw=="],
 
-    "@assistant-ui/core": ["@assistant-ui/core@0.1.17", "", { "dependencies": { "assistant-stream": "^0.3.12", "nanoid": "^5.1.9" }, "peerDependencies": { "@assistant-ui/store": "^0.2.9", "@assistant-ui/tap": "^0.5.10", "@types/react": "*", "assistant-cloud": "^0.1.27", "react": "^18 || ^19", "zustand": "^5.0.11" }, "optionalPeers": ["@types/react", "assistant-cloud", "react", "zustand"] }, "sha512-IWIP98UVQ9W+oF0yz8XqFRtaX8HtozWVUWt6D/BSV6cyKwLfJ8niHtLG74bSnllTnGcreU2El3GR/tIodR1XuA=="],
+    "@assistant-ui/core": ["@assistant-ui/core@0.2.2", "", { "dependencies": { "assistant-stream": "^0.3.14", "nanoid": "^5.1.11" }, "peerDependencies": { "@assistant-ui/store": "^0.2.10", "@assistant-ui/tap": "^0.5.11", "@types/react": "*", "assistant-cloud": "^0.1.27", "react": "^18 || ^19", "zustand": "^5.0.11" }, "optionalPeers": ["@types/react", "assistant-cloud", "react", "zustand"] }, "sha512-y1LY7P7T+X3zAZZpfwYppaCkuscDCvbtDtIx87E9fdsY3t9o0h6tjunYdRgExcRQyzfCOE4bECeylYTs4Ky/NA=="],
 
-    "@assistant-ui/react": ["@assistant-ui/react@0.12.28", "", { "dependencies": { "@assistant-ui/core": "^0.1.17", "@assistant-ui/store": "^0.2.9", "@assistant-ui/tap": "^0.5.10", "@radix-ui/primitive": "^1.1.3", "@radix-ui/react-compose-refs": "^1.1.2", "@radix-ui/react-context": "^1.1.3", "@radix-ui/react-primitive": "^2.1.4", "@radix-ui/react-use-callback-ref": "^1.1.1", "@radix-ui/react-use-escape-keydown": "^1.1.1", "assistant-cloud": "^0.1.27", "assistant-stream": "^0.3.12", "nanoid": "^5.1.9", "radix-ui": "^1.4.3", "react-textarea-autosize": "^8.5.9", "zod": "^4.3.6", "zustand": "^5.0.12" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^18 || ^19", "react-dom": "^18 || ^19" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-czjpexLK1lKnNDNM1YMJi8SufeKUWBICqiVUtiHMV+86PYGCwJykOZKkchI8MVbSQ62xZ8A1LfPO5W2IDjed3A=="],
+    "@assistant-ui/react": ["@assistant-ui/react@0.14.5", "", { "dependencies": { "@assistant-ui/core": "^0.2.2", "@assistant-ui/store": "^0.2.10", "@assistant-ui/tap": "^0.5.11", "@radix-ui/primitive": "^1.1.3", "@radix-ui/react-compose-refs": "^1.1.2", "@radix-ui/react-context": "^1.1.3", "@radix-ui/react-primitive": "^2.1.4", "@radix-ui/react-use-callback-ref": "^1.1.1", "@radix-ui/react-use-escape-keydown": "^1.1.1", "assistant-cloud": "^0.1.27", "assistant-stream": "^0.3.14", "nanoid": "^5.1.11", "radix-ui": "^1.4.3", "react-textarea-autosize": "^8.5.9", "safe-content-frame": "^0.0.19", "zod": "^4.4.3", "zustand": "^5.0.13" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^18 || ^19", "react-dom": "^18 || ^19" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Zx0Dtk39MEE+Bj3FFjCy9AylsXk2sN7sVqM5/ReVTtJOyUPk6c5NjvY2ovtMbtksXH3ZYVVP25J2AHBEwngruA=="],
 
-    "@assistant-ui/react-streamdown": ["@assistant-ui/react-streamdown@0.1.11", "", { "dependencies": { "rehype-harden": "^1.1.8", "rehype-raw": "^7.0.0", "rehype-sanitize": "^6.0.0", "streamdown": "^2.5.0" }, "peerDependencies": { "@assistant-ui/react": "^0.12.26", "@streamdown/cjk": "^1.0.0", "@streamdown/code": "^1.0.0", "@streamdown/math": "^1.0.0", "@streamdown/mermaid": "^1.0.0", "@types/react": "*", "react": "^18 || ^19" }, "optionalPeers": ["@streamdown/cjk", "@streamdown/code", "@streamdown/math", "@streamdown/mermaid", "@types/react"] }, "sha512-9y+89ZxotYSt81hChSVjK2kwUYRKq7UW/r5qoqZTpcb7119gc0NOj0dx9xxuyXE2QfR6EY8rW6yBz3g+Y7RrhQ=="],
+    "@assistant-ui/react-ag-ui": ["@assistant-ui/react-ag-ui@0.0.30", "", { "dependencies": { "@ag-ui/client": "^0.0.53", "@assistant-ui/core": "^0.2.1", "assistant-stream": "^0.3.14" }, "peerDependencies": { "@types/react": "*", "react": "^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-JYzQsSk+9cSRdq5qLf54areKern4yCO4MaZUOlxu0Ol0c+zzR/MvneTe+Ykcdux8TCdiw5S57XCjyTKzCcpStA=="],
+
+    "@assistant-ui/react-streamdown": ["@assistant-ui/react-streamdown@0.3.0", "", { "dependencies": { "rehype-harden": "^1.1.8", "rehype-raw": "^7.0.0", "rehype-sanitize": "^6.0.0", "streamdown": "^2.5.0" }, "peerDependencies": { "@assistant-ui/react": "^0.14.0", "@streamdown/cjk": "^1.0.0", "@streamdown/code": "^1.0.0", "@streamdown/math": "^1.0.0", "@streamdown/mermaid": "^1.0.0", "@types/react": "*", "react": "^18 || ^19" }, "optionalPeers": ["@streamdown/cjk", "@streamdown/code", "@streamdown/math", "@streamdown/mermaid", "@types/react"] }, "sha512-m7JaT2MwhfHL6TyENtpIo4UhWnLbauMoW6PzGKgvmeMbUfPcHF7OXWPMrN813eMXWtFr21jbaRt4Ip+hdvNNIQ=="],
 
     "@assistant-ui/store": ["@assistant-ui/store@0.2.10", "", { "dependencies": { "use-effect-event": "^2.0.3" }, "peerDependencies": { "@assistant-ui/tap": "^0.5.11", "@types/react": "*", "react": "^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-cgbSFIv0Ovu6yls4GQy7brLVx6qwUyLTf1Ki/lkj3UFJrO6oktxstosWvQBwk5mNgH6t3DOIrGSBDJSKRfCW5Q=="],
 
@@ -1924,6 +1940,8 @@
 
     "@posthog/types": ["@posthog/types@1.373.5", "", {}, "sha512-K7STCnRG/WBE1q0BwEkIcrJB5OqECaymsQj6Hp4Ntvaek4dqHkZGfp6hxwIPqQPjlOXwidwPLo+XGsn+CoZUyw=="],
 
+    "@protobuf-ts/protoc": ["@protobuf-ts/protoc@2.11.1", "", { "bin": { "protoc": "protoc.js" } }, "sha512-mUZJaV0daGO6HUX90o/atzQ6A7bbN2RSuHtdwo8SSF2Qoe3zHwa4IHyCN1evftTeHfLmdz+45qo47sL+5P8nyg=="],
+
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
     "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
@@ -2354,17 +2372,19 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.3.0", "", { "dependencies": { "@tailwindcss/node": "4.3.0", "@tailwindcss/oxide": "4.3.0", "tailwindcss": "4.3.0" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw=="],
 
-    "@tanstack/ai": ["@tanstack/ai@0.15.0", "", { "dependencies": { "@ag-ui/core": "0.0.49", "@tanstack/ai-event-client": "0.2.9", "partial-json": "^0.1.7" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-Ft1mZ1mwrtbmXjuarJ4I1f+HZwZ+doqg6EIaBtBTvZ7FHMtKzWIxqRngKOwBazv5Csv2lyOMM9E1nvH3/kzEKA=="],
+    "@tanstack/ai": ["@tanstack/ai@0.18.0", "", { "dependencies": { "@ag-ui/core": "^0.0.52", "@tanstack/ai-event-client": "0.3.2", "partial-json": "^0.1.7" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-RIS9dwPBOErob2i62ppie5GnxvzzI+PNZY8yy5bv2mmwPCoJp82qLdDxDC9T+GHQv+63g/xQUH69st+fK1u5lA=="],
 
-    "@tanstack/ai-client": ["@tanstack/ai-client@0.9.1", "", { "dependencies": { "@tanstack/ai": "0.16.0", "@tanstack/ai-event-client": "0.3.0" } }, "sha512-8tiiICtn/FwUDpzAPwF7NOZpRXrln1iKGAlmZzFnQJK6eJXT5FJRig7rRqGC7RnkIhX/D3GG2IIOpyuPACuakg=="],
+    "@tanstack/ai-client": ["@tanstack/ai-client@0.10.0", "", { "dependencies": { "@tanstack/ai": "0.18.0", "@tanstack/ai-event-client": "0.3.2" } }, "sha512-I5Ec0c81JsliGk+opc59cjMr8cQftQ8mc41mcRl7lY/sySFA2yPHZfCAiOwFq5Jq2zC6ZRviRBvZgYgXbXtOSQ=="],
 
     "@tanstack/ai-devtools-core": ["@tanstack/ai-devtools-core@0.3.29", "", { "dependencies": { "@tanstack/ai": "0.18.0", "@tanstack/ai-event-client": "0.3.2", "@tanstack/devtools-ui": "^0.5.1", "@tanstack/devtools-utils": "^0.4.0", "goober": "^2.1.18", "solid-js": "^1.9.10" } }, "sha512-SVjV9a/1SHSrmGCuGNt7REwtXieb1nlkn9JI9cyJwwE4lHnX+S5Rnan11/fdFvfrAffmP+tTNfZ5r+c9fuxduQ=="],
 
-    "@tanstack/ai-event-client": ["@tanstack/ai-event-client@0.2.9", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1" }, "peerDependencies": { "@tanstack/ai": "0.15.0" } }, "sha512-4Cpi1tc4fNXXzgMXUi303lGqP4M/dzvo1FsdIaPD/2qmxRbp3xlsLDa/DeH8fzv6b56L2pYyJvTOSH8nFBCg/g=="],
+    "@tanstack/ai-event-client": ["@tanstack/ai-event-client@0.3.2", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1" }, "peerDependencies": { "@tanstack/ai": "0.18.0" } }, "sha512-4GhqHFU6W00Uo10dgKZyHKwtTENtpIFmqy6jW2HmZpW6NrOBhwG71dspiwmQ+4NPn4foADfbEBnzdt0W5Ik0Jw=="],
 
-    "@tanstack/ai-openrouter": ["@tanstack/ai-openrouter@0.8.3", "", { "dependencies": { "@openrouter/sdk": "0.12.14", "@tanstack/ai": "0.15.0" } }, "sha512-BA0eDrhj7246Lnf3gtv9pOXkNwyFXrgKVqHG+ky0JwDrsc0Tl7Ql/M712L4cf4P5LWxrSQ5kOYTJ1Ahdhlnq6w=="],
+    "@tanstack/ai-openrouter": ["@tanstack/ai-openrouter@0.9.1", "", { "dependencies": { "@openrouter/sdk": "0.12.14", "@tanstack/ai-utils": "0.2.0" }, "peerDependencies": { "@tanstack/ai": "^0.18.0" } }, "sha512-dPcX4Dqy1e3na/M31WDLQ769JRAhtjx2/VqMZvEJZBgnG1bt2h2iY28gC0uXqxSmoCm4UMxWDwZ/HSb4R/oisg=="],
 
-    "@tanstack/ai-react": ["@tanstack/ai-react@0.8.2", "", { "dependencies": { "@tanstack/ai-client": "0.9.1" }, "peerDependencies": { "@tanstack/ai": "^0.16.0", "@types/react": ">=18.0.0", "react": ">=18.0.0" } }, "sha512-acDbBoWn85cnD2P2j2qXuapd8mVQwtCpkqzbjELThEc4ipMjqg3efzbCd6+KkhulAbCDQs7j6CGDxakbR9EoHw=="],
+    "@tanstack/ai-react": ["@tanstack/ai-react@0.10.0", "", { "dependencies": { "@tanstack/ai-client": "0.10.0" }, "peerDependencies": { "@tanstack/ai": "^0.18.0", "@types/react": ">=18.0.0", "react": ">=18.0.0" } }, "sha512-OmY0buHaHG0GxL0xvDQ4yUtI2JAE0A2b/hlxOQq6qKOsWMgECZ/QiEXyXGwgkLgMS9xQ30LXSVYZ3AnXolfU/w=="],
+
+    "@tanstack/ai-utils": ["@tanstack/ai-utils@0.2.0", "", {}, "sha512-ttFkUEg60sAUHPZZ9bwDuJS0K2pcI6JLpRcJS7FAiqD3+h3CtJZaF38eWG5nBy1w6fJ9zfaG7ExZf2AQpcyzDw=="],
 
     "@tanstack/db": ["@tanstack/db@0.6.5", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@tanstack/db-ivm": "0.1.18", "@tanstack/pacer-lite": "^0.2.1" }, "peerDependencies": { "typescript": ">=4.7" } }, "sha512-gtCuAo4UtC9SR/kTMu5fVEff6qZ2R1FZi9X7MybtHKA6wve7RePifGG6qBI4OmMB+7juT5/+glNbnqZOrG0/pg=="],
 
@@ -2617,6 +2637,8 @@
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
+
+    "@types/uuid": ["@types/uuid@10.0.0", "", {}, "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
@@ -2927,6 +2949,8 @@
     "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
     "common-ancestor-path": ["common-ancestor-path@2.0.0", "", {}, "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng=="],
+
+    "compare-versions": ["compare-versions@6.1.1", "", {}, "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg=="],
 
     "conf": ["conf@15.1.0", "", { "dependencies": { "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "atomically": "^2.0.3", "debounce-fn": "^6.0.0", "dot-prop": "^10.0.0", "env-paths": "^3.0.0", "json-schema-typed": "^8.0.1", "semver": "^7.7.2", "uint8array-extras": "^1.5.0" } }, "sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og=="],
 
@@ -3261,6 +3285,8 @@
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-json-patch": ["fast-json-patch@3.1.1", "", {}, "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="],
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
@@ -4238,7 +4264,11 @@
 
     "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
 
+    "rxjs": ["rxjs@7.8.1", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg=="],
+
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safe-content-frame": ["safe-content-frame@0.0.19", "", {}, "sha512-+R0IHHjvghT5O8bc8itf9AoS9MvzhUcD0p+hNINLgyEuFQJug3wt3ZuhLFZFG3bUzHi8UfQED4p6J3/Ft9oCtg=="],
 
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
 
@@ -4500,6 +4530,8 @@
 
     "unstorage": ["unstorage@2.0.0-alpha.7", "", { "peerDependencies": { "@azure/app-configuration": "^1.11.0", "@azure/cosmos": "^4.9.1", "@azure/data-tables": "^13.3.2", "@azure/identity": "^4.13.0", "@azure/keyvault-secrets": "^4.10.0", "@azure/storage-blob": "^12.31.0", "@capacitor/preferences": "^6 || ^7 || ^8", "@deno/kv": ">=0.13.0", "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0", "@planetscale/database": "^1.19.0", "@upstash/redis": "^1.36.2", "@vercel/blob": ">=0.27.3", "@vercel/functions": "^2.2.12 || ^3.0.0", "@vercel/kv": "^1.0.1", "aws4fetch": "^1.0.20", "chokidar": "^4 || ^5", "db0": ">=0.3.4", "idb-keyval": "^6.2.2", "ioredis": "^5.9.3", "lru-cache": "^11.2.6", "mongodb": "^6 || ^7", "ofetch": "*", "uploadthing": "^7.7.4" }, "optionalPeers": ["@azure/app-configuration", "@azure/cosmos", "@azure/data-tables", "@azure/identity", "@azure/keyvault-secrets", "@azure/storage-blob", "@capacitor/preferences", "@deno/kv", "@netlify/blobs", "@planetscale/database", "@upstash/redis", "@vercel/blob", "@vercel/functions", "@vercel/kv", "aws4fetch", "chokidar", "db0", "idb-keyval", "ioredis", "lru-cache", "mongodb", "ofetch", "uploadthing"] }, "sha512-ELPztchk2zgFJnakyodVY3vJWGW9jy//keJ32IOJVGUMyaPydwcA1FtVvWqT0TNRch9H+cMNEGllfVFfScImog=="],
 
+    "untruncate-json": ["untruncate-json@0.0.1", "", {}, "sha512-4W9enDK4X1y1s2S/Rz7ysw6kDuMS3VmRjMFg7GZrNO+98OSe+x5Lh7PKYoVjy3lW/1wmhs6HW0lusnQRHgMarA=="],
+
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
@@ -4664,11 +4696,21 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@ag-ui/client/@ag-ui/core": ["@ag-ui/core@0.0.53", "", { "dependencies": { "zod": "^3.22.4" } }, "sha512-11UocR7fFdMWw503bWCX2IOK15vbWfxT11Mn9xOiPBVO/UVcn57ywGrlLL4UaBlPgmUTvuzr2yYR2ElSqiN2wQ=="],
+
+    "@ag-ui/client/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
     "@ag-ui/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@ag-ui/encoder/@ag-ui/core": ["@ag-ui/core@0.0.53", "", { "dependencies": { "zod": "^3.22.4" } }, "sha512-11UocR7fFdMWw503bWCX2IOK15vbWfxT11Mn9xOiPBVO/UVcn57ywGrlLL4UaBlPgmUTvuzr2yYR2ElSqiN2wQ=="],
+
+    "@ag-ui/proto/@ag-ui/core": ["@ag-ui/core@0.0.53", "", { "dependencies": { "zod": "^3.22.4" } }, "sha512-11UocR7fFdMWw503bWCX2IOK15vbWfxT11Mn9xOiPBVO/UVcn57ywGrlLL4UaBlPgmUTvuzr2yYR2ElSqiN2wQ=="],
 
     "@assistant-ui/react/@radix-ui/react-context": ["@radix-ui/react-context@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw=="],
 
     "@assistant-ui/react/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
+
+    "@assistant-ui/react/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@assistant-ui/react-streamdown/streamdown": ["streamdown@2.5.0", "", { "dependencies": { "clsx": "^2.1.1", "hast-util-to-jsx-runtime": "^2.3.6", "html-url-attributes": "^3.0.1", "marked": "^17.0.1", "mermaid": "^11.12.2", "rehype-harden": "^1.1.8", "rehype-raw": "^7.0.0", "rehype-sanitize": "^6.0.0", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remend": "1.3.0", "tailwind-merge": "^3.4.0", "unified": "^11.0.5", "unist-util-visit": "^5.0.0", "unist-util-visit-parents": "^6.0.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-/tTnURfIOxZK/pqJAxsfCvETG/XCJHoWnk3jq9xLcuz6CSpnjjuxSRBTTL4PKGhxiZQf0lqPxGhImdpwcZ2XwA=="],
 
@@ -4875,16 +4917,6 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "@tanstack/ai-client/@tanstack/ai": ["@tanstack/ai@0.16.0", "", { "dependencies": { "@ag-ui/core": "0.0.49", "@tanstack/ai-event-client": "0.3.0", "partial-json": "^0.1.7" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-EsMGoMp9Y/H3A4JkhZZhfqk6S8bUxVcoJZhJea2omJtyv58YjcLlqBQFKYx+64egkYOgoORDyxj6bNI6Ne7dcA=="],
-
-    "@tanstack/ai-client/@tanstack/ai-event-client": ["@tanstack/ai-event-client@0.3.0", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1" }, "peerDependencies": { "@tanstack/ai": "0.16.0" } }, "sha512-rAXrgLgyxDszd1PVBWH4wpOyP89QpKLY6oAg8eBx44hVhEpkCM50AaoiDtrPCmxMjrucBz9OMkAU2Khb7EaZ6g=="],
-
-    "@tanstack/ai-devtools-core/@tanstack/ai": ["@tanstack/ai@0.18.0", "", { "dependencies": { "@ag-ui/core": "^0.0.52", "@tanstack/ai-event-client": "0.3.2", "partial-json": "^0.1.7" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-RIS9dwPBOErob2i62ppie5GnxvzzI+PNZY8yy5bv2mmwPCoJp82qLdDxDC9T+GHQv+63g/xQUH69st+fK1u5lA=="],
-
-    "@tanstack/ai-devtools-core/@tanstack/ai-event-client": ["@tanstack/ai-event-client@0.3.2", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1" }, "peerDependencies": { "@tanstack/ai": "0.18.0" } }, "sha512-4GhqHFU6W00Uo10dgKZyHKwtTENtpIFmqy6jW2HmZpW6NrOBhwG71dspiwmQ+4NPn4foADfbEBnzdt0W5Ik0Jw=="],
-
-    "@tanstack/ai-react/@tanstack/ai": ["@tanstack/ai@0.16.0", "", { "dependencies": { "@ag-ui/core": "0.0.49", "@tanstack/ai-event-client": "0.3.0", "partial-json": "^0.1.7" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-EsMGoMp9Y/H3A4JkhZZhfqk6S8bUxVcoJZhJea2omJtyv58YjcLlqBQFKYx+64egkYOgoORDyxj6bNI6Ne7dcA=="],
 
     "@tanstack/devtools-vite/@babel/parser": ["@babel/parser@7.29.3", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA=="],
 
@@ -5142,6 +5174,10 @@
 
     "yaml-language-server/yaml": ["yaml@2.7.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ=="],
 
+    "@ag-ui/encoder/@ag-ui/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@ag-ui/proto/@ag-ui/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
     "@assistant-ui/react-streamdown/streamdown/marked": ["marked@17.0.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA=="],
 
     "@assistant-ui/react-streamdown/streamdown/remend": ["remend@1.3.0", "", {}, "sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw=="],
@@ -5241,10 +5277,6 @@
     "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
     "@swc-node/sourcemap-support/source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
-
-    "@tanstack/ai-devtools-core/@tanstack/ai/@ag-ui/core": ["@ag-ui/core@0.0.52", "", { "dependencies": { "zod": "^3.22.4" } }, "sha512-Xo0bUaNV56EqylzcrAuhUkQX7et7+SZIrqZZtEByGwEq/I1EHny6ZMkWHLkKR7UNi0FJZwJyhKYmKJS3B2SEgA=="],
-
-    "@tanstack/ai-react/@tanstack/ai/@tanstack/ai-event-client": ["@tanstack/ai-event-client@0.3.0", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1" }, "peerDependencies": { "@tanstack/ai": "0.16.0" } }, "sha512-rAXrgLgyxDszd1PVBWH4wpOyP89QpKLY6oAg8eBx44hVhEpkCM50AaoiDtrPCmxMjrucBz9OMkAU2Khb7EaZ6g=="],
 
     "@tanstack/react-form/@tanstack/react-store/@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
 
@@ -5555,8 +5587,6 @@
     "@astrojs/react/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-5nlJ3AeJWCTSzR7AEqVjT/faWyqKU86kCi1lLmxVqmNR+j4HrYdns+eTGjS/vmrzCIe8inGQckUadvS0+JkKdQ=="],
 
     "@astrojs/react/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.5", "", { "os": "win32", "cpu": "x64" }, "sha512-PWypQR+d4FLfkhBIV+/kHsUELAnMpx1bRvvsn3p+/sAERbnCzFrtDRG2Xw5n+2zPxBK2+iaP+vetsRl4Ti7WgA=="],
-
-    "@tanstack/ai-devtools-core/@tanstack/ai/@ag-ui/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@tanstack/router-plugin/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -69,6 +69,7 @@
       "name": "web",
       "dependencies": {
         "@ag-ui/client": "catalog:ui",
+        "@ag-ui/core": "catalog:ui",
         "@assistant-ui/core": "catalog:ui",
         "@assistant-ui/react": "catalog:ui",
         "@assistant-ui/react-ag-ui": "catalog:ui",
@@ -484,6 +485,7 @@
       "name": "@modules/agents",
       "version": "0.1.0",
       "dependencies": {
+        "@ag-ui/core": "catalog:ui",
         "@core/ai": "workspace:*",
         "@core/database": "workspace:*",
         "@core/dbos": "workspace:*",
@@ -892,6 +894,7 @@
     },
     "ui": {
       "@ag-ui/client": "0.0.53",
+      "@ag-ui/core": "0.0.53",
       "@assistant-ui/core": "0.2.2",
       "@assistant-ui/react": "0.14.5",
       "@assistant-ui/react-ag-ui": "0.0.30",
@@ -952,7 +955,7 @@
   "packages": {
     "@ag-ui/client": ["@ag-ui/client@0.0.53", "", { "dependencies": { "@ag-ui/core": "0.0.53", "@ag-ui/encoder": "0.0.53", "@ag-ui/proto": "0.0.53", "@types/uuid": "^10.0.0", "compare-versions": "^6.1.1", "fast-json-patch": "^3.1.1", "rxjs": "7.8.1", "untruncate-json": "^0.0.1", "uuid": "^11.1.0", "zod": "^3.22.4" } }, "sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ=="],
 
-    "@ag-ui/core": ["@ag-ui/core@0.0.52", "", { "dependencies": { "zod": "^3.22.4" } }, "sha512-Xo0bUaNV56EqylzcrAuhUkQX7et7+SZIrqZZtEByGwEq/I1EHny6ZMkWHLkKR7UNi0FJZwJyhKYmKJS3B2SEgA=="],
+    "@ag-ui/core": ["@ag-ui/core@0.0.53", "", { "dependencies": { "zod": "^3.22.4" } }, "sha512-11UocR7fFdMWw503bWCX2IOK15vbWfxT11Mn9xOiPBVO/UVcn57ywGrlLL4UaBlPgmUTvuzr2yYR2ElSqiN2wQ=="],
 
     "@ag-ui/encoder": ["@ag-ui/encoder@0.0.53", "", { "dependencies": { "@ag-ui/core": "0.0.53", "@ag-ui/proto": "0.0.53" } }, "sha512-bAOcfVdm6U4H6G6tW+DZfwPEQm1w/snVBTwaFn9nJcEMW69M7/HZuwvEc/7Zo0rK1jRL32N/j60PwTAeky19fw=="],
 
@@ -4696,15 +4699,9 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
-    "@ag-ui/client/@ag-ui/core": ["@ag-ui/core@0.0.53", "", { "dependencies": { "zod": "^3.22.4" } }, "sha512-11UocR7fFdMWw503bWCX2IOK15vbWfxT11Mn9xOiPBVO/UVcn57ywGrlLL4UaBlPgmUTvuzr2yYR2ElSqiN2wQ=="],
-
     "@ag-ui/client/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@ag-ui/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
-    "@ag-ui/encoder/@ag-ui/core": ["@ag-ui/core@0.0.53", "", { "dependencies": { "zod": "^3.22.4" } }, "sha512-11UocR7fFdMWw503bWCX2IOK15vbWfxT11Mn9xOiPBVO/UVcn57ywGrlLL4UaBlPgmUTvuzr2yYR2ElSqiN2wQ=="],
-
-    "@ag-ui/proto/@ag-ui/core": ["@ag-ui/core@0.0.53", "", { "dependencies": { "zod": "^3.22.4" } }, "sha512-11UocR7fFdMWw503bWCX2IOK15vbWfxT11Mn9xOiPBVO/UVcn57ywGrlLL4UaBlPgmUTvuzr2yYR2ElSqiN2wQ=="],
 
     "@assistant-ui/react/@radix-ui/react-context": ["@radix-ui/react-context@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw=="],
 
@@ -4917,6 +4914,8 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@tanstack/ai/@ag-ui/core": ["@ag-ui/core@0.0.52", "", { "dependencies": { "zod": "^3.22.4" } }, "sha512-Xo0bUaNV56EqylzcrAuhUkQX7et7+SZIrqZZtEByGwEq/I1EHny6ZMkWHLkKR7UNi0FJZwJyhKYmKJS3B2SEgA=="],
 
     "@tanstack/devtools-vite/@babel/parser": ["@babel/parser@7.29.3", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA=="],
 
@@ -5174,10 +5173,6 @@
 
     "yaml-language-server/yaml": ["yaml@2.7.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ=="],
 
-    "@ag-ui/encoder/@ag-ui/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
-    "@ag-ui/proto/@ag-ui/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
     "@assistant-ui/react-streamdown/streamdown/marked": ["marked@17.0.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA=="],
 
     "@assistant-ui/react-streamdown/streamdown/remend": ["remend@1.3.0", "", {}, "sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw=="],
@@ -5277,6 +5272,8 @@
     "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
     "@swc-node/sourcemap-support/source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "@tanstack/ai/@ag-ui/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@tanstack/react-form/@tanstack/react-store/@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
 

--- a/core/ai/src/otel.ts
+++ b/core/ai/src/otel.ts
@@ -6,6 +6,7 @@ export interface AiTraceContext {
    organizationId?: string;
    teamId?: string;
    threadId?: string;
+   runId?: string;
    promptName?: string;
    promptVersion?: number;
    customProperties?: Record<string, AiTraceAttributeValue>;
@@ -27,6 +28,9 @@ export function aiTraceAttributes(context: AiTraceContext) {
       ...(context.threadId && {
          "thread.id": context.threadId,
          "gen_ai.conversation.id": context.threadId,
+      }),
+      ...(context.runId && {
+         "gen_ai.run.id": context.runId,
       }),
       ...(context.promptName && {
          $ai_prompt_name: context.promptName,

--- a/modules/agents/package.json
+++ b/modules/agents/package.json
@@ -19,6 +19,7 @@
       "typecheck": "tsgo"
    },
    "dependencies": {
+      "@ag-ui/core": "catalog:ui",
       "@core/ai": "workspace:*",
       "@core/database": "workspace:*",
       "@core/dbos": "workspace:*",

--- a/modules/agents/src/agent.ts
+++ b/modules/agents/src/agent.ts
@@ -22,6 +22,7 @@ export interface AgentChatOptions {
    headers: Headers;
    request: Request;
    threadId?: string;
+   runId?: string;
    messages: UIMessage[];
    pageContext?: PageContext;
    reasoningEffort?: "high" | "xhigh";
@@ -90,7 +91,8 @@ async function buildAgentChatArgs(options: AgentChatOptions) {
          parallelToolCalls: false,
       },
       agentLoopStrategy: maxIterations(8),
-      ...(options.threadId && { conversationId: options.threadId }),
+      ...(options.threadId && { threadId: options.threadId }),
+      ...(options.runId && { runId: options.runId }),
       abortController: options.abortSignal
          ? abortControllerFromSignal(options.abortSignal)
          : undefined,

--- a/modules/agents/src/agent.ts
+++ b/modules/agents/src/agent.ts
@@ -115,6 +115,9 @@ async function buildAgentChatArgs(options: AgentChatOptions) {
                      ...(options.threadId && {
                         agent_thread_id: options.threadId,
                      }),
+                     ...(options.runId && {
+                        agent_run_id: options.runId,
+                     }),
                      agent_turn_id: turnId,
                      ...(options.pageContext?.skillHint && {
                         agent_skill: options.pageContext.skillHint,

--- a/modules/agents/src/router/chat.ts
+++ b/modules/agents/src/router/chat.ts
@@ -1,5 +1,5 @@
 import { os } from "@orpc/server";
-import { and, asc, eq, gte, inArray, sql } from "drizzle-orm";
+import { and, asc, eq, gt, gte, inArray, sql } from "drizzle-orm";
 import dayjs from "dayjs";
 import { defineErrorCatalog } from "evlog";
 import { Result, TaggedError } from "better-result";
@@ -234,6 +234,13 @@ export const chatInputSchema = z.object({
 
 export type ChatInput = z.infer<typeof chatInputSchema>;
 
+interface AgUiChatParams {
+   messages: unknown[];
+   threadId: string;
+   runId: string;
+   forwardedProps: Record<string, unknown>;
+}
+
 const threadIdInputSchema = z.object({ threadId: threadSchema.shape.id });
 
 const createThreadInputSchema = insertThreadSchema
@@ -321,6 +328,29 @@ const messagePartSchema = z.discriminatedUnion("type", [
 const messagePartsSchema = z
    .array(messagePartSchema)
    .min(1) satisfies z.ZodType<UIMessage["parts"]>;
+
+const agUiTextContentPartSchema = z
+   .object({
+      type: z.literal("text"),
+      text: z.string(),
+   })
+   .passthrough();
+
+const agUiIncomingMessageSchema = z
+   .object({
+      id: z.string().optional(),
+      role: z.enum(["assistant", "system", "tool", "user"]),
+      content: z
+         .union([z.string(), z.array(agUiTextContentPartSchema)])
+         .optional(),
+   })
+   .passthrough();
+
+const agUiForwardedPropsSchema = z
+   .object({
+      pageContext: messagePageContextSchema.optional(),
+   })
+   .passthrough();
 
 const saveAssistantMessageInputSchema = threadIdInputSchema.extend({
    parts: messagePartsSchema,
@@ -426,6 +456,101 @@ const prepareChatHistoryWithThreadAdvisoryLock = (
          .where(eq(messages.threadId, input.threadId))
          .orderBy(asc(messages.createdAt));
    });
+
+function agUiContentText(
+   content: z.infer<typeof agUiIncomingMessageSchema>["content"],
+): string {
+   if (content === undefined) return "";
+   if (typeof content === "string") return content.trim();
+   return content
+      .map((part) => part.text)
+      .join("\n\n")
+      .trim();
+}
+
+async function prepareAgUiChatHistoryWithThreadAdvisoryLock(
+   context: ORPCContextWithOrganization,
+   params: AgUiChatParams,
+): Promise<UIMessage[]> {
+   const incoming = z.array(agUiIncomingMessageSchema).parse(params.messages);
+   const forwardedProps = agUiForwardedPropsSchema.parse(params.forwardedProps);
+
+   return context.db.transaction(async (tx) => {
+      await tx.execute(
+         sql`select pg_advisory_xact_lock(hashtext(${params.threadId}))`,
+      );
+
+      const existingRows = await tx
+         .select({
+            id: messages.id,
+            role: messages.role,
+            parts: messages.parts,
+            createdAt: messages.createdAt,
+         })
+         .from(messages)
+         .where(eq(messages.threadId, params.threadId))
+         .orderBy(asc(messages.createdAt));
+
+      const incomingIds = new Set(
+         incoming.flatMap((message) => (message.id ? [message.id] : [])),
+      );
+      const latestMatched = existingRows.reduce<
+         (typeof existingRows)[number] | undefined
+      >((matched, row) => (incomingIds.has(row.id) ? row : matched), undefined);
+
+      if (existingRows.length > 0) {
+         if (latestMatched) {
+            await tx
+               .delete(messages)
+               .where(
+                  and(
+                     eq(messages.threadId, params.threadId),
+                     gt(messages.createdAt, latestMatched.createdAt),
+                  ),
+               );
+         } else {
+            await tx
+               .delete(messages)
+               .where(eq(messages.threadId, params.threadId));
+         }
+      }
+
+      const existingIds = new Set(existingRows.map((row) => row.id));
+      const lastIncoming = incoming.at(-1);
+      if (
+         lastIncoming?.role === "user" &&
+         (!lastIncoming.id || !existingIds.has(lastIncoming.id))
+      ) {
+         const text = agUiContentText(lastIncoming.content);
+         if (text.length > 0) {
+            await tx.insert(messages).values({
+               threadId: params.threadId,
+               role: "user",
+               parts: [{ type: "text", content: text }],
+               metadata: forwardedProps.pageContext
+                  ? { pageContext: forwardedProps.pageContext }
+                  : null,
+            });
+         }
+      }
+
+      const rows = await tx
+         .select({
+            id: messages.id,
+            role: messages.role,
+            parts: messages.parts,
+         })
+         .from(messages)
+         .where(eq(messages.threadId, params.threadId))
+         .orderBy(asc(messages.createdAt));
+
+      return rows.map((row) => ({
+         id: row.id,
+         role: row.role,
+         parts: row.parts,
+      }));
+   });
+}
 
 export const list = protectedProcedure
    .input(listThreadsInputSchema)
@@ -863,6 +988,144 @@ export async function createThreadChatStream(options: {
    if (Result.isError(streamResult)) throw streamResult.error;
 
    return streamResult.value;
+}
+
+export async function createAgUiThreadChatStream(options: {
+   context: ORPCContextWithOrganization;
+   params: AgUiChatParams;
+   signal?: AbortSignal;
+}) {
+   const { context, params, signal } = options;
+   const result = await Result.gen(async function* () {
+      const input = chatInputSchema
+         .pick({ threadId: true })
+         .parse({ threadId: params.threadId });
+      const forwardedProps = agUiForwardedPropsSchema.parse(
+         params.forwardedProps,
+      );
+      const thread = yield* Result.await(
+         Result.tryPromise({
+            try: () =>
+               context.db.query.threads.findFirst({
+                  where: (f, { eq: eqFn }) => eqFn(f.id, input.threadId),
+               }),
+            catch: () =>
+               new AgentThreadError({
+                  error: threadErrors.THREAD_LOOKUP_FAILED({
+                     internal: { threadId: input.threadId },
+                  }),
+                  message: threadErrors.THREAD_LOOKUP_FAILED({
+                     internal: { threadId: input.threadId },
+                  }).message,
+                  threadId: input.threadId,
+               }),
+         }),
+      );
+      if (
+         !thread ||
+         thread.teamId !== context.teamId ||
+         thread.organizationId !== context.organizationId ||
+         thread.userId !== context.userId
+      ) {
+         yield* new AgentThreadError({
+            error: threadErrors.THREAD_NOT_FOUND({
+               internal: { threadId: input.threadId },
+            }),
+            message: threadErrors.THREAD_NOT_FOUND({
+               internal: { threadId: input.threadId },
+            }).message,
+            threadId: input.threadId,
+         });
+      }
+
+      log.info({
+         module: "agents.chat",
+         message: "agent chat send start",
+         userId: context.userId,
+         threadId: input.threadId,
+      });
+
+      const history = yield* Result.await(
+         Result.tryPromise({
+            try: () =>
+               prepareAgUiChatHistoryWithThreadAdvisoryLock(context, params),
+            catch: () =>
+               new AgentThreadError({
+                  error: threadErrors.CHAT_HISTORY_LOAD_FAILED({
+                     internal: { threadId: input.threadId },
+                  }),
+                  message: threadErrors.CHAT_HISTORY_LOAD_FAILED({
+                     internal: { threadId: input.threadId },
+                  }).message,
+                  threadId: input.threadId,
+               }),
+         }),
+      );
+      const settings = yield* Result.await(
+         Result.tryPromise({
+            try: () =>
+               context.db.query.agentSettings.findFirst({
+                  where: (f, { eq: eqFn }) => eqFn(f.teamId, context.teamId),
+               }),
+            catch: () =>
+               new AgentThreadError({
+                  error: threadErrors.CHAT_SETTINGS_LOAD_FAILED({
+                     internal: { threadId: input.threadId },
+                  }),
+                  message: threadErrors.CHAT_SETTINGS_LOAD_FAILED({
+                     internal: { threadId: input.threadId },
+                  }).message,
+                  threadId: input.threadId,
+               }),
+         }),
+      );
+      const chatSettings = chatSettingsSchema.parse(settings);
+      const abortController = new AbortController();
+      signal?.addEventListener("abort", () => abortController.abort(), {
+         once: true,
+      });
+      const stream = yield* Result.await(
+         Result.tryPromise({
+            try: () =>
+               createAgentChat({
+                  prompts: context.posthogPrompts,
+                  userId: context.userId,
+                  organizationId: context.organizationId,
+                  teamId: context.teamId,
+                  headers: context.headers,
+                  request: context.request,
+                  threadId: params.threadId,
+                  runId: params.runId,
+                  messages: history,
+                  pageContext: forwardedProps.pageContext,
+                  reasoningEffort: chatSettings.reasoningEffort,
+                  abortSignal: abortController.signal,
+                  extraMiddleware: createAgentRuntimeMiddlewares({
+                     db: context.db,
+                     pgBoss: context.pgBoss,
+                     threadId: params.threadId,
+                     teamId: context.teamId,
+                     organizationId: context.organizationId,
+                     history,
+                  }),
+               }),
+            catch: () =>
+               new AgentThreadError({
+                  error: threadErrors.CHAT_STREAM_CREATE_FAILED({
+                     internal: { threadId: input.threadId },
+                  }),
+                  message: threadErrors.CHAT_STREAM_CREATE_FAILED({
+                     internal: { threadId: input.threadId },
+                  }).message,
+                  threadId: input.threadId,
+               }),
+         }),
+      );
+
+      return Result.ok(stream);
+   });
+   if (Result.isError(result)) throw result.error;
+   return result.value;
 }
 
 export const chat = protectedProcedure

--- a/package.json
+++ b/package.json
@@ -148,8 +148,11 @@
             "vitest": "^4.1.4"
          },
          "ui": {
-            "@assistant-ui/react": "^0.12.28",
-            "@assistant-ui/react-streamdown": "^0.1.11",
+            "@ag-ui/client": "0.0.53",
+            "@assistant-ui/core": "0.2.2",
+            "@assistant-ui/react": "0.14.5",
+            "@assistant-ui/react-ag-ui": "0.0.30",
+            "@assistant-ui/react-streamdown": "0.3.0",
             "@json-render/core": "^0.18.0",
             "@json-render/react": "^0.18.0",
             "@json-render/shadcn": "^0.18.0",
@@ -197,9 +200,9 @@
             "vite-tsconfig-paths": "^6.1.1"
          },
          "tanstack-ai": {
-            "@tanstack/ai": "0.15.0",
-            "@tanstack/ai-react": "^0.8.1",
-            "@tanstack/ai-openrouter": "0.8.3"
+            "@tanstack/ai": "0.18.0",
+            "@tanstack/ai-react": "0.10.0",
+            "@tanstack/ai-openrouter": "0.9.1"
          },
          "workers": {
             "@dbos-inc/dbos-sdk": "^4.18.10",

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
          },
          "ui": {
             "@ag-ui/client": "0.0.53",
+            "@ag-ui/core": "0.0.53",
             "@assistant-ui/core": "0.2.2",
             "@assistant-ui/react": "0.14.5",
             "@assistant-ui/react-ag-ui": "0.0.30",


### PR DESCRIPTION
## Summary
- migrate Montte AI frontend from the custom TanStack AI bridge to assistant-ui AG-UI runtime
- accept AG-UI RunAgentInput on /api/chat and stream AG-UI SSE responses
- pass threadId/runId through the agents runtime and preserve persisted thread history
- align TanStack AI, assistant-ui, and AG-UI package versions
- fix transactions reactivation input to match the server contract

## Validation
- bun nx run @modules/agents:typecheck
- bun nx run web:typecheck
- bun nx run @modules/agents:check
- bun nx run web:check
- bun nx sync