### PR TITLE
refactor(inbox): migrate to better-result

### DIFF
--- a/modules/inbox/src/router/inbox.ts
+++ b/modules/inbox/src/router/inbox.ts
@@ -1,14 +1,51 @@
+import dayjs from "dayjs";
+import { Result, TaggedError } from "better-result";
+import { defineErrorCatalog } from "evlog";
 import { and, eq } from "drizzle-orm";
-import { fromPromise } from "neverthrow";
 import { z } from "zod";
 import { inboxItems } from "@core/database/schemas/inbox";
-import { WebAppError } from "@core/logging/errors";
 import { protectedProcedure } from "@core/orpc/server";
 import {
    inboxCountsSchema,
    inboxItemDtoSchema,
 } from "@modules/inbox/schemas/inbox-item";
 import { aggregateInbox } from "@modules/inbox/services/aggregate";
+
+const inboxRouterErrors = defineErrorCatalog("inbox.router", {
+   DISMISS_FAILED: {
+      status: 500,
+      message: "Falha ao dispensar item.",
+      tags: ["inbox"],
+   },
+   SNOOZE_FAILED: {
+      status: 500,
+      message: "Falha ao adiar item.",
+      tags: ["inbox"],
+   },
+   MARK_READ_FAILED: {
+      status: 500,
+      message: "Falha ao marcar como lido.",
+      tags: ["inbox"],
+   },
+});
+
+declare module "evlog" {
+   interface RegisteredErrorCatalogs {
+      "inbox.router": typeof inboxRouterErrors;
+   }
+}
+
+type InboxCatalogError =
+   | ReturnType<typeof inboxRouterErrors.DISMISS_FAILED>
+   | ReturnType<typeof inboxRouterErrors.SNOOZE_FAILED>
+   | ReturnType<typeof inboxRouterErrors.MARK_READ_FAILED>;
+
+class InboxError extends TaggedError("InboxError")<{
+   error: InboxCatalogError;
+   itemKey?: string;
+   message: string;
+   teamId: string;
+}>() {}
 
 const itemKeySchema = z.object({ itemKey: z.string().min(1) });
 
@@ -21,91 +58,117 @@ export const list = protectedProcedure
    )
    .handler(async ({ context }) => {
       const result = await aggregateInbox(context.db, context.teamId);
-      if (result.isErr()) throw result.error;
+      if (Result.isError(result)) throw result.error;
       return result.value;
    });
 
 export const dismiss = protectedProcedure
    .input(itemKeySchema)
    .handler(async ({ context, input }) => {
-      const now = new Date();
-      const result = await fromPromise(
-         context.db.transaction(async (tx) =>
-            tx
-               .insert(inboxItems)
-               .values({
-                  organizationId: context.organizationId,
-                  teamId: context.teamId,
-                  itemKey: input.itemKey,
-                  source: "deterministic",
-                  severity: "info",
-                  title: "Item dispensado",
-                  description: null,
-                  payload: { dismissedStub: true },
-                  dismissedAt: now,
-               })
-               .onConflictDoUpdate({
-                  target: [inboxItems.teamId, inboxItems.itemKey],
-                  set: { dismissedAt: now },
-               })
-               .returning(),
-         ),
-         () => WebAppError.internal("Falha ao dispensar item."),
-      );
-      if (result.isErr()) throw result.error;
-      return { ok: true as const };
+      const now = dayjs().toDate();
+      const result = await Result.tryPromise({
+         try: () =>
+            context.db.transaction(async (tx) =>
+               tx
+                  .insert(inboxItems)
+                  .values({
+                     organizationId: context.organizationId,
+                     teamId: context.teamId,
+                     itemKey: input.itemKey,
+                     source: "deterministic",
+                     severity: "info",
+                     title: "Item dispensado",
+                     description: null,
+                     payload: { dismissedStub: true },
+                     dismissedAt: now,
+                  })
+                  .onConflictDoUpdate({
+                     target: [inboxItems.teamId, inboxItems.itemKey],
+                     set: { dismissedAt: now },
+                  })
+                  .returning(),
+            ),
+         catch: () =>
+            new InboxError({
+               error: inboxRouterErrors.DISMISS_FAILED({
+                  internal: { itemKey: input.itemKey, teamId: context.teamId },
+               }),
+               itemKey: input.itemKey,
+               message: "Falha ao dispensar item.",
+               teamId: context.teamId,
+            }),
+      });
+      if (Result.isError(result)) throw result.error;
+      return { ok: true };
    });
 
 export const snooze = protectedProcedure
    .input(itemKeySchema.extend({ until: z.string().datetime() }))
    .handler(async ({ context, input }) => {
-      const until = new Date(input.until);
-      const result = await fromPromise(
-         context.db.transaction(async (tx) =>
-            tx
-               .insert(inboxItems)
-               .values({
-                  organizationId: context.organizationId,
-                  teamId: context.teamId,
-                  itemKey: input.itemKey,
-                  source: "deterministic",
-                  severity: "info",
-                  title: "Item adiado",
-                  description: null,
-                  payload: { snoozedStub: true },
-                  snoozeUntil: until,
-               })
-               .onConflictDoUpdate({
-                  target: [inboxItems.teamId, inboxItems.itemKey],
-                  set: { snoozeUntil: until },
-               })
-               .returning(),
-         ),
-         () => WebAppError.internal("Falha ao adiar item."),
-      );
-      if (result.isErr()) throw result.error;
-      return { ok: true as const };
+      const until = dayjs(input.until).toDate();
+      const result = await Result.tryPromise({
+         try: () =>
+            context.db.transaction(async (tx) =>
+               tx
+                  .insert(inboxItems)
+                  .values({
+                     organizationId: context.organizationId,
+                     teamId: context.teamId,
+                     itemKey: input.itemKey,
+                     source: "deterministic",
+                     severity: "info",
+                     title: "Item adiado",
+                     description: null,
+                     payload: { snoozedStub: true },
+                     snoozeUntil: until,
+                  })
+                  .onConflictDoUpdate({
+                     target: [inboxItems.teamId, inboxItems.itemKey],
+                     set: { snoozeUntil: until },
+                  })
+                  .returning(),
+            ),
+         catch: () =>
+            new InboxError({
+               error: inboxRouterErrors.SNOOZE_FAILED({
+                  internal: { itemKey: input.itemKey, teamId: context.teamId },
+               }),
+               itemKey: input.itemKey,
+               message: "Falha ao adiar item.",
+               teamId: context.teamId,
+            }),
+      });
+      if (Result.isError(result)) throw result.error;
+      return { ok: true };
    });
 
 export const markRead = protectedProcedure
    .input(z.object({ id: z.string().uuid() }))
    .handler(async ({ context, input }) => {
-      const now = new Date();
-      const result = await fromPromise(
-         context.db.transaction(async (tx) =>
-            tx
-               .update(inboxItems)
-               .set({ readAt: now })
-               .where(
-                  and(
-                     eq(inboxItems.id, input.id),
-                     eq(inboxItems.teamId, context.teamId),
-                  ),
-               )
-               .returning(),
-         ),
-         () => WebAppError.internal("Falha ao marcar como lido."),
-      );
-      if (result.isErr()) throw result.error;
-      return { ok: true as const };
+      const now = dayjs().toDate();
+      const result = await Result.tryPromise({
+         try: () =>
+            context.db.transaction(async (tx) =>
+               tx
+                  .update(inboxItems)
+                  .set({ readAt: now })
+                  .where(
+                     and(
+                        eq(inboxItems.id, input.id),
+                        eq(inboxItems.teamId, context.teamId),
+                     ),
+                  )
+                  .returning(),
+            ),
+         catch: () =>
+            new InboxError({
+               error: inboxRouterErrors.MARK_READ_FAILED({
+                  internal: { id: input.id, teamId: context.teamId },
+               }),
+               message: "Falha ao marcar como lido.",
+               teamId: context.teamId,
+            }),
+      });
+      if (Result.isError(result)) throw result.error;
+      return { ok: true };
    });

--- a/modules/inbox/src/services/aggregate.ts
+++ b/modules/inbox/src/services/aggregate.ts
@@ -1,114 +1,185 @@
+import dayjs from "dayjs";
+import { Result, TaggedError, type Result as ResultType } from "better-result";
+import { defineErrorCatalog } from "evlog";
 import { and, eq, gt, isNull, or } from "drizzle-orm";
-import { fromPromise, ok, ResultAsync } from "neverthrow";
+import { z } from "zod";
 import type { DatabaseInstance } from "@core/database/client";
 import { inboxItems } from "@core/database/schemas/inbox";
-import { WebAppError } from "@core/logging/errors";
 import {
+   inboxActionSchema,
    type InboxCounts,
+   inboxEntitySchema,
    type InboxItemDto,
+   inboxSourceSchema,
 } from "@modules/inbox/schemas/inbox-item";
 import { fetchDuePayments } from "@modules/inbox/services/sources/due-payments";
 import { fetchUncategorized } from "@modules/inbox/services/sources/uncategorized-tx";
 
-const SEVERITY_RANK = { urgent: 0, warning: 1, info: 2 } as const;
+const SEVERITY_RANK: Record<InboxItemDto["severity"], number> = {
+   urgent: 0,
+   warning: 1,
+   info: 2,
+};
 
-function fetchPersisted(db: DatabaseInstance, teamId: string) {
-   const now = new Date();
-   return fromPromise(
-      db
-         .select()
-         .from(inboxItems)
-         .where(
-            and(
-               eq(inboxItems.teamId, teamId),
-               isNull(inboxItems.dismissedAt),
-               or(
-                  isNull(inboxItems.snoozeUntil),
-                  gt(inboxItems.snoozeUntil, now),
+const inboxAggregateErrors = defineErrorCatalog("inbox.aggregate", {
+   LOAD_FAILED: {
+      status: 500,
+      message: "Falha ao carregar inbox.",
+      tags: ["inbox"],
+   },
+});
+
+declare module "evlog" {
+   interface RegisteredErrorCatalogs {
+      "inbox.aggregate": typeof inboxAggregateErrors;
+   }
+}
+
+type InboxCatalogError = ReturnType<typeof inboxAggregateErrors.LOAD_FAILED>;
+
+export class InboxError extends TaggedError("InboxError")<{
+   error: InboxCatalogError;
+   message: string;
+   teamId: string;
+}>() {}
+
+const inboxPayloadSchema = z
+   .object({
+      entity: inboxEntitySchema.optional(),
+      actions: z.array(inboxActionSchema).optional(),
+   })
+   .passthrough();
+
+function parsePersistedPayload(payload: Record<string, unknown>) {
+   const parsed = inboxPayloadSchema.safeParse(payload);
+   if (!parsed.success) return { actions: [] };
+   return parsed.data;
+}
+
+async function fetchPersisted(
+   db: DatabaseInstance,
+   teamId: string,
+): Promise<ResultType<InboxItemDto[], InboxError>> {
+   const now = dayjs().toDate();
+   const rows = await Result.tryPromise({
+      try: () =>
+         db
+            .select()
+            .from(inboxItems)
+            .where(
+               and(
+                  eq(inboxItems.teamId, teamId),
+                  isNull(inboxItems.dismissedAt),
+                  or(
+                     isNull(inboxItems.snoozeUntil),
+                     gt(inboxItems.snoozeUntil, now),
+                  ),
                ),
-            ),
-         )
-         .limit(50),
-      () => WebAppError.internal("Falha ao carregar inbox."),
-   ).andThen((rows) =>
-      ok(
-         rows.map<InboxItemDto>((r) => ({
-            id: r.id,
-            itemKey: r.itemKey,
-            source: r.source as InboxItemDto["source"],
-            severity: r.severity,
-            title: r.title,
-            description: r.description ?? null,
-            occurredAt: r.occurredAt.toISOString(),
-            readAt: r.readAt ? r.readAt.toISOString() : null,
+            )
+            .limit(50),
+      catch: () =>
+         new InboxError({
+            error: inboxAggregateErrors.LOAD_FAILED({ internal: { teamId } }),
+            message: "Falha ao carregar inbox.",
+            teamId,
+         }),
+   });
+
+   return rows.map((loadedRows) =>
+      loadedRows.map<InboxItemDto>((row) => {
+         const source = inboxSourceSchema.safeParse(row.source);
+         const payload = parsePersistedPayload(row.payload);
+         return {
+            id: row.id,
+            itemKey: row.itemKey,
+            source: source.success ? source.data : "agent",
+            severity: row.severity,
+            title: row.title,
+            description: row.description ?? null,
+            occurredAt: dayjs(row.occurredAt).toISOString(),
+            readAt: row.readAt ? dayjs(row.readAt).toISOString() : null,
             isPersisted: true,
-            entity: (r.payload as { entity?: InboxItemDto["entity"] })
-               .entity ?? { type: "team", id: r.teamId },
-            actions:
-               (r.payload as { actions?: InboxItemDto["actions"] }).actions ??
-               [],
-         })),
-      ),
+            entity: payload.entity ?? { type: "team", id: row.teamId },
+            actions: payload.actions ?? [],
+         };
+      }),
    );
 }
 
-function fetchDismissedKeys(db: DatabaseInstance, teamId: string) {
-   const now = new Date();
-   return fromPromise(
-      db
-         .select({
-            itemKey: inboxItems.itemKey,
-            dismissedAt: inboxItems.dismissedAt,
-            snoozeUntil: inboxItems.snoozeUntil,
-         })
-         .from(inboxItems)
-         .where(eq(inboxItems.teamId, teamId)),
-      () => WebAppError.internal("Falha ao carregar inbox."),
-   ).andThen((rows) =>
-      ok(
+async function fetchDismissedKeys(
+   db: DatabaseInstance,
+   teamId: string,
+): Promise<ResultType<Set<string>, InboxError>> {
+   const now = dayjs().toDate();
+   const rows = await Result.tryPromise({
+      try: () =>
+         db
+            .select({
+               itemKey: inboxItems.itemKey,
+               dismissedAt: inboxItems.dismissedAt,
+               snoozeUntil: inboxItems.snoozeUntil,
+            })
+            .from(inboxItems)
+            .where(eq(inboxItems.teamId, teamId)),
+      catch: () =>
+         new InboxError({
+            error: inboxAggregateErrors.LOAD_FAILED({ internal: { teamId } }),
+            message: "Falha ao carregar inbox.",
+            teamId,
+         }),
+   });
+
+   return rows.map(
+      (loadedRows) =>
          new Set(
-            rows
+            loadedRows
                .filter(
-                  (r) =>
-                     r.dismissedAt || (r.snoozeUntil && r.snoozeUntil > now),
+                  (row) =>
+                     row.dismissedAt ||
+                     (row.snoozeUntil && row.snoozeUntil > now),
                )
-               .map((r) => r.itemKey),
+               .map((row) => row.itemKey),
          ),
-      ),
    );
 }
 
-export function aggregateInbox(db: DatabaseInstance, teamId: string) {
-   return ResultAsync.combine([
-      fetchDuePayments(db, teamId),
-      fetchUncategorized(db, teamId),
-      fetchPersisted(db, teamId),
-      fetchDismissedKeys(db, teamId),
-   ]).andThen(([due, uncategorized, persisted, dismissed]) => {
+export async function aggregateInbox(db: DatabaseInstance, teamId: string) {
+   const [dueResult, uncategorizedResult, persistedResult, dismissedResult] =
+      await Promise.all([
+         fetchDuePayments(db, teamId),
+         fetchUncategorized(db, teamId),
+         fetchPersisted(db, teamId),
+         fetchDismissedKeys(db, teamId),
+      ]);
+
+   return Result.gen(function* () {
+      const due = yield* dueResult;
+      const uncategorized = yield* uncategorizedResult;
+      const persisted = yield* persistedResult;
+      const dismissed = yield* dismissedResult;
+
       const deterministic = [...due, ...uncategorized].filter(
-         (i) => !dismissed.has(i.itemKey),
+         (item) => !dismissed.has(item.itemKey),
       );
       const merged = [...persisted, ...deterministic];
       const seenKeys = new Set<string>();
-      const unique = merged.filter((i) => {
-         if (seenKeys.has(i.itemKey)) return false;
-         seenKeys.add(i.itemKey);
+      const unique = merged.filter((item) => {
+         if (seenKeys.has(item.itemKey)) return false;
+         seenKeys.add(item.itemKey);
          return true;
       });
       unique.sort((a, b) => {
-         const sev = SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity];
-         if (sev !== 0) return sev;
-         return (
-            new Date(b.occurredAt).getTime() - new Date(a.occurredAt).getTime()
-         );
+         const severity = SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity];
+         if (severity !== 0) return severity;
+         return dayjs(b.occurredAt).valueOf() - dayjs(a.occurredAt).valueOf();
       });
       const counts: InboxCounts = {
          total: unique.length,
-         urgent: unique.filter((i) => i.severity === "urgent").length,
-         warning: unique.filter((i) => i.severity === "warning").length,
-         info: unique.filter((i) => i.severity === "info").length,
-         unread: unique.filter((i) => !i.readAt).length,
+         urgent: unique.filter((item) => item.severity === "urgent").length,
+         warning: unique.filter((item) => item.severity === "warning").length,
+         info: unique.filter((item) => item.severity === "info").length,
+         unread: unique.filter((item) => !item.readAt).length,
       };
-      return ok({ items: unique.slice(0, 50), counts });
+      return Result.ok({ items: unique.slice(0, 50), counts });
    });
 }

--- a/modules/inbox/src/services/sources/due-payments.ts
+++ b/modules/inbox/src/services/sources/due-payments.ts
@@ -1,12 +1,34 @@
 import dayjs from "dayjs";
+import { Result, TaggedError, type Result as ResultType } from "better-result";
+import { defineErrorCatalog } from "evlog";
 import { and, eq, lte } from "drizzle-orm";
-import { fromPromise, ok } from "neverthrow";
-import { transactions } from "@core/database/schemas/transactions";
 import type { DatabaseInstance } from "@core/database/client";
-import { WebAppError } from "@core/logging/errors";
+import { transactions } from "@core/database/schemas/transactions";
 import type { InboxItemDto } from "@modules/inbox/schemas/inbox-item";
 
 const HORIZON_DAYS = 7;
+
+const inboxSourceErrors = defineErrorCatalog("inbox.source.due-payments", {
+   LOAD_FAILED: {
+      status: 500,
+      message: "Falha ao carregar vencimentos.",
+      tags: ["inbox", "due-payments"],
+   },
+});
+
+declare module "evlog" {
+   interface RegisteredErrorCatalogs {
+      "inbox.source.due-payments": typeof inboxSourceErrors;
+   }
+}
+
+type InboxCatalogError = ReturnType<typeof inboxSourceErrors.LOAD_FAILED>;
+
+export class InboxError extends TaggedError("InboxError")<{
+   error: InboxCatalogError;
+   message: string;
+   teamId: string;
+}>() {}
 
 function severityFor(daysUntil: number): "urgent" | "warning" | "info" {
    if (daysUntil < 0) return "urgent";
@@ -24,60 +46,70 @@ function describe(daysUntil: number, formattedDate: string): string {
    return `Vence em ${daysUntil} dias (${formattedDate}).`;
 }
 
-export function fetchDuePayments(db: DatabaseInstance, teamId: string) {
+export async function fetchDuePayments(
+   db: DatabaseInstance,
+   teamId: string,
+): Promise<ResultType<InboxItemDto[], InboxError>> {
    const horizon = dayjs().add(HORIZON_DAYS, "day").format("YYYY-MM-DD");
-   return fromPromise(
-      db
-         .select({
-            id: transactions.id,
-            name: transactions.name,
-            dueDate: transactions.dueDate,
-            type: transactions.type,
-            amount: transactions.amount,
-         })
-         .from(transactions)
-         .where(
-            and(
-               eq(transactions.teamId, teamId),
-               eq(transactions.ignored, false),
-               eq(transactions.status, "pending"),
-               lte(transactions.dueDate, horizon),
-            ),
-         )
-         .limit(50),
-      () => WebAppError.internal("Falha ao carregar vencimentos."),
-   ).andThen((rows) => {
+   const rows = await Result.tryPromise({
+      try: () =>
+         db
+            .select({
+               id: transactions.id,
+               name: transactions.name,
+               dueDate: transactions.dueDate,
+               type: transactions.type,
+               amount: transactions.amount,
+            })
+            .from(transactions)
+            .where(
+               and(
+                  eq(transactions.teamId, teamId),
+                  eq(transactions.ignored, false),
+                  eq(transactions.status, "pending"),
+                  lte(transactions.dueDate, horizon),
+               ),
+            )
+            .limit(50),
+      catch: () =>
+         new InboxError({
+            error: inboxSourceErrors.LOAD_FAILED({ internal: { teamId } }),
+            message: "Falha ao carregar vencimentos.",
+            teamId,
+         }),
+   });
+
+   return rows.map((loadedRows) => {
       const today = dayjs().startOf("day");
-      const items = rows
-         .filter((r) => r.dueDate)
-         .map<InboxItemDto>((r) => {
-            const due = dayjs(r.dueDate as string);
+      return loadedRows
+         .filter((row) => row.dueDate)
+         .map<InboxItemDto>((row) => {
+            const due = dayjs(row.dueDate);
             const daysUntil = due.diff(today, "day");
             const formatted = due.format("DD/MM/YYYY");
-            const itemKey = `due:transaction:${r.id}`;
-            const verb = r.type === "income" ? "Receber" : "Pagar";
+            const itemKey = `due:transaction:${row.id}`;
+            const verb = row.type === "income" ? "Receber" : "Pagar";
             return {
                id: itemKey,
                itemKey,
                source: "due",
                severity: severityFor(daysUntil),
-               title: r.name?.trim()
-                  ? `${verb}: ${r.name}`
-                  : `${verb} R$ ${r.amount}`,
+               title: row.name?.trim()
+                  ? `${verb}: ${row.name}`
+                  : `${verb} R$ ${row.amount}`,
                description: describe(daysUntil, formatted),
-               occurredAt: due.toDate().toISOString(),
+               occurredAt: due.toISOString(),
                readAt: null,
                isPersisted: false,
-               entity: { type: "transaction", id: r.id },
+               entity: { type: "transaction", id: row.id },
                actions: [
                   {
                      kind: "navigate",
                      label: "Ver transação",
-                     payload: { route: "transactions", id: r.id },
+                     payload: { route: "transactions", id: row.id },
                   },
                ],
             };
          });
-      return ok(items);
    });
 }

--- a/modules/inbox/src/services/sources/uncategorized-tx.ts
+++ b/modules/inbox/src/services/sources/uncategorized-tx.ts
@@ -1,27 +1,61 @@
 import dayjs from "dayjs";
+import { Result, TaggedError, type Result as ResultType } from "better-result";
+import { defineErrorCatalog } from "evlog";
 import { and, count, eq, isNull } from "drizzle-orm";
-import { fromPromise, ok } from "neverthrow";
 import type { DatabaseInstance } from "@core/database/client";
-import { WebAppError } from "@core/logging/errors";
 import { transactions } from "@core/database/schemas/transactions";
 import type { InboxItemDto } from "@modules/inbox/schemas/inbox-item";
 
-export function fetchUncategorized(db: DatabaseInstance, teamId: string) {
-   return fromPromise(
-      db
-         .select({ total: count() })
-         .from(transactions)
-         .where(
-            and(
-               eq(transactions.teamId, teamId),
-               eq(transactions.ignored, false),
-               isNull(transactions.categoryId),
+const inboxSourceErrors = defineErrorCatalog("inbox.source.uncategorized", {
+   LOAD_FAILED: {
+      status: 500,
+      message: "Falha ao carregar transações sem categoria.",
+      tags: ["inbox", "uncategorized"],
+   },
+});
+
+declare module "evlog" {
+   interface RegisteredErrorCatalogs {
+      "inbox.source.uncategorized": typeof inboxSourceErrors;
+   }
+}
+
+type InboxCatalogError = ReturnType<typeof inboxSourceErrors.LOAD_FAILED>;
+
+export class InboxError extends TaggedError("InboxError")<{
+   error: InboxCatalogError;
+   message: string;
+   teamId: string;
+}>() {}
+
+export async function fetchUncategorized(
+   db: DatabaseInstance,
+   teamId: string,
+): Promise<ResultType<InboxItemDto[], InboxError>> {
+   const rows = await Result.tryPromise({
+      try: () =>
+         db
+            .select({ total: count() })
+            .from(transactions)
+            .where(
+               and(
+                  eq(transactions.teamId, teamId),
+                  eq(transactions.ignored, false),
+                  isNull(transactions.categoryId),
+               ),
             ),
-         ),
-      () => WebAppError.internal("Falha ao carregar transações sem categoria."),
-   ).andThen((rows) => {
-      const total = Number(rows[0]?.total ?? 0);
-      if (total === 0) return ok([] as InboxItemDto[]);
+      catch: () =>
+         new InboxError({
+            error: inboxSourceErrors.LOAD_FAILED({ internal: { teamId } }),
+            message: "Falha ao carregar transações sem categoria.",
+            teamId,
+         }),
+   });
+
+   return rows.map((loadedRows) => {
+      const total = Number(loadedRows[0]?.total ?? 0);
+      if (total === 0) return [];
+
       const itemKey = "uncategorized:summary";
       const item: InboxItemDto = {
          id: itemKey,
@@ -31,7 +65,7 @@ export function fetchUncategorized(db: DatabaseInstance, teamId: string) {
          title: `${total} ${total === 1 ? "transação sem categoria" : "transações sem categoria"}`,
          description:
             "Categorize para melhorar análises e relatórios financeiros.",
-         occurredAt: dayjs().toDate().toISOString(),
+         occurredAt: dayjs().toISOString(),
          readAt: null,
          isPersisted: false,
          entity: { type: "team", id: teamId },
@@ -43,6 +77,6 @@ export function fetchUncategorized(db: DatabaseInstance, teamId: string) {
             },
          ],
       };
-      return ok([item]);
+      return [item];
    });
 }


### PR DESCRIPTION
## Resumo
- migra modules/inbox de neverthrow para better-result
- adiciona catálogos evlog locais e InboxError tipado
- atualiza aggregate/sources/router para Result.tryPromise e Result.gen

## Validação
- rg "neverthrow" modules/inbox/src
- bun run typecheck
- bun run check (0 erros; warnings existentes fora do escopo)
