### PR TITLE
refactor(transactions): migrate to TanStack DB collections

### DIFF
--- a/apps/web/src/integrations/tanstack-db/categories.ts
+++ b/apps/web/src/integrations/tanstack-db/categories.ts
@@ -11,7 +11,7 @@ import { orpc, type Inputs, type Outputs } from "@/integrations/orpc/client";
 export type CategoriesCollectionRow = Outputs["categories"]["getAll"][number];
 
 type CategoriesCollectionInput = Inputs["categories"]["getAll"];
-type CategoryCreateInput = Inputs["categories"]["create"];
+export type CategoryCreateInput = Inputs["categories"]["create"];
 type CategoryUpdateInput = Inputs["categories"]["update"];
 type CategoryImportInput = Inputs["categoriesBulk"]["importBatch"];
 

--- a/apps/web/src/integrations/tanstack-db/transactions.ts
+++ b/apps/web/src/integrations/tanstack-db/transactions.ts
@@ -258,6 +258,7 @@ export function buildOptimisticTransactionRow({
    bankAccountName,
    categoryName,
    creditCardName,
+   tagName,
 }: {
    id: string;
    input: TransactionCreateInput;
@@ -265,6 +266,7 @@ export function buildOptimisticTransactionRow({
    bankAccountName?: string | null;
    categoryName?: string | null;
    creditCardName?: string | null;
+   tagName?: string | null;
 }): TransactionsCollectionRow {
    const now = dayjs().toDate();
    return {
@@ -292,7 +294,7 @@ export function buildOptimisticTransactionRow({
       recurrenceOccurrenceNumber: null,
       paidAt: input.paidAt ?? null,
       statementPeriod: input.statementPeriod ?? null,
-      tagId: null,
+      tagId: input.tagId ?? null,
       suggestedTagId: null,
       createdAt: now,
       updatedAt: now,
@@ -300,7 +302,7 @@ export function buildOptimisticTransactionRow({
       creditCardName: creditCardName ?? null,
       bankAccountName: bankAccountName ?? null,
       suggestedCategoryName: null,
-      tagName: null,
+      tagName: tagName ?? null,
       suggestedTagName: null,
    };
 }
@@ -422,11 +424,12 @@ export function updateTransactionAction(collection: TransactionsCollection) {
                draft.bankAccountName = patch.bankAccountName;
             if (patch.categoryId !== undefined) {
                draft.categoryId = patch.categoryId;
+               draft.categoryName = patch.categoryName ?? null;
                draft.suggestedCategoryId = null;
                draft.suggestedCategoryName = null;
-            }
-            if (patch.categoryName !== undefined)
+            } else if (patch.categoryName !== undefined) {
                draft.categoryName = patch.categoryName;
+            }
             if (patch.creditCardId !== undefined)
                draft.creditCardId = patch.creditCardId;
             if (patch.creditCardName !== undefined)
@@ -490,6 +493,7 @@ export function bulkUpdateTransactionsAction(
                }
                if (patch.categoryId !== undefined) {
                   draft.categoryId = patch.categoryId;
+                  draft.categoryName = null;
                   draft.suggestedCategoryId = null;
                   draft.suggestedCategoryName = null;
                }

--- a/apps/web/src/integrations/tanstack-db/transactions.ts
+++ b/apps/web/src/integrations/tanstack-db/transactions.ts
@@ -1,0 +1,671 @@
+import dayjs from "dayjs";
+import {
+   parseOrderByExpression,
+   parseWhereExpression,
+   queryCollectionOptions,
+} from "@tanstack/query-db-collection";
+import type { QueryClient } from "@tanstack/query-core";
+import { createOptimisticAction } from "@tanstack/react-db";
+import type { Collection, LoadSubsetOptions } from "@tanstack/react-db";
+import { orpc, type Inputs, type Outputs } from "@/integrations/orpc/client";
+
+export type TransactionsCollectionRow =
+   Outputs["transactions"]["getAll"]["data"][number];
+
+export type TransactionCreateInput = Inputs["transactions"]["create"];
+export type TransactionUpdateInput = Inputs["transactions"]["update"];
+export type TransactionImportBulkInput = Inputs["transactions"]["importBulk"];
+
+type TransactionsCollectionInput = NonNullable<
+   Inputs["transactions"]["getAll"]
+>;
+
+type TransactionSortId = NonNullable<
+   TransactionsCollectionInput["sorting"]
+>[number]["id"];
+
+type TransactionsCollectionOptionsParams = {
+   queryClient: QueryClient;
+   teamId: string;
+   search?: string;
+   view?: "all" | "payable" | "receivable" | "settled" | "ignored";
+   overdueOnly?: boolean;
+   status?: Array<"pending" | "paid">;
+   bankAccountId?: string;
+};
+
+type TransactionsPageInfoCollectionOptionsParams = {
+   queryClient: QueryClient;
+   teamId: string;
+   search?: string;
+   view?: "all" | "payable" | "receivable" | "settled" | "ignored";
+   overdueOnly?: boolean;
+   status?: Array<"pending" | "paid">;
+   bankAccountId?: string;
+};
+
+type TransactionCreateActionInput = {
+   row: TransactionsCollectionRow;
+   input: TransactionCreateInput;
+};
+
+type TransactionsWhereInput = {
+   bankAccountId?: string;
+   overdueOnly?: boolean;
+   search?: string;
+   status?: Array<"pending" | "paid">;
+   view?: "all" | "payable" | "receivable" | "settled" | "ignored";
+};
+
+type TransactionUpdateActionInput = {
+   id: string;
+   patch: Omit<TransactionUpdateInput, "id"> &
+      Partial<
+         Pick<
+            TransactionsCollectionRow,
+            | "bankAccountName"
+            | "categoryName"
+            | "creditCardName"
+            | "suggestedCategoryName"
+            | "suggestedTagName"
+            | "tagName"
+         >
+      >;
+};
+
+type TransactionBulkUpdateActionInput = {
+   ids: string[];
+   patch: Omit<Inputs["transactions"]["bulkUpdate"], "ids">;
+};
+
+type TransactionIdActionInput = {
+   id: string;
+};
+
+type TransactionMarkAsPaidActionInput = Inputs["transactions"]["markAsPaid"];
+
+type TransactionImportActionInput = {
+   rows: TransactionsCollectionRow[];
+   input: TransactionImportBulkInput;
+};
+
+type TransactionsCollection = Collection<TransactionsCollectionRow, string>;
+
+function cleanSearchPattern(value: unknown) {
+   if (typeof value !== "string") return undefined;
+   const cleaned = value
+      .replace(/^%+|%+$/g, "")
+      .replace(/\\([\\%_])/g, "$1")
+      .trim();
+   return cleaned || undefined;
+}
+
+function parseTransactionStatus(value: unknown) {
+   if (value === "pending" || value === "paid") return value;
+   return undefined;
+}
+
+function parseTransactionView(value: unknown) {
+   if (
+      value === "all" ||
+      value === "payable" ||
+      value === "receivable" ||
+      value === "settled" ||
+      value === "ignored"
+   ) {
+      return value;
+   }
+   return undefined;
+}
+
+function mergeWhere(filters: TransactionsWhereInput[]): TransactionsWhereInput {
+   return filters.reduce((acc, filter) => ({ ...acc, ...filter }), {});
+}
+
+function parseTransactionsWhere(options: LoadSubsetOptions | undefined) {
+   return (
+      parseWhereExpression<TransactionsWhereInput>(options?.where, {
+         handlers: {
+            eq: (field: Array<string | number>, value: unknown) => {
+               const key = field.join(".");
+               if (key === "bankAccountId" && typeof value === "string") {
+                  return { bankAccountId: value };
+               }
+               if (key === "view") return { view: parseTransactionView(value) };
+               if (key === "overdueOnly" && value === true) {
+                  return { overdueOnly: true };
+               }
+               if (key === "status") {
+                  const parsed = parseTransactionStatus(value);
+                  return parsed ? { status: [parsed] } : {};
+               }
+               return {};
+            },
+            ilike: (field: Array<string | number>, value: unknown) => {
+               const key = field.join(".");
+               if (key !== "name" && key !== "description") return {};
+               return { search: cleanSearchPattern(value) };
+            },
+            and: (...filters: TransactionsWhereInput[]) => mergeWhere(filters),
+            or: (...filters: TransactionsWhereInput[]) => {
+               const search = filters.find((filter) => filter.search)?.search;
+               const statuses = filters.flatMap(
+                  (filter) => filter.status ?? [],
+               );
+               if (search) return { search };
+               if (statuses.length > 0) return { status: statuses };
+               return {};
+            },
+         },
+         onUnknownOperator: () => ({}),
+      }) ?? {}
+   );
+}
+
+function parseTransactionSortId(value: string): TransactionSortId | undefined {
+   switch (value) {
+      case "amount":
+      case "bankAccountName":
+      case "categoryName":
+      case "creditCardName":
+      case "date":
+      case "dueDate":
+      case "name":
+      case "status":
+      case "type":
+         return value;
+   }
+}
+
+function parseTransactionsSorting(options: LoadSubsetOptions | undefined) {
+   return parseOrderByExpression(options?.orderBy)
+      .map((sort) => {
+         const id = parseTransactionSortId(sort.field.join("."));
+         if (!id) return undefined;
+         return { id, desc: sort.direction === "desc" };
+      })
+      .filter((sort) => sort !== undefined);
+}
+
+function transactionsInputFromLoadSubsetOptions(
+   options: LoadSubsetOptions | undefined,
+   base: Omit<
+      TransactionsCollectionOptionsParams,
+      "queryClient" | "teamId"
+   > = {},
+): TransactionsCollectionInput {
+   const where = parseTransactionsWhere(options);
+   const sorting = parseTransactionsSorting(options);
+   const limit = options?.limit;
+   const input: TransactionsCollectionInput = {
+      page: 1,
+      pageSize: 1000,
+      search: where.search ?? base.search,
+      view: where.view ?? base.view,
+      overdueOnly: where.overdueOnly ?? base.overdueOnly,
+      status:
+         where.status && where.status.length > 0 ? where.status : base.status,
+      bankAccountId: where.bankAccountId ?? base.bankAccountId,
+      sorting,
+   };
+
+   if (limit !== undefined) {
+      const pageSize = Math.min(1000, Math.max(1, limit));
+      const offset = options?.offset ?? 0;
+      input.page = Math.floor(offset / pageSize) + 1;
+      input.pageSize = pageSize;
+   }
+
+   return input;
+}
+
+function hasLoadSubsetOptions(options: LoadSubsetOptions | undefined) {
+   return Boolean(
+      options?.where ||
+      options?.orderBy?.length ||
+      options?.limit !== undefined ||
+      options?.offset !== undefined,
+   );
+}
+
+async function safeRefetchTransactions(collection: TransactionsCollection) {
+   await collection.utils.refetch().catch(() => {});
+}
+
+export function buildOptimisticTransactionRowId(prefix = "__transaction_") {
+   if (typeof crypto !== "undefined") {
+      if (typeof crypto.randomUUID === "function") {
+         return `${prefix}${crypto.randomUUID()}`;
+      }
+
+      if (typeof crypto.getRandomValues === "function") {
+         const bytes = new Uint8Array(16);
+         crypto.getRandomValues(bytes);
+         const hex = Array.from(bytes, (byte) =>
+            byte.toString(16).padStart(2, "0"),
+         ).join("");
+         return `${prefix}${hex}`;
+      }
+   }
+
+   return `${prefix}${dayjs().valueOf().toString(36)}`;
+}
+
+export function buildOptimisticTransactionRow({
+   id,
+   input,
+   teamId,
+   bankAccountName,
+   categoryName,
+   creditCardName,
+}: {
+   id: string;
+   input: TransactionCreateInput;
+   teamId: string;
+   bankAccountName?: string | null;
+   categoryName?: string | null;
+   creditCardName?: string | null;
+}): TransactionsCollectionRow {
+   const now = dayjs().toDate();
+   return {
+      id,
+      teamId,
+      name: input.name ?? null,
+      type: input.type,
+      amount: input.amount,
+      description: input.description ?? null,
+      date: input.date,
+      bankAccountId: input.bankAccountId ?? null,
+      destinationBankAccountId: input.destinationBankAccountId ?? null,
+      creditCardId: input.creditCardId ?? null,
+      categoryId: input.categoryId ?? null,
+      suggestedCategoryId: null,
+      attachments: input.attachments ?? null,
+      paymentMethod: input.paymentMethod ?? null,
+      status: input.status ?? "paid",
+      ignored: input.ignored ?? false,
+      dueDate: input.dueDate ?? null,
+      installmentGroupId: null,
+      installmentNumber: null,
+      installmentCount: null,
+      recurrenceId: null,
+      recurrenceOccurrenceNumber: null,
+      paidAt: input.paidAt ?? null,
+      statementPeriod: input.statementPeriod ?? null,
+      tagId: null,
+      suggestedTagId: null,
+      createdAt: now,
+      updatedAt: now,
+      categoryName: categoryName ?? null,
+      creditCardName: creditCardName ?? null,
+      bankAccountName: bankAccountName ?? null,
+      suggestedCategoryName: null,
+      tagName: null,
+      suggestedTagName: null,
+   };
+}
+
+export function transactionsCollectionOptions({
+   queryClient,
+   teamId,
+   search,
+   view,
+   overdueOnly,
+   status,
+   bankAccountId,
+}: TransactionsCollectionOptionsParams) {
+   const base = { search, view, overdueOnly, status, bankAccountId };
+   return queryCollectionOptions({
+      id: [
+         "transactions",
+         teamId,
+         search ?? "",
+         view ?? "all",
+         overdueOnly ? "overdue" : "all-dates",
+         status?.join(",") ?? "all-status",
+         bankAccountId ?? "all-accounts",
+      ].join(":"),
+      queryKey: (options) =>
+         hasLoadSubsetOptions(options)
+            ? [
+                 "transactions",
+                 teamId,
+                 transactionsInputFromLoadSubsetOptions(options, base),
+              ]
+            : ["transactions", teamId, base],
+      queryFn: async (ctx) => {
+         const result = await orpc.transactions.getAll.call(
+            transactionsInputFromLoadSubsetOptions(
+               ctx.meta?.loadSubsetOptions,
+               base,
+            ),
+         );
+         return result.data;
+      },
+      queryClient,
+      getKey: (transaction: TransactionsCollectionRow) => transaction.id,
+      meta: {
+         notifyOnError: true,
+         errorMessage: "Não foi possível sincronizar os lançamentos.",
+      },
+      refetchInterval: 5_000,
+      syncMode: "on-demand",
+   });
+}
+
+export type TransactionsPageInfoCollectionRow = {
+   id: string;
+   total: number;
+};
+
+export function transactionsPageInfoCollectionOptions({
+   queryClient,
+   teamId,
+   search,
+   view,
+   overdueOnly,
+   status,
+   bankAccountId,
+}: TransactionsPageInfoCollectionOptionsParams) {
+   const id = [
+      teamId,
+      search ?? "",
+      view ?? "all",
+      overdueOnly ? "overdue" : "all-dates",
+      status?.join(",") ?? "all-status",
+      bankAccountId ?? "all-accounts",
+   ].join(":");
+   return queryCollectionOptions({
+      id: `transactions-page-info:${id}`,
+      queryKey: () => [
+         "transactions",
+         teamId,
+         "page-info",
+         search,
+         view,
+         overdueOnly,
+         status,
+         bankAccountId,
+      ],
+      queryFn: async () => {
+         const result = await orpc.transactions.getAll.call({
+            page: 1,
+            pageSize: 1,
+            search,
+            view,
+            overdueOnly,
+            status,
+            bankAccountId,
+         });
+         return [{ id, total: result.total }];
+      },
+      queryClient,
+      getKey: (row: TransactionsPageInfoCollectionRow) => row.id,
+      meta: {
+         notifyOnError: true,
+         errorMessage: "Não foi possível sincronizar os lançamentos.",
+      },
+      refetchInterval: 5_000,
+   });
+}
+
+export function updateTransactionAction(collection: TransactionsCollection) {
+   return createOptimisticAction<TransactionUpdateActionInput>({
+      onMutate: ({ id, patch }) => {
+         collection.update(id, (draft) => {
+            if (patch.amount !== undefined) draft.amount = patch.amount;
+            if (patch.attachments !== undefined)
+               draft.attachments = patch.attachments;
+            if (patch.bankAccountId !== undefined)
+               draft.bankAccountId = patch.bankAccountId;
+            if (patch.bankAccountName !== undefined)
+               draft.bankAccountName = patch.bankAccountName;
+            if (patch.categoryId !== undefined) {
+               draft.categoryId = patch.categoryId;
+               draft.suggestedCategoryId = null;
+               draft.suggestedCategoryName = null;
+            }
+            if (patch.categoryName !== undefined)
+               draft.categoryName = patch.categoryName;
+            if (patch.creditCardId !== undefined)
+               draft.creditCardId = patch.creditCardId;
+            if (patch.creditCardName !== undefined)
+               draft.creditCardName = patch.creditCardName;
+            if (patch.date !== undefined) draft.date = patch.date;
+            if (patch.description !== undefined)
+               draft.description = patch.description;
+            if (patch.destinationBankAccountId !== undefined) {
+               draft.destinationBankAccountId = patch.destinationBankAccountId;
+            }
+            if (patch.dueDate !== undefined) draft.dueDate = patch.dueDate;
+            if (patch.ignored !== undefined) draft.ignored = patch.ignored;
+            if (patch.name !== undefined) draft.name = patch.name;
+            if (patch.paidAt !== undefined) draft.paidAt = patch.paidAt;
+            if (patch.paymentMethod !== undefined)
+               draft.paymentMethod = patch.paymentMethod;
+            if (patch.statementPeriod !== undefined) {
+               draft.statementPeriod = patch.statementPeriod;
+            }
+            if (patch.status !== undefined) draft.status = patch.status;
+            if (patch.tagId !== undefined) {
+               draft.tagId = patch.tagId;
+               draft.suggestedTagId = null;
+               draft.suggestedTagName = null;
+            }
+            if (patch.tagName !== undefined) draft.tagName = patch.tagName;
+            if (patch.type !== undefined) draft.type = patch.type;
+            draft.updatedAt = dayjs().toDate();
+         });
+      },
+      mutationFn: async ({ id, patch }) => {
+         const updated = await orpc.transactions.update.call({ id, ...patch });
+         await safeRefetchTransactions(collection);
+         return updated;
+      },
+   });
+}
+
+export function createTransactionAction(collection: TransactionsCollection) {
+   return createOptimisticAction<TransactionCreateActionInput>({
+      onMutate: ({ row }) => {
+         collection.insert(row);
+      },
+      mutationFn: async ({ input }) => {
+         const created = await orpc.transactions.create.call(input);
+         await safeRefetchTransactions(collection);
+         return created;
+      },
+   });
+}
+
+export function bulkUpdateTransactionsAction(
+   collection: TransactionsCollection,
+) {
+   return createOptimisticAction<TransactionBulkUpdateActionInput>({
+      onMutate: ({ ids, patch }) => {
+         collection.update(ids, (drafts) => {
+            for (const draft of drafts) {
+               if (patch.bankAccountId !== undefined) {
+                  draft.bankAccountId = patch.bankAccountId;
+               }
+               if (patch.categoryId !== undefined) {
+                  draft.categoryId = patch.categoryId;
+                  draft.suggestedCategoryId = null;
+                  draft.suggestedCategoryName = null;
+               }
+               if (patch.date !== undefined) draft.date = patch.date;
+               if (patch.dueDate !== undefined) draft.dueDate = patch.dueDate;
+               if (patch.ignored !== undefined) draft.ignored = patch.ignored;
+               if (patch.status !== undefined) draft.status = patch.status;
+               draft.updatedAt = dayjs().toDate();
+            }
+         });
+      },
+      mutationFn: async ({ ids, patch }) => {
+         const updated = await orpc.transactions.bulkUpdate.call({
+            ids,
+            ...patch,
+         });
+         await safeRefetchTransactions(collection);
+         return updated;
+      },
+   });
+}
+
+export function removeTransactionAction(collection: TransactionsCollection) {
+   return createOptimisticAction<TransactionIdActionInput>({
+      onMutate: ({ id }) => {
+         collection.delete(id);
+      },
+      mutationFn: async ({ id }) => {
+         const removed = await orpc.transactions.remove.call({ id });
+         await safeRefetchTransactions(collection);
+         return removed;
+      },
+   });
+}
+
+export function bulkRemoveTransactionsAction(
+   collection: TransactionsCollection,
+) {
+   return createOptimisticAction<{ ids: string[] }>({
+      onMutate: ({ ids }) => {
+         collection.delete(ids);
+      },
+      mutationFn: async ({ ids }) => {
+         const removed = await orpc.transactions.bulkRemove.call({ ids });
+         await safeRefetchTransactions(collection);
+         return removed;
+      },
+   });
+}
+
+export function markTransactionAsPaidAction(
+   collection: TransactionsCollection,
+) {
+   return createOptimisticAction<TransactionMarkAsPaidActionInput>({
+      onMutate: ({ id, paidDate, bankAccountId }) => {
+         collection.update(id, (draft) => {
+            draft.status = "paid";
+            draft.ignored = false;
+            draft.paidAt = dayjs().toDate();
+            draft.date = paidDate ?? dayjs().format("YYYY-MM-DD");
+            if (bankAccountId !== undefined)
+               draft.bankAccountId = bankAccountId;
+         });
+      },
+      mutationFn: async (input) => {
+         const updated = await orpc.transactions.markAsPaid.call(input);
+         await safeRefetchTransactions(collection);
+         return updated;
+      },
+   });
+}
+
+export function markTransactionAsUnpaidAction(
+   collection: TransactionsCollection,
+) {
+   return createOptimisticAction<TransactionIdActionInput>({
+      onMutate: ({ id }) => {
+         collection.update(id, (draft) => {
+            draft.status = "pending";
+            draft.ignored = false;
+            draft.paidAt = null;
+         });
+      },
+      mutationFn: async ({ id }) => {
+         const updated = await orpc.transactions.markAsUnpaid.call({ id });
+         await safeRefetchTransactions(collection);
+         return updated;
+      },
+   });
+}
+
+export function cancelTransactionAction(collection: TransactionsCollection) {
+   return createOptimisticAction<TransactionIdActionInput>({
+      onMutate: ({ id }) => {
+         collection.update(id, (draft) => {
+            draft.ignored = true;
+         });
+      },
+      mutationFn: async ({ id }) => {
+         const updated = await orpc.transactions.cancel.call({ id });
+         await safeRefetchTransactions(collection);
+         return updated;
+      },
+   });
+}
+
+export function reactivateTransactionAction(
+   collection: TransactionsCollection,
+) {
+   return createOptimisticAction<TransactionIdActionInput>({
+      onMutate: ({ id }) => {
+         collection.update(id, (draft) => {
+            draft.ignored = false;
+         });
+      },
+      mutationFn: async ({ id }) => {
+         const updated = await orpc.transactions.reactivate.call({ id });
+         await safeRefetchTransactions(collection);
+         return updated;
+      },
+   });
+}
+
+export function importTransactionsAction(collection: TransactionsCollection) {
+   return createOptimisticAction<TransactionImportActionInput>({
+      onMutate: ({ rows }) => {
+         collection.insert(rows);
+      },
+      mutationFn: async ({ input }) => {
+         const imported = await orpc.transactions.importBulk.call(input);
+         await safeRefetchTransactions(collection);
+         return imported;
+      },
+   });
+}
+
+export function acceptSuggestedTransactionCategoryAction(
+   collection: TransactionsCollection,
+) {
+   return createOptimisticAction<TransactionIdActionInput>({
+      onMutate: ({ id }) => {
+         collection.update(id, (draft) => {
+            draft.categoryId = draft.suggestedCategoryId;
+            draft.categoryName = draft.suggestedCategoryName;
+            draft.suggestedCategoryId = null;
+            draft.suggestedCategoryName = null;
+            draft.updatedAt = dayjs().toDate();
+         });
+      },
+      mutationFn: async ({ id }) => {
+         const updated = await orpc.transactions.acceptSuggestedCategory.call({
+            id,
+         });
+         await safeRefetchTransactions(collection);
+         return updated;
+      },
+   });
+}
+
+export function dismissSuggestedTransactionCategoryAction(
+   collection: TransactionsCollection,
+) {
+   return createOptimisticAction<TransactionIdActionInput>({
+      onMutate: ({ id }) => {
+         collection.update(id, (draft) => {
+            draft.suggestedCategoryId = null;
+            draft.suggestedCategoryName = null;
+            draft.updatedAt = dayjs().toDate();
+         });
+      },
+      mutationFn: async ({ id }) => {
+         const updated = await orpc.transactions.dismissSuggestedCategory.call({
+            id,
+         });
+         await safeRefetchTransactions(collection);
+         return updated;
+      },
+   });
+}

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-form-sheet.tsx
@@ -47,7 +47,6 @@ import { useUploadFiles } from "@better-upload/client";
 import imageCompression from "browser-image-compression";
 import { format, of } from "@f-o-t/money";
 import { useForm } from "@tanstack/react-form";
-import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import dayjs from "dayjs";
 import {
    CheckIcon,
@@ -57,17 +56,23 @@ import {
    CornerDownRight,
    FileText,
 } from "lucide-react";
-import { fromPromise } from "neverthrow";
 import * as React from "react";
 import { z } from "zod";
-import { QueryBoundary } from "@/components/query-boundary";
 import { useSheet } from "@/hooks/use-sheet";
-import { orpc } from "@/integrations/orpc/client";
 import type { Outputs } from "@/integrations/orpc/client";
+import type { TransactionCreateInput } from "@/integrations/tanstack-db/transactions";
 import { buildInstallmentPreview } from "@/utils/finance/installments";
 import { CATEGORY_ICON_MAP } from "../-categories/category-icons";
 
 type CategoryNode = Outputs["categories"]["getAll"][number];
+
+type BankAccountNode = Outputs["bankAccounts"]["getAll"][number];
+
+type TransactionFormSheetProps = {
+   bankAccounts: BankAccountNode[];
+   categories: CategoryNode[];
+   onCreate: (input: TransactionCreateInput) => Promise<boolean>;
+};
 
 const TRANSACTION_TYPES = ["income", "expense", "transfer"] as const;
 type TransactionType = (typeof TRANSACTION_TYPES)[number];
@@ -628,90 +633,67 @@ function CategoryPicker({
    );
 }
 
-export function TransactionFormSheet() {
-   return (
-      <QueryBoundary
-         fallback={
-            <div className="flex flex-col gap-4 p-4">
-               <SheetHeader>
-                  <SheetTitle>Novo lançamento</SheetTitle>
-                  <SheetDescription>Carregando dados...</SheetDescription>
-               </SheetHeader>
-            </div>
-         }
-         errorTitle="Erro ao carregar dados"
-      >
-         <TransactionFormSheetContent />
-      </QueryBoundary>
-   );
-}
-
-function TransactionFormSheetContent() {
+export function TransactionFormSheet({
+   bankAccounts,
+   categories,
+   onCreate,
+}: TransactionFormSheetProps) {
    const { closeTopSheet } = useSheet();
-
-   const { data: bankAccounts } = useSuspenseQuery(
-      orpc.bankAccounts.getAll.queryOptions({}),
-   );
-   const { data: categoriesResult } = useSuspenseQuery(
-      orpc.categories.getAll.queryOptions({}),
-   );
 
    const bankOptions = bankAccounts.map((b) => ({
       value: b.id,
       label: b.name,
    }));
 
-   const createMutation = useMutation(
-      orpc.transactions.create.mutationOptions({
-         onSuccess: () => {
+   const submitCreate = React.useCallback(
+      async (input: TransactionCreateInput) => {
+         const created = await onCreate(input);
+         if (created) {
             toast.success("Lançamento criado com sucesso.");
             closeTopSheet();
-         },
-         onError: (e) => toast.error(e.message),
-      }),
+         }
+      },
+      [closeTopSheet, onCreate],
    );
+
    const form = useForm({
       defaultValues: DEFAULT_VALUES,
       validators: { onMount: formSchema, onChange: formSchema },
       onSubmit: async ({ value }) => {
          const attachments = value.attachments;
-         const result = await fromPromise(
-            createMutation.mutateAsync({
-               type: value.type,
-               name: value.name.trim(),
-               amount: String(value.amount),
-               date: value.date,
-               status: value.status,
-               ignored: value.ignored,
-               isInstallment:
-                  value.type !== "transfer" && !value.isRecurring
-                     ? value.isInstallment
-                     : false,
-               installmentCount:
-                  value.type !== "transfer" &&
-                  !value.isRecurring &&
-                  value.isInstallment
-                     ? value.installmentCount
-                     : undefined,
-               isRecurring: value.isRecurring,
-               recurrenceFrequency: value.isRecurring
-                  ? value.recurrenceFrequency
+         await submitCreate({
+            type: value.type,
+            name: value.name.trim(),
+            amount: String(value.amount),
+            date: value.date,
+            status: value.status,
+            ignored: value.ignored,
+            isInstallment:
+               value.type !== "transfer" && !value.isRecurring
+                  ? value.isInstallment
+                  : false,
+            installmentCount:
+               value.type !== "transfer" &&
+               !value.isRecurring &&
+               value.isInstallment
+                  ? value.installmentCount
                   : undefined,
-               dueDate: value.dueDate || null,
-               bankAccountId: value.bankAccountId || null,
-               destinationBankAccountId:
-                  value.type === "transfer"
-                     ? value.destinationBankAccountId || null
-                     : null,
-               categoryId:
-                  value.type === "transfer" ? null : value.categoryId || null,
-               attachments,
-               description: value.description.trim() || null,
-               paymentMethod: null,
-            }),
-            (e) => e,
-         );
-         if (result.isErr()) return;
+            isRecurring: value.isRecurring,
+            recurrenceFrequency: value.isRecurring
+               ? value.recurrenceFrequency
+               : undefined,
+            dueDate: value.dueDate || null,
+            bankAccountId: value.bankAccountId || null,
+            destinationBankAccountId:
+               value.type === "transfer"
+                  ? value.destinationBankAccountId || null
+                  : null,
+            categoryId:
+               value.type === "transfer" ? null : value.categoryId || null,
+            attachments,
+            description: value.description.trim() || null,
+            paymentMethod: null,
+         });
       },
    });
 
@@ -809,7 +791,7 @@ function TransactionFormSheetContent() {
 
             <form.Subscribe selector={(s) => s.values.type}>
                {(type) => {
-                  const filteredCategories = categoriesResult.filter((c) =>
+                  const filteredCategories = categories.filter((c) =>
                      type === "transfer"
                         ? false
                         : type === "income"

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-form-sheet.tsx
@@ -43,6 +43,7 @@ import { Textarea } from "@packages/ui/components/textarea";
 import { UploadDropzone } from "@packages/ui/components/upload-dropzone";
 import { UploadProgress } from "@packages/ui/components/upload-progress";
 import { cn } from "@packages/ui/lib/utils";
+import { Result } from "better-result";
 import { useUploadFiles } from "@better-upload/client";
 import imageCompression from "browser-image-compression";
 import { format, of } from "@f-o-t/money";
@@ -73,6 +74,19 @@ type TransactionFormSheetProps = {
    categories: CategoryNode[];
    onCreate: (input: TransactionCreateInput) => Promise<boolean>;
 };
+
+function getErrorMessage(error: unknown, fallback: string) {
+   if (
+      typeof error === "object" &&
+      error !== null &&
+      "message" in error &&
+      typeof error.message === "string" &&
+      error.message.length > 0
+   ) {
+      return error.message;
+   }
+   return fallback;
+}
 
 const TRANSACTION_TYPES = ["income", "expense", "transfer"] as const;
 type TransactionType = (typeof TRANSACTION_TYPES)[number];
@@ -647,11 +661,22 @@ export function TransactionFormSheet({
 
    const submitCreate = React.useCallback(
       async (input: TransactionCreateInput) => {
-         const created = await onCreate(input);
-         if (created) {
-            toast.success("Lançamento criado com sucesso.");
-            closeTopSheet();
+         const result = await Result.tryPromise({
+            try: () => onCreate(input),
+            catch: (error) => error,
+         });
+         if (Result.isError(result)) {
+            toast.error(
+               getErrorMessage(result.error, "Erro ao criar lançamento."),
+            );
+            return;
          }
+         if (!result.value) {
+            toast.error("Não foi possível criar o lançamento.");
+            return;
+         }
+         toast.success("Lançamento criado com sucesso.");
+         closeTopSheet();
       },
       [closeTopSheet, onCreate],
    );

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-columns.tsx
@@ -1,3 +1,4 @@
+import { Result } from "better-result";
 import { format, of } from "@f-o-t/money";
 import dayjs from "dayjs";
 import { Badge } from "@packages/ui/components/badge";
@@ -13,6 +14,7 @@ import {
    TooltipTrigger,
 } from "@packages/ui/components/tooltip";
 import type { ColumnDef, Row } from "@tanstack/react-table";
+import { useState } from "react";
 import {
    ArrowUpDown,
    CalendarClock,
@@ -62,9 +64,34 @@ function SuggestedCategoryCell({
 }: {
    id: string;
    categoryName: string | null;
-   onAccept?: (id: string) => void;
-   onDismiss?: (id: string) => void;
+   onAccept?: (id: string) => void | Promise<void>;
+   onDismiss?: (id: string) => void | Promise<void>;
 }) {
+   const [pendingAction, setPendingAction] = useState<
+      "accept" | "dismiss" | null
+   >(null);
+   const isPending = pendingAction !== null;
+
+   async function handleAccept() {
+      if (isPending) return;
+      setPendingAction("accept");
+      await Result.tryPromise({
+         try: () => Promise.resolve(onAccept?.(id)),
+         catch: (error) => error,
+      });
+      setPendingAction(null);
+   }
+
+   async function handleDismiss() {
+      if (isPending) return;
+      setPendingAction("dismiss");
+      await Result.tryPromise({
+         try: () => Promise.resolve(onDismiss?.(id)),
+         catch: (error) => error,
+      });
+      setPendingAction(null);
+   }
+
    return (
       <Popover>
          <PopoverTrigger asChild>
@@ -83,17 +110,19 @@ function SuggestedCategoryCell({
                <Button
                   size="sm"
                   className="flex-1"
-                  onClick={() => onAccept?.(id)}
+                  disabled={isPending}
+                  onClick={handleAccept}
                >
-                  Aceitar
+                  {pendingAction === "accept" ? "Aceitando..." : "Aceitar"}
                </Button>
                <Button
                   size="sm"
                   variant="outline"
                   className="flex-1"
-                  onClick={() => onDismiss?.(id)}
+                  disabled={isPending}
+                  onClick={handleDismiss}
                >
-                  Ignorar
+                  {pendingAction === "dismiss" ? "Ignorando..." : "Ignorar"}
                </Button>
             </div>
          </PopoverContent>
@@ -109,8 +138,8 @@ export function buildTransactionColumns(options?: {
    onUpdateImport?: (index: number, patch: Record<string, unknown>) => void;
    onCreateBankAccount?: (name: string) => Promise<string>;
    onCreateCategory?: (name: string) => Promise<string>;
-   onAcceptSuggestedCategory?: (id: string) => void;
-   onDismissSuggestedCategory?: (id: string) => void;
+   onAcceptSuggestedCategory?: (id: string) => void | Promise<void>;
+   onDismissSuggestedCategory?: (id: string) => void | Promise<void>;
    getRowStatus?: (id: string) => string | undefined;
    logoDevToken?: string;
 }): ColumnDef<TransactionRow>[] {

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-columns.tsx
@@ -12,7 +12,6 @@ import {
    TooltipContent,
    TooltipTrigger,
 } from "@packages/ui/components/tooltip";
-import { useMutation } from "@tanstack/react-query";
 import type { ColumnDef, Row } from "@tanstack/react-table";
 import {
    ArrowUpDown,
@@ -30,7 +29,6 @@ import { InlineEditSelect } from "@/blocks/data-table/inline-edit/inline-edit-se
 import { InlineEditText } from "@/blocks/data-table/inline-edit/inline-edit-text";
 import { BankLogoAvatar } from "@/components/bank-logo-avatar";
 import type { Outputs } from "@/integrations/orpc/client";
-import { orpc } from "@/integrations/orpc/client";
 
 export type TransactionRow = Outputs["transactions"]["getAll"]["data"][number];
 
@@ -59,17 +57,14 @@ function isImportRow(row: Row<TransactionRow>): number | null {
 function SuggestedCategoryCell({
    id,
    categoryName,
+   onAccept,
+   onDismiss,
 }: {
    id: string;
    categoryName: string | null;
+   onAccept?: (id: string) => void;
+   onDismiss?: (id: string) => void;
 }) {
-   const accept = useMutation(
-      orpc.transactions.acceptSuggestedCategory.mutationOptions(),
-   );
-   const dismiss = useMutation(
-      orpc.transactions.dismissSuggestedCategory.mutationOptions(),
-   );
-
    return (
       <Popover>
          <PopoverTrigger asChild>
@@ -88,8 +83,7 @@ function SuggestedCategoryCell({
                <Button
                   size="sm"
                   className="flex-1"
-                  disabled={accept.isPending || dismiss.isPending}
-                  onClick={() => accept.mutate({ id })}
+                  onClick={() => onAccept?.(id)}
                >
                   Aceitar
                </Button>
@@ -97,8 +91,7 @@ function SuggestedCategoryCell({
                   size="sm"
                   variant="outline"
                   className="flex-1"
-                  disabled={accept.isPending || dismiss.isPending}
-                  onClick={() => dismiss.mutate({ id })}
+                  onClick={() => onDismiss?.(id)}
                >
                   Ignorar
                </Button>
@@ -116,6 +109,8 @@ export function buildTransactionColumns(options?: {
    onUpdateImport?: (index: number, patch: Record<string, unknown>) => void;
    onCreateBankAccount?: (name: string) => Promise<string>;
    onCreateCategory?: (name: string) => Promise<string>;
+   onAcceptSuggestedCategory?: (id: string) => void;
+   onDismissSuggestedCategory?: (id: string) => void;
    getRowStatus?: (id: string) => string | undefined;
    logoDevToken?: string;
 }): ColumnDef<TransactionRow>[] {
@@ -324,6 +319,8 @@ export function buildTransactionColumns(options?: {
                   <SuggestedCategoryCell
                      id={row.original.id}
                      categoryName={row.original.suggestedCategoryName ?? null}
+                     onAccept={options?.onAcceptSuggestedCategory}
+                     onDismiss={options?.onDismissSuggestedCategory}
                   />
                );
             }

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
@@ -30,10 +30,13 @@ import {
    useTableBulkActions,
 } from "@/hooks/use-selection-toolbar";
 import {
-   useMutation,
-   useQueryClient,
-   useSuspenseQuery,
-} from "@tanstack/react-query";
+   createCollection,
+   eq,
+   ilike,
+   lt,
+   or,
+   useLiveQuery,
+} from "@tanstack/react-db";
 import { getRouteApi } from "@tanstack/react-router";
 import {
    getCoreRowModel,
@@ -57,6 +60,7 @@ import {
    Trash2,
    Undo2,
 } from "lucide-react";
+import { Result } from "better-result";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { toast } from "@packages/ui/hooks/use-toast";
 import { DataTableBody } from "@/blocks/data-table/data-table-body";
@@ -81,7 +85,40 @@ import { useCsvFile } from "@/hooks/use-csv-file";
 import { useOfxFile } from "@/hooks/use-ofx-file";
 import { useXlsxFile } from "@/hooks/use-xlsx-file";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
-import { orpc } from "@/integrations/orpc/client";
+import { useActiveTeam } from "@/hooks/use-active-team";
+import {
+   bankAccountsCollectionOptions,
+   buildOptimisticBankAccountRow,
+   buildOptimisticBankAccountRowId,
+   createBankAccountAction,
+   type BankAccountCreateInput,
+} from "@/integrations/tanstack-db/bank-accounts";
+import {
+   categoriesCollectionOptions,
+   createCategoryAction,
+   type CategoryCreateInput,
+   type CategoriesCollectionRow,
+} from "@/integrations/tanstack-db/categories";
+import { creditCardsCollectionOptions } from "@/integrations/tanstack-db/credit-cards";
+import {
+   buildOptimisticTransactionRow,
+   buildOptimisticTransactionRowId,
+   acceptSuggestedTransactionCategoryAction,
+   bulkRemoveTransactionsAction,
+   bulkUpdateTransactionsAction,
+   cancelTransactionAction,
+   createTransactionAction,
+   dismissSuggestedTransactionCategoryAction,
+   importTransactionsAction,
+   markTransactionAsPaidAction,
+   markTransactionAsUnpaidAction,
+   reactivateTransactionAction,
+   removeTransactionAction,
+   transactionsCollectionOptions,
+   transactionsPageInfoCollectionOptions,
+   updateTransactionAction,
+   type TransactionCreateInput,
+} from "@/integrations/tanstack-db/transactions";
 import {
    buildTransactionColumns,
    type BankAccountOption,
@@ -220,9 +257,59 @@ function parseImportStatus(value: unknown): {
    return { status: "pending", ignored: false };
 }
 
+function getErrorMessage(error: unknown, fallback: string) {
+   if (
+      typeof error === "object" &&
+      error !== null &&
+      "message" in error &&
+      typeof error.message === "string" &&
+      error.message.length > 0
+   ) {
+      return error.message;
+   }
+   return fallback;
+}
+
+function escapeIlikePattern(value: string) {
+   return value
+      .replace(/\\/g, "\\\\")
+      .replace(/%/g, "\\%")
+      .replace(/_/g, "\\_");
+}
+
+function buildInlineCategoryRow({
+   id,
+   name,
+   teamId,
+}: {
+   id: string;
+   name: string;
+   teamId: string;
+}): CategoriesCollectionRow {
+   const now = dayjs().toDate();
+   return {
+      id,
+      teamId,
+      parentId: null,
+      name,
+      type: "expense",
+      level: 0,
+      description: null,
+      isDefault: false,
+      color: null,
+      icon: null,
+      isArchived: false,
+      notes: null,
+      participatesDre: true,
+      dreGroupId: null,
+      createdAt: now,
+      updatedAt: now,
+   };
+}
+
 export function TransactionsList() {
    const navigate = routeApi.useNavigate();
-   const { publicEnv } = routeApi.useRouteContext();
+   const { publicEnv, queryClient } = routeApi.useRouteContext();
    const {
       sorting,
       columnFilters,
@@ -238,7 +325,7 @@ export function TransactionsList() {
 
    const { openAlertDialog } = useAlertDialog();
    const { openSheet } = useSheet();
-   const queryClient = useQueryClient();
+   const { activeTeamId } = useActiveTeam();
    const { parse: parseCsv, generate: generateCsv } = useCsvFile();
    const { parse: parseXlsx, generate: generateXlsx } = useXlsxFile();
    const { parse: parseOfx } = useOfxFile();
@@ -270,6 +357,89 @@ export function TransactionsList() {
          });
       },
       [navigate],
+   );
+
+   const trimmedSearch = search.trim();
+   const collectionTeamId = activeTeamId ?? "no-team";
+   const transactionsCollection = useMemo(
+      () =>
+         createCollection(
+            transactionsCollectionOptions({
+               queryClient,
+               teamId: collectionTeamId,
+               search: trimmedSearch || undefined,
+               view,
+               overdueOnly,
+               status: status.length > 0 ? status : undefined,
+               bankAccountId: bankId || undefined,
+            }),
+         ),
+      [
+         bankId,
+         collectionTeamId,
+         overdueOnly,
+         queryClient,
+         status,
+         trimmedSearch,
+         view,
+      ],
+   );
+
+   const transactionsPageInfoCollection = useMemo(
+      () =>
+         createCollection(
+            transactionsPageInfoCollectionOptions({
+               queryClient,
+               teamId: collectionTeamId,
+               search: trimmedSearch || undefined,
+               view,
+               overdueOnly,
+               status: status.length > 0 ? status : undefined,
+               bankAccountId: bankId || undefined,
+            }),
+         ),
+      [
+         bankId,
+         collectionTeamId,
+         overdueOnly,
+         queryClient,
+         status,
+         trimmedSearch,
+         view,
+      ],
+   );
+
+   const bankAccountsCollection = useMemo(
+      () =>
+         createCollection(
+            bankAccountsCollectionOptions({
+               queryClient,
+               teamId: collectionTeamId,
+            }),
+         ),
+      [collectionTeamId, queryClient],
+   );
+
+   const categoriesCollection = useMemo(
+      () =>
+         createCollection(
+            categoriesCollectionOptions({
+               queryClient,
+               teamId: collectionTeamId,
+            }),
+         ),
+      [collectionTeamId, queryClient],
+   );
+
+   const creditCardsCollection = useMemo(
+      () =>
+         createCollection(
+            creditCardsCollectionOptions({
+               queryClient,
+               teamId: collectionTeamId,
+            }),
+         ),
+      [collectionTeamId, queryClient],
    );
 
    const handleOverdueToggle = useCallback(
@@ -305,140 +475,354 @@ export function TransactionsList() {
       [navigate],
    );
 
-   const { data: result } = useSuspenseQuery(
-      orpc.transactions.getAll.queryOptions({
-         input: {
-            search: search || undefined,
-            view,
-            overdueOnly,
-            status: status.length > 0 ? status : undefined,
-            page,
-            pageSize,
-            sorting: normalizeTransactionSorting(sorting),
-            bankAccountId: bankId || undefined,
-         },
-      }),
+   const { data: liveTransactions } = useLiveQuery(
+      (q) => {
+         let query = q.from({ transaction: transactionsCollection });
+
+         if (view === "payable") {
+            query = query
+               .where(({ transaction }) => eq(transaction.type, "expense"))
+               .where(({ transaction }) => eq(transaction.status, "pending"))
+               .where(({ transaction }) => eq(transaction.ignored, false));
+         }
+         if (view === "receivable") {
+            query = query
+               .where(({ transaction }) => eq(transaction.type, "income"))
+               .where(({ transaction }) => eq(transaction.status, "pending"))
+               .where(({ transaction }) => eq(transaction.ignored, false));
+         }
+         if (view === "settled") {
+            query = query
+               .where(({ transaction }) => eq(transaction.status, "paid"))
+               .where(({ transaction }) => eq(transaction.ignored, false));
+         }
+         if (view === "ignored") {
+            query = query.where(({ transaction }) =>
+               eq(transaction.ignored, true),
+            );
+         }
+         if (overdueOnly) {
+            query = query
+               .where(({ transaction }) => eq(transaction.status, "pending"))
+               .where(({ transaction }) =>
+                  lt(transaction.dueDate, dayjs().format("YYYY-MM-DD")),
+               );
+         }
+         if (status.length === 1) {
+            const firstStatus = status[0];
+            if (firstStatus) {
+               query = query.where(({ transaction }) =>
+                  eq(transaction.status, firstStatus),
+               );
+            }
+         }
+         if (status.length > 1) {
+            query = query.where(({ transaction }) =>
+               or(
+                  eq(transaction.status, "pending"),
+                  eq(transaction.status, "paid"),
+               ),
+            );
+         }
+         if (bankId) {
+            query = query.where(({ transaction }) =>
+               eq(transaction.bankAccountId, bankId),
+            );
+         }
+         if (trimmedSearch) {
+            const pattern = `%${escapeIlikePattern(trimmedSearch)}%`;
+            query = query.where(({ transaction }) =>
+               or(
+                  ilike(transaction.name, pattern),
+                  ilike(transaction.description, pattern),
+               ),
+            );
+         }
+
+         const normalizedSorting = normalizeTransactionSorting(sorting);
+         if (normalizedSorting.length > 0) {
+            for (const rule of normalizedSorting) {
+               switch (rule.id) {
+                  case "amount":
+                     query = query.orderBy(
+                        ({ transaction }) => transaction.amount,
+                        rule.desc ? "desc" : "asc",
+                     );
+                     break;
+                  case "bankAccountName":
+                     query = query.orderBy(
+                        ({ transaction }) => transaction.bankAccountName,
+                        rule.desc ? "desc" : "asc",
+                     );
+                     break;
+                  case "categoryName":
+                     query = query.orderBy(
+                        ({ transaction }) => transaction.categoryName,
+                        rule.desc ? "desc" : "asc",
+                     );
+                     break;
+                  case "creditCardName":
+                     query = query.orderBy(
+                        ({ transaction }) => transaction.creditCardName,
+                        rule.desc ? "desc" : "asc",
+                     );
+                     break;
+                  case "date":
+                     query = query.orderBy(
+                        ({ transaction }) => transaction.date,
+                        rule.desc ? "desc" : "asc",
+                     );
+                     break;
+                  case "dueDate":
+                     query = query.orderBy(
+                        ({ transaction }) => transaction.dueDate,
+                        rule.desc ? "desc" : "asc",
+                     );
+                     break;
+                  case "name":
+                     query = query.orderBy(
+                        ({ transaction }) => transaction.name,
+                        rule.desc ? "desc" : "asc",
+                     );
+                     break;
+                  case "status":
+                     query = query.orderBy(
+                        ({ transaction }) => transaction.status,
+                        rule.desc ? "desc" : "asc",
+                     );
+                     break;
+                  case "type":
+                     query = query.orderBy(
+                        ({ transaction }) => transaction.type,
+                        rule.desc ? "desc" : "asc",
+                     );
+                     break;
+               }
+            }
+         } else {
+            query = query
+               .orderBy(({ transaction }) => transaction.date, "desc")
+               .orderBy(({ transaction }) => transaction.createdAt, "desc");
+         }
+
+         return query
+            .limit(pageSize)
+            .offset((page - 1) * pageSize)
+            .select(({ transaction }) => transaction);
+      },
+      [
+         bankId,
+         overdueOnly,
+         page,
+         pageSize,
+         sorting,
+         status,
+         transactionsCollection,
+         trimmedSearch,
+         view,
+      ],
    );
 
-   const { data: bankAccounts } = useSuspenseQuery(
-      orpc.bankAccounts.getAll.queryOptions({}),
+   const { data: pageInfoRows } = useLiveQuery(
+      (q) =>
+         q
+            .from({ pageInfo: transactionsPageInfoCollection })
+            .select(({ pageInfo }) => pageInfo),
+      [transactionsPageInfoCollection],
+   );
+
+   const { data: bankAccounts } = useLiveQuery(
+      (q) =>
+         q
+            .from({ bankAccount: bankAccountsCollection })
+            .select(({ bankAccount }) => bankAccount),
+      [bankAccountsCollection],
+   );
+
+   const { data: categoriesResult } = useLiveQuery(
+      (q) =>
+         q
+            .from({ category: categoriesCollection })
+            .where(({ category }) => eq(category.isArchived, false))
+            .select(({ category }) => category),
+      [categoriesCollection],
+   );
+
+   const { data: creditCardsResult } = useLiveQuery(
+      (q) =>
+         q
+            .from({ creditCard: creditCardsCollection })
+            .where(({ creditCard }) => eq(creditCard.status, "active"))
+            .select(({ creditCard }) => creditCard),
+      [creditCardsCollection],
+   );
+
+   const safeTransactions = useMemo(
+      () => liveTransactions ?? [],
+      [liveTransactions],
+   );
+   const safeBankAccounts = useMemo(() => bankAccounts ?? [], [bankAccounts]);
+   const safeCategories = useMemo(
+      () => categoriesResult ?? [],
+      [categoriesResult],
+   );
+   const safeCreditCards = useMemo(
+      () => creditCardsResult ?? [],
+      [creditCardsResult],
    );
 
    const selectedBankAccount = useMemo(
-      () => bankAccounts.find((account) => account.id === bankId),
-      [bankAccounts, bankId],
+      () => safeBankAccounts.find((account) => account.id === bankId),
+      [safeBankAccounts, bankId],
    );
 
-   const { data: categoriesResult } = useSuspenseQuery(
-      orpc.categories.getAll.queryOptions({}),
-   );
-
-   const { data: creditCardsResult } = useSuspenseQuery(
-      orpc.creditCards.getAll.queryOptions({ input: { pageSize: 100 } }),
-   );
-
-   const transactionData = result.data;
-   const total = result.total;
-
-   const importMutation = useMutation(
-      orpc.transactions.importBulk.mutationOptions({
-         meta: { skipGlobalInvalidation: true },
-      }),
-   );
-
-   const deleteMutation = useMutation(
-      orpc.transactions.remove.mutationOptions({
-         onSuccess: () => toast.success("Lançamento excluído com sucesso."),
-         onError: (error) =>
-            toast.error(error.message || "Erro ao excluir lançamento."),
-      }),
-   );
-
-   const updateMutation = useMutation(
-      orpc.transactions.update.mutationOptions({
-         onError: (error) =>
-            toast.error(error.message || "Erro ao atualizar lançamentos."),
-      }),
-   );
-
-   const markAsPaidMutation = useMutation(
-      orpc.transactions.markAsPaid.mutationOptions({
-         onSuccess: () => toast.success("Lançamento marcado como pago."),
-         onError: (error) =>
-            toast.error(error.message || "Erro ao marcar como pago."),
-      }),
-   );
-
-   const markAsUnpaidMutation = useMutation(
-      orpc.transactions.markAsUnpaid.mutationOptions({
-         onSuccess: () => toast.success("Pagamento desmarcado."),
-         onError: (error) =>
-            toast.error(error.message || "Erro ao desmarcar pagamento."),
-      }),
-   );
-
-   const cancelMutation = useMutation(
-      orpc.transactions.cancel.mutationOptions({
-         onSuccess: () => toast.success("Lançamento ignorado."),
-         onError: (error) =>
-            toast.error(error.message || "Erro ao ignorar lançamento."),
-      }),
-   );
-
-   const reactivateMutation = useMutation(
-      orpc.transactions.reactivate.mutationOptions({
-         onSuccess: () => toast.success("Lançamento reativado."),
-         onError: (error) =>
-            toast.error(error.message || "Erro ao reativar lançamento."),
-      }),
-   );
-
-   const createBankAccountMutation = useMutation(
-      orpc.bankAccounts.create.mutationOptions({
-         onError: (error) =>
-            toast.error(error.message || "Erro ao criar conta bancária."),
-      }),
-   );
-
-   const createCategoryMutation = useMutation(
-      orpc.categories.create.mutationOptions({
-         onError: (error) =>
-            toast.error(error.message || "Erro ao criar categoria."),
-      }),
-   );
+   const transactionData = safeTransactions;
+   const total = pageInfoRows?.[0]?.total ?? 0;
 
    const handleUpdate = useCallback(
       async (id: string, patch: Record<string, unknown>) => {
-         await updateMutation.mutateAsync({ id, ...patch });
+         const update = updateTransactionAction(transactionsCollection);
+         const transaction = update({ id, patch });
+         const result = await Result.tryPromise({
+            try: () => transaction.isPersisted.promise,
+            catch: (error) => error,
+         });
+         if (Result.isError(result)) {
+            toast.error(
+               getErrorMessage(result.error, "Erro ao atualizar lançamento."),
+            );
+         }
       },
-      [updateMutation],
+      [transactionsCollection],
    );
 
    const handleCreateBankAccount = useCallback(
       async (name: string): Promise<string> => {
-         const created = await createBankAccountMutation.mutateAsync({
+         if (!activeTeamId) {
+            toast.error("Time ativo não encontrado.");
+            return "";
+         }
+         const input: BankAccountCreateInput = {
             name,
             type: "checking",
+         };
+         const createBankAccount = createBankAccountAction(
+            bankAccountsCollection,
+         );
+         const transaction = createBankAccount({
+            row: buildOptimisticBankAccountRow({
+               id: buildOptimisticBankAccountRowId(),
+               input,
+               teamId: activeTeamId,
+            }),
+            input,
          });
-         return created.id;
+         const result = await Result.tryPromise({
+            try: () => transaction.isPersisted.promise,
+            catch: (error) => error,
+         });
+         if (Result.isError(result)) {
+            toast.error(
+               getErrorMessage(result.error, "Erro ao criar conta bancária."),
+            );
+            return "";
+         }
+         return result.value.id;
       },
-      [createBankAccountMutation],
+      [activeTeamId, bankAccountsCollection],
    );
 
    const handleCreateCategory = useCallback(
       async (name: string): Promise<string> => {
-         const created = await createCategoryMutation.mutateAsync({
+         if (!activeTeamId) {
+            toast.error("Time ativo não encontrado.");
+            return "";
+         }
+         const input: CategoryCreateInput = {
             name,
             type: "expense",
+         };
+         const id = buildOptimisticTransactionRowId("__category_");
+         const createCategory = createCategoryAction(categoriesCollection);
+         const transaction = createCategory({
+            row: buildInlineCategoryRow({ id, name, teamId: activeTeamId }),
+            input,
          });
-         return created.id;
+         const result = await Result.tryPromise({
+            try: () => transaction.isPersisted.promise,
+            catch: (error) => error,
+         });
+         if (Result.isError(result)) {
+            toast.error(
+               getErrorMessage(result.error, "Erro ao criar categoria."),
+            );
+            return "";
+         }
+         return result.value.id;
       },
-      [createCategoryMutation],
+      [activeTeamId, categoriesCollection],
+   );
+
+   const handleCreateTransaction = useCallback(
+      async (input: TransactionCreateInput) => {
+         if (!activeTeamId) {
+            toast.error("Time ativo não encontrado.");
+            return false;
+         }
+         const createTransaction = createTransactionAction(
+            transactionsCollection,
+         );
+         const transaction = createTransaction({
+            row: buildOptimisticTransactionRow({
+               id: buildOptimisticTransactionRowId(),
+               input,
+               teamId: activeTeamId,
+               bankAccountName:
+                  safeBankAccounts.find(
+                     (account) => account.id === input.bankAccountId,
+                  )?.name ?? null,
+               categoryName:
+                  safeCategories.find(
+                     (category) => category.id === input.categoryId,
+                  )?.name ?? null,
+               creditCardName:
+                  safeCreditCards.find((card) => card.id === input.creditCardId)
+                     ?.name ?? null,
+            }),
+            input,
+         });
+         const result = await Result.tryPromise({
+            try: () => transaction.isPersisted.promise,
+            catch: (error) => error,
+         });
+         if (Result.isError(result)) {
+            toast.error(
+               getErrorMessage(result.error, "Erro ao criar lançamento."),
+            );
+            return false;
+         }
+         return true;
+      },
+      [
+         activeTeamId,
+         safeBankAccounts,
+         safeCategories,
+         safeCreditCards,
+         transactionsCollection,
+      ],
    );
 
    const handleCreate = useCallback(() => {
-      openSheet({ renderChildren: () => <TransactionFormSheet /> });
-   }, [openSheet]);
+      openSheet({
+         renderChildren: () => (
+            <TransactionFormSheet
+               bankAccounts={safeBankAccounts}
+               categories={safeCategories}
+               onCreate={handleCreateTransaction}
+            />
+         ),
+      });
+   }, [handleCreateTransaction, openSheet, safeBankAccounts, safeCategories]);
 
    const handleDelete = useCallback(
       (transaction: TransactionRow) => {
@@ -450,28 +834,58 @@ export function TransactionsList() {
             cancelLabel: "Cancelar",
             variant: "destructive",
             onAction: async () => {
-               await deleteMutation.mutateAsync({ id: transaction.id });
+               const remove = removeTransactionAction(transactionsCollection);
+               const result = await Result.tryPromise({
+                  try: () => remove({ id: transaction.id }).isPersisted.promise,
+                  catch: (error) => error,
+               });
+               if (Result.isError(result)) {
+                  toast.error(
+                     getErrorMessage(
+                        result.error,
+                        "Erro ao excluir lançamento.",
+                     ),
+                  );
+                  return;
+               }
+               toast.success("Lançamento excluído com sucesso.");
             },
          });
       },
-      [openAlertDialog, deleteMutation],
+      [openAlertDialog, transactionsCollection],
    );
 
    const handleMarkPaid = useCallback(
       (tx: TransactionRow) => {
-         markAsPaidMutation.mutate({
+         const markAsPaid = markTransactionAsPaidAction(transactionsCollection);
+         const transaction = markAsPaid({
             id: tx.id,
             paidDate: dayjs().format("YYYY-MM-DD"),
          });
+         void transaction.isPersisted.promise.then(
+            () => toast.success("Lançamento marcado como pago."),
+            (error: unknown) =>
+               toast.error(getErrorMessage(error, "Erro ao marcar como pago.")),
+         );
       },
-      [markAsPaidMutation],
+      [transactionsCollection],
    );
 
    const handleMarkUnpaid = useCallback(
       (tx: TransactionRow) => {
-         markAsUnpaidMutation.mutate({ id: tx.id });
+         const markAsUnpaid = markTransactionAsUnpaidAction(
+            transactionsCollection,
+         );
+         const transaction = markAsUnpaid({ id: tx.id });
+         void transaction.isPersisted.promise.then(
+            () => toast.success("Pagamento desmarcado."),
+            (error: unknown) =>
+               toast.error(
+                  getErrorMessage(error, "Erro ao desmarcar pagamento."),
+               ),
+         );
       },
-      [markAsUnpaidMutation],
+      [transactionsCollection],
    );
 
    const handleCancel = useCallback(
@@ -484,18 +898,70 @@ export function TransactionsList() {
             cancelLabel: "Voltar",
             variant: "destructive",
             onAction: async () => {
-               await cancelMutation.mutateAsync({ id: tx.id });
+               const cancel = cancelTransactionAction(transactionsCollection);
+               const result = await Result.tryPromise({
+                  try: () => cancel({ id: tx.id }).isPersisted.promise,
+                  catch: (error) => error,
+               });
+               if (Result.isError(result)) {
+                  toast.error(
+                     getErrorMessage(
+                        result.error,
+                        "Erro ao ignorar lançamento.",
+                     ),
+                  );
+                  return;
+               }
+               toast.success("Lançamento ignorado.");
             },
          });
       },
-      [openAlertDialog, cancelMutation],
+      [openAlertDialog, transactionsCollection],
    );
 
    const handleReactivate = useCallback(
       (tx: TransactionRow) => {
-         reactivateMutation.mutate({ id: tx.id });
+         const reactivate = reactivateTransactionAction(transactionsCollection);
+         const transaction = reactivate({ id: tx.id });
+         void transaction.isPersisted.promise.then(
+            () => toast.success("Lançamento reativado."),
+            (error: unknown) =>
+               toast.error(
+                  getErrorMessage(error, "Erro ao reativar lançamento."),
+               ),
+         );
       },
-      [reactivateMutation],
+      [transactionsCollection],
+   );
+
+   const handleAcceptSuggestedCategory = useCallback(
+      (id: string) => {
+         const accept = acceptSuggestedTransactionCategoryAction(
+            transactionsCollection,
+         );
+         const transaction = accept({ id });
+         void transaction.isPersisted.promise.then(
+            () => toast.success("Categoria aplicada."),
+            (error: unknown) =>
+               toast.error(getErrorMessage(error, "Erro ao aplicar sugestão.")),
+         );
+      },
+      [transactionsCollection],
+   );
+
+   const handleDismissSuggestedCategory = useCallback(
+      (id: string) => {
+         const dismiss = dismissSuggestedTransactionCategoryAction(
+            transactionsCollection,
+         );
+         const transaction = dismiss({ id });
+         void transaction.isPersisted.promise.then(
+            () => toast.success("Sugestão ignorada."),
+            (error: unknown) =>
+               toast.error(getErrorMessage(error, "Erro ao ignorar sugestão.")),
+         );
+      },
+      [transactionsCollection],
    );
 
    const importConfig: DataImportConfig = useMemo(
@@ -529,14 +995,14 @@ export function TransactionsList() {
                dueDate: row.dueDate ? parseImportDate(row.dueDate) : null,
                bankAccountName: String(row.bankAccountName ?? "").trim(),
                bankAccountId: resolveImportId(
-                  bankAccounts,
+                  safeBankAccounts,
                   row.bankAccountName,
                ),
                categoryName: String(row.categoryName ?? "").trim(),
-               categoryId: resolveImportId(categoriesResult, row.categoryName),
+               categoryId: resolveImportId(safeCategories, row.categoryName),
                creditCardName: String(row.creditCardName ?? "").trim(),
                creditCardId: resolveImportId(
-                  creditCardsResult.data,
+                  safeCreditCards,
                   row.creditCardName,
                ),
                suggestedCategoryId: null,
@@ -561,9 +1027,9 @@ export function TransactionsList() {
                               Valor: "1500.00",
                               Status: "Efetivado",
                               Vencimento: "",
-                              Conta: bankAccounts[0]?.name ?? "",
+                              Conta: safeBankAccounts[0]?.name ?? "",
                               Cartão: "",
-                              Categoria: categoriesResult[0]?.name ?? "",
+                              Categoria: safeCategories[0]?.name ?? "",
                            },
                         ],
                         [
@@ -592,9 +1058,9 @@ export function TransactionsList() {
                               Valor: "1500.00",
                               Status: "Efetivado",
                               Vencimento: "",
-                              Conta: bankAccounts[0]?.name ?? "",
+                              Conta: safeBankAccounts[0]?.name ?? "",
                               Cartão: "",
-                              Categoria: categoriesResult[0]?.name ?? "",
+                              Categoria: safeCategories[0]?.name ?? "",
                            },
                         ],
                         [
@@ -626,12 +1092,12 @@ export function TransactionsList() {
                />
                <ImportBulkCategoryButton
                   bulkUpdate={bulkUpdate}
-                  categories={categoriesResult ?? []}
+                  categories={safeCategories}
                   clear={clear}
                   selectedIndices={selectedIndices}
                />
                <ImportBulkAccountButton
-                  bankAccounts={bankAccounts}
+                  bankAccounts={safeBankAccounts}
                   bulkUpdate={bulkUpdate}
                   clear={clear}
                   selectedIndices={selectedIndices}
@@ -639,16 +1105,19 @@ export function TransactionsList() {
             </>
          ),
          onImport: async (rows) => {
+            if (!activeTeamId) {
+               throw new Error("Time ativo não encontrado.");
+            }
             const transactions = rows.flatMap((r) => {
                const date = String(r.date ?? "");
                const amount = String(r.amount ?? "");
                if (!date || !amount) return [];
                const bankAccountId =
-                  resolveImportId(bankAccounts, r.bankAccountId) ??
-                  resolveImportId(bankAccounts, r.bankAccountName);
+                  resolveImportId(safeBankAccounts, r.bankAccountId) ??
+                  resolveImportId(safeBankAccounts, r.bankAccountName);
                const creditCardId =
-                  resolveImportId(creditCardsResult.data, r.creditCardId) ??
-                  resolveImportId(creditCardsResult.data, r.creditCardName);
+                  resolveImportId(safeCreditCards, r.creditCardId) ??
+                  resolveImportId(safeCreditCards, r.creditCardName);
                if (!bankAccountId && !creditCardId) return [];
                return [
                   {
@@ -659,8 +1128,8 @@ export function TransactionsList() {
                      bankAccountId,
                      destinationBankAccountId: null,
                      categoryId:
-                        resolveImportId(categoriesResult, r.categoryId) ??
-                        resolveImportId(categoriesResult, r.categoryName),
+                        resolveImportId(safeCategories, r.categoryId) ??
+                        resolveImportId(safeCategories, r.categoryName),
                      attachments: [],
                      description: null,
                      creditCardId,
@@ -678,26 +1147,56 @@ export function TransactionsList() {
                   "Nenhum lançamento válido para importar. Preencha data, valor e conta ou cartão.",
                );
             }
-            await importMutation.mutateAsync({
-               transactions,
-               autoCategorize: true,
+            const importTransactions = importTransactionsAction(
+               transactionsCollection,
+            );
+            const transaction = importTransactions({
+               input: { transactions, autoCategorize: true },
+               rows: transactions.map((input) =>
+                  buildOptimisticTransactionRow({
+                     id: buildOptimisticTransactionRowId(),
+                     input,
+                     teamId: activeTeamId,
+                     bankAccountName:
+                        safeBankAccounts.find(
+                           (account) => account.id === input.bankAccountId,
+                        )?.name ?? null,
+                     categoryName:
+                        safeCategories.find(
+                           (category) => category.id === input.categoryId,
+                        )?.name ?? null,
+                     creditCardName:
+                        safeCreditCards.find(
+                           (card) => card.id === input.creditCardId,
+                        )?.name ?? null,
+                  }),
+               ),
             });
-            await queryClient.invalidateQueries({
-               queryKey: orpc.transactions.getAll.queryKey(),
+            const result = await Result.tryPromise({
+               try: () => transaction.isPersisted.promise,
+               catch: (error) => error,
             });
+            if (Result.isError(result)) {
+               throw new Error(
+                  getErrorMessage(
+                     result.error,
+                     "Erro ao importar lançamentos.",
+                  ),
+               );
+            }
          },
       }),
       [
+         activeTeamId,
          parseCsv,
          parseXlsx,
          parseOfx,
          generateCsv,
          generateXlsx,
-         bankAccounts,
-         categoriesResult,
-         creditCardsResult.data,
-         importMutation,
-         queryClient,
+         safeBankAccounts,
+         safeCategories,
+         safeCreditCards,
+         transactionsCollection,
       ],
    );
 
@@ -707,13 +1206,15 @@ export function TransactionsList() {
 
    const columns = useMemo<ColumnDef<TransactionRow>[]>(() => {
       const base = buildTransactionColumns({
-         bankAccounts,
-         categories: categoriesResult,
-         creditCards: creditCardsResult.data,
+         bankAccounts: safeBankAccounts,
+         categories: safeCategories,
+         creditCards: safeCreditCards,
          onUpdate: handleUpdate,
          onUpdateImport: (idx, patch) => importUpdateRef.current?.(idx, patch),
          onCreateBankAccount: handleCreateBankAccount,
          onCreateCategory: handleCreateCategory,
+         onAcceptSuggestedCategory: handleAcceptSuggestedCategory,
+         onDismissSuggestedCategory: handleDismissSuggestedCategory,
          getRowStatus: (id) => transactionData.find((t) => t.id === id)?.status,
          logoDevToken: publicEnv?.LOGO_DEV_TOKEN,
       });
@@ -815,14 +1316,16 @@ export function TransactionsList() {
       };
       return [selectColumn, ...base, actionsColumn];
    }, [
-      bankAccounts,
-      categoriesResult,
-      creditCardsResult,
+      safeBankAccounts,
+      safeCategories,
+      safeCreditCards,
       transactionData,
       publicEnv?.LOGO_DEV_TOKEN,
       handleUpdate,
       handleCreateBankAccount,
       handleCreateCategory,
+      handleAcceptSuggestedCategory,
+      handleDismissSuggestedCategory,
       handleMarkPaid,
       handleMarkUnpaid,
       handleReactivate,
@@ -878,16 +1381,30 @@ export function TransactionsList() {
       onClear: resetSelection,
       children: (
          <>
-            <BulkIgnoreButton ids={selectedIds} onSuccess={resetSelection} />
-            <BulkStatusButton ids={selectedIds} onSuccess={resetSelection} />
-            <BulkDateButton ids={selectedIds} onSuccess={resetSelection} />
+            <BulkIgnoreButton
+               collection={transactionsCollection}
+               ids={selectedIds}
+               onSuccess={resetSelection}
+            />
+            <BulkStatusButton
+               collection={transactionsCollection}
+               ids={selectedIds}
+               onSuccess={resetSelection}
+            />
+            <BulkDateButton
+               collection={transactionsCollection}
+               ids={selectedIds}
+               onSuccess={resetSelection}
+            />
             <BulkCategoryButton
-               categories={categoriesResult ?? []}
+               categories={safeCategories}
+               collection={transactionsCollection}
                ids={selectedIds}
                onSuccess={resetSelection}
             />
             <BulkAccountButton
-               bankAccounts={bankAccounts}
+               bankAccounts={safeBankAccounts}
+               collection={transactionsCollection}
                ids={selectedIds}
                onSuccess={resetSelection}
             />
@@ -903,11 +1420,24 @@ export function TransactionsList() {
                      cancelLabel: "Cancelar",
                      variant: "destructive",
                      onAction: async () => {
-                        await Promise.allSettled(
-                           selectedIds.map((id) =>
-                              deleteMutation.mutateAsync({ id }),
-                           ),
+                        const bulkRemove = bulkRemoveTransactionsAction(
+                           transactionsCollection,
                         );
+                        const result = await Result.tryPromise({
+                           try: () =>
+                              bulkRemove({ ids: selectedIds }).isPersisted
+                                 .promise,
+                           catch: (error) => error,
+                        });
+                        if (Result.isError(result)) {
+                           toast.error(
+                              getErrorMessage(
+                                 result.error,
+                                 "Erro ao excluir lançamentos.",
+                              ),
+                           );
+                           return;
+                        }
                         resetSelection();
                      },
                   })
@@ -1038,17 +1568,13 @@ export function TransactionsList() {
 function BulkIgnoreButton({
    ids,
    onSuccess,
+   collection,
 }: {
    ids: string[];
    onSuccess: () => void;
+   collection: Parameters<typeof bulkUpdateTransactionsAction>[0];
 }) {
    const { openAlertDialog } = useAlertDialog();
-   const mutation = useMutation(
-      orpc.transactions.update.mutationOptions({
-         onError: (e) =>
-            toast.error(e.message || "Erro ao ignorar lançamentos."),
-      }),
-   );
 
    return (
       <SelectionActionButton
@@ -1061,14 +1587,23 @@ function BulkIgnoreButton({
                actionLabel: "Ignorar",
                cancelLabel: "Cancelar",
                onAction: async () => {
-                  const results = await Promise.allSettled(
-                     ids.map((id) =>
-                        mutation.mutateAsync({ id, ignored: true }),
-                     ),
-                  );
-                  if (results.every((r) => r.status === "fulfilled")) {
-                     onSuccess();
+                  const update = bulkUpdateTransactionsAction(collection);
+                  const result = await Result.tryPromise({
+                     try: () =>
+                        update({ ids, patch: { ignored: true } }).isPersisted
+                           .promise,
+                     catch: (error) => error,
+                  });
+                  if (Result.isError(result)) {
+                     toast.error(
+                        getErrorMessage(
+                           result.error,
+                           "Erro ao ignorar lançamentos.",
+                        ),
+                     );
+                     return;
                   }
+                  onSuccess();
                },
             })
          }
@@ -1081,25 +1616,28 @@ function BulkIgnoreButton({
 function BulkStatusButton({
    ids,
    onSuccess,
+   collection,
 }: {
    ids: string[];
    onSuccess: () => void;
+   collection: Parameters<typeof bulkUpdateTransactionsAction>[0];
 }) {
    const [open, setOpen] = useState(false);
-   const mutation = useMutation(
-      orpc.transactions.update.mutationOptions({
-         onError: (e) => toast.error(e.message || "Erro ao atualizar status."),
-      }),
-   );
 
    const apply = async (status: "pending" | "paid") => {
-      const results = await Promise.allSettled(
-         ids.map((id) => mutation.mutateAsync({ id, status })),
-      );
+      const update = bulkUpdateTransactionsAction(collection);
+      const result = await Result.tryPromise({
+         try: () => update({ ids, patch: { status } }).isPersisted.promise,
+         catch: (error) => error,
+      });
       setOpen(false);
-      if (results.every((r) => r.status === "fulfilled")) {
-         onSuccess();
+      if (Result.isError(result)) {
+         toast.error(
+            getErrorMessage(result.error, "Erro ao atualizar status."),
+         );
+         return;
       }
+      onSuccess();
    };
 
    const statusOptions = [
@@ -1120,7 +1658,6 @@ function BulkStatusButton({
                   <Button
                      key={opt.value}
                      className="justify-start text-sm"
-                     disabled={mutation.isPending}
                      variant="ghost"
                      onClick={() => apply(opt.value)}
                   >
@@ -1136,16 +1673,13 @@ function BulkStatusButton({
 function BulkDateButton({
    ids,
    onSuccess,
+   collection,
 }: {
    ids: string[];
    onSuccess: () => void;
+   collection: Parameters<typeof bulkUpdateTransactionsAction>[0];
 }) {
    const [open, setOpen] = useState(false);
-   const mutation = useMutation(
-      orpc.transactions.update.mutationOptions({
-         onError: (e) => toast.error(e.message || "Erro ao atualizar data."),
-      }),
-   );
 
    return (
       <Popover open={open} onOpenChange={setOpen}>
@@ -1160,10 +1694,22 @@ function BulkDateButton({
                onSelect={async (d) => {
                   if (!d) return;
                   const date = dayjs(d).format("YYYY-MM-DD");
-                  await Promise.allSettled(
-                     ids.map((id) => mutation.mutateAsync({ id, date })),
-                  );
+                  const update = bulkUpdateTransactionsAction(collection);
+                  const result = await Result.tryPromise({
+                     try: () =>
+                        update({ ids, patch: { date } }).isPersisted.promise,
+                     catch: (error) => error,
+                  });
                   setOpen(false);
+                  if (Result.isError(result)) {
+                     toast.error(
+                        getErrorMessage(
+                           result.error,
+                           "Erro ao atualizar data.",
+                        ),
+                     );
+                     return;
+                  }
                   onSuccess();
                }}
             />
@@ -1176,17 +1722,14 @@ function BulkCategoryButton({
    ids,
    categories,
    onSuccess,
+   collection,
 }: {
    ids: string[];
    categories: CategoryOption[];
    onSuccess: () => void;
+   collection: Parameters<typeof bulkUpdateTransactionsAction>[0];
 }) {
    const [open, setOpen] = useState(false);
-   const mutation = useMutation(
-      orpc.transactions.update.mutationOptions({
-         onError: (e) => toast.error(e.message || "Erro ao categorizar."),
-      }),
-   );
 
    return (
       <Popover open={open} onOpenChange={setOpen}>
@@ -1197,17 +1740,26 @@ function BulkCategoryButton({
          </PopoverTrigger>
          <PopoverContent align="start" className="w-64 p-0">
             <BulkLookupCommand
-               disabled={mutation.isPending}
                emptyMessage="Nenhuma categoria."
                options={categories}
                searchPlaceholder="Buscar..."
                onSelect={async (category) => {
-                  await Promise.allSettled(
-                     ids.map((id) =>
-                        mutation.mutateAsync({ id, categoryId: category.id }),
-                     ),
-                  );
+                  const update = bulkUpdateTransactionsAction(collection);
+                  const result = await Result.tryPromise({
+                     try: () =>
+                        update({
+                           ids,
+                           patch: { categoryId: category.id },
+                        }).isPersisted.promise,
+                     catch: (error) => error,
+                  });
                   setOpen(false);
+                  if (Result.isError(result)) {
+                     toast.error(
+                        getErrorMessage(result.error, "Erro ao categorizar."),
+                     );
+                     return;
+                  }
                   onSuccess();
                }}
             />
@@ -1220,17 +1772,14 @@ function BulkAccountButton({
    ids,
    bankAccounts,
    onSuccess,
+   collection,
 }: {
    ids: string[];
    bankAccounts: BankAccountOption[];
    onSuccess: () => void;
+   collection: Parameters<typeof bulkUpdateTransactionsAction>[0];
 }) {
    const [open, setOpen] = useState(false);
-   const mutation = useMutation(
-      orpc.transactions.update.mutationOptions({
-         onError: (e) => toast.error(e.message || "Erro ao alterar conta."),
-      }),
-   );
 
    return (
       <Popover open={open} onOpenChange={setOpen}>
@@ -1241,20 +1790,26 @@ function BulkAccountButton({
          </PopoverTrigger>
          <PopoverContent align="start" className="w-64 p-0">
             <BulkLookupCommand
-               disabled={mutation.isPending}
                emptyMessage="Nenhuma conta."
                options={bankAccounts}
                searchPlaceholder="Buscar..."
                onSelect={async (bankAccount) => {
-                  await Promise.allSettled(
-                     ids.map((id) =>
-                        mutation.mutateAsync({
-                           id,
-                           bankAccountId: bankAccount.id,
-                        }),
-                     ),
-                  );
+                  const update = bulkUpdateTransactionsAction(collection);
+                  const result = await Result.tryPromise({
+                     try: () =>
+                        update({
+                           ids,
+                           patch: { bankAccountId: bankAccount.id },
+                        }).isPersisted.promise,
+                     catch: (error) => error,
+                  });
                   setOpen(false);
+                  if (Result.isError(result)) {
+                     toast.error(
+                        getErrorMessage(result.error, "Erro ao alterar conta."),
+                     );
+                     return;
+                  }
                   onSuccess();
                }}
             />

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
@@ -508,21 +508,35 @@ export function TransactionsList() {
                   lt(transaction.dueDate, dayjs().format("YYYY-MM-DD")),
                );
          }
-         if (status.length === 1) {
-            const firstStatus = status[0];
+         const selectedStatuses = status.filter(
+            (selectedStatus) => selectedStatus !== undefined,
+         );
+         if (selectedStatuses.length === 1) {
+            const firstStatus = selectedStatuses[0];
             if (firstStatus) {
                query = query.where(({ transaction }) =>
                   eq(transaction.status, firstStatus),
                );
             }
          }
-         if (status.length > 1) {
-            query = query.where(({ transaction }) =>
-               or(
-                  eq(transaction.status, "pending"),
-                  eq(transaction.status, "paid"),
-               ),
-            );
+         if (selectedStatuses.length > 1) {
+            const [firstStatus, secondStatus, ...remainingStatuses] =
+               selectedStatuses;
+            if (firstStatus && secondStatus) {
+               query = query.where(({ transaction }) => {
+                  let statusFilter = or(
+                     eq(transaction.status, firstStatus),
+                     eq(transaction.status, secondStatus),
+                  );
+                  for (const selectedStatus of remainingStatuses) {
+                     statusFilter = or(
+                        statusFilter,
+                        eq(transaction.status, selectedStatus),
+                     );
+                  }
+                  return statusFilter;
+               });
+            }
          }
          if (bankId) {
             query = query.where(({ transaction }) =>
@@ -677,6 +691,7 @@ export function TransactionsList() {
    );
 
    const transactionData = safeTransactions;
+   const isTransactionsLoaded = liveTransactions !== undefined;
    const total = pageInfoRows?.[0]?.total ?? 0;
 
    const handleUpdate = useCallback(
@@ -856,34 +871,44 @@ export function TransactionsList() {
    );
 
    const handleMarkPaid = useCallback(
-      (tx: TransactionRow) => {
+      async (tx: TransactionRow) => {
          const markAsPaid = markTransactionAsPaidAction(transactionsCollection);
          const transaction = markAsPaid({
             id: tx.id,
             paidDate: dayjs().format("YYYY-MM-DD"),
          });
-         void transaction.isPersisted.promise.then(
-            () => toast.success("Lançamento marcado como pago."),
-            (error: unknown) =>
-               toast.error(getErrorMessage(error, "Erro ao marcar como pago.")),
-         );
+         const result = await Result.tryPromise({
+            try: () => transaction.isPersisted.promise,
+            catch: (error) => error,
+         });
+         if (Result.isError(result)) {
+            toast.error(
+               getErrorMessage(result.error, "Erro ao marcar como pago."),
+            );
+            return;
+         }
+         toast.success("Lançamento marcado como pago.");
       },
       [transactionsCollection],
    );
 
    const handleMarkUnpaid = useCallback(
-      (tx: TransactionRow) => {
+      async (tx: TransactionRow) => {
          const markAsUnpaid = markTransactionAsUnpaidAction(
             transactionsCollection,
          );
          const transaction = markAsUnpaid({ id: tx.id });
-         void transaction.isPersisted.promise.then(
-            () => toast.success("Pagamento desmarcado."),
-            (error: unknown) =>
-               toast.error(
-                  getErrorMessage(error, "Erro ao desmarcar pagamento."),
-               ),
-         );
+         const result = await Result.tryPromise({
+            try: () => transaction.isPersisted.promise,
+            catch: (error) => error,
+         });
+         if (Result.isError(result)) {
+            toast.error(
+               getErrorMessage(result.error, "Erro ao desmarcar pagamento."),
+            );
+            return;
+         }
+         toast.success("Pagamento desmarcado.");
       },
       [transactionsCollection],
    );
@@ -920,46 +945,62 @@ export function TransactionsList() {
    );
 
    const handleReactivate = useCallback(
-      (tx: TransactionRow) => {
+      async (tx: TransactionRow) => {
          const reactivate = reactivateTransactionAction(transactionsCollection);
          const transaction = reactivate({ id: tx.id });
-         void transaction.isPersisted.promise.then(
-            () => toast.success("Lançamento reativado."),
-            (error: unknown) =>
-               toast.error(
-                  getErrorMessage(error, "Erro ao reativar lançamento."),
-               ),
-         );
+         const result = await Result.tryPromise({
+            try: () => transaction.isPersisted.promise,
+            catch: (error) => error,
+         });
+         if (Result.isError(result)) {
+            toast.error(
+               getErrorMessage(result.error, "Erro ao reativar lançamento."),
+            );
+            return;
+         }
+         toast.success("Lançamento reativado.");
       },
       [transactionsCollection],
    );
 
    const handleAcceptSuggestedCategory = useCallback(
-      (id: string) => {
+      async (id: string) => {
          const accept = acceptSuggestedTransactionCategoryAction(
             transactionsCollection,
          );
          const transaction = accept({ id });
-         void transaction.isPersisted.promise.then(
-            () => toast.success("Categoria aplicada."),
-            (error: unknown) =>
-               toast.error(getErrorMessage(error, "Erro ao aplicar sugestão.")),
-         );
+         const result = await Result.tryPromise({
+            try: () => transaction.isPersisted.promise,
+            catch: (error) => error,
+         });
+         if (Result.isError(result)) {
+            toast.error(
+               getErrorMessage(result.error, "Erro ao aplicar sugestão."),
+            );
+            return;
+         }
+         toast.success("Categoria aplicada.");
       },
       [transactionsCollection],
    );
 
    const handleDismissSuggestedCategory = useCallback(
-      (id: string) => {
+      async (id: string) => {
          const dismiss = dismissSuggestedTransactionCategoryAction(
             transactionsCollection,
          );
          const transaction = dismiss({ id });
-         void transaction.isPersisted.promise.then(
-            () => toast.success("Sugestão ignorada."),
-            (error: unknown) =>
-               toast.error(getErrorMessage(error, "Erro ao ignorar sugestão.")),
-         );
+         const result = await Result.tryPromise({
+            try: () => transaction.isPersisted.promise,
+            catch: (error) => error,
+         });
+         if (Result.isError(result)) {
+            toast.error(
+               getErrorMessage(result.error, "Erro ao ignorar sugestão."),
+            );
+            return;
+         }
+         toast.success("Sugestão ignorada.");
       },
       [transactionsCollection],
    );
@@ -1542,7 +1583,7 @@ export function TransactionsList() {
                         table={table}
                      />
                   </Table>
-                  {table.getRowCount() === 0 && (
+                  {isTransactionsLoaded && table.getRowCount() === 0 && (
                      <Empty>
                         <EmptyHeader>
                            <EmptyMedia variant="icon">

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/chat/-layout/chat-layout.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/chat/-layout/chat-layout.tsx
@@ -54,7 +54,7 @@ function ChatLayoutDesktop({ children }: ChatLayoutProps) {
          </SidebarManager>
          <SidebarInset className="flex-1 overflow-hidden">
             <main className="flex h-full px-4 py-2">
-               <div className="self-center flex h-full w-full max-w-5xl">
+               <div className="mx-auto flex h-full w-full max-w-5xl">
                   <RouteTransition>{children}</RouteTransition>
                </div>
             </main>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/transactions.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/transactions.tsx
@@ -5,8 +5,6 @@ import { DataTableSkeleton } from "@/blocks/data-table/data-table-skeleton";
 import { QueryBoundary } from "@/components/query-boundary";
 import { TransactionsList } from "./-transactions/transactions-list";
 import { buildTransactionColumns } from "./-transactions/transactions-columns";
-import { normalizeTransactionSorting } from "./-transactions/transaction-sorting";
-import { orpc } from "@/integrations/orpc/client";
 
 const skeletonColumns = buildTransactionColumns();
 
@@ -39,55 +37,7 @@ export const Route = createFileRoute(
    "/_authenticated/$slug/$teamSlug/_dashboard/transactions",
 )({
    validateSearch: transactionsSearchSchema,
-   loaderDeps: ({
-      search: {
-         page,
-         pageSize,
-         sorting,
-         view,
-         overdueOnly,
-         status,
-         search,
-         bankId,
-      },
-   }) => ({
-      page,
-      pageSize,
-      sorting,
-      view,
-      overdueOnly,
-      status,
-      search,
-      bankId,
-   }),
-   loader: ({ context, deps }) => {
-      context.queryClient.prefetchQuery(
-         orpc.bankAccounts.getAll.queryOptions({}),
-      );
-      context.queryClient.prefetchQuery(
-         orpc.categories.getAll.queryOptions({}),
-      );
-      context.queryClient.prefetchQuery(
-         orpc.tags.getAll.queryOptions({ input: {} }),
-      );
-      context.queryClient.prefetchQuery(
-         orpc.creditCards.getAll.queryOptions({ input: {} }),
-      );
-      context.queryClient.prefetchQuery(
-         orpc.transactions.getAll.queryOptions({
-            input: {
-               page: deps.page,
-               pageSize: deps.pageSize,
-               sorting: normalizeTransactionSorting(deps.sorting),
-               view: deps.view,
-               overdueOnly: deps.overdueOnly,
-               status: deps.status.length > 0 ? deps.status : undefined,
-               search: deps.search || undefined,
-               bankAccountId: deps.bankId || undefined,
-            },
-         }),
-      );
-   },
+   ssr: false,
    pendingMs: 300,
    pendingComponent: () => (
       <main className="flex flex-1 min-h-0 flex-col gap-4 overflow-hidden">

--- a/modules/cashbook/src/router/transactions.ts
+++ b/modules/cashbook/src/router/transactions.ts
@@ -701,18 +701,156 @@ export const bulkUpdate = protectedProcedure
       });
       if (existingRows.isErr()) throw existingRows.error;
 
-      await Promise.all(
-         existingRows.value.map((row) =>
-            requireValidFinancialReferences(context.db, context.teamId, {
-               bankAccountId: data.bankAccountId ?? row.bankAccountId,
-               destinationBankAccountId:
-                  data.destinationBankAccountId ?? row.destinationBankAccountId,
-               categoryId: data.categoryId ?? row.categoryId,
-               tagId: tagId ?? row.tagId,
-               date: data.date ?? row.date,
+      const finalReferences = existingRows.value.map((row) => ({
+         bankAccountId:
+            data.bankAccountId !== undefined
+               ? data.bankAccountId
+               : row.bankAccountId,
+         destinationBankAccountId:
+            data.destinationBankAccountId !== undefined
+               ? data.destinationBankAccountId
+               : row.destinationBankAccountId,
+         categoryId:
+            data.categoryId !== undefined ? data.categoryId : row.categoryId,
+         tagId: tagId !== undefined ? tagId : row.tagId,
+         date: data.date !== undefined ? data.date : row.date,
+      }));
+
+      const bankAccountIds = new Set<string>();
+      const categoryIds = new Set<string>();
+      const tagIds = new Set<string>();
+      for (const refs of finalReferences) {
+         if (refs.bankAccountId) bankAccountIds.add(refs.bankAccountId);
+         if (refs.destinationBankAccountId) {
+            bankAccountIds.add(refs.destinationBankAccountId);
+         }
+         if (refs.categoryId) categoryIds.add(refs.categoryId);
+         if (refs.tagId) tagIds.add(refs.tagId);
+      }
+
+      const bankAccountRowsResult = await Result.tryPromise({
+         try: () =>
+            bankAccountIds.size > 0
+               ? context.db.query.bankAccounts.findMany({
+                    where: (f, { inArray }) =>
+                       inArray(f.id, Array.from(bankAccountIds)),
+                 })
+               : Promise.resolve([]),
+         catch: () =>
+            new TransactionRouterError({
+               error: transactionRouterErrors.INTERNAL(),
+               message: "Falha ao verificar contas bancárias.",
             }),
-         ),
+      });
+      if (bankAccountRowsResult.isErr()) throw bankAccountRowsResult.error;
+
+      const categoryRowsResult = await Result.tryPromise({
+         try: () =>
+            categoryIds.size > 0
+               ? context.db.query.categories.findMany({
+                    where: (f, { inArray }) =>
+                       inArray(f.id, Array.from(categoryIds)),
+                 })
+               : Promise.resolve([]),
+         catch: () =>
+            new TransactionRouterError({
+               error: transactionRouterErrors.INTERNAL(),
+               message: "Falha ao verificar categorias.",
+            }),
+      });
+      if (categoryRowsResult.isErr()) throw categoryRowsResult.error;
+
+      const tagRowsResult = await Result.tryPromise({
+         try: () =>
+            tagIds.size > 0
+               ? context.db.query.tags.findMany({
+                    where: (f, { inArray }) =>
+                       inArray(f.id, Array.from(tagIds)),
+                 })
+               : Promise.resolve([]),
+         catch: () =>
+            new TransactionRouterError({
+               error: transactionRouterErrors.INTERNAL(),
+               message: "Falha ao verificar Centros de Custo.",
+            }),
+      });
+      if (tagRowsResult.isErr()) throw tagRowsResult.error;
+
+      const bankAccountRows = new Map(
+         bankAccountRowsResult.value.map((account) => [account.id, account]),
       );
+      const categoryRows = new Map(
+         categoryRowsResult.value.map((category) => [category.id, category]),
+      );
+      const tagRows = new Map(tagRowsResult.value.map((tag) => [tag.id, tag]));
+
+      for (const refs of finalReferences) {
+         if (refs.bankAccountId) {
+            const account = bankAccountRows.get(refs.bankAccountId);
+            if (!account || account.teamId !== context.teamId) {
+               throw new TransactionRouterError({
+                  error: transactionRouterErrors.BAD_REQUEST(),
+                  message: "Conta bancária inválida.",
+               });
+            }
+            if (
+               account.initialBalanceDate &&
+               refs.date &&
+               dayjs(refs.date).isBefore(dayjs(account.initialBalanceDate))
+            ) {
+               throw new TransactionRouterError({
+                  error: transactionRouterErrors.BAD_REQUEST(),
+                  message: `Não é possível registrar lançamentos antes da data do saldo inicial (${dayjs(account.initialBalanceDate).format("DD/MM/YYYY")}).`,
+               });
+            }
+         }
+
+         if (refs.destinationBankAccountId) {
+            const account = bankAccountRows.get(refs.destinationBankAccountId);
+            if (!account || account.teamId !== context.teamId) {
+               throw new TransactionRouterError({
+                  error: transactionRouterErrors.BAD_REQUEST(),
+                  message: "Conta de destino inválida.",
+               });
+            }
+            if (
+               account.initialBalanceDate &&
+               refs.date &&
+               dayjs(refs.date).isBefore(dayjs(account.initialBalanceDate))
+            ) {
+               throw new TransactionRouterError({
+                  error: transactionRouterErrors.BAD_REQUEST(),
+                  message: `Não é possível registrar lançamentos antes da data do saldo inicial da conta de destino (${dayjs(account.initialBalanceDate).format("DD/MM/YYYY")}).`,
+               });
+            }
+         }
+
+         if (refs.categoryId) {
+            const category = categoryRows.get(refs.categoryId);
+            if (!category || category.teamId !== context.teamId) {
+               throw new TransactionRouterError({
+                  error: transactionRouterErrors.BAD_REQUEST(),
+                  message: "Categoria inválida.",
+               });
+            }
+            if (category.isArchived) {
+               throw new TransactionRouterError({
+                  error: transactionRouterErrors.BAD_REQUEST(),
+                  message: "Categoria arquivada.",
+               });
+            }
+         }
+
+         if (refs.tagId) {
+            const tag = tagRows.get(refs.tagId);
+            if (!tag || tag.teamId !== context.teamId) {
+               throw new TransactionRouterError({
+                  error: transactionRouterErrors.BAD_REQUEST(),
+                  message: "Centro de Custo inválido.",
+               });
+            }
+         }
+      }
 
       const updateData = (() => {
          if (tagId !== undefined && data.categoryId !== undefined) {

--- a/modules/cashbook/src/router/transactions.ts
+++ b/modules/cashbook/src/router/transactions.ts
@@ -1,5 +1,5 @@
 import dayjs from "dayjs";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { matchError, Result, TaggedError } from "better-result";
 import { defineErrorCatalog } from "evlog";
 import { z } from "zod";
@@ -18,6 +18,7 @@ import {
 } from "@modules/classification/workflows/enqueue";
 import {
    enforceCostCenterPolicy,
+   requireOwnedTransactionIds,
    requireTransactionRecurrence,
    requireTransaction,
    requireValidFinancialReferences,
@@ -654,6 +655,102 @@ export const update = protectedProcedure
       return updated.value;
    });
 
+export const bulkUpdate = protectedProcedure
+   .input(
+      z
+         .object({
+            ids: z.array(z.string().uuid()).min(1).max(500),
+         })
+         .merge(updateTransactionSchema),
+   )
+   .use(requireOwnedTransactionIds, (input) => input.ids)
+   .handler(async ({ context, input }) => {
+      const { ids, tagId, ...data } = input;
+      if ("tagId" in input) {
+         const policyResult = await Result.tryPromise({
+            try: () =>
+               context.db.query.financialConfig.findFirst({
+                  where: (f, { eq }) => eq(f.teamId, context.teamId),
+               }),
+            catch: () =>
+               new TransactionRouterError({
+                  error: transactionRouterErrors.INTERNAL(),
+                  message: "Falha ao verificar configurações.",
+               }),
+         });
+         if (policyResult.isErr()) throw policyResult.error;
+         if (policyResult.value?.costCenterRequired && !input.tagId) {
+            throw new TransactionRouterError({
+               error: transactionRouterErrors.FORBIDDEN(),
+               message: "Centro de Custo é obrigatório para este espaço.",
+            });
+         }
+      }
+
+      const existingRows = await Result.tryPromise({
+         try: () =>
+            context.db.query.transactions.findMany({
+               where: (f, { and, inArray, eq }) =>
+                  and(inArray(f.id, ids), eq(f.teamId, context.teamId)),
+            }),
+         catch: () =>
+            new TransactionRouterError({
+               error: transactionRouterErrors.INTERNAL(),
+               message: "Falha ao verificar lançamentos.",
+            }),
+      });
+      if (existingRows.isErr()) throw existingRows.error;
+
+      await Promise.all(
+         existingRows.value.map((row) =>
+            requireValidFinancialReferences(context.db, context.teamId, {
+               bankAccountId: data.bankAccountId ?? row.bankAccountId,
+               destinationBankAccountId:
+                  data.destinationBankAccountId ?? row.destinationBankAccountId,
+               categoryId: data.categoryId ?? row.categoryId,
+               tagId: tagId ?? row.tagId,
+               date: data.date ?? row.date,
+            }),
+         ),
+      );
+
+      const updateData = (() => {
+         if (tagId !== undefined && data.categoryId !== undefined) {
+            return {
+               ...data,
+               tagId,
+               suggestedTagId: null,
+               suggestedCategoryId: null,
+            };
+         }
+         if (tagId !== undefined) {
+            return { ...data, tagId, suggestedTagId: null };
+         }
+         if (data.categoryId !== undefined) {
+            return { ...data, suggestedCategoryId: null };
+         }
+         return data;
+      })();
+
+      const updated = await Result.tryPromise({
+         try: () =>
+            context.db.transaction(async (tx) =>
+               tx
+                  .update(transactions)
+                  .set(updateData)
+                  .where(inArray(transactions.id, ids))
+                  .returning(),
+            ),
+         catch: () =>
+            new TransactionRouterError({
+               error: transactionRouterErrors.INTERNAL(),
+               message: "Falha ao atualizar lançamentos.",
+            }),
+      });
+      if (updated.isErr()) throw updated.error;
+      return updated.value;
+   });
+
 export const remove = protectedProcedure
    .input(idSchema)
    .use(requireTransaction, (input) => input.id)
@@ -667,6 +764,27 @@ export const remove = protectedProcedure
             new TransactionRouterError({
                error: transactionRouterErrors.INTERNAL(),
                message: "Falha ao excluir lançamento.",
+            }),
+      });
+      if (result.isErr()) throw result.error;
+      return { success: true };
+   });
+
+export const bulkRemove = protectedProcedure
+   .input(z.object({ ids: z.array(z.string().uuid()).min(1).max(500) }))
+   .use(requireOwnedTransactionIds, (input) => input.ids)
+   .handler(async ({ context, input }) => {
+      const result = await Result.tryPromise({
+         try: () =>
+            context.db.transaction(async (tx) =>
+               tx
+                  .delete(transactions)
+                  .where(inArray(transactions.id, input.ids)),
+            ),
+         catch: () =>
+            new TransactionRouterError({
+               error: transactionRouterErrors.INTERNAL(),
+               message: "Falha ao excluir lançamentos.",
             }),
       });
       if (result.isErr()) throw result.error;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Migramos a listagem de lançamentos para coleções do `@tanstack/react-db` com queries reativas e ações otimistas, removendo `react-query` e o prefetch do loader. Adicionamos `bulkUpdate`/`bulkRemove` no router com validações fortes e mensagens de erro claras; tratamento de erros assíncronos foi reforçado em toda a UI.

- **Mudanças por camada**
  - Router
    - Novos endpoints `bulkUpdate`/`bulkRemove` com `requireOwnedTransactionIds`.
    - Validação de contas, categorias e centros de custo; bloqueio por data anterior ao saldo inicial.
    - Limpeza de `suggestedCategoryId`/`suggestedTagId` ao atualizar categoria/tag; mensagens de erro mais objetivas.
  - Repositório
    - Nova coleção `apps/web/src/integrations/tanstack-db/transactions.ts` com parsing de `where`/`orderBy`, paginação via `LoadSubsetOptions` e ID otimista.
    - Coleção de page-info para totalização; `refetchInterval` de 5s e `syncMode: on-demand`.
    - Ações otimistas: `create/update/bulkUpdate/remove/bulkRemove/markAsPaid/markAsUnpaid/cancel/reactivate/import/acceptSuggestedCategory/dismissSuggestedCategory`.
    - Busca `ilike` com escape seguro; uso de `@tanstack/query-db-collection` e `@tanstack/query-core`.
    - `categories.ts`: export de `CategoryCreateInput` para criação inline.
  - Componente
    - `transactions-list.tsx`: migração para `createCollection` + `useLiveQuery`; filtros (view/status/overdue/conta/busca) e sorting no client; paginação por subset; estado vazio só após carga.
    - Importação com linhas otimistas; criação inline de conta/categoria com ações otimistas; bulk actions usam `bulkUpdate`/`bulkRemove`.
    - `transactions-columns.tsx`: célula de sugestão de categoria com `onAccept`/`onDismiss`.
    - `transaction-form-sheet.tsx`: recebe `bankAccounts`, `categories` e `onCreate`; criação via ação otimista com toasts de erro/sucesso.
    - `routes/transactions.tsx`: removido prefetch/loader; `ssr: false` para evitar problemas de hidratação.
    - Chat: ajuste visual de centragem no layout (`mx-auto`).
  - Store
    - Estado de lançamentos, page-info, contas, categorias e cartões agora em coleções do `@tanstack/react-db`.

- **Testes**
  - Listagem/paginação/total: filtros (view/status/overdue/conta) e sorting aplicam corretamente; busca com `%`, `_`, `\` escapados.
  - CRUD: criar/editar/excluir/reativar/aceitar/ignorar sugestão/marcar pago/desmarcar com UI otimista e refetch; toasts em falha.
  - Bulk: `ignored`, `status`, `date`, `categoryId`, `bankAccountId` atualizam múltiplos itens; políticas (ex.: CC obrigatório) respeitadas com erro claro.
  - Importação: CSV/XLSX/OFX cria linhas “fantasma”, confirma no servidor; autocategorização com aceitar/ignorar funcionando.
  - Navegação: sem flicker; sem warnings de SSR/hidratação.

<sup>Written for commit 7a460392160eeec97db2bda44b3e32ce0bd77f14. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/983?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

