### PR TITLE
feat(database): add relationships schema and optional transaction link

### DIFF
--- a/apps/web/src/integrations/tanstack-db/transactions.ts
+++ b/apps/web/src/integrations/tanstack-db/transactions.ts
@@ -296,6 +296,7 @@ export function buildOptimisticTransactionRow({
       statementPeriod: input.statementPeriod ?? null,
       tagId: input.tagId ?? null,
       suggestedTagId: null,
+      relationshipId: null,
       createdAt: now,
       updatedAt: now,
       categoryName: categoryName ?? null,

--- a/core/database/src/relations.ts
+++ b/core/database/src/relations.ts
@@ -15,6 +15,7 @@ import { bankAccounts } from "@core/database/schemas/bank-accounts";
 import { categories } from "@core/database/schemas/categories";
 import { creditCards } from "@core/database/schemas/credit-cards";
 import { creditCardStatements } from "@core/database/schemas/credit-card-statements";
+import { parties } from "@core/database/schemas/relationships";
 import { tags } from "@core/database/schemas/tags";
 import {
    transactionRecurrences,
@@ -167,6 +168,10 @@ export const transactionsRelations = relations(
          fields: [transactions.tagId],
          references: [tags.id],
       }),
+      party: one(parties, {
+         fields: [transactions.relationshipId],
+         references: [parties.id],
+      }),
       recurrence: one(transactionRecurrences, {
          fields: [transactions.recurrenceId],
          references: [transactionRecurrences.id],
@@ -175,6 +180,10 @@ export const transactionsRelations = relations(
       items: many(transactionItems),
    }),
 );
+
+export const partiesRelations = relations(parties, ({ many }) => ({
+   transactions: many(transactions),
+}));
 
 export const transactionRecurrencesRelations = relations(
    transactionRecurrences,

--- a/core/database/src/schema.ts
+++ b/core/database/src/schema.ts
@@ -7,6 +7,7 @@ export * from "@core/database/schemas/credit-card-statements";
 export * from "@core/database/schemas/credit-card-statement-totals";
 export * from "@core/database/schemas/inbox";
 export * from "@core/database/schemas/reports";
+export * from "@core/database/schemas/relationships";
 export * from "@core/database/schemas/workflows";
 export * from "@core/database/schemas/settings-financial";
 export * from "@core/database/schemas/tags";

--- a/core/database/src/schemas/relationships.ts
+++ b/core/database/src/schemas/relationships.ts
@@ -1,0 +1,56 @@
+import { sql } from "drizzle-orm";
+import {
+   index,
+   pgSchema,
+   text,
+   timestamp,
+   uniqueIndex,
+   uuid,
+} from "drizzle-orm/pg-core";
+
+export const relationships = pgSchema("relationships");
+
+export const partyRoleEnum = relationships.enum("party_role", [
+   "customer",
+   "supplier",
+]);
+
+export const partyKindEnum = relationships.enum("party_kind", [
+   "person",
+   "company",
+]);
+
+export const parties = relationships.table(
+   "parties",
+   {
+      id: uuid("id")
+         .default(sql`pg_catalog.gen_random_uuid()`)
+         .primaryKey(),
+      teamId: uuid("team_id").notNull(),
+      role: partyRoleEnum("role").notNull(),
+      kind: partyKindEnum("kind").notNull(),
+      name: text("name").notNull(),
+      documentNumber: text("document_number"),
+      email: text("email"),
+      phone: text("phone"),
+      archivedAt: timestamp("archived_at", { withTimezone: true }),
+      createdAt: timestamp("created_at", { withTimezone: true })
+         .notNull()
+         .defaultNow(),
+      updatedAt: timestamp("updated_at", { withTimezone: true })
+         .notNull()
+         .defaultNow()
+         .$onUpdate(() => new Date()),
+   },
+   (table) => [
+      index("parties_team_id_idx").on(table.teamId),
+      index("parties_role_idx").on(table.role),
+      index("parties_archived_at_idx").on(table.archivedAt),
+      uniqueIndex("parties_team_id_role_document_number_uq")
+         .on(table.teamId, table.role, table.documentNumber)
+         .where(sql`${table.documentNumber} IS NOT NULL`),
+   ],
+);
+
+export type Party = typeof parties.$inferSelect;
+export type NewParty = typeof parties.$inferInsert;

--- a/core/database/src/schemas/transactions.ts
+++ b/core/database/src/schemas/transactions.ts
@@ -16,6 +16,7 @@ import { bankAccounts } from "@core/database/schemas/bank-accounts";
 import { categories } from "@core/database/schemas/categories";
 import { creditCards } from "@core/database/schemas/credit-cards";
 import { tags } from "@core/database/schemas/tags";
+import { parties } from "@core/database/schemas/relationships";
 import { z } from "zod";
 
 export const attachmentSchema = z.object({
@@ -108,6 +109,9 @@ export const transactions = financeSchema.table(
       suggestedTagId: uuid("suggested_tag_id").references(() => tags.id, {
          onDelete: "set null",
       }),
+      relationshipId: uuid("relationship_id").references(() => parties.id, {
+         onDelete: "set null",
+      }),
       createdAt: timestamp("created_at", { withTimezone: true })
          .notNull()
          .defaultNow(),
@@ -131,6 +135,7 @@ export const transactions = financeSchema.table(
       ),
       index("transactions_tag_id_idx").on(table.tagId),
       index("transactions_suggested_tag_id_idx").on(table.suggestedTagId),
+      index("transactions_relationship_id_idx").on(table.relationshipId),
       index("transactions_status_idx").on(table.status),
       index("transactions_ignored_idx").on(table.ignored),
       index("transactions_due_date_idx").on(table.dueDate),


### PR DESCRIPTION
## Resumo

- Cria o novo schema PostgreSQL `relationships` com a tabela operacional `parties`.
- Adiciona o vínculo opcional `relationshipId` em `finance.transactions` apontando para `relationships.parties(id)`.
- Adiciona índices e unique parcial conforme escopo:
  - `teamId`, `role`, `archivedAt` em `relationships.parties`.
  - `relationshipId` em `finance.transactions`.
  - unique parcial por `(teamId, role, documentNumber)` quando `documentNumber IS NOT NULL`.

## Validação

- `bunx oxfmt --write core/database/src/schemas/relationships.ts core/database/src/schemas/transactions.ts core/database/src/schema.ts`
- `bun --filter @core/database typecheck`
- `bun --filter @core/database build`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cria o schema `relationships` com a tabela `parties` e adiciona `relationshipId` opcional em `finance.transactions`, incluindo relações Drizzle (`transactions.party` ↔ `parties.transactions`). Prepara a V1 de Relacionamentos (MON-1134) sem quebrar fluxos atuais e com deduplicação por documento.

- **New Features**
  - Schema `relationships.parties`: enums `party_role` (customer|supplier) e `party_kind` (person|company); campos `id`, `teamId`, `role`, `kind`, `name`, `documentNumber?`, `email?`, `phone?`, `archivedAt?`, `createdAt`, `updatedAt` (TZ, `defaultNow`, `$onUpdate`).
  - Índices/constraints: `teamId`, `role`, `archivedAt` em `relationships.parties`; unique parcial `(teamId, role, documentNumber)` quando `documentNumber IS NOT NULL`; índice `relationshipId` em `finance.transactions`.
  - `finance.transactions`: `relationshipId` nullable, FK para `relationships.parties(id)` com `onDelete: set null`.
  - Relações Drizzle: `transactions.party` e `parties.transactions` em `@core/database/src/relations.ts`.
  - Barrel `@core/database/src/schema.ts`: exporta `relationships`.
  - `apps/web`: insert otimista de transação passa a setar `relationshipId: null`.
  - Por que (MON-1134): permitir vincular transações a clientes/fornecedores e evitar duplicidade por documento dentro da mesma role/time.
  - Impacto por camada:
    - Router: sem mudanças.
    - Repositório: novos tipos `Party`/`NewParty` e relations habilitam carregar `party`; repositórios de transações podem aceitar/retornar `relationshipId`.
    - Componente: sem mudança agora; UI poderá listar/selecionar relacionamento futuramente.
    - Store: estado/shape de transação passa a incluir `relationshipId`; inserts otimistas usam `null`.

- **Migration**
  - Aplicar migração do `@core/database`: criar schema `relationships`, tabela `parties` e coluna/índice em `finance.transactions`.
  - Checklist de teste:
    - Inserir `Party` com e sem `documentNumber`; validar unique parcial (mesmo documento permitido em roles diferentes; bloqueado para mesma role+time).
    - Criar `Transaction` com `relationshipId` válido e `NULL`; validar FK, índice e `onDelete: set null`.
    - Consultar `transactions` incluindo `party` e, a partir de `parties`, listar `transactions`; validar tipagem no `@core/database`.
    - Build/typecheck: `bun --filter @core/database typecheck && bun --filter @core/database build` e `bun --filter apps/web typecheck`.
    - Verificar planos de consulta para índices `teamId`, `role`, `archivedAt` e `relationshipId`.

<sup>Written for commit 4ab25ef4409db0e2e89ad713784f8575952bc12f. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/984?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

