### PR TITLE
feat: validação e normalização para documento de relacionamento

### DIFF
--- a/core/database/__tests__/schemas/relationships-validators.test.ts
+++ b/core/database/__tests__/schemas/relationships-validators.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "vitest";
+import {
+   createPartyCompanySchema,
+   createPartyPersonSchema,
+   isValidCpf,
+   isValidCnpj,
+   normalizeDocument,
+   normalizePhone,
+   updatePartySchema,
+} from "@core/database/schemas/relationships";
+
+describe("relationships helpers", () => {
+   it("normaliza documento removendo máscara e converte para maiúsculo", () => {
+      const result = normalizeDocument(" 12.abc.345/6789-de  ");
+      expect(result).toBe("12ABC3456789DE");
+   });
+
+   it("normaliza telefone removendo máscara", () => {
+      expect(normalizePhone("(11) 98765-4321")).toBe("11987654321");
+   });
+
+   it("valida CPF corretamente", () => {
+      expect(isValidCpf("52998224725")).toBe(true);
+      expect(isValidCpf("52998224724")).toBe(false);
+   });
+
+   it("valida CNPJ alfanumérico", () => {
+      expect(isValidCnpj("12ABC34501DE35")).toBe(true);
+      expect(isValidCnpj("12ABC34501DE36")).toBe(false);
+   });
+});
+
+describe("createPartyPersonSchema", () => {
+   const baseInput = {
+      role: "customer",
+      kind: "person",
+      name: "João Souza",
+   };
+
+   it("aceita CPF válido", () => {
+      const result = createPartyPersonSchema.safeParse({
+         ...baseInput,
+         documentNumber: "529.982.247-25",
+         email: "joao@teste.com",
+         phone: "(11) 98765-4321",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+         expect(result.data.documentNumber).toBe("52998224725");
+         expect(result.data.phone).toBe("11987654321");
+      }
+   });
+
+   it("rejeita CPF inválido", () => {
+      const result = createPartyPersonSchema.safeParse({
+         ...baseInput,
+         documentNumber: "529.982.247-24",
+      });
+      expect(result.success).toBe(false);
+   });
+
+   it("rejeita CNPJ em pessoa", () => {
+      const result = createPartyPersonSchema.safeParse({
+         ...baseInput,
+         documentNumber: "12ABC34501DE35",
+      });
+      expect(result.success).toBe(false);
+   });
+
+   it("aceita documento vazio", () => {
+      const result = createPartyPersonSchema.safeParse({
+         ...baseInput,
+         documentNumber: "  ",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+         expect(result.data.documentNumber).toBe(null);
+      }
+   });
+
+   it("aceita nome com 2 caracteres", () => {
+      const result = createPartyPersonSchema.safeParse({
+         ...baseInput,
+         name: "An",
+      });
+      expect(result.success).toBe(true);
+   });
+
+   it("converte email vazio para null", () => {
+      const result = createPartyPersonSchema.safeParse({
+         ...baseInput,
+         email: "   ",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+         expect(result.data.email).toBe(null);
+      }
+   });
+
+   it("converte telefone vazio para null", () => {
+      const result = createPartyPersonSchema.safeParse({
+         ...baseInput,
+         phone: "   ",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+         expect(result.data.phone).toBe(null);
+      }
+   });
+
+   it("rejeita nome com 1 caractere", () => {
+      expect(
+         createPartyPersonSchema.safeParse({
+            ...baseInput,
+            name: "A",
+         }).success,
+      ).toBe(false);
+   });
+
+   it("rejeita nome com mais de 160 caracteres", () => {
+      expect(
+         createPartyPersonSchema.safeParse({
+            ...baseInput,
+            name: "A".repeat(161),
+         }).success,
+      ).toBe(false);
+   });
+
+   it("rejeita e-mail inválido", () => {
+      expect(
+         createPartyPersonSchema.safeParse({
+            ...baseInput,
+            email: "email-invalido",
+         }).success,
+      ).toBe(false);
+   });
+
+   it("rejeita telefone com tamanho inválido", () => {
+      expect(
+         createPartyPersonSchema.safeParse({
+            ...baseInput,
+            phone: "(11) 1234-789",
+         }).success,
+      ).toBe(false);
+   });
+});
+
+describe("createPartyCompanySchema", () => {
+   it("aceita CNPJ válido", () => {
+      const result = createPartyCompanySchema.safeParse({
+         role: "supplier",
+         kind: "company",
+         name: "Loja do Zé",
+         documentNumber: "11.222.333/0001-81",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+         expect(result.data.documentNumber).toBe("11222333000181");
+      }
+   });
+
+   it("rejeita CNPJ inválido", () => {
+      expect(
+         createPartyCompanySchema.safeParse({
+            role: "supplier",
+            kind: "company",
+            name: "Loja do Zé",
+            documentNumber: "11.222.333/0001-82",
+         }).success,
+      ).toBe(false);
+   });
+
+   it("rejeita CPF em empresa", () => {
+      expect(
+         createPartyCompanySchema.safeParse({
+            role: "supplier",
+            kind: "company",
+            name: "Loja do Zé",
+            documentNumber: "529.982.247-25",
+         }).success,
+      ).toBe(false);
+   });
+
+   it("aceita CNPJ alfanumérico válido", () => {
+      expect(
+         createPartyCompanySchema.safeParse({
+            role: "supplier",
+            kind: "company",
+            name: "Loja do Zé",
+            documentNumber: "12ABC34501DE35",
+         }).success,
+      ).toBe(true);
+   });
+
+   it("aceita documento vazio", () => {
+      expect(
+         createPartyCompanySchema.safeParse({
+            role: "supplier",
+            kind: "company",
+            name: "Loja do Zé",
+            documentNumber: " ",
+         }).success,
+      ).toBe(true);
+   });
+});
+
+describe("updatePartySchema", () => {
+   it("rejeita trocar tipo sem informar documento", () => {
+      const result = updatePartySchema.safeParse({
+         kind: "person",
+      });
+      expect(result.success).toBe(false);
+   });
+
+   it("aceita trocar tipo com documento vazio", () => {
+      const result = updatePartySchema.safeParse({
+         kind: "company",
+         documentNumber: "   ",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+         expect(result.data.documentNumber).toBe(null);
+      }
+   });
+
+   it("aceita trocar tipo com documento null", () => {
+      const result = updatePartySchema.safeParse({
+         kind: "company",
+         documentNumber: null,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+         expect(result.data.documentNumber).toBe(null);
+      }
+   });
+
+   it("rejeita kind incoerente com documento atual: company com CPF", () => {
+      const result = updatePartySchema.safeParse({
+         kind: "company",
+         documentNumber: "529.982.247-25",
+      });
+      expect(result.success).toBe(false);
+   });
+
+   it("rejeita person com CNPJ no documento", () => {
+      const result = updatePartySchema.safeParse({
+         kind: "person",
+         documentNumber: "11.222.333/0001-81",
+      });
+      expect(result.success).toBe(false);
+   });
+
+   it("falha atualizar apenas documento sem informar tipo", () => {
+      const result = updatePartySchema.safeParse({
+         documentNumber: "529.982.247-25",
+      });
+      expect(result.success).toBe(false);
+   });
+});

--- a/core/database/src/schemas/relationships.ts
+++ b/core/database/src/schemas/relationships.ts
@@ -1,4 +1,5 @@
 import { sql } from "drizzle-orm";
+import { createInsertSchema } from "drizzle-zod";
 import {
    index,
    pgSchema,
@@ -7,6 +8,7 @@ import {
    uniqueIndex,
    uuid,
 } from "drizzle-orm/pg-core";
+import { z } from "zod";
 
 export const relationships = pgSchema("relationships");
 
@@ -54,3 +56,352 @@ export const parties = relationships.table(
 
 export type Party = typeof parties.$inferSelect;
 export type NewParty = typeof parties.$inferInsert;
+
+export const partyRoleValues: readonly ["customer", "supplier"] = [
+   "customer",
+   "supplier",
+];
+export const partyKindValues: readonly ["person", "company"] = [
+   "person",
+   "company",
+];
+
+const CPF_REGEX = /^\d{11}$/;
+const CNPJ_REGEX = /^[A-Z0-9]{12}\d{2}$/;
+const PHONE_DIGITS = /^\d{10,11}$/;
+const ALPHANUMERIC_WITHOUT_MASK = /[^A-Z0-9]/g;
+const ONLY_DIGITS = /\D/g;
+
+const CPF_WEIGHT_FIRST_DIGIT = [10, 9, 8, 7, 6, 5, 4, 3, 2];
+const CPF_WEIGHT_SECOND_DIGIT = [11, 10, 9, 8, 7, 6, 5, 4, 3, 2];
+const CNPJ_FIRST_DIGIT_WEIGHTS = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+const CNPJ_SECOND_DIGIT_WEIGHTS = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+
+export const normalizeDocument = (value: string | null | undefined) => {
+   if (value == null) {
+      return null;
+   }
+
+   const normalized = value
+      .toUpperCase()
+      .replace(ALPHANUMERIC_WITHOUT_MASK, "");
+
+   if (normalized.length === 0) {
+      return null;
+   }
+
+   return normalized;
+};
+
+const normalizeDocumentInput = (value: unknown): unknown => {
+   if (value === null || value === undefined) {
+      return null;
+   }
+
+   if (typeof value !== "string") {
+      return value;
+   }
+
+   return normalizeDocument(value);
+};
+
+function normalizeNullableText(value: unknown): unknown {
+   if (value == null) {
+      return null;
+   }
+
+   if (typeof value !== "string") {
+      return value;
+   }
+
+   const trimmed = value.trim();
+
+   if (trimmed.length === 0) {
+      return null;
+   }
+
+   return trimmed;
+}
+
+export const normalizePhone = (value: string | null | undefined) => {
+   if (value == null) {
+      return null;
+   }
+
+   const digits = value.replace(ONLY_DIGITS, "");
+
+   if (digits.length === 0) {
+      return null;
+   }
+
+   return digits;
+};
+
+const normalizePhoneInput = (value: unknown): unknown => {
+   if (value === null || value === undefined) {
+      return null;
+   }
+
+   if (typeof value !== "string") {
+      return value;
+   }
+
+   return normalizePhone(value);
+};
+
+function cpfDigit(values: string, weights: readonly number[]): number {
+   const total = values
+      .split("")
+      .reduce(
+         (acc, digit, index) => acc + Number(digit) * (weights[index] ?? 0),
+         0,
+      );
+
+   const remainder = total % 11;
+   return remainder < 2 ? 0 : 11 - remainder;
+}
+
+function cnpjCharValue(char: string): number {
+   const code = char.charCodeAt(0);
+   return code - 48;
+}
+
+function cnpjDigit(values: string, weights: readonly number[]): number {
+   const total = values
+      .split("")
+      .reduce(
+         (acc, char, index) =>
+            acc + cnpjCharValue(char) * (weights[index] ?? 0),
+         0,
+      );
+
+   const remainder = total % 11;
+   return remainder < 2 ? 0 : 11 - remainder;
+}
+
+export function isValidCpf(value: string): boolean {
+   const normalized = normalizeDocument(value);
+
+   if (normalized === null) {
+      return false;
+   }
+
+   if (normalized.length !== 11) {
+      return false;
+   }
+
+   if (!CPF_REGEX.test(normalized)) {
+      return false;
+   }
+
+   const firstCharacter = normalized[0];
+
+   if (firstCharacter === undefined) {
+      return false;
+   }
+
+   const allSame = normalized
+      .split("")
+      .every((digit) => digit === firstCharacter);
+   if (allSame) {
+      return false;
+   }
+
+   const body = normalized.slice(0, 9);
+   const firstCheckDigit = cpfDigit(body, CPF_WEIGHT_FIRST_DIGIT);
+   const secondCheckDigit = cpfDigit(
+      `${body}${firstCheckDigit}`,
+      CPF_WEIGHT_SECOND_DIGIT,
+   );
+
+   return `${firstCheckDigit}${secondCheckDigit}` === normalized.slice(9);
+}
+
+export function isValidCnpj(value: string): boolean {
+   const normalized = normalizeDocument(value);
+
+   if (normalized === null) {
+      return false;
+   }
+
+   if (!CNPJ_REGEX.test(normalized)) {
+      return false;
+   }
+
+   const firstCharacter = normalized[0];
+   if (firstCharacter === undefined) {
+      return false;
+   }
+
+   const allSame = normalized
+      .split("")
+      .every((digit) => digit === firstCharacter);
+   if (allSame) {
+      return false;
+   }
+
+   const body = normalized.slice(0, 12);
+   const firstCheckDigit = cnpjDigit(body, CNPJ_FIRST_DIGIT_WEIGHTS);
+   const secondCheckDigit = cnpjDigit(
+      `${body}${firstCheckDigit}`,
+      CNPJ_SECOND_DIGIT_WEIGHTS,
+   );
+
+   return `${firstCheckDigit}${secondCheckDigit}` === normalized.slice(12);
+}
+
+const nameSchema = z
+   .string()
+   .trim()
+   .min(2, "Nome deve ter no mínimo 2 caracteres.")
+   .max(160, "Nome deve ter no máximo 160 caracteres.");
+
+const documentBaseSchema = z.preprocess(
+   normalizeDocumentInput,
+   z.string().nullable().optional(),
+);
+
+const emailSchema = z.preprocess(
+   normalizeNullableText,
+   z.string().email("E-mail inválido.").nullable().optional(),
+);
+
+const phoneSchema = z.preprocess(
+   normalizePhoneInput,
+   z
+      .string()
+      .nullable()
+      .optional()
+      .superRefine((value, ctx) => {
+         if (value === null || value === undefined) {
+            return;
+         }
+
+         if (!PHONE_DIGITS.test(value)) {
+            ctx.addIssue({
+               code: z.ZodIssueCode.custom,
+               message: "Telefone deve ter 10 ou 11 dígitos.",
+            });
+         }
+      }),
+);
+
+const personDocumentSchema = documentBaseSchema.superRefine((value, ctx) => {
+   if (value === null || value === undefined) {
+      return;
+   }
+
+   if (!isValidCpf(value)) {
+      ctx.addIssue({
+         code: z.ZodIssueCode.custom,
+         message: "CPF inválido.",
+      });
+   }
+});
+
+const companyDocumentSchema = documentBaseSchema.superRefine((value, ctx) => {
+   if (value === null || value === undefined) {
+      return;
+   }
+
+   if (!isValidCnpj(value)) {
+      ctx.addIssue({
+         code: z.ZodIssueCode.custom,
+         message: "CNPJ inválido.",
+      });
+   }
+});
+
+const basePartySchema = createInsertSchema(parties).pick({
+   name: true,
+   role: true,
+   kind: true,
+   documentNumber: true,
+   email: true,
+   phone: true,
+});
+
+export const createPartyPersonSchema = basePartySchema.extend({
+   name: nameSchema,
+   role: z.enum(partyRoleValues),
+   kind: z.literal("person"),
+   documentNumber: personDocumentSchema,
+   email: emailSchema,
+   phone: phoneSchema,
+});
+
+export const createPartyCompanySchema = basePartySchema.extend({
+   name: nameSchema,
+   role: z.enum(partyRoleValues),
+   kind: z.literal("company"),
+   documentNumber: companyDocumentSchema,
+   email: emailSchema,
+   phone: phoneSchema,
+});
+
+export const createPartySchema = z.discriminatedUnion("kind", [
+   createPartyPersonSchema,
+   createPartyCompanySchema,
+]);
+
+export const updatePartySchema = basePartySchema
+   .extend({
+      name: nameSchema.optional(),
+      role: z.enum(partyRoleValues).optional(),
+      kind: z.enum(partyKindValues).optional(),
+      documentNumber: documentBaseSchema,
+      email: emailSchema,
+      phone: phoneSchema,
+   })
+   .partial()
+   .superRefine((data, ctx) => {
+      if (data.kind !== undefined) {
+         if (data.documentNumber === undefined) {
+            ctx.addIssue({
+               code: z.ZodIssueCode.custom,
+               path: ["documentNumber"],
+               message:
+                  "Documento é obrigatório ao alterar o tipo de relacionamento.",
+            });
+            return;
+         }
+
+         if (data.documentNumber === null) {
+            return;
+         }
+
+         if (data.kind === "person") {
+            if (!isValidCpf(data.documentNumber)) {
+               ctx.addIssue({
+                  code: z.ZodIssueCode.custom,
+                  path: ["documentNumber"],
+                  message: "CPF inválido.",
+               });
+            }
+
+            return;
+         }
+
+         if (!isValidCnpj(data.documentNumber)) {
+            ctx.addIssue({
+               code: z.ZodIssueCode.custom,
+               path: ["documentNumber"],
+               message: "CNPJ inválido.",
+            });
+         }
+
+         return;
+      }
+
+      if (data.documentNumber !== undefined && data.documentNumber !== null) {
+         ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["kind"],
+            message:
+               "Informe o tipo de relacionamento para validar o documento.",
+         });
+      }
+   });
+
+export type CreatePartyInput = z.infer<typeof createPartySchema>;
+export type UpdatePartyInput = z.infer<typeof updatePartySchema>;


### PR DESCRIPTION
Implementa validação e normalização de documento/telefone para relacionamentos (person/company), com CPF e CNPJ (inclui CNPJ alfanumérico), e testes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adiciona validação e normalização de documento e telefone para Relacionamentos (Clientes/Fornecedores), com suporte a CPF e CNPJ (inclui CNPJ alfanumérico), alinhado ao MON-1135. Garante entradas limpas e regras por tipo antes de persistir no `core/database`.

- Novas funcionalidades
  - Helpers em `@core/database/schemas/relationships`: `normalizeDocument`, `normalizePhone`, `isValidCpf`, `isValidCnpj`.
  - Schemas com `zod`/`drizzle-zod`: `createPartyPersonSchema`, `createPartyCompanySchema`, `createPartySchema`, `updatePartySchema`.
  - Regras: remove máscara/ruído, CNPJ em uppercase; CPF validado matematicamente; CNPJ numérico e alfanumérico com dígitos verificadores; campos vazios viram `null`; nome 2..160; e-mail opcional com `.email()`; telefone BR com 10–11 dígitos.
  - Consistência por tipo: `person` aceita vazio ou CPF válido; `company` aceita vazio ou CNPJ válido.
  - Atualização: `updatePartySchema` exige `kind` quando `documentNumber` é informado e exige `documentNumber` (pode ser vazio/null) quando `kind` é informado; rejeita combinações incoerentes (CPF em `company`, CNPJ em `person`).
  - Impacto por camada:
    - Repositório (`core/database`): valida/normaliza no insert/update de `party`, reduzindo erros de persistência.
    - Router/Componente/Store: sem mudanças de contrato; UI pode manter máscaras, backend salva valores normalizados.

- Checklist de teste
  - Normalização de documento/telefone.
  - CPF válido/inválido; CNPJ numérico e alfanumérico válido/inválido.
  - Regras por `kind` e erros cruzados (CPF↔CNPJ).
  - Conversão de `email`, `phone`, `documentNumber` vazios para `null`.
  - Nome 2..160; telefone 10/11 dígitos.
  - `updatePartySchema`: exige `kind` ao alterar documento; exige documento ao alterar `kind`; aceita `null`/vazio; rejeita incoerências.

<sup>Written for commit befa9c4438c7543254e43b600b179592d8c3193a. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/985?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

