### PR TITLE
refactor(web:reports): migrate report module to TanStack DB

### DIFF
--- a/apps/web/src/integrations/tanstack-db/reports.ts
+++ b/apps/web/src/integrations/tanstack-db/reports.ts
@@ -1,0 +1,392 @@
+import dayjs from "dayjs";
+import { queryCollectionOptions } from "@tanstack/query-db-collection";
+import type { QueryClient } from "@tanstack/query-core";
+import { createOptimisticAction } from "@tanstack/react-db";
+import type { Collection } from "@tanstack/react-db";
+import { orpc, type Inputs, type Outputs } from "@/integrations/orpc/client";
+
+export type ReportRow = Outputs["reports"]["list"][number];
+export type ReportCreateInput = Inputs["reports"]["create"];
+export type ProfitAndLossReportRow = Outputs["reports"]["profitAndLoss"] & {
+   id: string;
+};
+export type CashFlowReportRow = Outputs["reports"]["cashFlow"] & { id: string };
+export type CostCentersReportRow =
+   Outputs["reports"]["expensesByCostCenter"] & { id: string };
+export type AgingReportRow = Outputs["reports"]["aging"] & { id: string };
+export type CategoryExpensesReportRow =
+   Outputs["reports"]["expensesByCategory"] & { id: string };
+export type ReportTransactionRow =
+   Outputs["transactions"]["getAll"]["data"][number];
+export type TransactionSummaryRow = { id: string; total: number };
+
+export type ReportCollection = Collection<ReportRow, string>;
+
+export function buildReportCollectionRowId(prefix = "__report_") {
+   if (typeof crypto !== "undefined") {
+      if (typeof crypto.randomUUID === "function") {
+         return `${prefix}${crypto.randomUUID()}`;
+      }
+
+      if (typeof crypto.getRandomValues === "function") {
+         const bytes = new Uint8Array(16);
+         crypto.getRandomValues(bytes);
+         const hex = Array.from(bytes, (byte) =>
+            byte.toString(16).padStart(2, "0"),
+         ).join("");
+         return `${prefix}${hex}`;
+      }
+   }
+
+   return `${prefix}${dayjs().valueOf().toString(36)}`;
+}
+
+type ReportCollectionOptionsParams = {
+   queryClient: QueryClient;
+   teamId: string;
+};
+
+type ReportIdInput = {
+   id: string;
+};
+
+type ReportCreateActionInput = {
+   row: ReportRow;
+   input: ReportCreateInput;
+};
+
+type BulkReportRemoveInput = Inputs["reports"]["bulkRemove"];
+
+type ProfitAndLossInput = Inputs["reports"]["profitAndLoss"];
+type CashFlowInput = Inputs["reports"]["cashFlow"];
+type CostCentersInput = Inputs["reports"]["expensesByCostCenter"];
+type AgingInput = Inputs["reports"]["aging"];
+type CategoryExpensesInput = Inputs["reports"]["expensesByCategory"];
+type TransactionsGetAllInput = Inputs["transactions"]["getAll"];
+type TransactionsSummaryInput = Inputs["transactions"]["getSummary"];
+
+type ProfitAndLossCollectionInput = {
+   queryClient: QueryClient;
+   input: ProfitAndLossInput;
+};
+
+type CashFlowCollectionInput = {
+   queryClient: QueryClient;
+   input: CashFlowInput;
+};
+
+type CostCentersCollectionInput = {
+   queryClient: QueryClient;
+   input: CostCentersInput;
+};
+
+type AgingCollectionInput = {
+   queryClient: QueryClient;
+   input: AgingInput;
+};
+
+type CategoryExpensesCollectionInput = {
+   queryClient: QueryClient;
+   input: CategoryExpensesInput;
+};
+
+type ReportTransactionsCollectionInput = {
+   queryClient: QueryClient;
+   input: TransactionsGetAllInput;
+};
+
+type ReportTransactionSummaryCollectionInput = {
+   queryClient: QueryClient;
+   input: TransactionsSummaryInput;
+};
+
+async function safeRefetchReportCollection(collection: ReportCollection) {
+   await collection.utils.refetch().catch(() => {});
+}
+
+function buildReportOutputId(namespace: string, input: unknown) {
+   return `${namespace}:${JSON.stringify(input ?? {})}`;
+}
+
+export function buildOptimisticReportRow({
+   id,
+   input,
+   teamId,
+}: {
+   id: string;
+   input: ReportCreateInput;
+   teamId: string;
+}): ReportRow {
+   const now = dayjs().toDate();
+   return {
+      id,
+      teamId,
+      name: input.name,
+      type: input.type,
+      source: "manual",
+      config: {
+         dateFrom: input.config.dateFrom,
+         dateTo: input.config.dateTo,
+         status: input.config.status ?? "all",
+         dreOnly: input.config.dreOnly ?? true,
+         agingType: input.config.agingType ?? "income",
+         agingStatus: input.config.agingStatus ?? "open",
+         categoryDepth: input.config.categoryDepth ?? "group",
+         minAmount: input.config.minAmount ?? 0,
+         bankAccountId: input.config.bankAccountId,
+         categoryId: input.config.categoryId,
+         tagId: input.config.tagId,
+      },
+      createdAt: now,
+      updatedAt: now,
+   };
+}
+
+export function reportsCollectionOptions({
+   queryClient,
+   teamId,
+}: ReportCollectionOptionsParams) {
+   return queryCollectionOptions({
+      id: `reports:${teamId}`,
+      queryKey: ["reports", teamId],
+      queryFn: () => orpc.reports.list.call(),
+      queryClient,
+      getKey: (report) => report.id,
+      syncMode: "on-demand",
+      refetchInterval: 5_000,
+      meta: {
+         notifyOnError: true,
+         errorMessage: "Não foi possível sincronizar os relatórios.",
+      },
+   });
+}
+
+export function reportByIdCollectionOptions({
+   queryClient,
+   teamId,
+   id,
+}: {
+   queryClient: QueryClient;
+   teamId: string;
+   id: string;
+}) {
+   return queryCollectionOptions({
+      id: `reports-by-id:${teamId}:${id}`,
+      queryKey: ["reports", teamId, id],
+      queryFn: async () => {
+         const report = await orpc.reports.get.call({ id });
+         return [report];
+      },
+      queryClient,
+      getKey: (report) => report.id,
+      syncMode: "on-demand",
+      meta: {
+         notifyOnError: true,
+         errorMessage: "Não foi possível carregar o relatório.",
+      },
+   });
+}
+
+export function createReportAction(collection: ReportCollection) {
+   return createOptimisticAction<ReportCreateActionInput>({
+      onMutate: ({ row }) => {
+         collection.insert(row);
+      },
+      mutationFn: async ({ input }) => {
+         const created = await orpc.reports.create.call(input);
+         await safeRefetchReportCollection(collection);
+         return created;
+      },
+   });
+}
+
+export function removeReportAction(collection: ReportCollection) {
+   return createOptimisticAction<ReportIdInput>({
+      onMutate: ({ id }) => {
+         collection.delete(id);
+      },
+      mutationFn: async ({ id }) => {
+         const removed = await orpc.reports.remove.call({ id });
+         await safeRefetchReportCollection(collection);
+         return removed;
+      },
+   });
+}
+
+export function bulkRemoveReportAction(collection: ReportCollection) {
+   return createOptimisticAction<BulkReportRemoveInput>({
+      onMutate: ({ ids }) => {
+         collection.delete(ids);
+      },
+      mutationFn: async ({ ids }) => {
+         const removed = await orpc.reports.bulkRemove.call({ ids });
+         await safeRefetchReportCollection(collection);
+         return removed;
+      },
+   });
+}
+
+export function profitAndLossReportCollectionOptions({
+   queryClient,
+   input,
+}: ProfitAndLossCollectionInput) {
+   const id = buildReportOutputId("profit-and-loss", input);
+   return queryCollectionOptions({
+      id,
+      queryKey: ["reports", "profit-and-loss", input],
+      queryFn: async () => {
+         const report = await orpc.reports.profitAndLoss.call(input);
+         const row: ProfitAndLossReportRow = { ...report, id };
+         return [row];
+      },
+      queryClient,
+      getKey: (report) => report.id,
+      syncMode: "on-demand",
+      meta: {
+         notifyOnError: true,
+         errorMessage: "Não foi possível carregar o DRE.",
+      },
+   });
+}
+
+export function cashFlowReportCollectionOptions({
+   queryClient,
+   input,
+}: CashFlowCollectionInput) {
+   const id = buildReportOutputId("cash-flow", input);
+   return queryCollectionOptions({
+      id,
+      queryKey: ["reports", "cash-flow", input],
+      queryFn: async () => {
+         const report = await orpc.reports.cashFlow.call(input);
+         const row: CashFlowReportRow = { ...report, id };
+         return [row];
+      },
+      queryClient,
+      getKey: (report) => report.id,
+      syncMode: "on-demand",
+      meta: {
+         notifyOnError: true,
+         errorMessage: "Não foi possível carregar o fluxo de caixa.",
+      },
+   });
+}
+
+export function costCentersReportCollectionOptions({
+   queryClient,
+   input,
+}: CostCentersCollectionInput) {
+   const id = buildReportOutputId("cost-centers", input);
+   return queryCollectionOptions({
+      id,
+      queryKey: ["reports", "cost-centers", input],
+      queryFn: async () => {
+         const report = await orpc.reports.expensesByCostCenter.call(input);
+         const row: CostCentersReportRow = { ...report, id };
+         return [row];
+      },
+      queryClient,
+      getKey: (report) => report.id,
+      syncMode: "on-demand",
+      meta: {
+         notifyOnError: true,
+         errorMessage:
+            "Não foi possível carregar despesas por centro de custo.",
+      },
+   });
+}
+
+export function agingReportCollectionOptions({
+   queryClient,
+   input,
+}: AgingCollectionInput) {
+   const id = buildReportOutputId("aging", input);
+   return queryCollectionOptions({
+      id,
+      queryKey: ["reports", "aging", input],
+      queryFn: async () => {
+         const report = await orpc.reports.aging.call(input);
+         const row: AgingReportRow = { ...report, id };
+         return [row];
+      },
+      queryClient,
+      getKey: (report) => report.id,
+      syncMode: "on-demand",
+      meta: {
+         notifyOnError: true,
+         errorMessage: "Não foi possível carregar o aging.",
+      },
+   });
+}
+
+export function categoryExpensesReportCollectionOptions({
+   queryClient,
+   input,
+}: CategoryExpensesCollectionInput) {
+   const id = buildReportOutputId("categories", input);
+   return queryCollectionOptions({
+      id,
+      queryKey: ["reports", "categories", input],
+      queryFn: async () => {
+         const report = await orpc.reports.expensesByCategory.call(input);
+         const row: CategoryExpensesReportRow = { ...report, id };
+         return [row];
+      },
+      queryClient,
+      getKey: (report) => report.id,
+      syncMode: "on-demand",
+      meta: {
+         notifyOnError: true,
+         errorMessage: "Não foi possível carregar despesas por categoria.",
+      },
+   });
+}
+
+export function reportTransactionsCollectionOptions({
+   queryClient,
+   input,
+}: ReportTransactionsCollectionInput) {
+   return queryCollectionOptions({
+      id: buildReportOutputId("transactions", {
+         ...input,
+         reportSnapshot: true,
+      }),
+      queryKey: ["reports", "transactions", input],
+      queryFn: async () => {
+         const result = await orpc.transactions.getAll.call(input);
+         return result.data;
+      },
+      queryClient,
+      getKey: (row: ReportTransactionRow) => row.id,
+      syncMode: "on-demand",
+      meta: {
+         notifyOnError: true,
+         errorMessage: "Não foi possível carregar os lançamentos da snapshot.",
+      },
+   });
+}
+
+export function reportTransactionsSummaryCollectionOptions({
+   queryClient,
+   input,
+}: ReportTransactionSummaryCollectionInput) {
+   return queryCollectionOptions({
+      id: buildReportOutputId("transactions-summary", input),
+      queryKey: ["reports", "transactions-summary", input],
+      queryFn: async () => {
+         const summary = await orpc.transactions.getSummary.call(input);
+         const row: TransactionSummaryRow = {
+            id: buildReportOutputId("transactions-summary", input),
+            total: summary.totalCount,
+         };
+         return [row];
+      },
+      queryClient,
+      getKey: (row) => row.id,
+      syncMode: "on-demand",
+      meta: {
+         notifyOnError: true,
+         errorMessage: "Não foi possível carregar o total de lançamentos.",
+      },
+   });
+}

--- a/apps/web/src/integrations/tanstack-db/reports.ts
+++ b/apps/web/src/integrations/tanstack-db/reports.ts
@@ -68,44 +68,81 @@ type TransactionsSummaryInput = Inputs["transactions"]["getSummary"];
 type ProfitAndLossCollectionInput = {
    queryClient: QueryClient;
    input: ProfitAndLossInput;
+   teamId: string;
 };
 
 type CashFlowCollectionInput = {
    queryClient: QueryClient;
    input: CashFlowInput;
+   teamId: string;
 };
 
 type CostCentersCollectionInput = {
    queryClient: QueryClient;
    input: CostCentersInput;
+   teamId: string;
 };
 
 type AgingCollectionInput = {
    queryClient: QueryClient;
    input: AgingInput;
+   teamId: string;
 };
 
 type CategoryExpensesCollectionInput = {
    queryClient: QueryClient;
    input: CategoryExpensesInput;
+   teamId: string;
 };
 
 type ReportTransactionsCollectionInput = {
    queryClient: QueryClient;
    input: TransactionsGetAllInput;
+   teamId: string;
 };
 
 type ReportTransactionSummaryCollectionInput = {
    queryClient: QueryClient;
    input: TransactionsSummaryInput;
+   teamId: string;
 };
 
 async function safeRefetchReportCollection(collection: ReportCollection) {
-   await collection.utils.refetch().catch(() => {});
+   await collection.utils.refetch().catch((error: unknown) => {
+      // eslint-disable-next-line no-console -- refetch failures must be observable but should not break successful mutations.
+      console.error(
+         "safeRefetchReportCollection: falha ao sincronizar coleção de relatórios",
+         {
+            collectionId: collection.id,
+            error,
+         },
+      );
+   });
+}
+
+function stableStringify(value: unknown): string {
+   if (value === null || typeof value !== "object") {
+      return JSON.stringify(value);
+   }
+
+   if (Array.isArray(value)) {
+      return `[${value.map(stableStringify).join(",")}]`;
+   }
+
+   if (value instanceof Date) {
+      return JSON.stringify(value.toISOString());
+   }
+
+   const entries = Object.entries(value).sort(([a], [b]) => a.localeCompare(b));
+   return `{${entries
+      .map(
+         ([key, nested]) => `${JSON.stringify(key)}:${stableStringify(nested)}`,
+      )
+      .join(",")}}`;
 }
 
 function buildReportOutputId(namespace: string, input: unknown) {
-   return `${namespace}:${JSON.stringify(input ?? {})}`;
+   return `${namespace}:${stableStringify(input ?? {})}`;
 }
 
 export function buildOptimisticReportRow({
@@ -229,11 +266,12 @@ export function bulkRemoveReportAction(collection: ReportCollection) {
 export function profitAndLossReportCollectionOptions({
    queryClient,
    input,
+   teamId,
 }: ProfitAndLossCollectionInput) {
-   const id = buildReportOutputId("profit-and-loss", input);
+   const id = buildReportOutputId("profit-and-loss", { ...input, teamId });
    return queryCollectionOptions({
       id,
-      queryKey: ["reports", "profit-and-loss", input],
+      queryKey: ["reports", "profit-and-loss", teamId, input],
       queryFn: async () => {
          const report = await orpc.reports.profitAndLoss.call(input);
          const row: ProfitAndLossReportRow = { ...report, id };
@@ -252,11 +290,12 @@ export function profitAndLossReportCollectionOptions({
 export function cashFlowReportCollectionOptions({
    queryClient,
    input,
+   teamId,
 }: CashFlowCollectionInput) {
-   const id = buildReportOutputId("cash-flow", input);
+   const id = buildReportOutputId("cash-flow", { ...input, teamId });
    return queryCollectionOptions({
       id,
-      queryKey: ["reports", "cash-flow", input],
+      queryKey: ["reports", "cash-flow", teamId, input],
       queryFn: async () => {
          const report = await orpc.reports.cashFlow.call(input);
          const row: CashFlowReportRow = { ...report, id };
@@ -275,11 +314,12 @@ export function cashFlowReportCollectionOptions({
 export function costCentersReportCollectionOptions({
    queryClient,
    input,
+   teamId,
 }: CostCentersCollectionInput) {
-   const id = buildReportOutputId("cost-centers", input);
+   const id = buildReportOutputId("cost-centers", { ...input, teamId });
    return queryCollectionOptions({
       id,
-      queryKey: ["reports", "cost-centers", input],
+      queryKey: ["reports", "cost-centers", teamId, input],
       queryFn: async () => {
          const report = await orpc.reports.expensesByCostCenter.call(input);
          const row: CostCentersReportRow = { ...report, id };
@@ -299,11 +339,12 @@ export function costCentersReportCollectionOptions({
 export function agingReportCollectionOptions({
    queryClient,
    input,
+   teamId,
 }: AgingCollectionInput) {
-   const id = buildReportOutputId("aging", input);
+   const id = buildReportOutputId("aging", { ...input, teamId });
    return queryCollectionOptions({
       id,
-      queryKey: ["reports", "aging", input],
+      queryKey: ["reports", "aging", teamId, input],
       queryFn: async () => {
          const report = await orpc.reports.aging.call(input);
          const row: AgingReportRow = { ...report, id };
@@ -322,11 +363,12 @@ export function agingReportCollectionOptions({
 export function categoryExpensesReportCollectionOptions({
    queryClient,
    input,
+   teamId,
 }: CategoryExpensesCollectionInput) {
-   const id = buildReportOutputId("categories", input);
+   const id = buildReportOutputId("categories", { ...input, teamId });
    return queryCollectionOptions({
       id,
-      queryKey: ["reports", "categories", input],
+      queryKey: ["reports", "categories", teamId, input],
       queryFn: async () => {
          const report = await orpc.reports.expensesByCategory.call(input);
          const row: CategoryExpensesReportRow = { ...report, id };
@@ -345,13 +387,16 @@ export function categoryExpensesReportCollectionOptions({
 export function reportTransactionsCollectionOptions({
    queryClient,
    input,
+   teamId,
 }: ReportTransactionsCollectionInput) {
+   const id = buildReportOutputId("transactions", {
+      ...input,
+      reportSnapshot: true,
+      teamId,
+   });
    return queryCollectionOptions({
-      id: buildReportOutputId("transactions", {
-         ...input,
-         reportSnapshot: true,
-      }),
-      queryKey: ["reports", "transactions", input],
+      id,
+      queryKey: ["reports", "transactions", teamId, input],
       queryFn: async () => {
          const result = await orpc.transactions.getAll.call(input);
          return result.data;
@@ -369,14 +414,16 @@ export function reportTransactionsCollectionOptions({
 export function reportTransactionsSummaryCollectionOptions({
    queryClient,
    input,
+   teamId,
 }: ReportTransactionSummaryCollectionInput) {
+   const id = buildReportOutputId("transactions-summary", { ...input, teamId });
    return queryCollectionOptions({
-      id: buildReportOutputId("transactions-summary", input),
-      queryKey: ["reports", "transactions-summary", input],
+      id,
+      queryKey: ["reports", "transactions-summary", teamId, input],
       queryFn: async () => {
          const summary = await orpc.transactions.getSummary.call(input);
          const row: TransactionSummaryRow = {
-            id: buildReportOutputId("transactions-summary", input),
+            id,
             total: summary.totalCount,
          };
          return [row];

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-reports/report-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-reports/report-form-sheet.tsx
@@ -17,15 +17,22 @@ import {
 } from "@packages/ui/components/sheet";
 import { toast } from "@packages/ui/hooks/use-toast";
 import { useForm } from "@tanstack/react-form";
-import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
+import { type Collection } from "@tanstack/react-db";
 import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
 import { fromPromise } from "neverthrow";
+import { useMemo } from "react";
 import { z } from "zod";
 import { useDashboardSlugs } from "@/hooks/use-dashboard-slugs";
 import { useSheet } from "@/hooks/use-sheet";
-import { orpc } from "@/integrations/orpc/client";
+import {
+   buildOptimisticReportRow,
+   buildReportCollectionRowId,
+   createReportAction,
+   type ReportCreateInput,
+   type ReportRow,
+} from "@/integrations/tanstack-db/reports";
 import { REPORT_LABELS, type ReportType } from "./report-labels";
 
 const REPORT_TYPES = [
@@ -97,47 +104,66 @@ function parseStatus(value: string): ReportStatus | undefined {
    return STATUSES.find((status) => status === value);
 }
 
-export function ReportFormSheet() {
+type ReportFormSheetProps = {
+   collection: Collection<ReportRow, string>;
+   teamId: string;
+};
+
+export function ReportFormSheet({ collection, teamId }: ReportFormSheetProps) {
    const { closeTopSheet } = useSheet();
    const navigate = useNavigate();
    const { slug, teamSlug } = useDashboardSlugs();
-
-   const createMutation = useMutation(
-      orpc.reports.create.mutationOptions({
-         onSuccess: (report) => {
-            toast.success("Relatório criado.");
-            closeTopSheet();
-            navigate({
-               to: "/$slug/$teamSlug/reports/$reportId",
-               params: { slug, teamSlug, reportId: report.id },
-            });
-         },
-         onError: (e) => toast.error(e.message),
-      }),
+   const createReport = useMemo(
+      () => createReportAction(collection),
+      [collection],
    );
 
    const form = useForm({
       defaultValues: DEFAULT_VALUES,
       validators: { onMount: formSchema, onChange: formSchema },
       onSubmit: async ({ value }) => {
-         const result = await fromPromise(
-            createMutation.mutateAsync({
-               name: value.name.trim(),
-               type: value.type,
-               config: {
-                  dateFrom: value.dateFrom,
-                  dateTo: value.dateTo,
-                  status: value.status,
-                  dreOnly: true,
-                  agingType: "income",
-                  agingStatus: "open",
-                  categoryDepth: "group",
-                  minAmount: 0,
-               },
+         const input: ReportCreateInput = {
+            name: value.name.trim(),
+            type: value.type,
+            config: {
+               dateFrom: value.dateFrom,
+               dateTo: value.dateTo,
+               status: value.status,
+               dreOnly: true,
+               agingType: "income",
+               agingStatus: "open",
+               categoryDepth: "group",
+               minAmount: 0,
+            },
+         };
+         const create = createReport({
+            row: buildOptimisticReportRow({
+               id: buildReportCollectionRowId(),
+               input,
+               teamId,
             }),
-            (e) => e,
+            input,
+         });
+         const result = await fromPromise(
+            create.isPersisted.promise,
+            (error) => error,
          );
-         if (result.isErr()) return;
+         if (result.isErr()) {
+            const message =
+               result.error instanceof Error
+                  ? result.error.message
+                  : "Não foi possível criar o relatório.";
+            toast.error(message);
+            return;
+         }
+
+         const report = result.value;
+         toast.success("Relatório criado.");
+         closeTopSheet();
+         navigate({
+            to: "/$slug/$teamSlug/reports/$reportId",
+            params: { slug, teamSlug, reportId: report.id },
+         });
       },
    });
 

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-reports/report-panels.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-reports/report-panels.tsx
@@ -92,33 +92,61 @@ function marginValue(report: ProfitAndLossReport) {
 export function ReportData({
    report,
    queryClient,
+   teamId,
 }: {
    report: SavedReport;
    queryClient: QueryClient;
+   teamId: string;
 }) {
    if (report.type === "dre")
       return (
-         <ProfitAndLossData config={report.config} queryClient={queryClient} />
+         <ProfitAndLossData
+            config={report.config}
+            queryClient={queryClient}
+            teamId={teamId}
+         />
       );
    if (report.type === "cash-flow")
-      return <CashFlowData config={report.config} queryClient={queryClient} />;
+      return (
+         <CashFlowData
+            config={report.config}
+            queryClient={queryClient}
+            teamId={teamId}
+         />
+      );
    if (report.type === "cost-centers")
       return (
-         <CostCentersData config={report.config} queryClient={queryClient} />
+         <CostCentersData
+            config={report.config}
+            queryClient={queryClient}
+            teamId={teamId}
+         />
       );
    if (report.type === "aging")
-      return <AgingData config={report.config} queryClient={queryClient} />;
+      return (
+         <AgingData
+            config={report.config}
+            queryClient={queryClient}
+            teamId={teamId}
+         />
+      );
    return (
-      <CategoryExpensesData config={report.config} queryClient={queryClient} />
+      <CategoryExpensesData
+         config={report.config}
+         queryClient={queryClient}
+         teamId={teamId}
+      />
    );
 }
 
 function ProfitAndLossData({
    config,
    queryClient,
+   teamId,
 }: {
    config: ReportConfig;
    queryClient: QueryClient;
+   teamId: string;
 }) {
    const reportInput = useMemo(
       () => ({
@@ -186,9 +214,10 @@ function ProfitAndLossData({
             profitAndLossReportCollectionOptions({
                queryClient,
                input: reportInput,
+               teamId,
             }),
          ),
-      [queryClient, reportInput],
+      [queryClient, teamId, reportInput],
    );
    const transactionsCollection = useMemo(
       () =>
@@ -196,9 +225,10 @@ function ProfitAndLossData({
             reportTransactionsCollectionOptions({
                queryClient,
                input: transactionsInput,
+               teamId,
             }),
          ),
-      [queryClient, transactionsInput],
+      [queryClient, teamId, transactionsInput],
    );
    const transactionsSummaryCollection = useMemo(
       () =>
@@ -206,9 +236,10 @@ function ProfitAndLossData({
             reportTransactionsSummaryCollectionOptions({
                queryClient,
                input: summaryInput,
+               teamId,
             }),
          ),
-      [queryClient, summaryInput],
+      [queryClient, teamId, summaryInput],
    );
    const { data: reports, isLoading: isReportLoading } = useLiveQuery(
       (q) =>
@@ -259,9 +290,11 @@ function ProfitAndLossData({
 function CashFlowData({
    config,
    queryClient,
+   teamId,
 }: {
    config: ReportConfig;
    queryClient: QueryClient;
+   teamId: string;
 }) {
    const collectionInput = useMemo(
       () => ({
@@ -287,9 +320,10 @@ function CashFlowData({
             cashFlowReportCollectionOptions({
                queryClient,
                input: collectionInput,
+               teamId,
             }),
          ),
-      [queryClient, collectionInput],
+      [queryClient, teamId, collectionInput],
    );
    const { data, isLoading: isReportLoading } = useLiveQuery(
       (q) => q.from({ report: collection }).select(({ report }) => report),
@@ -304,9 +338,11 @@ function CashFlowData({
 function CostCentersData({
    config,
    queryClient,
+   teamId,
 }: {
    config: ReportConfig;
    queryClient: QueryClient;
+   teamId: string;
 }) {
    const collectionInput = useMemo(
       () => ({
@@ -332,9 +368,10 @@ function CostCentersData({
             costCentersReportCollectionOptions({
                queryClient,
                input: collectionInput,
+               teamId,
             }),
          ),
-      [queryClient, collectionInput],
+      [queryClient, teamId, collectionInput],
    );
    const { data, isLoading: isReportLoading } = useLiveQuery(
       (q) => q.from({ report: collection }).select(({ report }) => report),
@@ -349,9 +386,11 @@ function CostCentersData({
 function AgingData({
    config,
    queryClient,
+   teamId,
 }: {
    config: ReportConfig;
    queryClient: QueryClient;
+   teamId: string;
 }) {
    const collectionInput = useMemo(
       () => ({
@@ -377,9 +416,10 @@ function AgingData({
             agingReportCollectionOptions({
                queryClient,
                input: collectionInput,
+               teamId,
             }),
          ),
-      [queryClient, collectionInput],
+      [queryClient, teamId, collectionInput],
    );
    const { data, isLoading: isReportLoading } = useLiveQuery(
       (q) => q.from({ report: collection }).select(({ report }) => report),
@@ -394,9 +434,11 @@ function AgingData({
 function CategoryExpensesData({
    config,
    queryClient,
+   teamId,
 }: {
    config: ReportConfig;
    queryClient: QueryClient;
+   teamId: string;
 }) {
    const collectionInput = useMemo(
       () => ({
@@ -426,9 +468,10 @@ function CategoryExpensesData({
             categoryExpensesReportCollectionOptions({
                queryClient,
                input: collectionInput,
+               teamId,
             }),
          ),
-      [queryClient, collectionInput],
+      [queryClient, teamId, collectionInput],
    );
    const { data, isLoading: isReportLoading } = useLiveQuery(
       (q) => q.from({ report: collection }).select(({ report }) => report),

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-reports/report-panels.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-reports/report-panels.tsx
@@ -16,7 +16,8 @@ import {
    TableRow,
 } from "@packages/ui/components/table";
 import { cn } from "@packages/ui/lib/utils";
-import { useSuspenseQueries, useSuspenseQuery } from "@tanstack/react-query";
+import { createCollection, useLiveQuery } from "@tanstack/react-db";
+import type { QueryClient } from "@tanstack/query-core";
 import dayjs from "dayjs";
 import {
    AlertCircle,
@@ -30,9 +31,18 @@ import {
    Table2,
    TrendingUp,
 } from "lucide-react";
+import { useMemo } from "react";
 import type { ReactNode } from "react";
-import { orpc } from "@/integrations/orpc/client";
-import type { Outputs } from "@/integrations/orpc/client";
+import {
+   agingReportCollectionOptions,
+   cashFlowReportCollectionOptions,
+   categoryExpensesReportCollectionOptions,
+   costCentersReportCollectionOptions,
+   profitAndLossReportCollectionOptions,
+   reportTransactionsCollectionOptions,
+   reportTransactionsSummaryCollectionOptions,
+} from "@/integrations/tanstack-db/reports";
+import { type Inputs, type Outputs } from "@/integrations/orpc/client";
 import type { SavedReport } from "./report-labels";
 
 type ReportConfig = SavedReport["config"];
@@ -79,122 +89,355 @@ function marginValue(report: ProfitAndLossReport) {
    return numberValue(report.totals.result) / income;
 }
 
-export function ReportData({ report }: { report: SavedReport }) {
+export function ReportData({
+   report,
+   queryClient,
+}: {
+   report: SavedReport;
+   queryClient: QueryClient;
+}) {
    if (report.type === "dre")
-      return <ProfitAndLossData config={report.config} />;
+      return (
+         <ProfitAndLossData config={report.config} queryClient={queryClient} />
+      );
    if (report.type === "cash-flow")
-      return <CashFlowData config={report.config} />;
+      return <CashFlowData config={report.config} queryClient={queryClient} />;
    if (report.type === "cost-centers")
-      return <CostCentersData config={report.config} />;
-   if (report.type === "aging") return <AgingData config={report.config} />;
-   return <CategoryExpensesData config={report.config} />;
+      return (
+         <CostCentersData config={report.config} queryClient={queryClient} />
+      );
+   if (report.type === "aging")
+      return <AgingData config={report.config} queryClient={queryClient} />;
+   return (
+      <CategoryExpensesData config={report.config} queryClient={queryClient} />
+   );
 }
 
-function ProfitAndLossData({ config }: { config: ReportConfig }) {
-   const [reportQuery, transactionsQuery] = useSuspenseQueries({
-      queries: [
-         orpc.reports.profitAndLoss.queryOptions({
-            input: {
-               dateFrom: config.dateFrom,
-               dateTo: config.dateTo,
-               status: config.status,
-               bankAccountId: config.bankAccountId,
-               categoryId: config.categoryId,
-               tagId: config.tagId,
-               dreOnly: config.dreOnly,
-            },
-         }),
-         orpc.transactions.getAll.queryOptions({
-            input: {
-               dateFrom: config.dateFrom,
-               dateTo: config.dateTo,
-               status: transactionStatusFilter(config.status),
-               bankAccountId: config.bankAccountId,
-               categoryId: config.categoryId,
-               tagId: config.tagId,
-               page: 1,
-               pageSize: 100,
-               sorting: [{ id: "date", desc: true }],
-            },
-         }),
+function ProfitAndLossData({
+   config,
+   queryClient,
+}: {
+   config: ReportConfig;
+   queryClient: QueryClient;
+}) {
+   const reportInput = useMemo(
+      () => ({
+         dateFrom: config.dateFrom,
+         dateTo: config.dateTo,
+         status: config.status,
+         bankAccountId: config.bankAccountId,
+         categoryId: config.categoryId,
+         tagId: config.tagId,
+         dreOnly: config.dreOnly,
+      }),
+      [
+         config.dateFrom,
+         config.dateTo,
+         config.status,
+         config.bankAccountId,
+         config.categoryId,
+         config.tagId,
+         config.dreOnly,
       ],
-   });
+   );
+   const transactionsInput = useMemo<Inputs["transactions"]["getAll"]>(
+      () => ({
+         dateFrom: config.dateFrom,
+         dateTo: config.dateTo,
+         status: transactionStatusFilter(config.status),
+         bankAccountId: config.bankAccountId,
+         categoryId: config.categoryId,
+         tagId: config.tagId,
+         page: 1,
+         pageSize: 100,
+         sorting: [{ id: "date", desc: true }],
+      }),
+      [
+         config.dateFrom,
+         config.dateTo,
+         config.status,
+         config.bankAccountId,
+         config.categoryId,
+         config.tagId,
+      ],
+   );
+   const summaryInput = useMemo(
+      () => ({
+         dateFrom: config.dateFrom,
+         dateTo: config.dateTo,
+         status: transactionStatusFilter(config.status),
+         bankAccountId: config.bankAccountId,
+         categoryId: config.categoryId,
+         tagId: config.tagId,
+      }),
+      [
+         config.dateFrom,
+         config.dateTo,
+         config.status,
+         config.bankAccountId,
+         config.categoryId,
+         config.tagId,
+      ],
+   );
+
+   const reportCollection = useMemo(
+      () =>
+         createCollection(
+            profitAndLossReportCollectionOptions({
+               queryClient,
+               input: reportInput,
+            }),
+         ),
+      [queryClient, reportInput],
+   );
+   const transactionsCollection = useMemo(
+      () =>
+         createCollection(
+            reportTransactionsCollectionOptions({
+               queryClient,
+               input: transactionsInput,
+            }),
+         ),
+      [queryClient, transactionsInput],
+   );
+   const transactionsSummaryCollection = useMemo(
+      () =>
+         createCollection(
+            reportTransactionsSummaryCollectionOptions({
+               queryClient,
+               input: summaryInput,
+            }),
+         ),
+      [queryClient, summaryInput],
+   );
+   const { data: reports, isLoading: isReportLoading } = useLiveQuery(
+      (q) =>
+         q.from({ report: reportCollection }).select(({ report }) => report),
+      [reportCollection],
+   );
+   const { data: transactions, isLoading: isTransactionsLoading } =
+      useLiveQuery(
+         (q) =>
+            q
+               .from({ transaction: transactionsCollection })
+               .select(({ transaction }) => transaction),
+         [transactionsCollection],
+      );
+   const { data: summaries, isLoading: isSummaryLoading } = useLiveQuery(
+      (q) =>
+         q
+            .from({ summary: transactionsSummaryCollection })
+            .select(({ summary }) => summary),
+      [transactionsSummaryCollection],
+   );
+
+   const report = reports[0];
+   const transactionRows = transactions.filter(
+      (row) => row.type !== "transfer",
+   );
+   const summary = summaries[0];
+   const transactionTotal = summary?.total ?? transactions.length;
+
+   if (
+      !report ||
+      isReportLoading ||
+      isTransactionsLoading ||
+      isSummaryLoading
+   ) {
+      return <EmptyReport title="Carregando relatório DRE" />;
+   }
 
    return (
       <ProfitAndLossPanel
-         report={reportQuery.data}
-         transactions={transactionsQuery.data.data.filter(
-            (row) => row.type !== "transfer",
-         )}
-         transactionTotal={transactionsQuery.data.total}
+         report={report}
+         transactions={transactionRows}
+         transactionTotal={transactionTotal}
       />
    );
 }
 
-function CashFlowData({ config }: { config: ReportConfig }) {
-   const { data } = useSuspenseQuery(
-      orpc.reports.cashFlow.queryOptions({
-         input: {
-            dateFrom: config.dateFrom,
-            dateTo: config.dateTo,
-            status: config.status,
-            bankAccountId: config.bankAccountId,
-            categoryId: config.categoryId,
-            tagId: config.tagId,
-         },
+function CashFlowData({
+   config,
+   queryClient,
+}: {
+   config: ReportConfig;
+   queryClient: QueryClient;
+}) {
+   const collectionInput = useMemo(
+      () => ({
+         dateFrom: config.dateFrom,
+         dateTo: config.dateTo,
+         status: config.status,
+         bankAccountId: config.bankAccountId,
+         categoryId: config.categoryId,
+         tagId: config.tagId,
       }),
+      [
+         config.dateFrom,
+         config.dateTo,
+         config.status,
+         config.bankAccountId,
+         config.categoryId,
+         config.tagId,
+      ],
    );
-   return <CashFlowPanel report={data} />;
+   const collection = useMemo(
+      () =>
+         createCollection(
+            cashFlowReportCollectionOptions({
+               queryClient,
+               input: collectionInput,
+            }),
+         ),
+      [queryClient, collectionInput],
+   );
+   const { data, isLoading: isReportLoading } = useLiveQuery(
+      (q) => q.from({ report: collection }).select(({ report }) => report),
+      [collection],
+   );
+   const report = data[0];
+   if (!report || isReportLoading)
+      return <EmptyReport title="Carregando fluxo de caixa" />;
+   return <CashFlowPanel report={report} />;
 }
 
-function CostCentersData({ config }: { config: ReportConfig }) {
-   const { data } = useSuspenseQuery(
-      orpc.reports.expensesByCostCenter.queryOptions({
-         input: {
-            dateFrom: config.dateFrom,
-            dateTo: config.dateTo,
-            status: config.status,
-            bankAccountId: config.bankAccountId,
-            categoryId: config.categoryId,
-            tagId: config.tagId,
-         },
+function CostCentersData({
+   config,
+   queryClient,
+}: {
+   config: ReportConfig;
+   queryClient: QueryClient;
+}) {
+   const collectionInput = useMemo(
+      () => ({
+         dateFrom: config.dateFrom,
+         dateTo: config.dateTo,
+         status: config.status,
+         bankAccountId: config.bankAccountId,
+         categoryId: config.categoryId,
+         tagId: config.tagId,
       }),
+      [
+         config.dateFrom,
+         config.dateTo,
+         config.status,
+         config.bankAccountId,
+         config.categoryId,
+         config.tagId,
+      ],
    );
-   return <CostCentersPanel report={data} />;
+   const collection = useMemo(
+      () =>
+         createCollection(
+            costCentersReportCollectionOptions({
+               queryClient,
+               input: collectionInput,
+            }),
+         ),
+      [queryClient, collectionInput],
+   );
+   const { data, isLoading: isReportLoading } = useLiveQuery(
+      (q) => q.from({ report: collection }).select(({ report }) => report),
+      [collection],
+   );
+   const report = data[0];
+   if (!report || isReportLoading)
+      return <EmptyReport title="Carregando despesas por centro de custo" />;
+   return <CostCentersPanel report={report} />;
 }
 
-function AgingData({ config }: { config: ReportConfig }) {
-   const { data } = useSuspenseQuery(
-      orpc.reports.aging.queryOptions({
-         input: {
-            type: config.agingType,
-            dateFrom: config.dateFrom,
-            dateTo: config.dateTo,
-            categoryId: config.categoryId,
-            tagId: config.tagId,
-            status: config.agingStatus,
-         },
+function AgingData({
+   config,
+   queryClient,
+}: {
+   config: ReportConfig;
+   queryClient: QueryClient;
+}) {
+   const collectionInput = useMemo(
+      () => ({
+         type: config.agingType,
+         dateFrom: config.dateFrom,
+         dateTo: config.dateTo,
+         categoryId: config.categoryId,
+         tagId: config.tagId,
+         status: config.agingStatus,
       }),
+      [
+         config.agingType,
+         config.dateFrom,
+         config.dateTo,
+         config.categoryId,
+         config.tagId,
+         config.agingStatus,
+      ],
    );
-   return <AgingPanel report={data} />;
+   const collection = useMemo(
+      () =>
+         createCollection(
+            agingReportCollectionOptions({
+               queryClient,
+               input: collectionInput,
+            }),
+         ),
+      [queryClient, collectionInput],
+   );
+   const { data, isLoading: isReportLoading } = useLiveQuery(
+      (q) => q.from({ report: collection }).select(({ report }) => report),
+      [collection],
+   );
+   const report = data[0];
+   if (!report || isReportLoading)
+      return <EmptyReport title="Carregando aging" />;
+   return <AgingPanel report={report} />;
 }
 
-function CategoryExpensesData({ config }: { config: ReportConfig }) {
-   const { data } = useSuspenseQuery(
-      orpc.reports.expensesByCategory.queryOptions({
-         input: {
-            dateFrom: config.dateFrom,
-            dateTo: config.dateTo,
-            status: config.status,
-            bankAccountId: config.bankAccountId,
-            categoryId: config.categoryId,
-            tagId: config.tagId,
-            depth: config.categoryDepth,
-            minAmount: config.minAmount,
-         },
+function CategoryExpensesData({
+   config,
+   queryClient,
+}: {
+   config: ReportConfig;
+   queryClient: QueryClient;
+}) {
+   const collectionInput = useMemo(
+      () => ({
+         dateFrom: config.dateFrom,
+         dateTo: config.dateTo,
+         status: config.status,
+         bankAccountId: config.bankAccountId,
+         categoryId: config.categoryId,
+         tagId: config.tagId,
+         depth: config.categoryDepth,
+         minAmount: config.minAmount,
       }),
+      [
+         config.dateFrom,
+         config.dateTo,
+         config.status,
+         config.bankAccountId,
+         config.categoryId,
+         config.tagId,
+         config.categoryDepth,
+         config.minAmount,
+      ],
    );
-   return <CategoryExpensesPanel report={data} />;
+   const collection = useMemo(
+      () =>
+         createCollection(
+            categoryExpensesReportCollectionOptions({
+               queryClient,
+               input: collectionInput,
+            }),
+         ),
+      [queryClient, collectionInput],
+   );
+   const { data, isLoading: isReportLoading } = useLiveQuery(
+      (q) => q.from({ report: collection }).select(({ report }) => report),
+      [collection],
+   );
+   const report = data[0];
+   if (!report || isReportLoading)
+      return <EmptyReport title="Carregando despesas por categoria" />;
+   return <CategoryExpensesPanel report={report} />;
 }
 
 function EmptyReport({ title }: { title: string }) {

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/reports/$reportId.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/reports/$reportId.tsx
@@ -29,7 +29,7 @@ export const Route = createFileRoute(
    ssr: false,
    pendingMs: 300,
    pendingComponent: ReportDetailSkeleton,
-   errorComponent: ReportDetailError,
+   errorComponent: SplitErrorComponent,
    head: () => ({
       meta: [{ title: "Relatório — Montte" }],
    }),
@@ -45,7 +45,7 @@ function ReportDetailSkeleton() {
    );
 }
 
-function ReportDetailError() {
+function SplitErrorComponent() {
    const { slug, teamSlug } = useDashboardSlugs();
    return (
       <main className="flex flex-1 min-h-0 flex-col gap-4 overflow-hidden px-4 pb-4">
@@ -109,7 +109,7 @@ function ReportDetailWithTeam({ teamId }: { teamId: string }) {
    );
    const report = reportRows[0];
 
-   if (!isLoading && !report) return <ReportDetailError />;
+   if (!isLoading && !report) return <SplitErrorComponent />;
 
    if (!report) {
       return <ReportDetailSkeleton />;
@@ -140,7 +140,11 @@ function ReportDetailWithTeam({ teamId }: { teamId: string }) {
                fallback={<ReportDetailSkeleton />}
                errorTitle="Erro ao carregar dados"
             >
-               <ReportData report={report} queryClient={queryClient} />
+               <ReportData
+                  report={report}
+                  queryClient={queryClient}
+                  teamId={teamId}
+               />
             </QueryBoundary>
          </div>
       </div>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/reports/$reportId.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/reports/$reportId.tsx
@@ -1,7 +1,8 @@
 import { Button } from "@packages/ui/components/button";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { createCollection, useLiveQuery } from "@tanstack/react-db";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import dayjs from "dayjs";
+import { useMemo } from "react";
 import {
    ArrowLeft,
    CalendarDays,
@@ -15,8 +16,9 @@ import {
    AnnouncementTitle,
 } from "@/components/blocks/announcement";
 import { QueryBoundary } from "@/components/query-boundary";
+import { useActiveTeam } from "@/hooks/use-active-team";
 import { useDashboardSlugs } from "@/hooks/use-dashboard-slugs";
-import { orpc } from "@/integrations/orpc/client";
+import { reportByIdCollectionOptions } from "@/integrations/tanstack-db/reports";
 import { REPORT_LABELS, type SavedReport } from "../-reports/report-labels";
 import { ReportData } from "../-reports/report-panels";
 import { DefaultHeader } from "../../-layout/default-header";
@@ -24,11 +26,7 @@ import { DefaultHeader } from "../../-layout/default-header";
 export const Route = createFileRoute(
    "/_authenticated/$slug/$teamSlug/_dashboard/reports/$reportId",
 )({
-   loader: ({ context, params }) => {
-      context.queryClient.prefetchQuery(
-         orpc.reports.get.queryOptions({ input: { id: params.reportId } }),
-      );
-   },
+   ssr: false,
    pendingMs: 300,
    pendingComponent: ReportDetailSkeleton,
    errorComponent: ReportDetailError,
@@ -83,12 +81,39 @@ function ReportDetailPage() {
 }
 
 function ReportDetailContent() {
+   const { activeTeamId } = useActiveTeam();
+   if (!activeTeamId) return <ReportDetailSkeleton />;
+   return <ReportDetailWithTeam teamId={activeTeamId} />;
+}
+
+function ReportDetailWithTeam({ teamId }: { teamId: string }) {
    const { reportId } = Route.useParams();
+   const { queryClient } = Route.useRouteContext();
    const { slug, teamSlug } = useDashboardSlugs();
    const navigate = useNavigate();
-   const { data: report } = useSuspenseQuery(
-      orpc.reports.get.queryOptions({ input: { id: reportId } }),
+   const reportCollection = useMemo(
+      () =>
+         createCollection(
+            reportByIdCollectionOptions({
+               queryClient,
+               id: reportId,
+               teamId,
+            }),
+         ),
+      [queryClient, reportId, teamId],
    );
+   const { data: reportRows, isLoading } = useLiveQuery(
+      (q) =>
+         q.from({ report: reportCollection }).select(({ report }) => report),
+      [reportCollection],
+   );
+   const report = reportRows[0];
+
+   if (!isLoading && !report) return <ReportDetailError />;
+
+   if (!report) {
+      return <ReportDetailSkeleton />;
+   }
 
    return (
       <div className="flex flex-1 min-h-0 flex-col gap-4">
@@ -115,7 +140,7 @@ function ReportDetailContent() {
                fallback={<ReportDetailSkeleton />}
                errorTitle="Erro ao carregar dados"
             >
-               <ReportData report={report} />
+               <ReportData report={report} queryClient={queryClient} />
             </QueryBoundary>
          </div>
       </div>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/reports/index.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/reports/index.tsx
@@ -11,17 +11,16 @@ import { ScrollArea } from "@packages/ui/components/scroll-area";
 import { SearchInput } from "@packages/ui/components/search-input";
 import { Table, TableCell, TableRow } from "@packages/ui/components/table";
 import { cn } from "@packages/ui/lib/utils";
-import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { createCollection, ilike, useLiveQuery } from "@tanstack/react-db";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import {
    flexRender,
    getCoreRowModel,
-   getFilteredRowModel,
-   getSortedRowModel,
    useReactTable,
    type ColumnDef,
 } from "@tanstack/react-table";
 import { Plus, ReceiptText, Trash2 } from "lucide-react";
+import { fromPromise } from "neverthrow";
 import { useCallback, useMemo } from "react";
 import { toast } from "@packages/ui/hooks/use-toast";
 import { z } from "zod";
@@ -33,6 +32,7 @@ import { useDataTableLayout } from "@/blocks/data-table/use-data-table-layout";
 import { useDebouncedSearch } from "@/blocks/data-table/use-debounced-search";
 import { useTableUrlState } from "@/blocks/data-table/use-table-url-state";
 import { QueryBoundary } from "@/components/query-boundary";
+import { useActiveTeam } from "@/hooks/use-active-team";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import { useDashboardSlugs } from "@/hooks/use-dashboard-slugs";
 import {
@@ -40,12 +40,15 @@ import {
    useTableBulkActions,
 } from "@/hooks/use-selection-toolbar";
 import { useSheet } from "@/hooks/use-sheet";
-import { orpc } from "@/integrations/orpc/client";
+import {
+   bulkRemoveReportAction,
+   removeReportAction,
+   reportsCollectionOptions,
+} from "@/integrations/tanstack-db/reports";
 import { ReportFormSheet } from "../-reports/report-form-sheet";
 import { type SavedReport } from "../-reports/report-labels";
 import { buildReportsColumns } from "../-reports/reports-columns";
 import { DefaultHeader } from "../../-layout/default-header";
-
 const searchSchema = z.object({
    sorting: z
       .array(z.object({ id: z.string(), desc: z.boolean() }))
@@ -65,10 +68,8 @@ const skeletonColumns = buildReportsColumns();
 export const Route = createFileRoute(
    "/_authenticated/$slug/$teamSlug/_dashboard/reports/",
 )({
+   ssr: false,
    validateSearch: searchSchema,
-   loader: ({ context }) => {
-      context.queryClient.prefetchQuery(orpc.reports.list.queryOptions());
-   },
    pendingMs: 300,
    pendingComponent: ReportsSkeleton,
    head: () => ({
@@ -100,11 +101,33 @@ function ReportsPage() {
    );
 }
 
+function getErrorMessage(error: unknown, fallback: string) {
+   if (
+      typeof error === "object" &&
+      error !== null &&
+      "message" in error &&
+      typeof error.message === "string" &&
+      error.message.length > 0
+   ) {
+      return error.message;
+   }
+   return fallback;
+}
+
 function ReportsList() {
+   const { activeTeamId } = useActiveTeam();
+   if (!activeTeamId) {
+      return <ReportsSkeleton />;
+   }
+   return <ReportsListWithTeam teamId={activeTeamId} />;
+}
+
+function ReportsListWithTeam({ teamId }: { teamId: string }) {
    const navigate = useNavigate();
    const routeNavigate = Route.useNavigate();
    const { slug, teamSlug } = useDashboardSlugs();
    const { sorting, columnFilters, search, page, pageSize } = Route.useSearch();
+   const { queryClient } = Route.useRouteContext();
    const { openSheet } = useSheet();
    const { openAlertDialog } = useAlertDialog();
    const layout = useDataTableLayout("reports");
@@ -118,13 +141,110 @@ function ReportsList() {
          }),
    });
 
-   const { data: reports } = useSuspenseQuery(orpc.reports.list.queryOptions());
+   const reportsCollection = useMemo(
+      () =>
+         createCollection(
+            reportsCollectionOptions({
+               queryClient,
+               teamId,
+            }),
+         ),
+      [teamId, queryClient],
+   );
+   const baseSearch = search.trim();
+   const { data: allReports } = useLiveQuery(
+      (q) => {
+         let query = q.from({ report: reportsCollection });
 
-   const removeMutation = useMutation(
-      orpc.reports.remove.mutationOptions({
-         onSuccess: () => toast.success("Relatório excluído."),
-         onError: (error) => toast.error(error.message),
-      }),
+         if (baseSearch) {
+            query = query.where(({ report }) =>
+               ilike(report.name, `%${baseSearch}%`),
+            );
+         }
+
+         for (const rule of sorting) {
+            switch (rule.id) {
+               case "name":
+                  query = query.orderBy(
+                     ({ report }) => report.name,
+                     rule.desc ? "desc" : "asc",
+                  );
+                  break;
+               case "type":
+                  query = query.orderBy(
+                     ({ report }) => report.type,
+                     rule.desc ? "desc" : "asc",
+                  );
+                  break;
+               case "createdAt":
+                  query = query.orderBy(
+                     ({ report }) => report.createdAt,
+                     rule.desc ? "desc" : "asc",
+                  );
+                  break;
+            }
+         }
+
+         if (sorting.length === 0) {
+            query = query.orderBy(({ report }) => report.createdAt, "desc");
+         }
+
+         return query.select(({ report }) => report);
+      },
+      [baseSearch, reportsCollection, sorting],
+   );
+
+   const { data: reports } = useLiveQuery(
+      (q) => {
+         let query = q.from({ report: reportsCollection });
+
+         if (baseSearch) {
+            query = query.where(({ report }) =>
+               ilike(report.name, `%${baseSearch}%`),
+            );
+         }
+
+         for (const rule of sorting) {
+            switch (rule.id) {
+               case "name":
+                  query = query.orderBy(
+                     ({ report }) => report.name,
+                     rule.desc ? "desc" : "asc",
+                  );
+                  break;
+               case "type":
+                  query = query.orderBy(
+                     ({ report }) => report.type,
+                     rule.desc ? "desc" : "asc",
+                  );
+                  break;
+               case "createdAt":
+                  query = query.orderBy(
+                     ({ report }) => report.createdAt,
+                     rule.desc ? "desc" : "asc",
+                  );
+                  break;
+            }
+         }
+
+         if (sorting.length === 0) {
+            query = query.orderBy(({ report }) => report.createdAt, "desc");
+         }
+
+         return query
+            .limit(pageSize)
+            .offset((page - 1) * pageSize)
+            .select(({ report }) => report);
+      },
+      [baseSearch, page, pageSize, reportsCollection, sorting],
+   );
+   const removeReport = useMemo(
+      () => removeReportAction(reportsCollection),
+      [reportsCollection],
+   );
+   const bulkRemoveReport = useMemo(
+      () => bulkRemoveReportAction(reportsCollection),
+      [reportsCollection],
    );
 
    const handleDelete = useCallback(
@@ -136,24 +256,34 @@ function ReportsList() {
             cancelLabel: "Cancelar",
             variant: "destructive",
             onAction: async () => {
-               await removeMutation.mutateAsync({ id: report.id });
+               const transaction = removeReport({ id: report.id });
+               const result = await fromPromise(
+                  transaction.isPersisted.promise,
+                  (error) => error,
+               );
+               if (result.isErr()) {
+                  toast.error(
+                     getErrorMessage(
+                        result.error,
+                        "Erro ao excluir relatório.",
+                     ),
+                  );
+                  return;
+               }
+               toast.success("Relatório excluído.");
             },
          });
       },
-      [openAlertDialog, removeMutation],
+      [openAlertDialog, removeReport],
    );
 
    const handleOpenCreate = useCallback(() => {
-      openSheet({ renderChildren: () => <ReportFormSheet /> });
-   }, [openSheet]);
-
-   const filteredReports = useMemo(() => {
-      const query = search.trim().toLowerCase();
-      if (!query) return reports;
-      return reports.filter((report) =>
-         report.name.toLowerCase().includes(query),
-      );
-   }, [reports, search]);
+      openSheet({
+         renderChildren: () => (
+            <ReportFormSheet collection={reportsCollection} teamId={teamId} />
+         ),
+      });
+   }, [openSheet, reportsCollection, teamId]);
 
    const columns = useMemo<ColumnDef<SavedReport>[]>(() => {
       const selectColumn: ColumnDef<SavedReport> = {
@@ -198,15 +328,18 @@ function ReportsList() {
             search: (prev) => ({ ...prev, ...next }),
             replace: true,
          }),
-      totalRows: filteredReports.length,
+      totalRows: allReports.length,
    });
 
    const table = useReactTable({
-      data: filteredReports,
+      data: reports,
       columns,
       getRowId: (row) => row.id,
       columnResizeMode: "onChange",
       defaultColumn: { minSize: 80, size: 160, maxSize: 600 },
+      manualFiltering: true,
+      manualSorting: true,
+      manualPagination: true,
       state: { ...urlState.state, ...layout.state },
       onSortingChange: urlState.onSortingChange,
       onColumnFiltersChange: urlState.onColumnFiltersChange,
@@ -216,9 +349,8 @@ function ReportsList() {
       onColumnOrderChange: layout.onColumnOrderChange,
       onColumnVisibilityChange: layout.onColumnVisibilityChange,
       onColumnPinningChange: layout.onColumnPinningChange,
+      pageCount: urlState.pageCount,
       getCoreRowModel: getCoreRowModel(),
-      getSortedRowModel: getSortedRowModel(),
-      getFilteredRowModel: getFilteredRowModel(),
    });
 
    const selectedRows = table.getSelectedRowModel().rows;
@@ -239,11 +371,21 @@ function ReportsList() {
                   cancelLabel: "Cancelar",
                   variant: "destructive",
                   onAction: async () => {
-                     await Promise.allSettled(
-                        selectedIds.map((id) =>
-                           removeMutation.mutateAsync({ id }),
-                        ),
+                     const result = await fromPromise(
+                        bulkRemoveReport({ ids: selectedIds }).isPersisted
+                           .promise,
+                        (error) => error,
                      );
+                     if (result.isErr()) {
+                        toast.error(
+                           getErrorMessage(
+                              result.error,
+                              "Erro ao excluir relatórios.",
+                           ),
+                        );
+                        return;
+                     }
+                     toast.success("Relatórios excluídos.");
                      table.resetRowSelection();
                   },
                });
@@ -341,12 +483,12 @@ function ReportsList() {
                   </EmptyMedia>
                   <EmptyHeader>
                      <EmptyTitle>
-                        {reports.length === 0
+                        {!baseSearch && allReports.length === 0
                            ? "Nenhum relatório criado"
                            : "Nenhum relatório encontrado"}
                      </EmptyTitle>
                      <EmptyDescription>
-                        {reports.length === 0
+                        {!baseSearch && allReports.length === 0
                            ? "Crie o primeiro relatório para visualizar os dados do espaço atual."
                            : "Ajuste a busca ou crie um novo relatório."}
                      </EmptyDescription>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/reports/index.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/reports/index.tsx
@@ -114,6 +114,57 @@ function getErrorMessage(error: unknown, fallback: string) {
    return fallback;
 }
 
+type ReportQuery<T> = {
+   where: (callback: (refs: any) => unknown) => T;
+   orderBy: (callback: (refs: any) => unknown, direction?: "asc" | "desc") => T;
+};
+
+function applyFiltersAndSorting<TQuery extends ReportQuery<TQuery>>(
+   query: TQuery,
+   baseSearch: string,
+   sorting: Array<{ id: string; desc: boolean }>,
+) {
+   let filteredQuery: TQuery = query;
+
+   if (baseSearch) {
+      filteredQuery = filteredQuery.where(({ report }) =>
+         ilike(report.name, `%${baseSearch}%`),
+      );
+   }
+
+   for (const rule of sorting) {
+      switch (rule.id) {
+         case "name":
+            filteredQuery = filteredQuery.orderBy(
+               ({ report }) => report.name,
+               rule.desc ? "desc" : "asc",
+            );
+            break;
+         case "type":
+            filteredQuery = filteredQuery.orderBy(
+               ({ report }) => report.type,
+               rule.desc ? "desc" : "asc",
+            );
+            break;
+         case "createdAt":
+            filteredQuery = filteredQuery.orderBy(
+               ({ report }) => report.createdAt,
+               rule.desc ? "desc" : "asc",
+            );
+            break;
+      }
+   }
+
+   if (sorting.length === 0) {
+      filteredQuery = filteredQuery.orderBy(
+         ({ report }) => report.createdAt,
+         "desc",
+      );
+   }
+
+   return filteredQuery;
+}
+
 function ReportsList() {
    const { activeTeamId } = useActiveTeam();
    if (!activeTeamId) {
@@ -154,84 +205,24 @@ function ReportsListWithTeam({ teamId }: { teamId: string }) {
    const baseSearch = search.trim();
    const { data: allReports } = useLiveQuery(
       (q) => {
-         let query = q.from({ report: reportsCollection });
-
-         if (baseSearch) {
-            query = query.where(({ report }) =>
-               ilike(report.name, `%${baseSearch}%`),
-            );
-         }
-
-         for (const rule of sorting) {
-            switch (rule.id) {
-               case "name":
-                  query = query.orderBy(
-                     ({ report }) => report.name,
-                     rule.desc ? "desc" : "asc",
-                  );
-                  break;
-               case "type":
-                  query = query.orderBy(
-                     ({ report }) => report.type,
-                     rule.desc ? "desc" : "asc",
-                  );
-                  break;
-               case "createdAt":
-                  query = query.orderBy(
-                     ({ report }) => report.createdAt,
-                     rule.desc ? "desc" : "asc",
-                  );
-                  break;
-            }
-         }
-
-         if (sorting.length === 0) {
-            query = query.orderBy(({ report }) => report.createdAt, "desc");
-         }
-
-         return query.select(({ report }) => report);
+         const baseQuery = applyFiltersAndSorting(
+            q.from({ report: reportsCollection }),
+            baseSearch,
+            sorting,
+         );
+         return baseQuery.select(({ report }) => report);
       },
       [baseSearch, reportsCollection, sorting],
    );
 
    const { data: reports } = useLiveQuery(
       (q) => {
-         let query = q.from({ report: reportsCollection });
-
-         if (baseSearch) {
-            query = query.where(({ report }) =>
-               ilike(report.name, `%${baseSearch}%`),
-            );
-         }
-
-         for (const rule of sorting) {
-            switch (rule.id) {
-               case "name":
-                  query = query.orderBy(
-                     ({ report }) => report.name,
-                     rule.desc ? "desc" : "asc",
-                  );
-                  break;
-               case "type":
-                  query = query.orderBy(
-                     ({ report }) => report.type,
-                     rule.desc ? "desc" : "asc",
-                  );
-                  break;
-               case "createdAt":
-                  query = query.orderBy(
-                     ({ report }) => report.createdAt,
-                     rule.desc ? "desc" : "asc",
-                  );
-                  break;
-            }
-         }
-
-         if (sorting.length === 0) {
-            query = query.orderBy(({ report }) => report.createdAt, "desc");
-         }
-
-         return query
+         const baseQuery = applyFiltersAndSorting(
+            q.from({ report: reportsCollection }),
+            baseSearch,
+            sorting,
+         );
+         return baseQuery
             .limit(pageSize)
             .offset((page - 1) * pageSize)
             .select(({ report }) => report);

--- a/core/database/drizzle.config.ts
+++ b/core/database/drizzle.config.ts
@@ -20,5 +20,6 @@ export default {
       "platform",
       "agents",
       "settings",
+      "relationships",
    ],
 } satisfies Config;

--- a/core/database/src/testing/setup-test-db.ts
+++ b/core/database/src/testing/setup-test-db.ts
@@ -18,6 +18,7 @@ export async function setupTestDb() {
       "finance",
       "crm",
       "platform",
+      "relationships",
    ]);
    await apply();
 

--- a/modules/insights/src/router/reports.ts
+++ b/modules/insights/src/router/reports.ts
@@ -195,6 +195,10 @@ const expensesByCategoryFilters = z
    });
 const idSchema = z.object({ id: z.string().uuid() });
 
+const idsSchema = z.object({
+   ids: z.array(z.string().uuid()).min(1).max(500),
+});
+
 type BaseFilters = z.infer<typeof baseFilters>;
 
 export const get = protectedProcedure
@@ -315,6 +319,51 @@ export const remove = protectedProcedure
          });
       }
       return { success: true };
+   });
+
+export const bulkRemove = protectedProcedure
+   .input(idsSchema)
+   .handler(async ({ context, input }) => {
+      const ids = [...new Set(input.ids)];
+      const existing = await Result.tryPromise({
+         try: () =>
+            context.db.query.reports.findMany({
+               where: (f, { and, eq, inArray }) =>
+                  and(eq(f.teamId, context.teamId), inArray(f.id, ids)),
+            }),
+         catch: () =>
+            new InsightsError({
+               error: insightsRouterErrors.LOAD_FAILED(),
+               message: "Falha ao validar relatórios selecionados.",
+            }),
+      });
+      if (Result.isError(existing)) throw existing.error;
+      if (existing.value.length !== ids.length) {
+         throw new InsightsError({
+            error: insightsRouterErrors.NOT_FOUND(),
+            message: "Algum relatório selecionado não foi encontrado.",
+         });
+      }
+
+      const removed = await Result.tryPromise({
+         try: () =>
+            context.db
+               .delete(reports)
+               .where(
+                  and(
+                     eq(reports.teamId, context.teamId),
+                     inArray(reports.id, ids),
+                  ),
+               )
+               .returning({ id: reports.id }),
+         catch: () =>
+            new InsightsError({
+               error: insightsRouterErrors.DELETE_FAILED(),
+               message: "Falha ao excluir relatórios.",
+            }),
+      });
+      if (Result.isError(removed)) throw removed.error;
+      return { deleted: removed.value.length };
    });
 
 function moneyValue(value: string | number | null | undefined) {

--- a/modules/insights/src/router/reports.ts
+++ b/modules/insights/src/router/reports.ts
@@ -325,45 +325,53 @@ export const bulkRemove = protectedProcedure
    .input(idsSchema)
    .handler(async ({ context, input }) => {
       const ids = [...new Set(input.ids)];
-      const existing = await Result.tryPromise({
+      const deletedResult = await Result.tryPromise({
          try: () =>
-            context.db.query.reports.findMany({
-               where: (f, { and, eq, inArray }) =>
-                  and(eq(f.teamId, context.teamId), inArray(f.id, ids)),
-            }),
-         catch: () =>
-            new InsightsError({
-               error: insightsRouterErrors.LOAD_FAILED(),
-               message: "Falha ao validar relatórios selecionados.",
-            }),
-      });
-      if (Result.isError(existing)) throw existing.error;
-      if (existing.value.length !== ids.length) {
-         throw new InsightsError({
-            error: insightsRouterErrors.NOT_FOUND(),
-            message: "Algum relatório selecionado não foi encontrado.",
-         });
-      }
+            context.db.transaction(async (tx) => {
+               const existing = await tx.query.reports.findMany({
+                  where: (f, { and, eq, inArray }) =>
+                     and(eq(f.teamId, context.teamId), inArray(f.id, ids)),
+               });
 
-      const removed = await Result.tryPromise({
-         try: () =>
-            context.db
-               .delete(reports)
-               .where(
-                  and(
-                     eq(reports.teamId, context.teamId),
-                     inArray(reports.id, ids),
-                  ),
-               )
-               .returning({ id: reports.id }),
+               if (existing.length !== ids.length) {
+                  return null;
+               }
+
+               const deleted = await tx
+                  .delete(reports)
+                  .where(
+                     and(
+                        eq(reports.teamId, context.teamId),
+                        inArray(reports.id, ids),
+                     ),
+                  )
+                  .returning({ id: reports.id });
+
+               return {
+                  deleted,
+                  expected: ids.length,
+               };
+            }),
          catch: () =>
             new InsightsError({
                error: insightsRouterErrors.DELETE_FAILED(),
                message: "Falha ao excluir relatórios.",
             }),
       });
-      if (Result.isError(removed)) throw removed.error;
-      return { deleted: removed.value.length };
+      if (Result.isError(deletedResult)) throw deletedResult.error;
+      if (!deletedResult.value) {
+         throw new InsightsError({
+            error: insightsRouterErrors.NOT_FOUND(),
+            message: "Algum relatório selecionado não foi encontrado.",
+         });
+      }
+      if (deletedResult.value.deleted.length !== deletedResult.value.expected) {
+         throw new InsightsError({
+            error: insightsRouterErrors.DELETE_FAILED(),
+            message: "Falha ao excluir todos os relatórios selecionados.",
+         });
+      }
+      return { deleted: deletedResult.value.deleted.length };
    });
 
 function moneyValue(value: string | number | null | undefined) {

--- a/scripts/db-push.ts
+++ b/scripts/db-push.ts
@@ -41,7 +41,16 @@ function getEnvFilePath(_packageDir: string, env: string) {
    throw new Error(`No environment file found for ${env} in apps/web`);
 }
 
-const REQUIRED_SCHEMAS = ["auth", "finance", "crm", "platform"];
+const REQUIRED_SCHEMAS = [
+   "auth",
+   "finance",
+   "crm",
+   "platform",
+   "inbox",
+   "agents",
+   "settings",
+   "relationships",
+];
 
 async function ensureSchemas(envFile: string): Promise<void> {
    loadDotenv({ path: envFile });

--- a/scripts/ensure-schemas.ts
+++ b/scripts/ensure-schemas.ts
@@ -13,6 +13,7 @@ const REQUIRED_SCHEMAS = [
    "inbox",
    "agents",
    "settings",
+   "relationships",
 ];
 
 const colors = {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Migramos o módulo de relatórios para `@tanstack/react-db` com coleções e LiveQuery, agora sempre escopado por `teamId` e com exclusão transacional (única e em massa). A navegação ficou mais fluida e o consumo de API diminuiu.

- **Refactors**
  - Store: nova integração em `integrations/tanstack-db/reports.ts` usando `@tanstack/react-db`/`@tanstack/query-db-collection` com coleções por tipo (lista, por id, DRE, fluxo de caixa, centros de custo, aging, despesas por categoria, lançamentos e resumo), ids/keys estáveis por `teamId`+input, sync on-demand, refetch a cada 5s e `meta.errorMessage`; expõe actions otimizadas (`create`, `remove`, `bulkRemove`) e utilitários (`buildReportCollectionRowId`, `buildOptimisticReportRow`).
  - Componentes:
    - `report-form-sheet`: recebe `collection` e `teamId`, usa `createOptimisticAction`, aguarda `isPersisted` para navegar e exibe toast de erro em falha.
    - `report-panels`: trocado para `createCollection`/`useLiveQuery`; `ReportData` recebe `queryClient`/`teamId`; adicionada coleção de resumo de lançamentos; filtros consistentes e placeholders de loading.
    - Listagem (`reports/index.tsx`): busca com `ilike`, ordenação/paginação manuais (nome/tipo/criado em), total via consulta completa e página via `limit/offset`; `remove`/`bulkRemove` aguardam `isPersisted` e tratam erros; passa `collection`/`teamId` ao formulário; SSR desativado.
    - Detalhe (`reports/$reportId.tsx`): carrega por coleção `reportById` escopada por `teamId`, skeleton/erro adequados; SSR desativado.
  - Router (backend): `reports.bulkRemove` com validação de IDs, escopo por `teamId` e exclusão transacional; remoção única também transacional; mensagens de erro claras.
  - Repositório: sem mudanças de schema nos relatórios; adicionada exigência do schema `relationships` em `drizzle.config`, `setup-test-db`, `scripts/db-push` e `scripts/ensure-schemas`.
  - Impacto por camada: router (escopo por `teamId`, delete transacional, +bulkRemove), componentes (listas, painéis, formulário), store (migração p/ `tanstack-db`), repositório (infra de schemas).

- **Checklist de Teste**
  - Criação: aparece imediatamente; navega após persistir; falhas mostram toast.
  - Remoção única/em massa: itens somem; sucesso com toast; erro parcial retorna mensagem da API.
  - Busca/ordem/paginação: `ilike` por nome; ordenação por nome/tipo/criado em; paginação via `page`/`pageSize`; total pela coleção completa.
  - Painéis (DRE, Fluxo de Caixa, Centros de Custo, Aging, Despesas por Categoria): carregam via coleção; placeholders aparecem; dados respeitam filtros.
  - Snapshot de lançamentos: ignora transfers; total via coleção de resumo.
  - Escopo por time: trocar time exibe somente relatórios do time ativo.
  - Falhas de rede: toasts conforme `meta.errorMessage`.
  - Navegação sem SSR: páginas de lista e detalhe carregam no client corretamente.

<sup>Written for commit ba318ccb893265782f9fea8f358b5e36e6441d94. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/986?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

