### PR TITLE
feat(relationships): add relationships module and refactor workflows

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -56,6 +56,7 @@
       "@modules/classification": "workspace:*",
       "@modules/inbox": "workspace:*",
       "@modules/insights": "workspace:*",
+      "@modules/relationships": "workspace:*",
       "@modules/workflows": "workspace:*",
       "@orpc/client": "catalog:orpc",
       "@orpc/json-schema": "catalog:orpc",

--- a/apps/web/src/integrations/orpc/router/index.ts
+++ b/apps/web/src/integrations/orpc/router/index.ts
@@ -11,6 +11,7 @@ import * as cnpjRouter from "@modules/account/router/cnpj";
 import * as financialSettingsRouter from "@modules/account/router/financial-settings";
 import * as inboxRouter from "@modules/inbox/router/inbox";
 import * as reportsRouter from "@modules/insights/router/reports";
+import * as relationshipsRouter from "@modules/relationships/router";
 import * as workflowsRouter from "@modules/workflows/router";
 import * as onboardingRouter from "@modules/account/router/onboarding";
 import * as organizationRouter from "@modules/account/router/organization";
@@ -48,6 +49,7 @@ export default {
    statements: statementsRouter,
    tags: tagsRouter,
    team: teamRouter,
+   relationships: relationshipsRouter,
    transactions: transactionsRouter,
    workflows: workflowsRouter,
    organization: organizationRouter,

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -27,6 +27,7 @@
          "@modules/cashbook/*": ["../../modules/cashbook/src/*"],
          "@modules/classification/*": ["../../modules/classification/src/*"],
          "@modules/inbox/*": ["../../modules/inbox/src/*"],
+         "@modules/relationships/*": ["../../modules/relationships/src/*"],
          "@modules/workflows/*": ["../../modules/workflows/src/*"]
       }
    },

--- a/bun.lock
+++ b/bun.lock
@@ -111,6 +111,7 @@
         "@modules/classification": "workspace:*",
         "@modules/inbox": "workspace:*",
         "@modules/insights": "workspace:*",
+        "@modules/relationships": "workspace:*",
         "@modules/workflows": "workspace:*",
         "@orpc/client": "catalog:orpc",
         "@orpc/json-schema": "catalog:orpc",
@@ -641,6 +642,25 @@
         "dayjs": "catalog:ui",
         "drizzle-orm": "catalog:database",
         "neverthrow": "catalog:validation",
+        "zod": "catalog:validation",
+      },
+      "devDependencies": {
+        "@tooling/typescript": "workspace:*",
+        "typescript": "catalog:development",
+        "vitest": "catalog:testing",
+      },
+    },
+    "modules/relationships": {
+      "name": "@modules/relationships",
+      "version": "0.1.0",
+      "dependencies": {
+        "@core/authentication": "workspace:*",
+        "@core/database": "workspace:*",
+        "@core/orpc": "workspace:*",
+        "better-result": "catalog:validation",
+        "dayjs": "catalog:ui",
+        "drizzle-orm": "catalog:database",
+        "evlog": "catalog:logging",
         "zod": "catalog:validation",
       },
       "devDependencies": {
@@ -1706,6 +1726,8 @@
     "@modules/inbox": ["@modules/inbox@workspace:modules/inbox"],
 
     "@modules/insights": ["@modules/insights@workspace:modules/insights"],
+
+    "@modules/relationships": ["@modules/relationships@workspace:modules/relationships"],
 
     "@modules/workflows": ["@modules/workflows@workspace:modules/workflows"],
 

--- a/modules/relationships/package.json
+++ b/modules/relationships/package.json
@@ -1,0 +1,33 @@
+{
+   "name": "@modules/relationships",
+   "version": "0.1.0",
+   "private": true,
+   "license": "Apache-2.0",
+   "type": "module",
+   "exports": {
+      "./router/*": "./src/router/*.ts",
+      "./*": "./src/*.ts"
+   },
+   "scripts": {
+      "check": "oxlint ./src",
+      "format": "oxfmt --write ./src",
+      "format:check": "oxfmt --check ./src",
+      "test": "vitest run --passWithNoTests",
+      "typecheck": "tsgo"
+   },
+   "dependencies": {
+      "@core/authentication": "workspace:*",
+      "@core/database": "workspace:*",
+      "@core/orpc": "workspace:*",
+      "better-result": "catalog:validation",
+      "dayjs": "catalog:ui",
+      "drizzle-orm": "catalog:database",
+      "evlog": "catalog:logging",
+      "zod": "catalog:validation"
+   },
+   "devDependencies": {
+      "@tooling/typescript": "workspace:*",
+      "typescript": "catalog:development",
+      "vitest": "catalog:testing"
+   }
+}

--- a/modules/relationships/package.json
+++ b/modules/relationships/package.json
@@ -5,6 +5,7 @@
    "license": "Apache-2.0",
    "type": "module",
    "exports": {
+      "./router": "./src/router/index.ts",
       "./router/*": "./src/router/*.ts",
       "./*": "./src/*.ts"
    },

--- a/modules/relationships/src/router/index.ts
+++ b/modules/relationships/src/router/index.ts
@@ -1,0 +1,566 @@
+import dayjs from "dayjs";
+import {
+   and,
+   count,
+   desc,
+   eq,
+   ilike,
+   isNotNull,
+   isNull,
+   ne,
+   or,
+   sql,
+} from "drizzle-orm";
+import { Result, TaggedError } from "better-result";
+import { defineErrorCatalog } from "evlog";
+import { z } from "zod";
+import {
+   createPartySchema,
+   partyRoleValues,
+   parties,
+   updatePartySchema,
+} from "@core/database/schemas/relationships";
+import { cnpjDataSchema } from "@core/authentication/server";
+import { protectedProcedure } from "@core/orpc/server";
+import type { ORPCContextWithOrganization } from "@core/orpc/context";
+
+type PartyRole = (typeof partyRoleValues)[number];
+
+type DbClient = ORPCContextWithOrganization["db"];
+
+const relationshipRoleSchema = z.enum(partyRoleValues);
+
+const relationshipsRouterErrors = defineErrorCatalog("relationships.router", {
+   BAD_REQUEST: {
+      status: 400,
+      message: "Requisição inválida em relacionamentos.",
+      tags: ["relationships"],
+   },
+   CONFLICT: {
+      status: 409,
+      message: "Conflito ao gerenciar relacionamento.",
+      tags: ["relationships"],
+   },
+   FORBIDDEN: {
+      status: 403,
+      message: "Ação não permitida em relacionamentos.",
+      tags: ["relationships"],
+   },
+   INTERNAL: {
+      status: 500,
+      message: "Falha interna em relacionamentos.",
+      tags: ["relationships"],
+   },
+   NOT_FOUND: {
+      status: 404,
+      message: "Relacionamento não encontrado.",
+      tags: ["relationships"],
+   },
+});
+
+declare module "evlog" {
+   interface RegisteredErrorCatalogs {
+      "relationships.router": typeof relationshipsRouterErrors;
+   }
+}
+
+type RelationshipsRouterCatalogError =
+   | ReturnType<typeof relationshipsRouterErrors.BAD_REQUEST>
+   | ReturnType<typeof relationshipsRouterErrors.CONFLICT>
+   | ReturnType<typeof relationshipsRouterErrors.FORBIDDEN>
+   | ReturnType<typeof relationshipsRouterErrors.INTERNAL>
+   | ReturnType<typeof relationshipsRouterErrors.NOT_FOUND>;
+
+class RelationshipsRouterError extends TaggedError("RelationshipsRouterError")<{
+   error: RelationshipsRouterCatalogError;
+   message: string;
+}>() {}
+
+const ensureRow = <T>(row: T | undefined, message: string) =>
+   row
+      ? Result.ok(row)
+      : Result.err(
+           new RelationshipsRouterError({
+              error: relationshipsRouterErrors.NOT_FOUND(),
+              message,
+           }),
+        );
+
+const listInput = z.object({
+   role: relationshipRoleSchema,
+   q: z.string().trim().max(160).optional(),
+   archived: z.boolean().default(false),
+   limit: z.number().int().min(1).max(250).default(50),
+   offset: z.number().int().min(0).default(0),
+});
+
+const idInput = z.object({
+   id: z.string().uuid(),
+});
+
+const createInput = createPartySchema;
+const updateInput = idInput.merge(updatePartySchema);
+
+const cnpjLookupInput = z.object({
+   cnpj: z
+      .string()
+      .transform((value) => value.replace(/\D/g, ""))
+      .refine((value) => value.length === 14, {
+         message: "CNPJ deve conter 14 dígitos.",
+      }),
+});
+
+function roleFriendly(role: PartyRole) {
+   if (role === "customer") return "cliente";
+   return "fornecedor";
+}
+
+function formatDuplicateMessage(role: PartyRole) {
+   return `Já existe um ${roleFriendly(role)} com esse documento para este time.`;
+}
+
+async function getOwnedRelationship(db: DbClient, teamId: string, id: string) {
+   return Result.tryPromise({
+      try: () =>
+         db.query.parties.findFirst({
+            where: (f, { and, eq }) => and(eq(f.id, id), eq(f.teamId, teamId)),
+         }),
+      catch: () =>
+         new RelationshipsRouterError({
+            error: relationshipsRouterErrors.INTERNAL(),
+            message: "Falha ao localizar relacionamento.",
+         }),
+   });
+}
+
+async function findDuplicateByDocument(
+   db: DbClient,
+   teamId: string,
+   role: PartyRole,
+   documentNumber: string,
+   excludeId?: string,
+) {
+   return Result.tryPromise({
+      try: () =>
+         db.query.parties.findFirst({
+            where: (f, { and, eq }) => {
+               if (excludeId) {
+                  return and(
+                     eq(f.teamId, teamId),
+                     eq(f.role, role),
+                     eq(f.documentNumber, documentNumber),
+                     ne(f.id, excludeId),
+                  );
+               }
+
+               return and(
+                  eq(f.teamId, teamId),
+                  eq(f.role, role),
+                  eq(f.documentNumber, documentNumber),
+               );
+            },
+            columns: { id: true },
+         }),
+      catch: () =>
+         new RelationshipsRouterError({
+            error: relationshipsRouterErrors.INTERNAL(),
+            message: "Falha ao verificar documento duplicado.",
+         }),
+   });
+}
+
+async function hasFinancialLink(
+   db: DbClient,
+   teamId: string,
+   relationshipId: string,
+) {
+   return Result.tryPromise({
+      try: () =>
+         db.query.transactions.findFirst({
+            where: (f, { and, eq }) =>
+               and(eq(f.teamId, teamId), eq(f.relationshipId, relationshipId)),
+            columns: { id: true },
+         }),
+      catch: () =>
+         new RelationshipsRouterError({
+            error: relationshipsRouterErrors.INTERNAL(),
+            message: "Falha ao verificar vínculo financeiro.",
+         }),
+   });
+}
+
+const fetchBrasilApi = (cnpj: string) =>
+   Result.tryPromise({
+      try: () =>
+         fetch(`https://brasilapi.com.br/api/cnpj/v1/${cnpj}`, {
+            signal: AbortSignal.timeout(10000),
+            headers: { "User-Agent": "Montte-ERP/1.0" },
+         }),
+      catch: () =>
+         new RelationshipsRouterError({
+            error: relationshipsRouterErrors.INTERNAL(),
+            message: "Não foi possível consultar o CNPJ. Tente novamente.",
+         }),
+   });
+
+const readBrasilApiResponse = (response: Response) =>
+   Result.tryPromise({
+      try: () => response.json(),
+      catch: () =>
+         new RelationshipsRouterError({
+            error: relationshipsRouterErrors.INTERNAL(),
+            message: "Não foi possível consultar o CNPJ. Tente novamente.",
+         }),
+   });
+
+export const list = protectedProcedure
+   .input(listInput)
+   .handler(async ({ context, input }) => {
+      const search = input.q?.trim();
+      const result = await Result.tryPromise({
+         try: async () => {
+            const whereBase = and(
+               eq(parties.teamId, context.teamId),
+               eq(parties.role, input.role),
+               input.archived
+                  ? isNotNull(parties.archivedAt)
+                  : isNull(parties.archivedAt),
+            );
+
+            const where = search
+               ? and(
+                    whereBase,
+                    or(
+                       ilike(parties.name, `%${search}%`),
+                       sql`${parties.documentNumber} ilike ${`%${search}%`}`,
+                       sql`${parties.email} ilike ${`%${search}%`}`,
+                       sql`${parties.phone} ilike ${`%${search}%`}`,
+                    ),
+                 )
+               : whereBase;
+
+            const [data, countRows] = await Promise.all([
+               context.db
+                  .select()
+                  .from(parties)
+                  .where(where)
+                  .orderBy(desc(parties.name))
+                  .limit(input.limit)
+                  .offset(input.offset),
+               context.db.select({ total: count() }).from(parties).where(where),
+            ]);
+
+            return {
+               data,
+               total: countRows[0]?.total ?? 0,
+               limit: input.limit,
+               offset: input.offset,
+            };
+         },
+         catch: () =>
+            new RelationshipsRouterError({
+               error: relationshipsRouterErrors.INTERNAL(),
+               message: "Falha ao listar relacionamentos.",
+            }),
+      });
+      if (Result.isError(result)) throw result.error;
+      return result.value;
+   });
+
+export const create = protectedProcedure
+   .input(createInput)
+   .handler(async ({ context, input }) => {
+      if (input.documentNumber) {
+         const duplicate = await findDuplicateByDocument(
+            context.db,
+            context.teamId,
+            input.role,
+            input.documentNumber,
+         );
+         if (Result.isError(duplicate)) throw duplicate.error;
+         if (duplicate.value) {
+            throw new RelationshipsRouterError({
+               error: relationshipsRouterErrors.CONFLICT(),
+               message: formatDuplicateMessage(input.role),
+            });
+         }
+      }
+
+      const created = await Result.tryPromise({
+         try: () =>
+            context.db.transaction(async (tx) => {
+               const [row] = await tx
+                  .insert(parties)
+                  .values({ ...input, teamId: context.teamId })
+                  .returning();
+               return row;
+            }),
+         catch: () =>
+            new RelationshipsRouterError({
+               error: relationshipsRouterErrors.INTERNAL(),
+               message: "Falha ao criar relacionamento.",
+            }),
+      });
+      if (Result.isError(created)) throw created.error;
+      const result = ensureRow(
+         created.value,
+         "Falha ao criar relacionamento: insert vazio.",
+      );
+      if (Result.isError(result)) throw result.error;
+      return result.value;
+   });
+
+export const update = protectedProcedure
+   .input(updateInput)
+   .handler(async ({ context, input }) => {
+      const { id, ...payload } = input;
+      const relationshipResult = await getOwnedRelationship(
+         context.db,
+         context.teamId,
+         id,
+      );
+      if (Result.isError(relationshipResult)) throw relationshipResult.error;
+      const relationship = relationshipResult.value;
+      if (!relationship) {
+         throw new RelationshipsRouterError({
+            error: relationshipsRouterErrors.NOT_FOUND(),
+            message: "Relacionamento não encontrado.",
+         });
+      }
+
+      if (relationship.archivedAt) {
+         throw new RelationshipsRouterError({
+            error: relationshipsRouterErrors.FORBIDDEN(),
+            message: "Relacionamento arquivado não pode ser atualizado.",
+         });
+      }
+
+      const nextRole = payload.role ?? relationship.role;
+      const nextDocument =
+         payload.documentNumber === undefined
+            ? relationship.documentNumber
+            : payload.documentNumber;
+
+      if (nextDocument) {
+         const duplicate = await findDuplicateByDocument(
+            context.db,
+            context.teamId,
+            nextRole,
+            nextDocument,
+            id,
+         );
+         if (Result.isError(duplicate)) throw duplicate.error;
+         if (duplicate.value) {
+            throw new RelationshipsRouterError({
+               error: relationshipsRouterErrors.CONFLICT(),
+               message: formatDuplicateMessage(nextRole),
+            });
+         }
+      }
+
+      const updated = await Result.tryPromise({
+         try: async () =>
+            context.db.transaction(async (tx) => {
+               const [row] = await tx
+                  .update(parties)
+                  .set({
+                     ...payload,
+                     role: nextRole,
+                     updatedAt: dayjs().toDate(),
+                  })
+                  .where(eq(parties.id, relationship.id))
+                  .returning();
+               return row;
+            }),
+         catch: () =>
+            new RelationshipsRouterError({
+               error: relationshipsRouterErrors.INTERNAL(),
+               message: "Falha ao atualizar relacionamento.",
+            }),
+      });
+      if (Result.isError(updated)) throw updated.error;
+      const result = ensureRow(
+         updated.value,
+         "Falha ao atualizar relacionamento: update vazio.",
+      );
+      if (Result.isError(result)) throw result.error;
+      return result.value;
+   });
+
+const deleteRelationship = protectedProcedure
+   .input(idInput)
+   .handler(async ({ context, input }) => {
+      const relationshipResult = await getOwnedRelationship(
+         context.db,
+         context.teamId,
+         input.id,
+      );
+      if (Result.isError(relationshipResult)) throw relationshipResult.error;
+      const relationship = relationshipResult.value;
+      if (!relationship) {
+         throw new RelationshipsRouterError({
+            error: relationshipsRouterErrors.NOT_FOUND(),
+            message: "Relacionamento não encontrado.",
+         });
+      }
+
+      const financialResult = await hasFinancialLink(
+         context.db,
+         context.teamId,
+         relationship.id,
+      );
+      if (Result.isError(financialResult)) throw financialResult.error;
+      if (financialResult.value) {
+         throw new RelationshipsRouterError({
+            error: relationshipsRouterErrors.CONFLICT(),
+            message:
+               "Relacionamento com vínculo financeiro não pode ser excluído. Use o arquivamento para ocultá-lo.",
+         });
+      }
+
+      const deleted = await Result.tryPromise({
+         try: () =>
+            context.db.transaction(async (tx) => {
+               const [row] = await tx
+                  .delete(parties)
+                  .where(eq(parties.id, relationship.id))
+                  .returning({ id: parties.id });
+               return row;
+            }),
+         catch: () =>
+            new RelationshipsRouterError({
+               error: relationshipsRouterErrors.INTERNAL(),
+               message: "Falha ao excluir relacionamento.",
+            }),
+      });
+      if (Result.isError(deleted)) throw deleted.error;
+      return { success: true };
+   });
+
+export const archive = protectedProcedure
+   .input(idInput)
+   .handler(async ({ context, input }) => {
+      const relationshipResult = await getOwnedRelationship(
+         context.db,
+         context.teamId,
+         input.id,
+      );
+      if (Result.isError(relationshipResult)) throw relationshipResult.error;
+      const relationship = relationshipResult.value;
+      if (!relationship) {
+         throw new RelationshipsRouterError({
+            error: relationshipsRouterErrors.NOT_FOUND(),
+            message: "Relacionamento não encontrado.",
+         });
+      }
+
+      const archived = await Result.tryPromise({
+         try: () =>
+            context.db.transaction(async (tx) => {
+               const [row] = await tx
+                  .update(parties)
+                  .set({ archivedAt: dayjs().toDate() })
+                  .where(eq(parties.id, relationship.id))
+                  .returning();
+               return row;
+            }),
+         catch: () =>
+            new RelationshipsRouterError({
+               error: relationshipsRouterErrors.INTERNAL(),
+               message: "Falha ao arquivar relacionamento.",
+            }),
+      });
+      if (Result.isError(archived)) throw archived.error;
+      const result = ensureRow(
+         archived.value,
+         "Falha ao arquivar relacionamento: update vazio.",
+      );
+      if (Result.isError(result)) throw result.error;
+      return result.value;
+   });
+
+export const restore = protectedProcedure
+   .input(idInput)
+   .handler(async ({ context, input }) => {
+      const relationshipResult = await getOwnedRelationship(
+         context.db,
+         context.teamId,
+         input.id,
+      );
+      if (Result.isError(relationshipResult)) throw relationshipResult.error;
+      const relationship = relationshipResult.value;
+      if (!relationship) {
+         throw new RelationshipsRouterError({
+            error: relationshipsRouterErrors.NOT_FOUND(),
+            message: "Relacionamento não encontrado.",
+         });
+      }
+
+      const restored = await Result.tryPromise({
+         try: () =>
+            context.db.transaction(async (tx) => {
+               const [row] = await tx
+                  .update(parties)
+                  .set({ archivedAt: null })
+                  .where(eq(parties.id, relationship.id))
+                  .returning();
+               return row;
+            }),
+         catch: () =>
+            new RelationshipsRouterError({
+               error: relationshipsRouterErrors.INTERNAL(),
+               message: "Falha ao restaurar relacionamento.",
+            }),
+      });
+      if (Result.isError(restored)) throw restored.error;
+      const result = ensureRow(
+         restored.value,
+         "Falha ao restaurar relacionamento: update vazio.",
+      );
+      if (Result.isError(result)) throw result.error;
+      return result.value;
+   });
+
+export const cnpjLookup = protectedProcedure
+   .input(cnpjLookupInput)
+   .handler(async ({ input }) => {
+      const responseResult = await fetchBrasilApi(input.cnpj);
+      if (Result.isError(responseResult)) throw responseResult.error;
+      if (!responseResult.value.ok) {
+         if (responseResult.value.status === 404) {
+            throw new RelationshipsRouterError({
+               error: relationshipsRouterErrors.NOT_FOUND(),
+               message: "CNPJ não encontrado ou inválido.",
+            });
+         }
+
+         throw new RelationshipsRouterError({
+            error: relationshipsRouterErrors.INTERNAL(),
+            message: "Não foi possível consultar o CNPJ. Tente novamente.",
+         });
+      }
+
+      const payloadResult = await readBrasilApiResponse(responseResult.value);
+      if (Result.isError(payloadResult)) throw payloadResult.error;
+
+      const parsedResult = await Result.try({
+         try: () => cnpjDataSchema.parse(payloadResult.value),
+         catch: () =>
+            new RelationshipsRouterError({
+               error: relationshipsRouterErrors.INTERNAL(),
+               message: "Não foi possível consultar o CNPJ. Tente novamente.",
+            }),
+      });
+      if (parsedResult.isErr()) throw parsedResult.error;
+
+      if (parsedResult.value.descricao_situacao_cadastral !== "ATIVA") {
+         throw new RelationshipsRouterError({
+            error: relationshipsRouterErrors.BAD_REQUEST(),
+            message: "Este CNPJ não está ativo na Receita Federal.",
+         });
+      }
+
+      return parsedResult.value;
+   });
+
+export { deleteRelationship as delete };

--- a/modules/relationships/src/router/index.ts
+++ b/modules/relationships/src/router/index.ts
@@ -434,6 +434,8 @@ const deleteRelationship = protectedProcedure
             }),
       });
       if (Result.isError(deleted)) throw deleted.error;
+      const result = ensureRow(deleted.value, "Relacionamento não encontrado.");
+      if (Result.isError(result)) throw result.error;
       return { success: true };
    });
 

--- a/modules/relationships/tsconfig.json
+++ b/modules/relationships/tsconfig.json
@@ -8,11 +8,10 @@
       "rootDir": "../..",
       "jsx": "react-jsx",
       "paths": {
-         "@core/authentication": ["../../core/authentication/src/index.ts"],
          "@core/authentication/*": ["../../core/authentication/src/*"],
          "@core/database": ["../../core/database/src/index.ts"],
          "@core/database/*": ["../../core/database/src/*"],
-         "@core/orpc": ["../../core/orpc/src/index.ts"],
+
          "@core/orpc/*": ["../../core/orpc/src/*"],
          "@modules/relationships/*": ["./src/*"]
       }

--- a/modules/relationships/tsconfig.json
+++ b/modules/relationships/tsconfig.json
@@ -1,0 +1,26 @@
+{
+   "extends": "@tooling/typescript/core.json",
+   "compilerOptions": {
+      "composite": false,
+      "declaration": false,
+      "declarationMap": false,
+      "noEmit": true,
+      "rootDir": "../..",
+      "jsx": "react-jsx",
+      "paths": {
+         "@core/authentication": ["../../core/authentication/src/index.ts"],
+         "@core/authentication/*": ["../../core/authentication/src/*"],
+         "@core/database": ["../../core/database/src/index.ts"],
+         "@core/database/*": ["../../core/database/src/*"],
+         "@core/orpc": ["../../core/orpc/src/index.ts"],
+         "@core/orpc/*": ["../../core/orpc/src/*"],
+         "@modules/relationships/*": ["./src/*"]
+      }
+   },
+   "include": ["src"],
+   "references": [
+      {
+         "path": "../../core/database"
+      }
+   ]
+}

--- a/modules/workflows/src/router.ts
+++ b/modules/workflows/src/router.ts
@@ -15,11 +15,11 @@ import {
    buildHumanLabel,
    buildNextRunAt,
    createWorkflowIdempotencyKey,
-   getWorkflowScheduleNode,
+   findWorkflowScheduleNode,
    normalizeWorkflowTimezone,
    WORKFLOW_EXECUTE_QUEUE_NAME,
    WORKFLOW_EXECUTE_WORKFLOW_NAME,
-} from "./runtime";
+} from "./runtime-constants";
 import {
    createWorkflowGraphFromTemplate,
    getWorkflowTemplate,
@@ -68,6 +68,16 @@ function isIntegerInRange(value: string, min: number, max: number) {
    if (!/^\d+$/.test(value)) return false;
    const numeric = Number(value);
    return Number.isInteger(numeric) && numeric >= min && numeric <= max;
+}
+
+function getWorkflowScheduleNodeOrThrow(graph: Workflow["graph"]) {
+   const node = findWorkflowScheduleNode(graph);
+   if (!node)
+      throw new WorkflowsRouterError({
+         error: workflowsRouterErrors.INVALID_GRAPH(),
+         message: "Workflow sem nó de agenda esperado.",
+      });
+   return node;
 }
 
 function isSupportedWorkflowCron(cron: string) {
@@ -394,7 +404,7 @@ export const update = protectedProcedure
    .input(updateSchema)
    .handler(async ({ context, input }) => {
       const workflow = await loadWorkflowForTeam(context, input.id);
-      const scheduleNode = getWorkflowScheduleNode(input.graph);
+      const scheduleNode = getWorkflowScheduleNodeOrThrow(input.graph);
       const timezoneValue = normalizeWorkflowTimezone(
          scheduleNode.data.timezone,
       );
@@ -442,7 +452,7 @@ async function activateWorkflowForTeam(
 ) {
    const workflow = await loadWorkflowForTeam(context, id);
    assertWorkflowCanActivate(workflow);
-   const scheduleNode = getWorkflowScheduleNode(workflow.graph);
+   const scheduleNode = getWorkflowScheduleNodeOrThrow(workflow.graph);
    const nextRunAt = buildNextRunAtOrThrow(
       scheduleNode.data.cron,
       normalizeWorkflowTimezone(scheduleNode.data.timezone),
@@ -566,7 +576,7 @@ export const bulkActivate = protectedProcedure
       const workflowIds = owned.map((workflow) => workflow.id);
       const now = dayjs().toDate();
       const nextRuns = owned.map((workflow) => {
-         const scheduleNode = getWorkflowScheduleNode(workflow.graph);
+         const scheduleNode = getWorkflowScheduleNodeOrThrow(workflow.graph);
          return {
             id: workflow.id,
             nextRunAt: buildNextRunAtOrThrow(

--- a/modules/workflows/src/runtime-constants.ts
+++ b/modules/workflows/src/runtime-constants.ts
@@ -1,0 +1,168 @@
+import "dayjs/locale/pt-br";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+import { CronExpressionParser } from "cron-parser";
+import {
+   type ReportConfig,
+   type ReportType,
+} from "@core/database/schemas/reports";
+import type { WorkflowGraph } from "@core/database/schemas/workflows";
+import type { WorkflowTemplatePeriod } from "./templates";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.locale("pt-br");
+
+export const WORKFLOW_TIMEZONE = "America/Sao_Paulo";
+export const WORKFLOW_EXECUTE_QUEUE_NAME = "workflows/execute";
+export const WORKFLOW_SCHEDULER_QUEUE_NAME = "workflows/scheduler";
+export const WORKFLOW_EXECUTE_WORKFLOW_NAME = "executeWorkflowWorkflowFn";
+export const WORKFLOW_SCHEDULER_WORKFLOW_NAME = "pollDueWorkflowsWorkflowFn";
+
+export type WorkflowPeriod = {
+   from: Date;
+   to: Date;
+};
+
+export function normalizeWorkflowTimezone(
+   timezoneValue: string | null | undefined,
+) {
+   return timezoneValue === WORKFLOW_TIMEZONE
+      ? timezoneValue
+      : WORKFLOW_TIMEZONE;
+}
+
+export function buildHumanLabel(cron: string) {
+   const [minute, hour, dayOfMonth, , dayOfWeek] = cron.split(" ");
+   const hourLabel = hour?.padStart(2, "0") ?? "00";
+   const minuteLabel = minute?.padStart(2, "0") ?? "00";
+   if (dayOfMonth && dayOfMonth !== "*" && dayOfWeek === "*") {
+      return `Todo dia ${dayOfMonth} às ${hourLabel}:${minuteLabel}`;
+   }
+   if (dayOfWeek && dayOfWeek !== "*" && dayOfMonth === "*") {
+      const weekdayNames = [
+         "domingo",
+         "segunda",
+         "terça",
+         "quarta",
+         "quinta",
+         "sexta",
+         "sábado",
+      ];
+      const normalizedWeekday = ((Number(dayOfWeek) % 7) + 7) % 7;
+      const weekday = weekdayNames[normalizedWeekday] ?? "segunda";
+      return `Toda ${weekday} às ${hourLabel}:${minuteLabel}`;
+   }
+   return `Agendado às ${hourLabel}:${minuteLabel}`;
+}
+
+export function buildNextRunAt(
+   cron: string,
+   timezoneValue: string,
+   currentDate: Date,
+) {
+   const interval = CronExpressionParser.parse(cron, {
+      currentDate,
+      tz: timezoneValue,
+   });
+   return interval.next().toDate();
+}
+
+export function computeWorkflowPeriod(
+   period: WorkflowTemplatePeriod,
+   scheduledFor: Date,
+   timezoneValue: string,
+): WorkflowPeriod {
+   const local = dayjs(scheduledFor).tz(timezoneValue);
+   if (period === "previous-month") {
+      const currentMonthStart = local.startOf("month");
+      return {
+         from: currentMonthStart.subtract(1, "month").toDate(),
+         to: currentMonthStart.toDate(),
+      };
+   }
+   if (period === "current-month") {
+      const monthStart = local.startOf("month");
+      return {
+         from: monthStart.toDate(),
+         to: monthStart.add(1, "month").toDate(),
+      };
+   }
+   const weekday = local.day();
+   const mondayOffset = weekday === 0 ? -6 : 1 - weekday;
+   const weekStart = local.startOf("day").add(mondayOffset, "day");
+   if (period === "previous-week") {
+      return {
+         from: weekStart.subtract(7, "day").toDate(),
+         to: weekStart.toDate(),
+      };
+   }
+   return {
+      from: weekStart.toDate(),
+      to: weekStart.add(7, "day").toDate(),
+   };
+}
+
+export function renderWorkflowName(
+   template: string,
+   period: WorkflowPeriod,
+   timezoneValue: string,
+) {
+   const start = dayjs(period.from).tz(timezoneValue);
+   const end = dayjs(period.to).tz(timezoneValue);
+   return template
+      .replaceAll("{month}", start.format("MMMM"))
+      .replaceAll("{year}", start.format("YYYY"))
+      .replaceAll("{week}", start.format("DD/MM"))
+      .replaceAll(
+         "{range}",
+         `${start.format("DD/MM")} — ${end.format("DD/MM")}`,
+      );
+}
+
+export function buildWorkflowReportConfig(input: {
+   reportType: ReportType;
+   period: WorkflowPeriod;
+   timezone: string;
+}): ReportConfig {
+   const start = dayjs(input.period.from).tz(input.timezone);
+   const end = dayjs(input.period.to).tz(input.timezone).subtract(1, "day");
+   const base: ReportConfig = {
+      dateFrom: start.format("YYYY-MM-DD"),
+      dateTo: end.format("YYYY-MM-DD"),
+      status: "paid",
+      bankAccountId: undefined,
+      categoryId: undefined,
+      tagId: undefined,
+      dreOnly: true,
+      agingType: "income",
+      agingStatus: "open",
+      categoryDepth: "group",
+      minAmount: 0,
+   };
+   if (input.reportType === "aging") {
+      return { ...base, agingType: "expense" };
+   }
+   return base;
+}
+
+export function createWorkflowIdempotencyKey(
+   workflowId: string,
+   scheduledFor: Date,
+) {
+   return `${workflowId}-${scheduledFor.toISOString()}`;
+}
+
+export function findWorkflowScheduleNode(graph: WorkflowGraph) {
+   return graph.nodes.find(
+      (node): node is WorkflowGraph["nodes"][0] =>
+         node.type === "scheduleTrigger",
+   );
+}
+
+export function findWorkflowActionNode(graph: WorkflowGraph) {
+   return graph.nodes.find(
+      (node): node is WorkflowGraph["nodes"][1] => node.type === "createReport",
+   );
+}

--- a/modules/workflows/src/runtime.ts
+++ b/modules/workflows/src/runtime.ts
@@ -1,11 +1,7 @@
-import "dayjs/locale/pt-br";
-import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
-import timezone from "dayjs/plugin/timezone";
 import { Result, TaggedError } from "better-result";
 import { defineErrorCatalog } from "evlog";
 import { and, desc, eq } from "drizzle-orm";
-import { CronExpressionParser } from "cron-parser";
+import dayjs from "dayjs";
 import {
    reports,
    type ReportConfig,
@@ -18,17 +14,27 @@ import {
    type WorkflowRunTriggeredBy,
 } from "@core/database/schemas/workflows";
 import { workflowsDataSource } from "./data-source";
-import type { WorkflowTemplatePeriod } from "./templates";
+import {
+   buildNextRunAt,
+   findWorkflowActionNode,
+   findWorkflowScheduleNode,
+} from "./runtime-constants";
 
-dayjs.extend(utc);
-dayjs.extend(timezone);
-dayjs.locale("pt-br");
-
-export const WORKFLOW_TIMEZONE = "America/Sao_Paulo";
-export const WORKFLOW_EXECUTE_QUEUE_NAME = "workflows/execute";
-export const WORKFLOW_SCHEDULER_QUEUE_NAME = "workflows/scheduler";
-export const WORKFLOW_EXECUTE_WORKFLOW_NAME = "executeWorkflowWorkflowFn";
-export const WORKFLOW_SCHEDULER_WORKFLOW_NAME = "pollDueWorkflowsWorkflowFn";
+export { WORKFLOW_TIMEZONE } from "./runtime-constants";
+export { WORKFLOW_EXECUTE_QUEUE_NAME } from "./runtime-constants";
+export { WORKFLOW_SCHEDULER_QUEUE_NAME } from "./runtime-constants";
+export { WORKFLOW_EXECUTE_WORKFLOW_NAME } from "./runtime-constants";
+export { WORKFLOW_SCHEDULER_WORKFLOW_NAME } from "./runtime-constants";
+export type { WorkflowPeriod } from "./runtime-constants";
+export {
+   buildHumanLabel,
+   buildNextRunAt,
+   computeWorkflowPeriod,
+   createWorkflowIdempotencyKey,
+   normalizeWorkflowTimezone,
+   renderWorkflowName,
+   buildWorkflowReportConfig,
+} from "./runtime-constants";
 
 export const workflowsRuntimeErrors = defineErrorCatalog("workflows.runtime", {
    EXECUTE_FAILED: {
@@ -110,138 +116,8 @@ function isWorkflowRunNotFoundError(error: unknown) {
    );
 }
 
-export type WorkflowPeriod = {
-   from: Date;
-   to: Date;
-};
-
-export function normalizeWorkflowTimezone(
-   timezoneValue: string | null | undefined,
-) {
-   return timezoneValue === WORKFLOW_TIMEZONE
-      ? timezoneValue
-      : WORKFLOW_TIMEZONE;
-}
-
-export function buildHumanLabel(cron: string) {
-   const [minute, hour, dayOfMonth, , dayOfWeek] = cron.split(" ");
-   const hourLabel = hour?.padStart(2, "0") ?? "00";
-   const minuteLabel = minute?.padStart(2, "0") ?? "00";
-   if (dayOfMonth && dayOfMonth !== "*" && dayOfWeek === "*") {
-      return `Todo dia ${dayOfMonth} às ${hourLabel}:${minuteLabel}`;
-   }
-   if (dayOfWeek && dayOfWeek !== "*" && dayOfMonth === "*") {
-      const weekdayNames = [
-         "domingo",
-         "segunda",
-         "terça",
-         "quarta",
-         "quinta",
-         "sexta",
-         "sábado",
-      ];
-      const normalizedWeekday = ((Number(dayOfWeek) % 7) + 7) % 7;
-      const weekday = weekdayNames[normalizedWeekday] ?? "segunda";
-      return `Toda ${weekday} às ${hourLabel}:${minuteLabel}`;
-   }
-   return `Agendado às ${hourLabel}:${minuteLabel}`;
-}
-
-export function buildNextRunAt(
-   cron: string,
-   timezoneValue: string,
-   currentDate: Date,
-) {
-   const interval = CronExpressionParser.parse(cron, {
-      currentDate,
-      tz: timezoneValue,
-   });
-   return interval.next().toDate();
-}
-
-export function computeWorkflowPeriod(
-   period: WorkflowTemplatePeriod,
-   scheduledFor: Date,
-   timezoneValue: string,
-): WorkflowPeriod {
-   const local = dayjs(scheduledFor).tz(timezoneValue);
-   if (period === "previous-month") {
-      const currentMonthStart = local.startOf("month");
-      return {
-         from: currentMonthStart.subtract(1, "month").toDate(),
-         to: currentMonthStart.toDate(),
-      };
-   }
-   if (period === "current-month") {
-      const monthStart = local.startOf("month");
-      return {
-         from: monthStart.toDate(),
-         to: monthStart.add(1, "month").toDate(),
-      };
-   }
-   const weekday = local.day();
-   const mondayOffset = weekday === 0 ? -6 : 1 - weekday;
-   const weekStart = local.startOf("day").add(mondayOffset, "day");
-   if (period === "previous-week") {
-      return {
-         from: weekStart.subtract(7, "day").toDate(),
-         to: weekStart.toDate(),
-      };
-   }
-   return {
-      from: weekStart.toDate(),
-      to: weekStart.add(7, "day").toDate(),
-   };
-}
-
-export function renderWorkflowName(
-   template: string,
-   period: WorkflowPeriod,
-   timezoneValue: string,
-) {
-   const start = dayjs(period.from).tz(timezoneValue);
-   const end = dayjs(period.to).tz(timezoneValue);
-   return template
-      .replaceAll("{month}", start.format("MMMM"))
-      .replaceAll("{year}", start.format("YYYY"))
-      .replaceAll("{week}", start.format("DD/MM"))
-      .replaceAll(
-         "{range}",
-         `${start.format("DD/MM")} — ${end.format("DD/MM")}`,
-      );
-}
-
-export function buildWorkflowReportConfig(input: {
-   reportType: ReportType;
-   period: WorkflowPeriod;
-   timezone: string;
-}): ReportConfig {
-   const start = dayjs(input.period.from).tz(input.timezone);
-   const end = dayjs(input.period.to).tz(input.timezone).subtract(1, "day");
-   const base: ReportConfig = {
-      dateFrom: start.format("YYYY-MM-DD"),
-      dateTo: end.format("YYYY-MM-DD"),
-      status: "paid",
-      bankAccountId: undefined,
-      categoryId: undefined,
-      tagId: undefined,
-      dreOnly: true,
-      agingType: "income",
-      agingStatus: "open",
-      categoryDepth: "group",
-      minAmount: 0,
-   };
-   if (input.reportType === "aging") {
-      return { ...base, agingType: "expense" };
-   }
-   return base;
-}
-
 export function getWorkflowScheduleNode(graph: WorkflowGraph) {
-   const node = graph.nodes.find(
-      (node): node is WorkflowGraph["nodes"][0] =>
-         node.type === "scheduleTrigger",
-   );
+   const node = findWorkflowScheduleNode(graph);
    if (!node) {
       throw new WorkflowsRuntimeError({
          error: workflowsRuntimeErrors.WORKFLOW_NOT_FOUND(),
@@ -252,9 +128,7 @@ export function getWorkflowScheduleNode(graph: WorkflowGraph) {
 }
 
 export function getWorkflowActionNode(graph: WorkflowGraph) {
-   const node = graph.nodes.find(
-      (node): node is WorkflowGraph["nodes"][1] => node.type === "createReport",
-   );
+   const node = findWorkflowActionNode(graph);
    if (!node) {
       throw new WorkflowsRuntimeError({
          error: workflowsRuntimeErrors.WORKFLOW_NOT_FOUND(),
@@ -549,13 +423,6 @@ export async function updateWorkflowNextRunAt(input: {
          message: "Workflow não encontrado para atualizar próxima execução.",
       });
    return result.value;
-}
-
-export function createWorkflowIdempotencyKey(
-   workflowId: string,
-   scheduledFor: Date,
-) {
-   return `${workflowId}-${scheduledFor.toISOString()}`;
 }
 
 export async function createWorkflowReport(input: {

--- a/modules/workflows/src/scheduler.ts
+++ b/modules/workflows/src/scheduler.ts
@@ -10,10 +10,12 @@ import {
    markWorkflowRunFailed,
    normalizeWorkflowTimezone,
    updateWorkflowNextRunAt,
+} from "./runtime";
+import {
    WORKFLOW_EXECUTE_QUEUE_NAME,
    WORKFLOW_SCHEDULER_QUEUE_NAME,
    WORKFLOW_SCHEDULER_WORKFLOW_NAME,
-} from "./runtime";
+} from "./runtime-constants";
 import { executeWorkflowWorkflow } from "./workflows/execute-workflow.workflow";
 
 const BATCH_SIZE = 20;

--- a/modules/workflows/src/setup-workflows.ts
+++ b/modules/workflows/src/setup-workflows.ts
@@ -3,7 +3,7 @@ import { env } from "@core/environment/worker";
 import {
    WORKFLOW_EXECUTE_QUEUE_NAME,
    WORKFLOW_SCHEDULER_QUEUE_NAME,
-} from "./runtime";
+} from "./runtime-constants";
 import { executeWorkflowWorkflow } from "./workflows/execute-workflow.workflow";
 import { pollDueWorkflowsWorkflow } from "./scheduler";
 

--- a/modules/workflows/src/workflows/execute-workflow.workflow.ts
+++ b/modules/workflows/src/workflows/execute-workflow.workflow.ts
@@ -2,8 +2,6 @@ import { DBOS } from "@dbos-inc/dbos-sdk";
 import { Result } from "better-result";
 import { registerWorkflowOnce } from "@core/dbos/factory";
 import {
-   buildWorkflowReportConfig,
-   computeWorkflowPeriod,
    createWorkflowReport,
    getWorkflowActionNode,
    getWorkflowScheduleNode,
@@ -12,13 +10,17 @@ import {
    markWorkflowRunFailed,
    markWorkflowRunRunning,
    markWorkflowRunSucceeded,
-   normalizeWorkflowTimezone,
-   renderWorkflowName,
    updateWorkflowNextRunAt,
    workflowsRuntimeErrors,
    WorkflowsRuntimeError,
    WORKFLOW_EXECUTE_WORKFLOW_NAME,
 } from "../runtime";
+import {
+   buildWorkflowReportConfig,
+   computeWorkflowPeriod,
+   normalizeWorkflowTimezone,
+   renderWorkflowName,
+} from "../runtime-constants";
 
 async function executeWorkflowWorkflowFn(input: {
    workflowId: string;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Implementa o módulo `@modules/relationships` com router único baseado em `role` e integra no oRPC; refatora `@modules/workflows` extraindo constantes/utis para tornar o agendamento mais explícito e seguro. Atende ao MON-1136 ao unificar clientes e fornecedores e padronizar erros/ownership por time.

- **New Features**
  - Router único `relationships`: `list`, `create`, `update`, `delete`, `archive`, `restore`, `cnpjLookup`.
  - `list` com filtros: `role`, `q`, `archived`, `limit`, `offset`; busca por nome/documento/e-mail/telefone; ordenação por nome (desc).
  - Regras: dedupe por documento no mesmo `role` e `team`; permitido documento igual em `roles` diferentes; mensagens em pt-BR.
  - Restrições: `delete` bloqueado se houver transações; `archive`/`restore` sempre; `update` bloqueado se arquivado.
  - Integração: router agregado ao oRPC da web; adiciona `@modules/relationships` em `apps/web/package.json` e alias em `apps/web/tsconfig.json`.

- **Refactors**
  - `@modules/workflows`: move `WORKFLOW_*`, timezone, cron, período, nome e config de relatório para `runtime-constants.ts`; reexporta no `runtime.ts`.
  - Substitui buscas diretas de nós por `findWorkflowScheduleNode`/`findWorkflowActionNode`; valida nó de agenda no `router.ts` com erro claro.
  - Atualiza imports em `router.ts`, `scheduler.ts`, `setup-workflows.ts`, `workflows/execute-workflow.workflow.ts`; remove duplicações em `runtime.ts`.
  - `@modules/relationships`: corrige export do router (inclui `export { deleteRelationship as delete }`) e reforça validação de exclusão.
  - Impacto nas camadas:
    - Router: novo router `relationships`; validação de grafo e uso de constantes em workflows.
    - Repositório: consultas via `@core/database/schemas/relationships`; verificação de vínculos financeiros por transações.
    - Componentes/Store: sem mudanças.

Checklist de testes
- Relationships
  - List: separação por `role`; `archived` true/false; paginação (`limit`/`offset`); busca (`q`) por nome/documento/e-mail/telefone; total correto.
  - Create/Update: dedupe por documento no mesmo `role` e `team`; permitido igual em `roles` diferentes; bloqueio de `update` quando arquivado; ownership por `team`.
  - Delete: bloqueado com mensagem clara quando houver transações; permitido sem vínculos; endpoint `delete` acessível via oRPC.
  - Archive/Restore: `archivedAt` definido/limpo corretamente.
  - CNPJ: sucesso com CNPJ ativo; 404 retorna NOT_FOUND; inativo retorna BAD_REQUEST; timeouts/erros retornam INTERNAL; mensagens em pt-BR.
- Workflows
  - `buildNextRunAt` e `buildHumanLabel` funcionam após extração; `normalizeWorkflowTimezone` mantém `America/Sao_Paulo`.
  - `update`, `activate`, `bulkActivate`: erro quando nó de agenda falta; cálculo de `nextRunAt` correto.
  - Filas: nomes `WORKFLOW_EXECUTE_QUEUE_NAME` e `WORKFLOW_SCHEDULER_QUEUE_NAME` intactos; setup registra workflows.

<sup>Written for commit 4ed2dd98fa44b90b45dc12f2cc5ce534aa053b01. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/987?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

