### PR TITLE
Manoelnetocarvalho03/mon 1143 importacao de contas falha sem informar saldo invalido

### DIFF
--- a/apps/web-e2e/tests/bank-accounts-create.spec.ts
+++ b/apps/web-e2e/tests/bank-accounts-create.spec.ts
@@ -33,6 +33,19 @@ async function clearBankAccountSearch(page: Page) {
    await page.getByPlaceholder("Buscar conta por nome...").fill("");
 }
 
+async function uploadBankAccountsCsv(page: Page, csv: string) {
+   await page.getByRole("button", { name: "Importar dados" }).click();
+   await page
+      .locator('input[type="file"]')
+      .first()
+      .setInputFiles({
+         name: "contas-bancarias.csv",
+         mimeType: "text/csv",
+         buffer: Buffer.from(csv, "utf8"),
+      });
+   await expect(page.getByText("Importando")).toBeVisible();
+}
+
 test.afterEach(async ({ e2eSession }) => {
    const team = await findTeamByOrgAndSlug(
       e2eSession.orgSlug,
@@ -42,6 +55,36 @@ test.afterEach(async ({ e2eSession }) => {
    for (const id of createdIds.splice(0)) {
       await deleteBankAccountById(team.id, id);
    }
+});
+
+test("importação permite alterar tipo e mostra ações em massa", async ({
+   page,
+   e2eSession,
+}) => {
+   const name = `Import Tipo E2E ${stamp()}`;
+   await gotoBankAccounts(page, e2eSession);
+   await uploadBankAccountsCsv(
+      page,
+      `Nome,Tipo,Saldo Inicial,Código do Banco,Banco\n${name},,100.00,341,Itaú\n`,
+   );
+
+   const row = page.getByRole("row").filter({ hasText: name });
+   await expect(row).toBeVisible();
+   await expect(row.getByLabel("Tipo")).toHaveText("Conta Corrente");
+
+   await row.getByLabel("Selecionar linha").click();
+   await expect(
+      page.locator("[data-selection-toolbar]").getByText("1"),
+   ).toBeVisible();
+
+   await page.getByRole("button", { name: "Trocar tipo" }).click();
+   await page.getByRole("button", { name: "Caixa Físico" }).click();
+   await expect(row.getByLabel("Tipo")).toHaveText("Caixa Físico");
+
+   await row.getByRole("button", { name: "Salvar" }).click();
+   await expect(page.getByText("Linha importada com sucesso.")).toBeVisible();
+   await rememberCreatedAccount(e2eSession, name);
+   await expectBankAccountRowVisible(page, name);
 });
 
 test("cria conta bancária com validações, máscaras e autocomplete", async ({

--- a/apps/web/src/blocks/data-table/data-import/data-import-section.tsx
+++ b/apps/web/src/blocks/data-table/data-import/data-import-section.tsx
@@ -11,6 +11,9 @@ import { fromPromise } from "neverthrow";
 import { useCallback, useMemo, useState } from "react";
 import { toast } from "@packages/ui/hooks/use-toast";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
+import { InlineEditMoney } from "../inline-edit/inline-edit-money";
+import { InlineEditSelect } from "../inline-edit/inline-edit-select";
+import { InlineEditText } from "../inline-edit/inline-edit-text";
 import type { DataImportConfig } from "./use-data-import";
 import type { UseDataImportApi } from "./use-data-import";
 
@@ -431,6 +434,8 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
                         ? (importRows[rowIdx] ?? null)
                         : null;
                      const val = importedRow ? importedRow[accKey] : rawVal;
+                     const meta = col.columnDef.meta;
+                     const ariaLabel = meta?.label ?? accKey;
                      // oxlint-ignore no-explicit-any
                      const fakeCtx: any = importedRow
                         ? {
@@ -464,13 +469,52 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
                            )}
                            key={col.id}
                         >
-                           {fakeCtx
-                              ? flexRender(col.columnDef.cell, fakeCtx)
-                              : String(rawVal) || (
-                                   <span className="text-muted-foreground/30">
-                                      —
-                                   </span>
-                                )}
+                           {importedRow &&
+                           meta?.isEditable &&
+                           meta.cellComponent === "select" ? (
+                              <InlineEditSelect
+                                 ariaLabel={ariaLabel}
+                                 onSave={(value) => {
+                                    api.updateRow(rowIdx, { [accKey]: value });
+                                    return Promise.resolve();
+                                 }}
+                                 options={meta.editOptions ?? []}
+                                 value={String(val ?? "")}
+                              />
+                           ) : importedRow &&
+                             meta?.isEditable &&
+                             (meta.cellComponent === "text" ||
+                                meta.cellComponent === "textarea") ? (
+                              <InlineEditText
+                                 ariaLabel={ariaLabel}
+                                 onSave={(value) => {
+                                    api.updateRow(rowIdx, { [accKey]: value });
+                                    return Promise.resolve();
+                                 }}
+                                 placeholder="—"
+                                 value={String(val ?? "")}
+                              />
+                           ) : importedRow &&
+                             meta?.isEditable &&
+                             meta.cellComponent === "money" ? (
+                              <InlineEditMoney
+                                 ariaLabel={ariaLabel}
+                                 onSave={(value) => {
+                                    api.updateRow(rowIdx, { [accKey]: value });
+                                    return Promise.resolve();
+                                 }}
+                                 value={Number(val) || 0}
+                                 valueInCents={false}
+                              />
+                           ) : fakeCtx ? (
+                              flexRender(col.columnDef.cell, fakeCtx)
+                           ) : (
+                              String(rawVal) || (
+                                 <span className="text-muted-foreground/30">
+                                    —
+                                 </span>
+                              )
+                           )}
                         </TableCell>
                      );
                   })}

--- a/apps/web/src/blocks/data-table/data-import/data-import-section.tsx
+++ b/apps/web/src/blocks/data-table/data-import/data-import-section.tsx
@@ -179,7 +179,7 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
 
    return (
       <TableBody>
-         <TableRow className="hover:bg-transparent">
+         <TableRow className="sticky top-10 z-30 bg-muted hover:bg-transparent">
             <TableCell className="bg-muted px-4 py-2" colSpan={colCount}>
                <div className="flex items-center justify-between gap-4">
                   <div className="flex items-center gap-2">
@@ -246,7 +246,7 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
             </TableCell>
          </TableRow>
 
-         <TableRow className="bg-muted/20 hover:bg-muted/20">
+         <TableRow className="sticky top-20 z-20 bg-muted/20 hover:bg-muted/20">
             {visibleCols.map((col) => {
                if (col.id === "__select") {
                   return (

--- a/apps/web/src/blocks/data-table/data-import/data-import-section.tsx
+++ b/apps/web/src/blocks/data-table/data-import/data-import-section.tsx
@@ -1,4 +1,4 @@
-import type { Table } from "@tanstack/react-table";
+import type { Column, Table } from "@tanstack/react-table";
 import { flexRender } from "@tanstack/react-table";
 import { Badge } from "@packages/ui/components/badge";
 import { Button } from "@packages/ui/components/button";
@@ -37,6 +37,20 @@ interface InnerProps<TData> extends DataImportSectionProps<TData> {
    state: NonNullable<UseDataImportApi["state"]>;
 }
 
+function getColumnAccessorKey<TData>(col: Column<TData, unknown>) {
+   return "accessorKey" in col.columnDef && col.columnDef.accessorKey != null
+      ? String(col.columnDef.accessorKey)
+      : col.id;
+}
+
+function isImportableColumn<TData>(col: Column<TData, unknown>) {
+   return (
+      col.id !== "__select" &&
+      col.id !== "__actions" &&
+      !col.columnDef.meta?.importIgnore
+   );
+}
+
 function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
    const { openAlertDialog } = useAlertDialog();
    const [editingColKey, setEditingColKey] = useState<string | null>(null);
@@ -46,23 +60,46 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
    const { selectedIndices, ignoredIndices } = api;
    const hasImportRows = importRows.length > 0;
    const visibleCols = table.getVisibleLeafColumns();
-   const colCount = visibleCols.length;
+   const importableColumns = useMemo(
+      () => visibleCols.filter(isImportableColumn),
+      [visibleCols],
+   );
+   const montteColumns = useMemo(() => {
+      const requiredColumns = importableColumns.filter(
+         (col) => col.columnDef.meta?.required,
+      );
+      const optionalColumns = importableColumns.filter(
+         (col) => !col.columnDef.meta?.required,
+      );
+      return [...requiredColumns, ...optionalColumns];
+   }, [importableColumns]);
+   const hasSelectColumn = visibleCols.some((col) => col.id === "__select");
+   const hasActionsColumn = visibleCols.some((col) => col.id === "__actions");
+   const mappedHeaders = useMemo(
+      () =>
+         new Set(
+            Object.values(mapping).filter(
+               (value) => value && value !== "__none__",
+            ),
+         ),
+      [mapping],
+   );
+   const extraHeaders = useMemo(
+      () => rawHeaders.filter((header) => !mappedHeaders.has(header)),
+      [mappedHeaders, rawHeaders],
+   );
+   const colCount =
+      (hasSelectColumn ? 1 : 0) +
+      montteColumns.length +
+      (hasActionsColumn ? 1 : 0) +
+      extraHeaders.length;
    const activeCount = rawRows.length - ignoredIndices.size;
 
    const duplicateIndices = useMemo(() => {
       if (!hasImportRows) return new Set<number>();
-      const firstCol = visibleCols.find(
-         (col) =>
-            col.id !== "__select" &&
-            col.id !== "__actions" &&
-            !col.columnDef.meta?.importIgnore,
-      );
+      const firstCol = montteColumns[0];
       if (!firstCol) return new Set<number>();
-      const accKey =
-         "accessorKey" in firstCol.columnDef &&
-         firstCol.columnDef.accessorKey != null
-            ? String(firstCol.columnDef.accessorKey)
-            : firstCol.id;
+      const accKey = getColumnAccessorKey(firstCol);
       const existing = new Set(
          table
             .getCoreRowModel()
@@ -76,7 +113,7 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
          if (val && existing.has(val)) result.add(i);
       });
       return result;
-   }, [importRows, hasImportRows, table, visibleCols]);
+   }, [importRows, hasImportRows, table, montteColumns]);
 
    const headerOptions = useMemo(
       () => [
@@ -103,6 +140,14 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
          return entry;
       },
       [hasImportRows, importRows, rawHeaders, rawRows],
+   );
+
+   const getRawValue = useCallback(
+      (row: string[], header: string) => {
+         const idx = rawHeaders.indexOf(header);
+         return idx >= 0 ? (row[idx] ?? "") : "";
+      },
+      [rawHeaders],
    );
 
    const saveRow = useCallback(
@@ -250,31 +295,57 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
          </TableRow>
 
          <TableRow className="sticky top-20 z-20 bg-muted/20 hover:bg-muted/20">
-            {visibleCols.map((col) => {
-               if (col.id === "__select") {
-                  return (
-                     <TableCell className="w-10 px-2" key={col.id}>
-                        <Checkbox
-                           aria-label="Selecionar todos"
-                           checked={
-                              someSelected ? "indeterminate" : allSelected
-                           }
-                           onCheckedChange={api.toggleAll}
-                        />
-                     </TableCell>
-                  );
-               }
-               if (col.id === "__actions") return <TableCell key={col.id} />;
-               const accKey =
-                  "accessorKey" in col.columnDef &&
-                  col.columnDef.accessorKey != null
-                     ? String(col.columnDef.accessorKey)
-                     : col.id;
-               const currentHeader = mapping[accKey] ?? "";
-               const isEditing = editingColKey === accKey;
+            {hasSelectColumn && <TableCell className="w-10 px-2" />}
+            {montteColumns.map((col) => {
+               const label = col.columnDef.meta?.label ?? col.id;
                const required = col.columnDef.meta?.required;
                return (
-                  <TableCell className="py-1 pr-2" key={col.id}>
+                  <TableCell
+                     className="bg-muted/20 py-1 pr-2"
+                     key={`montte-label-${col.id}`}
+                  >
+                     <span className="text-xs font-medium">
+                        {label}
+                        {required && (
+                           <span
+                              aria-label="Campo obrigatório"
+                              className="ml-0.5 text-destructive"
+                           >
+                              *
+                           </span>
+                        )}
+                     </span>
+                  </TableCell>
+               );
+            })}
+            {hasActionsColumn && <TableCell key="montte-label-actions" />}
+            {extraHeaders.map((header, index) => (
+               <TableCell
+                  className="bg-muted/20 py-1 pr-2"
+                  key={`montte-label-extra-${header}-${index}`}
+               >
+                  <span className="text-xs text-muted-foreground/60">
+                     &nbsp;
+                  </span>
+               </TableCell>
+            ))}
+         </TableRow>
+         <TableRow className="sticky top-32 z-20 bg-muted/20 hover:bg-muted/20">
+            {hasSelectColumn && (
+               <TableCell className="w-10 px-2">
+                  <Checkbox
+                     aria-label="Selecionar todos"
+                     checked={someSelected ? "indeterminate" : allSelected}
+                     onCheckedChange={api.toggleAll}
+                  />
+               </TableCell>
+            )}
+            {montteColumns.map((col) => {
+               const accKey = getColumnAccessorKey(col);
+               const currentHeader = mapping[accKey] ?? "";
+               const isEditing = editingColKey === accKey;
+               return (
+                  <TableCell className="py-1 pr-2" key={`montte-map-${col.id}`}>
                      {isEditing ? (
                         <Combobox
                            defaultOpen
@@ -294,7 +365,11 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
                      ) : (
                         <Button
                            className="flex w-full items-center justify-start gap-2 px-2 py-2 text-left text-xs"
-                           data-testid="mapping-header-button"
+                           data-testid={
+                              col.columnDef.meta?.required
+                                 ? "unmapped-required"
+                                 : undefined
+                           }
                            onClick={() => setEditingColKey(accKey)}
                            type="button"
                            variant="ghost"
@@ -302,28 +377,10 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
                            {currentHeader ? (
                               <span className="flex-1 truncate font-medium text-foreground">
                                  {currentHeader}
-                                 {required && (
-                                    <span
-                                       aria-label="Obrigatório"
-                                       className="ml-0.5 text-destructive"
-                                    >
-                                       *
-                                    </span>
-                                 )}
                               </span>
                            ) : (
-                              <span
-                                 className={cn(
-                                    "flex-1 truncate italic",
-                                    required
-                                       ? "text-destructive/70"
-                                       : "text-muted-foreground/50",
-                                 )}
-                                 data-testid={
-                                    required ? "unmapped-required" : undefined
-                                 }
-                              >
-                                 {required ? "Não mapeado *" : "Não mapeado"}
+                              <span className="flex-1 truncate italic text-muted-foreground/50">
+                                 Não mapeado
                               </span>
                            )}
                         </Button>
@@ -331,6 +388,15 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
                   </TableCell>
                );
             })}
+            {hasActionsColumn && <TableCell key="montte-mapping-actions" />}
+            {extraHeaders.map((header, index) => (
+               <TableCell
+                  className="py-1 pr-2"
+                  key={`montte-extra-${header}-${index}`}
+               >
+                  <span className="text-xs font-medium">{header}</span>
+               </TableCell>
+            ))}
          </TableRow>
 
          {rawRows.map((row, rowIdx) => {
@@ -351,85 +417,20 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
                   )}
                   key={`__import_${rowIdx}`}
                >
-                  {visibleCols.map((col) => {
-                     if (col.id === "__select") {
-                        return (
-                           <TableCell className="w-10 px-2" key={col.id}>
-                              <Checkbox
-                                 aria-label="Selecionar linha"
-                                 checked={isSelected}
-                                 disabled={isIgnored}
-                                 onCheckedChange={() => api.toggleRow(rowIdx)}
-                              />
-                           </TableCell>
-                        );
-                     }
-                     if (col.id === "__actions") {
-                        return (
-                           <TableCell key={col.id}>
-                              <div className="flex items-center justify-end gap-2">
-                                 {isIgnored ? (
-                                    <Button
-                                       className="h-7 px-2 text-xs"
-                                       onClick={() => api.restoreRow(rowIdx)}
-                                       size="sm"
-                                       tooltip="Restaurar linha"
-                                       type="button"
-                                       variant="ghost"
-                                    >
-                                       Restaurar
-                                    </Button>
-                                 ) : (
-                                    <>
-                                       {isDuplicate && (
-                                          <span className="flex items-center shrink-0">
-                                             <TriangleAlert
-                                                aria-hidden="true"
-                                                className="size-4 text-destructive"
-                                             />
-                                             <span className="sr-only">
-                                                Linha duplicada
-                                             </span>
-                                          </span>
-                                       )}
-                                       <Button
-                                          className="h-7 px-2 text-xs text-muted-foreground hover:text-foreground"
-                                          onClick={() => api.ignoreRow(rowIdx)}
-                                          size="sm"
-                                          tooltip="Ignorar linha"
-                                          type="button"
-                                          variant="ghost"
-                                       >
-                                          Ignorar
-                                       </Button>
-                                       <Button
-                                          className="h-7 px-2 text-xs"
-                                          onClick={() => handleSaveRow(rowIdx)}
-                                          size="sm"
-                                          tooltip="Salvar esta linha"
-                                          type="button"
-                                          variant="outline"
-                                       >
-                                          <Check className="size-3" />
-                                          Salvar
-                                       </Button>
-                                    </>
-                                 )}
-                              </div>
-                           </TableCell>
-                        );
-                     }
-                     const accKey =
-                        "accessorKey" in col.columnDef &&
-                        col.columnDef.accessorKey != null
-                           ? String(col.columnDef.accessorKey)
-                           : col.id;
+                  {hasSelectColumn && (
+                     <TableCell className="w-10 px-2">
+                        <Checkbox
+                           aria-label="Selecionar linha"
+                           checked={isSelected}
+                           disabled={isIgnored}
+                           onCheckedChange={() => api.toggleRow(rowIdx)}
+                        />
+                     </TableCell>
+                  )}
+                  {montteColumns.map((col) => {
+                     const accKey = getColumnAccessorKey(col);
                      const fileHeader = mapping[accKey];
-                     const headerIdx = fileHeader
-                        ? rawHeaders.indexOf(fileHeader)
-                        : -1;
-                     const rawVal =
-                        headerIdx >= 0 ? (row[headerIdx] ?? "") : "";
+                     const rawVal = getRawValue(row, fileHeader ?? "");
                      const importedRow = hasImportRows
                         ? (importRows[rowIdx] ?? null)
                         : null;
@@ -514,6 +515,77 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
                                     —
                                  </span>
                               )
+                           )}
+                        </TableCell>
+                     );
+                  })}
+                  {hasActionsColumn && (
+                     <TableCell>
+                        <div className="flex items-center justify-end gap-2">
+                           {isIgnored ? (
+                              <Button
+                                 className="h-7 px-2 text-xs"
+                                 onClick={() => api.restoreRow(rowIdx)}
+                                 size="sm"
+                                 tooltip="Restaurar linha"
+                                 type="button"
+                                 variant="ghost"
+                              >
+                                 Restaurar
+                              </Button>
+                           ) : (
+                              <>
+                                 {isDuplicate && (
+                                    <span className="flex items-center shrink-0">
+                                       <TriangleAlert
+                                          aria-hidden="true"
+                                          className="size-4 text-destructive"
+                                       />
+                                       <span className="sr-only">
+                                          Linha duplicada
+                                       </span>
+                                    </span>
+                                 )}
+                                 <Button
+                                    className="h-7 px-2 text-xs text-muted-foreground hover:text-foreground"
+                                    onClick={() => api.ignoreRow(rowIdx)}
+                                    size="sm"
+                                    tooltip="Ignorar linha"
+                                    type="button"
+                                    variant="ghost"
+                                 >
+                                    Ignorar
+                                 </Button>
+                                 <Button
+                                    className="h-7 px-2 text-xs"
+                                    onClick={() => handleSaveRow(rowIdx)}
+                                    size="sm"
+                                    tooltip="Salvar esta linha"
+                                    type="button"
+                                    variant="outline"
+                                 >
+                                    <Check className="size-3" />
+                                    Salvar
+                                 </Button>
+                              </>
+                           )}
+                        </div>
+                     </TableCell>
+                  )}
+                  {extraHeaders.map((header, index) => {
+                     const rawVal = getRawValue(row, header);
+                     return (
+                        <TableCell
+                           className={cn(
+                              "truncate",
+                              isIgnored && "line-through",
+                           )}
+                           key={`__import_${rowIdx}_extra_${header}_${index}`}
+                        >
+                           {rawVal || (
+                              <span className="text-muted-foreground/30">
+                                 —
+                              </span>
                            )}
                         </TableCell>
                      );

--- a/apps/web/src/blocks/data-table/data-import/use-data-import.tsx
+++ b/apps/web/src/blocks/data-table/data-import/use-data-import.tsx
@@ -142,6 +142,23 @@ export interface UseDataImportApi {
    restoreRow: (index: number) => void;
 }
 
+function buildImportRows(
+   rawRows: string[][],
+   rawHeaders: string[],
+   mapping: Record<string, string>,
+   mapRow?: DataImportConfig["mapRow"],
+): Record<string, unknown>[] {
+   return rawRows.map((rawRow, i) => {
+      const mapped: Record<string, string> = {};
+      for (const [colKey, fileHeader] of Object.entries(mapping)) {
+         if (!fileHeader) continue;
+         const idx = rawHeaders.indexOf(fileHeader);
+         mapped[colKey] = idx >= 0 ? (rawRow[idx] ?? "") : "";
+      }
+      return mapRow ? mapRow(mapped, i) : mapped;
+   });
+}
+
 export function useDataImport<TData>({
    table,
    config,
@@ -313,15 +330,12 @@ export function useDataImport<TData>({
    const start = useCallback(
       (data: RawImportData) => {
          const mapping = autoMatch(data.headers, importableColumns);
-         const importRows = data.rows.map((rawRow, i) => {
-            const mapped: Record<string, string> = {};
-            for (const [colKey, fileHeader] of Object.entries(mapping)) {
-               if (!fileHeader) continue;
-               const idx = data.headers.indexOf(fileHeader);
-               mapped[colKey] = idx >= 0 ? (rawRow[idx] ?? "") : "";
-            }
-            return config.mapRow ? config.mapRow(mapped, i) : mapped;
-         });
+         const importRows = buildImportRows(
+            data.rows,
+            data.headers,
+            mapping,
+            config.mapRow,
+         );
          setState({
             rawHeaders: data.headers,
             rawRows: data.rows,
@@ -342,8 +356,21 @@ export function useDataImport<TData>({
 
    const updateMapping = useCallback(
       (mapping: Record<string, string>) =>
-         setState((s) => (s ? { ...s, mapping } : s)),
-      [],
+         setState((s) =>
+            s
+               ? {
+                    ...s,
+                    mapping,
+                    importRows: buildImportRows(
+                       s.rawRows,
+                       s.rawHeaders,
+                       mapping,
+                       config.mapRow,
+                    ),
+                 }
+               : s,
+         ),
+      [config.mapRow],
    );
 
    const removeRows = useCallback(

--- a/apps/web/src/blocks/data-table/data-table-header.tsx
+++ b/apps/web/src/blocks/data-table/data-table-header.tsx
@@ -165,17 +165,25 @@ function SortableTableHead<TData>({ header }: SortableTableHeadProps<TData>) {
         }
       : {};
 
+   const isPinned = col.getIsPinned();
+   const pinStyles = getPinStyles(col);
+   const headerStyles: CSSProperties = {
+      width: header.getSize(),
+      textAlign: align,
+      position: "sticky",
+      top: 0,
+      background: "var(--card)",
+      zIndex: isPinned ? 3 : 4,
+      ...pinStyles,
+      ...sortableStyle,
+   };
+
    return (
       <TableHead
          ref={reorderable ? setNodeRef : undefined}
          colSpan={header.colSpan}
          aria-sort={canSort ? ariaSort : undefined}
-         style={{
-            width: header.getSize(),
-            textAlign: align,
-            ...getPinStyles(col),
-            ...sortableStyle,
-         }}
+         style={headerStyles}
          className={cn(
             "relative",
             col.getIsPinned() && "shadow-[inset_-1px_0_0_var(--border)]",

--- a/apps/web/src/blocks/data-table/data-table-header.tsx
+++ b/apps/web/src/blocks/data-table/data-table-header.tsx
@@ -170,12 +170,12 @@ function SortableTableHead<TData>({ header }: SortableTableHeadProps<TData>) {
    const headerStyles: CSSProperties = {
       width: header.getSize(),
       textAlign: align,
+      ...pinStyles,
+      ...sortableStyle,
       position: "sticky",
       top: 0,
       background: "var(--card)",
-      zIndex: isPinned ? 3 : 4,
-      ...pinStyles,
-      ...sortableStyle,
+      zIndex: isDragging ? 5 : isPinned ? 4 : col.getCanPin() ? 3 : 4,
    };
 
    return (

--- a/apps/web/src/hooks/use-selection-toolbar.tsx
+++ b/apps/web/src/hooks/use-selection-toolbar.tsx
@@ -37,9 +37,9 @@ const externalStore = createStore<ExternalState>({
 });
 
 export const clearSelectionToolbar = () =>
-   internalStore.setState(() => ({
+   internalStore.setState((s) => ({
+      ...s,
       selectedIndices: new Set<number>(),
-      renderActions: null,
    }));
 
 const addToSelection = (i: number) =>

--- a/apps/web/src/integrations/tanstack-db/reports.ts
+++ b/apps/web/src/integrations/tanstack-db/reports.ts
@@ -166,7 +166,7 @@ export function buildOptimisticReportRow({
          dateTo: input.config.dateTo,
          status: input.config.status ?? "all",
          dreOnly: input.config.dreOnly ?? true,
-         agingType: input.config.agingType ?? "income",
+         agingType: input.config.agingType ?? "all",
          agingStatus: input.config.agingStatus ?? "open",
          categoryDepth: input.config.categoryDepth ?? "group",
          minAmount: input.config.minAmount ?? 0,

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-bank-accounts/bank-accounts-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-bank-accounts/bank-accounts-columns.tsx
@@ -68,8 +68,16 @@ const TYPE_ICONS: Record<BankAccountRow["type"], ReactNode> = {
    investment: <TrendingUp className="size-3" />,
 };
 
-function formatBRL(value: string | number): string {
-   return format(of(String(value), "BRL"), "pt-BR");
+function formatBRL(value: string | number | null | undefined): string {
+   if (value === null || value === undefined || value === "") return "—";
+
+   const raw = String(value).trim();
+   if (raw === "") return "—";
+
+   const parsed = Number(raw);
+   if (!Number.isFinite(parsed)) return "—";
+
+   return format(of(raw, "BRL"), "pt-BR");
 }
 
 interface BuildBankAccountColumnsOptions {
@@ -160,7 +168,8 @@ export function buildBankAccountColumns(
          accessorKey: "currentBalance",
          header: "Saldo Atual",
          cell: ({ row }) => {
-            const balance = Number(row.original.currentBalance);
+            const parsedBalance = Number(row.original.currentBalance);
+            const balance = Number.isFinite(parsedBalance) ? parsedBalance : 0;
             return (
                <Announcement>
                   <AnnouncementTag
@@ -202,7 +211,8 @@ export function buildBankAccountColumns(
             </TooltipProvider>
          ),
          cell: ({ row }) => {
-            const balance = Number(row.original.projectedBalance);
+            const parsedBalance = Number(row.original.projectedBalance);
+            const balance = Number.isFinite(parsedBalance) ? parsedBalance : 0;
             return (
                <Announcement>
                   <AnnouncementTag

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-reports/report-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-reports/report-form-sheet.tsx
@@ -130,7 +130,7 @@ export function ReportFormSheet({ collection, teamId }: ReportFormSheetProps) {
                dateTo: value.dateTo,
                status: value.status,
                dreOnly: true,
-               agingType: "income",
+               agingType: "all",
                agingStatus: "open",
                categoryDepth: "group",
                minAmount: 0,

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-reports/report-panels.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-reports/report-panels.tsx
@@ -53,6 +53,7 @@ type AgingReport = Outputs["reports"]["aging"];
 type CategoryExpenseReport = Outputs["reports"]["expensesByCategory"];
 type TransactionRow = Outputs["transactions"]["getAll"]["data"][number];
 type TransactionStatus = "pending" | "paid";
+const AGING_REPORT_TYPE: Inputs["reports"]["aging"]["type"] = "all";
 
 function formatBRL(value: string | number): string {
    return format(of(String(value), "BRL"), "pt-BR");
@@ -81,6 +82,12 @@ function transactionStatusFilter(
 ): TransactionStatus | TransactionStatus[] {
    if (status === "all") return ["pending", "paid"];
    return status;
+}
+
+function agingTypeLabel(type: "income" | "expense" | "transfer") {
+   if (type === "income") return "A receber";
+   if (type === "expense") return "A pagar";
+   return "Transferência";
 }
 
 function marginValue(report: ProfitAndLossReport) {
@@ -392,9 +399,9 @@ function AgingData({
    queryClient: QueryClient;
    teamId: string;
 }) {
-   const collectionInput = useMemo(
+   const collectionInput = useMemo<Inputs["reports"]["aging"]>(
       () => ({
-         type: config.agingType,
+         type: AGING_REPORT_TYPE,
          dateFrom: config.dateFrom,
          dateTo: config.dateTo,
          categoryId: config.categoryId,
@@ -402,7 +409,6 @@ function AgingData({
          status: config.agingStatus,
       }),
       [
-         config.agingType,
          config.dateFrom,
          config.dateTo,
          config.categoryId,
@@ -1008,6 +1014,7 @@ function AgingPanel({ report }: { report: AgingReport }) {
          <TableHeader>
             <TableRow>
                <TableHead>Categoria</TableHead>
+               <TableHead>Tipo</TableHead>
                <TableHead>Lançamento</TableHead>
                <TableHead>Vencimento</TableHead>
                <TableHead>Centro de Custo</TableHead>
@@ -1021,6 +1028,7 @@ function AgingPanel({ report }: { report: AgingReport }) {
                   <TableCell className="font-medium">
                      {row.categoryName ?? "Sem categoria"}
                   </TableCell>
+                  <TableCell>{agingTypeLabel(row.type)}</TableCell>
                   <TableCell>{row.name}</TableCell>
                   <TableCell>
                      {dayjs(row.dueDate).format("DD/MM/YYYY")}

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-columns.tsx
@@ -337,6 +337,7 @@ export function buildTransactionColumns(options?: {
             editOptions: categoryOptionsList,
             onCreateOption: options?.onCreateCategory,
             groupable: true,
+            required: true,
             formatGroupLabel: (value) =>
                value ? String(value) : "Sem categoria",
          },

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
@@ -1109,7 +1109,7 @@ export function TransactionsList() {
          template: {
             label: "Baixar modelo",
             description:
-               "Inclui Data, Nome, Tipo, Valor, Status e referências por nome.",
+               "Inclui Data, Nome, Tipo, Valor, Status e referências por nome. A categoria é obrigatória.",
             formats: [
                {
                   filename: "modelo-lancamentos.csv",
@@ -1205,17 +1205,41 @@ export function TransactionsList() {
             if (!activeTeamId) {
                throw new Error("Time ativo não encontrado.");
             }
-            const transactions = rows.flatMap((r) => {
+            const missingCategoryRows: number[] = [];
+            const missingReferenceRows: number[] = [];
+            const invalidDateValueRows: number[] = [];
+            const invalidAmountRows: number[] = [];
+            const transactions = rows.flatMap((r, index) => {
+               const line = index + 2;
                const date = String(r.date ?? "");
                const amount = String(r.amount ?? "");
-               if (!date || !amount) return [];
                const bankAccountId =
                   resolveImportId(safeBankAccounts, r.bankAccountId) ??
                   resolveImportId(safeBankAccounts, r.bankAccountName);
                const creditCardId =
                   resolveImportId(safeCreditCards, r.creditCardId) ??
                   resolveImportId(safeCreditCards, r.creditCardName);
-               if (!bankAccountId && !creditCardId) return [];
+               const categoryId =
+                  resolveImportId(safeCategories, r.categoryId) ??
+                  resolveImportId(safeCategories, r.categoryName);
+
+               if (!date) {
+                  invalidDateValueRows.push(line);
+                  return [];
+               }
+               if (!amount) {
+                  invalidAmountRows.push(line);
+                  return [];
+               }
+               if (!bankAccountId && !creditCardId) {
+                  missingReferenceRows.push(line);
+                  return [];
+               }
+               if (!categoryId) {
+                  missingCategoryRows.push(line);
+                  return [];
+               }
+
                return [
                   {
                      type: parseImportType(r.type, 1),
@@ -1224,9 +1248,7 @@ export function TransactionsList() {
                      name: r.name ? String(r.name) : null,
                      bankAccountId,
                      destinationBankAccountId: null,
-                     categoryId:
-                        resolveImportId(safeCategories, r.categoryId) ??
-                        resolveImportId(safeCategories, r.categoryName),
+                     categoryId,
                      attachments: [],
                      description: null,
                      creditCardId,
@@ -1239,16 +1261,42 @@ export function TransactionsList() {
                   },
                ];
             });
+            if (missingCategoryRows.length > 0) {
+               throw new Error(
+                  `A categoria é obrigatória. Preencha a categoria nas linhas: ${missingCategoryRows.join(", ")}.`,
+               );
+            }
+            if (
+               invalidDateValueRows.length > 0 ||
+               invalidAmountRows.length > 0
+            ) {
+               throw new Error(
+                  `Preencha data e valor nas linhas: ${[
+                     ...invalidDateValueRows,
+                     ...invalidAmountRows,
+                  ]
+                     .filter(
+                        (value, index, array) => array.indexOf(value) === index,
+                     )
+                     .sort((left, right) => left - right)
+                     .join(", ")}.`,
+               );
+            }
+            if (missingReferenceRows.length > 0) {
+               throw new Error(
+                  `Informe conta ou cartão nas linhas: ${missingReferenceRows.join(", ")}.`,
+               );
+            }
             if (transactions.length === 0) {
                throw new Error(
-                  "Nenhum lançamento válido para importar. Preencha data, valor e conta ou cartão.",
+                  "Nenhum lançamento válido para importar. Preencha data, valor, categoria e conta ou cartão.",
                );
             }
             const importTransactions = importTransactionsAction(
                transactionsCollection,
             );
             const transaction = importTransactions({
-               input: { transactions, autoCategorize: true },
+               input: { transactions, autoCategorize: false },
                rows: transactions.map((input) =>
                   buildOptimisticTransactionRow({
                      id: buildOptimisticTransactionRowId(),

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
@@ -158,6 +158,54 @@ function normalizeImportLookup(value: unknown): string {
       .replace(/[̀-ͯ]/g, "");
 }
 
+const IMPORT_HEADER_LABELS: Record<string, string> = {
+   data: "Data",
+   date: "Data",
+   datetxn: "Data",
+   duedate: "Vencimento",
+   valor: "Valor",
+   amount: "Valor",
+   valorbr: "Valor",
+   desc: "Nome",
+   description: "Nome",
+   descr: "Nome",
+   memo: "Nome",
+   detalhe: "Nome",
+   tipo: "Tipo",
+   type: "Tipo",
+   status: "Status",
+   conta: "Conta",
+   bankaccountname: "Conta",
+   bankaccount: "Conta",
+   contaid: "Conta",
+   banco: "Conta",
+   cartao: "Cartão",
+   card: "Cartão",
+   creditcard: "Cartão",
+   creditcardname: "Cartão",
+   categoria: "Categoria",
+   category: "Categoria",
+   categoryname: "Categoria",
+   categoriaid: "Categoria",
+   vencimento: "Vencimento",
+   fitid: "Identificador",
+   reference: "Referência",
+};
+
+function normalizeImportHeader(value: string): string {
+   const normalized = normalizeImportLookup(value)
+      .toLowerCase()
+      .replace(/[^a-z0-9]/g, "");
+   return (IMPORT_HEADER_LABELS[normalized] ?? value.trim()) || "";
+}
+
+function localizeImportHeaders<T extends { headers: string[] }>(result: T): T {
+   return {
+      ...result,
+      headers: result.headers.map(normalizeImportHeader),
+   };
+}
+
 function resolveImportId(
    options: ImportLookupItem[],
    value: unknown,
@@ -1016,9 +1064,16 @@ export function TransactionsList() {
          },
          parseFile: async (file: File) => {
             const ext = file.name.split(".").pop()?.toLowerCase();
-            if (ext === "ofx") return parseOfx(file);
-            if (ext === "xlsx" || ext === "xls") return parseXlsx(file);
-            return parseCsv(file);
+            if (ext === "ofx") {
+               const parsed = await parseOfx(file);
+               return localizeImportHeaders(parsed);
+            }
+            if (ext === "xlsx" || ext === "xls") {
+               const parsed = await parseXlsx(file);
+               return localizeImportHeaders(parsed);
+            }
+            const parsed = await parseCsv(file);
+            return localizeImportHeaders(parsed);
          },
          mapRow: (row, i) => {
             const parsedAmount = parseImportAmount(row.amount);

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
@@ -165,6 +165,7 @@ const IMPORT_HEADER_LABELS: Record<string, string> = {
    duedate: "Vencimento",
    valor: "Valor",
    amount: "Valor",
+   name: "Nome",
    valorbr: "Valor",
    desc: "Nome",
    description: "Nome",

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/bank-accounts.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/bank-accounts.tsx
@@ -104,6 +104,46 @@ function resolveType(raw: unknown): BankAccountRow["type"] | undefined {
    return undefined;
 }
 
+function normalizeImportAmount(raw: unknown): string | undefined {
+   const trimmed = String(raw ?? "").trim();
+   if (!trimmed) return undefined;
+   if (!/^-?[\d.,]+$/.test(trimmed)) return undefined;
+   const hasComma = trimmed.includes(",");
+   const hasDot = trimmed.includes(".");
+
+   if (hasComma && hasDot) {
+      const isCommaDecimal =
+         trimmed.lastIndexOf(",") > trimmed.lastIndexOf(".");
+      return isCommaDecimal
+         ? trimmed.replace(/\./g, "").replace(",", ".")
+         : trimmed.replace(/,/g, "");
+   }
+   if (hasComma) return trimmed.replace(",", ".");
+   return trimmed;
+}
+
+function parseImportBalance(raw: unknown): {
+   raw: string;
+   normalized: string;
+   isValid: boolean;
+} {
+   const rawValue = String(raw ?? "").trim();
+   if (!rawValue) {
+      return { raw: "", normalized: "0", isValid: true };
+   }
+   const normalized = normalizeImportAmount(rawValue);
+   const isValid =
+      normalized !== undefined &&
+      !Number.isNaN(Number(normalized)) &&
+      /^-?\d+(?:\.\d+)?$/.test(normalized);
+
+   if (!isValid) {
+      return { raw: rawValue, normalized: "0", isValid: false };
+   }
+
+   return { raw: rawValue, normalized, isValid: true };
+}
+
 const searchSchema = z.object({
    sorting: z
       .array(z.object({ id: z.string(), desc: z.boolean() }))
@@ -361,18 +401,25 @@ function BankAccountsList() {
             { key: "branch", label: "Agência" },
             { key: "accountNumber", label: "Conta" },
          ],
-         mapRow: (row, i) => ({
-            id: `__import_${i + 1}`,
-            name: String(row.name ?? "").trim(),
-            type: row.type,
-            color: "#6366f1",
-            bankCode: String(row.bankCode ?? "").trim(),
-            bankName: String(row.bankName ?? "").trim(),
-            branch: String(row.branch ?? "").trim(),
-            accountNumber: String(row.accountNumber ?? "").trim(),
-            initialBalance: String(row.initialBalance ?? "0"),
-            iconUrl: null,
-         }),
+         mapRow: (row, i) => {
+            const initialBalance =
+               String(row.initialBalance ?? "").trim() || "0";
+            return {
+               id: `__import_${i + 1}`,
+               importLine: i + 2,
+               name: String(row.name ?? "").trim(),
+               type: row.type,
+               color: "#6366f1",
+               bankCode: String(row.bankCode ?? "").trim(),
+               bankName: String(row.bankName ?? "").trim(),
+               branch: String(row.branch ?? "").trim(),
+               accountNumber: String(row.accountNumber ?? "").trim(),
+               initialBalance,
+               currentBalance: initialBalance,
+               projectedBalance: initialBalance,
+               iconUrl: null,
+            };
+         },
          template: {
             label: "Baixar modelo",
             description:
@@ -483,21 +530,47 @@ function BankAccountsList() {
             }
 
             const normalizedRows = rows
-               .map((r) => {
+               .map((r, index) => {
                   const type = resolveType(r.type);
                   if (!type) return null;
+                  const parsedBalance = parseImportBalance(r.initialBalance);
                   return {
+                     line:
+                        typeof r.importLine === "number" && r.importLine > 0
+                           ? r.importLine
+                           : index + 2,
                      r,
                      type,
                      bankCode: String(r.bankCode ?? "").trim(),
                      bankName: String(r.bankName ?? "").trim(),
                      branch: String(r.branch ?? "").trim(),
                      accountNumber: String(r.accountNumber ?? "").trim(),
+                     parsedBalance,
                   };
                })
                .filter((entry): entry is NonNullable<typeof entry> =>
                   Boolean(entry),
                );
+
+            const invalidBalances = normalizedRows.filter(
+               (entry) => !entry.parsedBalance.isValid,
+            );
+            if (invalidBalances.length > 0) {
+               const maxDetails = 3;
+               const details = invalidBalances
+                  .slice(0, maxDetails)
+                  .map(
+                     (entry) =>
+                        `linha ${entry.line}: "${entry.parsedBalance.raw || "vazio"}"`,
+                  )
+                  .join(", ");
+               const extraCount = invalidBalances.length - maxDetails;
+               const extraText =
+                  extraCount > 0 ? ` (mais ${extraCount} linha(s))` : "";
+               throw new Error(
+                  `Saldo Inicial inválido em ${invalidBalances.length} linha(s): ${details}${extraText}. Use somente números. Exemplo: 1500.00`,
+               );
+            }
 
             const invalidBankCode = normalizedRows.some((entry) => {
                if (entry.type === "cash") return false;
@@ -541,7 +614,7 @@ function BankAccountsList() {
                      bankName: isCash ? null : entry.bankName,
                      branch: isCash ? null : entry.branch || null,
                      accountNumber: isCash ? null : entry.accountNumber || null,
-                     initialBalance: String(entry.r.initialBalance ?? "0"),
+                     initialBalance: entry.parsedBalance.normalized,
                   };
                   return {
                      input,

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/bank-accounts.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/bank-accounts.tsx
@@ -408,7 +408,7 @@ function BankAccountsList() {
                id: `__import_${i + 1}`,
                importLine: i + 2,
                name: String(row.name ?? "").trim(),
-               type: row.type,
+               type: resolveType(row.type) ?? row.type,
                color: "#6366f1",
                bankCode: String(row.bankCode ?? "").trim(),
                bankName: String(row.bankName ?? "").trim(),

--- a/core/database/src/schemas/reports.ts
+++ b/core/database/src/schemas/reports.ts
@@ -30,7 +30,7 @@ export const reportConfigSchema = z
       categoryId: z.string().uuid().optional(),
       tagId: z.string().uuid().optional(),
       dreOnly: z.boolean().default(true),
-      agingType: z.enum(["income", "expense"]).default("income"),
+      agingType: z.enum(["income", "expense", "all"]).default("all"),
       agingStatus: z.enum(["open", "overdue", "settled"]).default("open"),
       categoryDepth: z.enum(["group", "subcategory"]).default("group"),
       minAmount: z.number().nonnegative().default(0),

--- a/modules/agents/src/tools/reports.ts
+++ b/modules/agents/src/tools/reports.ts
@@ -19,7 +19,7 @@ const generateFinancialReportInputSchema = z
       startDate: isoDate,
       endDate: isoDate,
       status: z.enum(["paid", "pending", "all"]).default("paid"),
-      type: z.enum(["income", "expense"]).optional(),
+      type: z.enum(["income", "expense", "all"]).optional(),
       categoryId: uuid.optional(),
       costCenterId: uuid.optional(),
       bankAccountId: uuid.optional(),
@@ -81,7 +81,7 @@ export function buildReportReadTools({ client }: ReportReadToolDeps) {
                   return client.reports.aging({
                      dateFrom: input.startDate,
                      dateTo: input.endDate,
-                     type: input.type ?? "income",
+                     type: input.type ?? "all",
                      ...(input.status === "paid"
                         ? { status: "settled" }
                         : input.status === "pending"

--- a/modules/insights/__tests__/router/reports.test.ts
+++ b/modules/insights/__tests__/router/reports.test.ts
@@ -1,0 +1,78 @@
+import { call } from "@orpc/server";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { setupTestDb } from "@core/database/testing/setup-test-db";
+import { seedTeam } from "@core/database/testing/factories";
+import { transactions } from "@core/database/schemas/transactions";
+import { createTestContext } from "@core/orpc/testing/create-test-context";
+import { createMockServerModule } from "@core/orpc/testing/mock-server";
+
+vi.mock("@core/orpc/server", () => createMockServerModule());
+
+import { aging } from "../../src/router/reports";
+
+let testDb: Awaited<ReturnType<typeof setupTestDb>>;
+
+beforeAll(async () => {
+   testDb = await setupTestDb();
+}, 30_000);
+
+afterAll(async () => {
+   await testDb.cleanup();
+});
+
+describe("reports router", () => {
+   it("aging inclui contas a pagar e a receber pendentes pelo vencimento no período", async () => {
+      const { teamId, organizationId } = await seedTeam(testDb.db);
+      const ctx = createTestContext(testDb.db, { teamId, organizationId });
+
+      await testDb.db.insert(transactions).values([
+         {
+            teamId,
+            type: "expense",
+            name: "Conta a pagar",
+            amount: "120.00",
+            date: "2026-04-10",
+            dueDate: "2026-05-29",
+            status: "pending",
+            ignored: false,
+         },
+         {
+            teamId,
+            type: "income",
+            name: "Conta a receber",
+            amount: "250.00",
+            date: "2026-04-12",
+            dueDate: "2026-05-30",
+            status: "pending",
+            ignored: false,
+         },
+         {
+            teamId,
+            type: "transfer",
+            name: "Transferência pendente",
+            amount: "90.00",
+            date: "2026-04-15",
+            dueDate: "2026-05-30",
+            status: "pending",
+            ignored: false,
+         },
+      ]);
+
+      const report = await call(
+         aging,
+         {
+            type: "all",
+            dateFrom: "2026-05-01",
+            dateTo: "2026-05-31",
+            status: "open",
+         },
+         { context: ctx },
+      );
+
+      expect(report.rows.map((row) => row.name)).toEqual([
+         "Conta a pagar",
+         "Conta a receber",
+      ]);
+      expect(report.rows.map((row) => row.type)).toEqual(["expense", "income"]);
+   });
+});

--- a/modules/insights/src/router/reports.ts
+++ b/modules/insights/src/router/reports.ts
@@ -156,7 +156,7 @@ const cashFlowFilters = z
 const expensesByCostCenterFilters = cashFlowFilters;
 const agingFilters = z
    .object({
-      type: z.enum(["income", "expense"]).default("income"),
+      type: z.enum(["income", "expense", "all"]).default("all"),
       dateFrom: isoDate,
       dateTo: isoDate,
       categoryId: optionalUuid,
@@ -868,10 +868,12 @@ export const aging = protectedProcedure
       const conditions: SQL[] = [
          eq(transactions.teamId, context.teamId),
          eq(transactions.ignored, false),
-         eq(transactions.type, input.type),
          gte(transactions.dueDate, input.dateFrom),
          lte(transactions.dueDate, input.dateTo),
       ];
+      if (input.type === "all")
+         conditions.push(inArray(transactions.type, ["income", "expense"]));
+      else conditions.push(eq(transactions.type, input.type));
       if (input.status === "settled")
          conditions.push(eq(transactions.status, "paid"));
       if (input.status === "open")
@@ -892,6 +894,7 @@ export const aging = protectedProcedure
                   name: sql<string>`COALESCE(${transactions.name}, ${transactions.description}, 'Lançamento')`,
                   dueDate: transactions.dueDate,
                   amount: transactions.amount,
+                  type: transactions.type,
                   status: transactions.status,
                   tagName: tags.name,
                   categoryName: categories.name,
@@ -932,6 +935,7 @@ export const aging = protectedProcedure
             name: row.name,
             dueDate: row.dueDate,
             amount: money(row.amount),
+            type: row.type,
             status: row.status,
             tagName: row.tagName,
             categoryName: row.categoryName,

--- a/modules/workflows/src/runtime-constants.ts
+++ b/modules/workflows/src/runtime-constants.ts
@@ -136,14 +136,11 @@ export function buildWorkflowReportConfig(input: {
       categoryId: undefined,
       tagId: undefined,
       dreOnly: true,
-      agingType: "income",
+      agingType: "all",
       agingStatus: "open",
       categoryDepth: "group",
       minAmount: 0,
    };
-   if (input.reportType === "aging") {
-      return { ...base, agingType: "expense" };
-   }
    return base;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Resolve a falha na importação de contas quando o “Saldo Inicial” está em formato inválido, exibindo uma mensagem clara com as linhas problemáticas (MON-1143). Atualiza o relatório de Aging para incluir receitas e despesas por padrão e melhora a UX do importador com edição inline, cabeçalhos “sticky” e validações mais rígidas.

- Bug Fixes
  - Contas: valida e normaliza “Saldo Inicial” (ex.: “1.500,00” → “1500.00”); bloqueia valores inválidos com mensagem que lista até 3 linhas e o valor bruto, sugerindo “Exemplo: 1500.00”.
  - Contas: formatação BRL tolera vazio/inválido, exibindo “—”, evitando exceções no render.
  - Importador: recalcula as linhas importadas ao alterar o mapeamento, prevenindo inconsistências.
  - Lançamentos: erros específicos quando faltam categoria (obrigatória), data/valor ou referência (conta/cartão). Mensagens listam as linhas afetadas.
  - Lançamentos: headers de CSV/XLSX/OFX são localizados/normalizados para melhorar o auto-mapeamento (ex.: “amount”, “valorbr” → “Valor”).

- New Features
  - Importador: edição inline nas linhas importadas para select, texto e dinheiro (`InlineEditSelect`, `InlineEditText`, `InlineEditMoney`).
  - Importador: cabeçalhos e linha de mapeamento “sticky”; colunas Montte priorizam obrigatórias; colunas extras exibem headers não mapeados; “Selecionar todos” e ações em massa visíveis.
  - Lançamentos: categoria marcada como obrigatória no componente; template atualizado; `autoCategorize` desabilitado para respeitar a categoria do arquivo.
  - Relatórios (Aging): tipo padrão passa a “all” (inclui “A pagar” e “A receber”); UI exibe coluna “Tipo”; schema e ferramentas de leitura atualizados para aceitar “income | expense | all”.

Impacto por camada:
- Router: ajustes nos routes de contas e lançamentos (validações e parsing de arquivos); `insights/reports.aging` passa a aceitar “all” e retorna o tipo.
- Componentes: `data-import-section` (UI sticky, edição inline, colunas extras), `data-table-header` (sticky), colunas de contas/lançamentos (formatação, required), painéis de relatórios (Aging com coluna “Tipo”).
- Store: `use-selection-toolbar` limpa seleção sem resetar ações.
- Repositório: schema de relatórios atualizado para `agingType: "income" | "expense" | "all"` (default “all”).

Checklist de testes:
- Importar contas com “Saldo Inicial” inválido (ex.: “1.2.3”, texto, “1,2.3”) deve exibir: “Saldo Inicial inválido em N linha(s): linha X: "valor"... Use somente números. Exemplo: 1500.00”.
- Importar contas com saldo vazio assume “0” sem erro.
- Alterar mapeamento após upload atualiza imediatamente a pré-visualização.
- Importar lançamentos sem categoria falha listando as linhas; idem para data/valor ausentes e quando não há conta/cartão; auto-mapeamento reconhece Data, Valor, Nome, Tipo, Conta/Cartão, Categoria, Status.
- E2E `apps/web-e2e/tests/bank-accounts-create.spec.ts`: troca de tipo em massa e salvamento da linha importada.
- Relatórios (Aging): com `type = all`, resultado inclui “A pagar” e “A receber” e não inclui “Transferência”; UI mostra coluna “Tipo”.

<sup>Written for commit cc7c7842ad255cd1d39fb152b4bebb3c322a10eb. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/988?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

