### PR TITLE
Corrigir listagem de arquivos nos workflows de AI

### DIFF
--- a/.flue/agents/pr-review.ts
+++ b/.flue/agents/pr-review.ts
@@ -71,9 +71,10 @@ async function runRequiredCommand(
    if (Result.isError(commandResult)) return Result.err(commandResult.error);
 
    if (commandResult.value.exitCode !== 0) {
+      const stderr = commandResult.value.stderr?.trim();
       return Result.err(
          new PrReviewAgentError({
-            message: failureMessage,
+            message: stderr ? `${failureMessage}\n${stderr}` : failureMessage,
             cause: commandResult.value.stderr,
          }),
       );
@@ -420,11 +421,12 @@ export default async function ({ init, payload, env }: FlueContext) {
             runRequiredCommand(
                session,
                ghCommand([
-                  "api",
-                  `repos/${repo}/pulls/${prNumber}/files`,
-                  "--paginate",
-                  "--jq",
-                  '.[] | "- " + .filename + " (+" + (.additions|tostring) + " -" + (.deletions|tostring) + ")"',
+                  "pr",
+                  "diff",
+                  prNumber,
+                  "--repo",
+                  repo,
+                  "--name-only",
                ]),
                "Falha ao listar arquivos alterados da PR.",
             ),

--- a/.flue/agents/security-audit.ts
+++ b/.flue/agents/security-audit.ts
@@ -75,9 +75,10 @@ async function runRequiredCommand(
    if (Result.isError(commandResult)) return Result.err(commandResult.error);
 
    if (commandResult.value.exitCode !== 0) {
+      const stderr = commandResult.value.stderr?.trim();
       return Result.err(
          new SecurityAuditAgentError({
-            message: failureMessage,
+            message: stderr ? `${failureMessage}\n${stderr}` : failureMessage,
             cause: commandResult.value.stderr,
          }),
       );
@@ -252,7 +253,7 @@ export default async function ({ init, payload, env }: FlueContext) {
             ),
             runRequiredCommand(
                session,
-               `gh api repos/${repo}/pulls/${prNumber}/files --paginate --jq '.[] | "- " + .filename + " (+" + (.additions|tostring) + " -" + (.deletions|tostring) + ")"'`,
+               `gh pr diff ${prNumber} --repo ${repo} --name-only`,
                "Falha ao listar arquivos alterados da PR.",
             ),
             runRequiredCommand(


### PR DESCRIPTION
## Summary
- Troca a listagem de arquivos dos agentes para `gh pr diff --name-only`
- Remove dependência de `gh pr files --json`/`gh api pulls files`, que falhou no runner
- Inclui stderr na mensagem de erro para facilitar diagnóstico futuro

## Checks
- gh pr diff 990 --repo Montte-erp/montte-nx --name-only
- git diff --check

Obs: `bunx flue build --target node` tentou resolver o pacote errado (`flue` Firebase) nesta worktree limpa, então não foi usado como validação final.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrige a listagem de arquivos nos agentes `pr-review` e `security-audit` ao trocar `gh api`/`gh pr files --json` por `gh pr diff --name-only`. Evita falhas no runner e melhora o diagnóstico ao incluir `stderr` nas mensagens de erro.

- **Bug Fixes**
  - Substitui chamadas a `gh api repos/.../pulls/.../files` e `gh pr files --json` por `gh pr diff <pr> --repo <org/repo> --name-only` nos agentes `.flue/agents/pr-review.ts` e `.flue/agents/security-audit.ts`.
  - Anexa `stderr` à mensagem de erro quando um comando obrigatório falha, facilitando triagem.
  - Saída da listagem agora contém apenas nomes de arquivos (sem contagem de adições/remoções), garantindo compatibilidade com o runner.
  - Impacto por camada:
    - Router: sem mudanças
    - Repositório: sem mudanças
    - Componente: agentes `pr-review` e `security-audit` atualizados para usar `gh pr diff`
    - Store: sem mudanças

- **Testes**
  - Executar `gh pr diff <PR> --repo <org/repo> --name-only` localmente e no runner; verificar que retorna a lista de arquivos.
  - Rodar os agentes e confirmar que a listagem aparece sem falhas e apenas com nomes.
  - Forçar um erro (ex.: PR inexistente) para validar que o `stderr` é incluído na mensagem de erro.
  - `git diff --check` sem apontar problemas.

<sup>Written for commit 8d7ae43990d7c0b7c2fe26a468661c281a0b6a57. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/992?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

