### PR TITLE
Tornar listagem de arquivos dos workflows de AI resiliente

### DIFF
--- a/.flue/agents/pr-review.ts
+++ b/.flue/agents/pr-review.ts
@@ -55,6 +55,31 @@ function ghCommand(args: Array<string | number>) {
    return ["gh", ...args.map(shellQuote)].join(" ");
 }
 
+function prFilesCommand(prNumber: string, repo: string) {
+   return [
+      ghCommand([
+         "pr",
+         "view",
+         prNumber,
+         "--repo",
+         repo,
+         "--json",
+         "files",
+         "--jq",
+         '.files[] | "- " + .path + " (+" + (.additions|tostring) + " -" + (.deletions|tostring) + ")"',
+      ]),
+      ghCommand(["pr", "diff", prNumber, "--repo", repo, "--name-only"]),
+      ghCommand([
+         "api",
+         `repos/${repo}/pulls/${prNumber}/files`,
+         "--paginate",
+         "--jq",
+         '.[] | "- " + .filename + " (+" + (.additions|tostring) + " -" + (.deletions|tostring) + ")"',
+      ]),
+      "printf '%s\\n' 'Não foi possível listar arquivos alterados; use o diff completo abaixo.'",
+   ].join(" || ");
+}
+
 async function runRequiredCommand(
    session: FlueSession,
    command: string,
@@ -420,17 +445,7 @@ export default async function ({ init, payload, env }: FlueContext) {
             ),
             runRequiredCommand(
                session,
-               ghCommand([
-                  "pr",
-                  "view",
-                  prNumber,
-                  "--repo",
-                  repo,
-                  "--json",
-                  "files",
-                  "--jq",
-                  '.files[] | "- " + .path + " (+" + (.additions|tostring) + " -" + (.deletions|tostring) + ")"',
-               ]),
+               prFilesCommand(prNumber, repo),
                "Falha ao listar arquivos alterados da PR.",
             ),
             runRequiredCommand(

--- a/.flue/agents/security-audit.ts
+++ b/.flue/agents/security-audit.ts
@@ -59,6 +59,15 @@ class SecurityAuditAgentError extends TaggedError("SecurityAuditAgentError")<{
    cause?: unknown;
 }>() {}
 
+function prFilesCommand(prNumber: string, repo: string) {
+   return [
+      `gh pr view ${prNumber} --repo ${repo} --json files --jq '.files[] | "- " + .path + " (+" + (.additions|tostring) + " -" + (.deletions|tostring) + ")"'`,
+      `gh pr diff ${prNumber} --repo ${repo} --name-only`,
+      `gh api repos/${repo}/pulls/${prNumber}/files --paginate --jq '.[] | "- " + .filename + " (+" + (.additions|tostring) + " -" + (.deletions|tostring) + ")"'`,
+      "printf '%s\\n' 'Não foi possível listar arquivos alterados; use o diff completo abaixo.'",
+   ].join(" || ");
+}
+
 async function runRequiredCommand(
    session: FlueSession,
    command: string,
@@ -253,7 +262,7 @@ export default async function ({ init, payload, env }: FlueContext) {
             ),
             runRequiredCommand(
                session,
-               `gh pr view ${prNumber} --repo ${repo} --json files --jq '.files[] | "- " + .path + " (+" + (.additions|tostring) + " -" + (.deletions|tostring) + ")"'`,
+               prFilesCommand(prNumber, repo),
                "Falha ao listar arquivos alterados da PR.",
             ),
             runRequiredCommand(


### PR DESCRIPTION
## Summary
- Adiciona fallback em cadeia para listar arquivos da PR nos agentes (`gh pr view`, `gh pr diff`, `gh api`)
- Garante saída bem-sucedida mesmo se todas as estratégias falharem, porque o diff completo já é coletado em seguida
- Aplica o mesmo comportamento no PR Review e no Security Audit

## Checks
- Comando encadeado de listagem contra PR #990 retornou exit 0 e arquivos
- flue build --target node via binário local
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Torna a listagem de arquivos das PRs nos agentes de Review e Security Audit resiliente com fallback em cadeia. Evita interromper o fluxo quando um comando do `gh` falha e garante contexto mínimo antes do diff completo.

- **Bug Fixes**
  - Extrai `prFilesCommand(prNumber, repo)` para encadear: `gh pr view ... --json files --jq ...` || `gh pr diff ... --name-only` || `gh api repos/.../pulls/.../files --paginate --jq ...` || `printf` de aviso.
  - Substitui chamadas diretas pela função de fallback em `.flue/agents/pr-review.ts` e `.flue/agents/security-audit.ts`, mantendo `runRequiredCommand` e mensagens de erro consistentes.
  - Por quê: reduzir falhas intermitentes do `gh` (permissões, forks, paginação) e não bloquear a execução; o próximo passo já coleta o diff completo.
  - Camadas impactadas: agentes (PR Review e Security Audit). Sem mudanças em router, repositório, componente ou store.

- **Testes**
  - Fallback encadeado validado contra PR #990: exit 0 com listagem.
  - `flue build --target node` via binário local ok.
  - `git diff --check` sem pendências.

<sup>Written for commit d3c5db1359f3163f2e6c84f172cbd322b15a0b1e. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/994?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

