### PR TITLE
Evitar falha dos workflows de AI na listagem opcional de arquivos

### DIFF
--- a/.flue/agents/pr-review.ts
+++ b/.flue/agents/pr-review.ts
@@ -55,31 +55,6 @@ function ghCommand(args: Array<string | number>) {
    return ["gh", ...args.map(shellQuote)].join(" ");
 }
 
-function prFilesCommand(prNumber: string, repo: string) {
-   return [
-      ghCommand([
-         "pr",
-         "view",
-         prNumber,
-         "--repo",
-         repo,
-         "--json",
-         "files",
-         "--jq",
-         '.files[] | "- " + .path + " (+" + (.additions|tostring) + " -" + (.deletions|tostring) + ")"',
-      ]),
-      ghCommand(["pr", "diff", prNumber, "--repo", repo, "--name-only"]),
-      ghCommand([
-         "api",
-         `repos/${repo}/pulls/${prNumber}/files`,
-         "--paginate",
-         "--jq",
-         '.[] | "- " + .filename + " (+" + (.additions|tostring) + " -" + (.deletions|tostring) + ")"',
-      ]),
-      "printf '%s\\n' 'Não foi possível listar arquivos alterados; use o diff completo abaixo.'",
-   ].join(" || ");
-}
-
 async function runRequiredCommand(
    session: FlueSession,
    command: string,
@@ -445,8 +420,8 @@ export default async function ({ init, payload, env }: FlueContext) {
             ),
             runRequiredCommand(
                session,
-               prFilesCommand(prNumber, repo),
-               "Falha ao listar arquivos alterados da PR.",
+               "printf '%s\\n' 'Listagem de arquivos omitida; consulte o diff completo abaixo.'",
+               "Falha ao preparar lista de arquivos alterados da PR.",
             ),
             runRequiredCommand(
                session,

--- a/.flue/agents/security-audit.ts
+++ b/.flue/agents/security-audit.ts
@@ -59,15 +59,6 @@ class SecurityAuditAgentError extends TaggedError("SecurityAuditAgentError")<{
    cause?: unknown;
 }>() {}
 
-function prFilesCommand(prNumber: string, repo: string) {
-   return [
-      `gh pr view ${prNumber} --repo ${repo} --json files --jq '.files[] | "- " + .path + " (+" + (.additions|tostring) + " -" + (.deletions|tostring) + ")"'`,
-      `gh pr diff ${prNumber} --repo ${repo} --name-only`,
-      `gh api repos/${repo}/pulls/${prNumber}/files --paginate --jq '.[] | "- " + .filename + " (+" + (.additions|tostring) + " -" + (.deletions|tostring) + ")"'`,
-      "printf '%s\\n' 'Não foi possível listar arquivos alterados; use o diff completo abaixo.'",
-   ].join(" || ");
-}
-
 async function runRequiredCommand(
    session: FlueSession,
    command: string,
@@ -262,8 +253,8 @@ export default async function ({ init, payload, env }: FlueContext) {
             ),
             runRequiredCommand(
                session,
-               prFilesCommand(prNumber, repo),
-               "Falha ao listar arquivos alterados da PR.",
+               "printf '%s\\n' 'Listagem de arquivos omitida; consulte o diff completo abaixo.'",
+               "Falha ao preparar lista de arquivos alterados da PR.",
             ),
             runRequiredCommand(
                session,


### PR DESCRIPTION
## Summary
- Remove chamadas `gh` da listagem opcional de arquivos alterados
- Mantém uma mensagem placeholder para `changed-files.md`
- O diff completo continua sendo coletado logo em seguida e é a fonte principal do review/audit

## Checks
- flue build --target node via binário local
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Evita a quebra dos workflows de revisão e auditoria ao tornar opcional a listagem de arquivos da PR, removendo a dependência do `gh`. O diff completo segue como fonte principal para review e audit, conforme AGENTS.md.

- **Bug Fixes**
  - Removida a execução de `gh pr view`, `gh pr diff --name-only` e `gh api .../pulls/.../files` na listagem opcional de arquivos.
  - Em `.flue/agents/pr-review.ts` e `.flue/agents/security-audit.ts`, a etapa de “lista de arquivos” agora imprime apenas um placeholder: "Listagem de arquivos omitida; consulte o diff completo abaixo." via `printf`.
  - Mantida a coleta do diff completo na etapa seguinte, que segue sendo a base para análise (alinhado ao AGENTS.md: listagem é opcional e não deve bloquear o fluxo).
  - Impacto nas camadas: router, repositório, componente e store não são afetados; alteração restrita à camada de agentes/workflows.

Checklist de teste:
- `flue build --target node` OK.
- Executar os agentes sem `gh` instalado ou sem token: workflow não falha; placeholder é exibido e o diff completo é coletado depois.
- Em PR real, verificar logs: mensagem de listagem omitida seguida pelo diff; etapas de review/audit continuam funcionando.
- `git diff --check` limpo.

<sup>Written for commit f018e0c2e1b42a9c8fd456c6250763dfbe7717b4. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/995?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

