### PR TITLE
Pré-coletar contexto dos workflows de AI no Actions

### DIFF
--- a/.flue/agents/pr-review.ts
+++ b/.flue/agents/pr-review.ts
@@ -226,12 +226,13 @@ async function publishIssueComment({
    repo,
    prNumber,
    body,
+   token,
 }: {
    repo: string;
    prNumber: number;
    body: string;
+   token: string | undefined;
 }) {
-   const token = process.env.GH_TOKEN;
    if (!token) {
       return Result.err(
          new PrReviewAgentError({
@@ -286,13 +287,14 @@ async function publishReview({
    prNumber,
    body,
    comments,
+   token,
 }: {
    repo: string;
    prNumber: number;
    body: string;
    comments: Array<z.infer<typeof reviewCommentSchema>>;
+   token: string | undefined;
 }) {
-   const token = process.env.GH_TOKEN;
    if (!token) {
       return Result.err(
          new PrReviewAgentError({
@@ -395,6 +397,11 @@ export default async function ({ init, payload, env }: FlueContext) {
    }
 
    const repo = repoResult.data;
+   const githubToken =
+      env.GH_TOKEN ??
+      env.GITHUB_TOKEN ??
+      process.env.GH_TOKEN ??
+      process.env.GITHUB_TOKEN;
 
    const outputDirResult = await Result.tryPromise({
       try: () => mkdir(outputDir, { recursive: true }),
@@ -675,6 +682,7 @@ Regras para comments:
       prNumber,
       body: reviewResult.value.summary,
       comments: inlineComments.valid,
+      token: githubToken,
    });
 
    if (Result.isError(publishResult)) {
@@ -687,6 +695,7 @@ Regras para comments:
          repo,
          prNumber,
          body: reviewResult.value.summary,
+         token: githubToken,
       });
       if (Result.isError(fallbackCommentResult))
          throw fallbackCommentResult.error;

--- a/.flue/agents/pr-review.ts
+++ b/.flue/agents/pr-review.ts
@@ -1,5 +1,4 @@
 import type { FlueContext } from "@flue/runtime";
-import { local } from "@flue/runtime/node";
 import { Result, TaggedError } from "better-result";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { z } from "zod";
@@ -19,6 +18,7 @@ const prPayloadSchema = z.object({
    prNumber: z.number().int().nonnegative().optional(),
    repo: safeRepoSchema.optional(),
    outputDir: safeOutputDirSchema.default(".agent-artifacts/pr-review"),
+   contextDir: safeOutputDirSchema.default(".agent-artifacts/pr-review/input"),
 });
 
 const reviewCommentSchema = z.object({
@@ -39,48 +39,24 @@ const reviewResultSchema = z.object({
    comments: z.array(reviewCommentSchema).default([]),
 });
 
-type FlueHarness = Awaited<ReturnType<FlueContext["init"]>>;
-type FlueSession = Awaited<ReturnType<FlueHarness["session"]>>;
-
 class PrReviewAgentError extends TaggedError("PrReviewAgentError")<{
    message: string;
    cause?: unknown;
 }>() {}
 
-function shellQuote(value: string | number) {
-   return `'${String(value).replace(/'/gu, `'"'"'`)}'`;
-}
-
-function ghCommand(args: Array<string | number>) {
-   return ["gh", ...args.map(shellQuote)].join(" ");
-}
-
-async function runRequiredCommand(
-   session: FlueSession,
-   command: string,
-   failureMessage: string,
-) {
-   const commandResult = await Result.tryPromise({
-      try: () => Promise.resolve(session.shell(command)),
+async function readPreparedContext(filePath: string, failureMessage: string) {
+   return Result.tryPromise({
+      try: async () => ({
+         stdout: await readFile(filePath, "utf8"),
+         stderr: "",
+         exitCode: 0,
+      }),
       catch: (cause) =>
          new PrReviewAgentError({
             message: failureMessage,
             cause,
          }),
    });
-   if (Result.isError(commandResult)) return Result.err(commandResult.error);
-
-   if (commandResult.value.exitCode !== 0) {
-      const stderr = commandResult.value.stderr?.trim();
-      return Result.err(
-         new PrReviewAgentError({
-            message: stderr ? `${failureMessage}\n${stderr}` : failureMessage,
-            cause: commandResult.value.stderr,
-         }),
-      );
-   }
-
-   return Result.ok(commandResult.value);
 }
 
 function parseReviewResult(raw: string) {
@@ -246,6 +222,65 @@ function splitValidInlineComments(
    return { valid, skipped };
 }
 
+async function publishIssueComment({
+   repo,
+   prNumber,
+   body,
+}: {
+   repo: string;
+   prNumber: number;
+   body: string;
+}) {
+   const token = process.env.GH_TOKEN;
+   if (!token) {
+      return Result.err(
+         new PrReviewAgentError({
+            message: "GH_TOKEN não configurado no ambiente.",
+         }),
+      );
+   }
+
+   const responseResult = await Result.tryPromise({
+      try: () =>
+         fetch(
+            `https://api.github.com/repos/${repo}/issues/${prNumber}/comments`,
+            {
+               method: "POST",
+               headers: {
+                  Accept: "application/vnd.github+json",
+                  Authorization: `Bearer ${token}`,
+                  "Content-Type": "application/json",
+                  "X-GitHub-Api-Version": "2022-11-28",
+               },
+               body: JSON.stringify({ body }),
+            },
+         ),
+      catch: (cause) =>
+         new PrReviewAgentError({
+            message: "Falha ao publicar comentário no GitHub.",
+            cause,
+         }),
+   });
+   if (Result.isError(responseResult)) return Result.err(responseResult.error);
+   if (responseResult.value.ok) return Result.ok(undefined);
+
+   const bodyResult = await Result.tryPromise({
+      try: () => responseResult.value.text(),
+      catch: (cause) =>
+         new PrReviewAgentError({
+            message: "Falha ao ler erro da API do GitHub.",
+            cause,
+         }),
+   });
+
+   return Result.err(
+      new PrReviewAgentError({
+         message: `GitHub retornou ${responseResult.value.status} ao publicar comentário.`,
+         cause: Result.isOk(bodyResult) ? bodyResult.value : bodyResult.error,
+      }),
+   );
+}
+
 async function publishReview({
    repo,
    prNumber,
@@ -332,6 +367,7 @@ export default async function ({ init, payload, env }: FlueContext) {
       prNumber: payloadPrNumber,
       repo: payloadRepo,
       outputDir,
+      contextDir,
    } = parsedPayload.data;
    const envPrNumber = z.coerce
       .number()
@@ -360,38 +396,6 @@ export default async function ({ init, payload, env }: FlueContext) {
 
    const repo = repoResult.data;
 
-   const harnessResult = await Result.tryPromise({
-      try: () =>
-         init({
-            name: "pr-review-context",
-            sandbox: local({
-               env: {
-                  GH_TOKEN: process.env.GH_TOKEN,
-               },
-            }),
-            model: false,
-         }),
-      catch: (cause) =>
-         new PrReviewAgentError({
-            message:
-               "Falha ao inicializar Flue para contexto de revisão de PR.",
-            cause,
-         }),
-   });
-   if (Result.isError(harnessResult)) throw harnessResult.error;
-
-   const sessionResult = await Result.tryPromise({
-      try: () => harnessResult.value.session(),
-      catch: (cause) =>
-         new PrReviewAgentError({
-            message: "Falha ao abrir sessão Flue para revisão de PR.",
-            cause,
-         }),
-   });
-   if (Result.isError(sessionResult)) throw sessionResult.error;
-
-   const session = sessionResult.value;
-
    const outputDirResult = await Result.tryPromise({
       try: () => mkdir(outputDir, { recursive: true }),
       catch: (cause) =>
@@ -405,93 +409,37 @@ export default async function ({ init, payload, env }: FlueContext) {
    const contextResult = await Result.tryPromise({
       try: () =>
          Promise.all([
-            runRequiredCommand(
-               session,
-               ghCommand([
-                  "pr",
-                  "view",
-                  prNumber,
-                  "--repo",
-                  repo,
-                  "--json",
-                  "number,title,author,state,isDraft,reviewDecision,additions,deletions,changedFiles,labels,url,body",
-               ]),
-               "Falha ao coletar metadados da PR.",
+            readPreparedContext(
+               `${contextDir}/pr-metadata.json`,
+               "Falha ao ler metadados preparados da PR.",
             ),
-            runRequiredCommand(
-               session,
-               "printf '%s\\n' 'Listagem de arquivos omitida; consulte o diff completo abaixo.'",
-               "Falha ao preparar lista de arquivos alterados da PR.",
+            readPreparedContext(
+               `${contextDir}/changed-files.md`,
+               "Falha ao ler lista preparada de arquivos da PR.",
             ),
-            runRequiredCommand(
-               session,
-               ghCommand(["pr", "diff", prNumber, "--repo", repo]),
-               "Falha ao coletar diff da PR.",
+            readPreparedContext(
+               `${contextDir}/pr.patch`,
+               "Falha ao ler diff preparado da PR.",
             ),
-            runRequiredCommand(
-               session,
-               ghCommand([
-                  "pr",
-                  "view",
-                  prNumber,
-                  "--repo",
-                  repo,
-                  "--json",
-                  "commits",
-                  "--jq",
-                  ".commits[].message",
-               ]),
-               "Falha ao coletar commits da PR.",
+            readPreparedContext(
+               `${contextDir}/commits.md`,
+               "Falha ao ler commits preparados da PR.",
             ),
-            runRequiredCommand(
-               session,
-               `${ghCommand([
-                  "pr",
-                  "checks",
-                  prNumber,
-                  "--repo",
-                  repo,
-                  "--json",
-                  "name,status,conclusion",
-               ])} || true`,
-               "Falha ao coletar checks da PR.",
+            readPreparedContext(
+               `${contextDir}/checks.json`,
+               "Falha ao ler checks preparados da PR.",
             ),
-            runRequiredCommand(
-               session,
-               ghCommand([
-                  "pr",
-                  "view",
-                  prNumber,
-                  "--repo",
-                  repo,
-                  "--json",
-                  "reviews",
-                  "--jq",
-                  '.reviews[] | "- " + .state + " - " + .author.login + " - " + .body',
-               ]),
-               "Falha ao coletar reviews da PR.",
+            readPreparedContext(
+               `${contextDir}/reviews.md`,
+               "Falha ao ler reviews preparados da PR.",
             ),
-            runRequiredCommand(
-               session,
-               ghCommand([
-                  "api",
-                  `repos/${repo}/pulls/${prNumber}/comments`,
-                  "--paginate",
-                  "--jq",
-                  '.[] | "- " + .path + ":" + ((.line // 0)|tostring) + " - " + .user.login + " - " + .body',
-               ]),
-               "Falha ao coletar comentários inline da PR.",
+            readPreparedContext(
+               `${contextDir}/inline-review-comments.md`,
+               "Falha ao ler comentários inline preparados da PR.",
             ),
-            runRequiredCommand(
-               session,
-               ghCommand([
-                  "api",
-                  `repos/${repo}/issues/${prNumber}/comments`,
-                  "--paginate",
-                  "--jq",
-                  '.[] | "- " + .user.login + " - " + .body',
-               ]),
-               "Falha ao coletar comentários gerais da PR.",
+            readPreparedContext(
+               `${contextDir}/general-pr-comments.md`,
+               "Falha ao ler comentários gerais preparados da PR.",
             ),
             readFile("AGENTS.md", "utf8"),
             readFile(".agents/skills/code-review/SKILL.md", "utf8"),
@@ -735,19 +683,11 @@ Regras para comments:
          String(publishResult.error.cause ?? publishResult.error.message),
       );
 
-      const fallbackCommentResult = await runRequiredCommand(
-         session,
-         ghCommand([
-            "pr",
-            "comment",
-            prNumber,
-            "--repo",
-            repo,
-            "--body-file",
-            outputFile,
-         ]),
-         "Falha ao comentar revisão fallback na PR.",
-      );
+      const fallbackCommentResult = await publishIssueComment({
+         repo,
+         prNumber,
+         body: reviewResult.value.summary,
+      });
       if (Result.isError(fallbackCommentResult))
          throw fallbackCommentResult.error;
    }

--- a/.flue/agents/pr-review.ts
+++ b/.flue/agents/pr-review.ts
@@ -1,4 +1,5 @@
 import type { FlueContext } from "@flue/runtime";
+import { Octokit } from "@octokit/core";
 import { Result, TaggedError } from "better-result";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { z } from "zod";
@@ -241,45 +242,26 @@ async function publishIssueComment({
       );
    }
 
-   const responseResult = await Result.tryPromise({
-      try: () =>
-         fetch(
-            `https://api.github.com/repos/${repo}/issues/${prNumber}/comments`,
+   const [owner, repoName] = repo.split("/");
+   const octokit = new Octokit({ auth: token });
+   return Result.tryPromise({
+      try: async () => {
+         await octokit.request(
+            "POST /repos/{owner}/{repo}/issues/{num}/comments",
             {
-               method: "POST",
-               headers: {
-                  Accept: "application/vnd.github+json",
-                  Authorization: `Bearer ${token}`,
-                  "Content-Type": "application/json",
-                  "X-GitHub-Api-Version": "2022-11-28",
-               },
-               body: JSON.stringify({ body }),
+               owner,
+               repo: repoName,
+               num: prNumber,
+               body,
             },
-         ),
+         );
+      },
       catch: (cause) =>
          new PrReviewAgentError({
             message: "Falha ao publicar comentário no GitHub.",
             cause,
          }),
    });
-   if (Result.isError(responseResult)) return Result.err(responseResult.error);
-   if (responseResult.value.ok) return Result.ok(undefined);
-
-   const bodyResult = await Result.tryPromise({
-      try: () => responseResult.value.text(),
-      catch: (cause) =>
-         new PrReviewAgentError({
-            message: "Falha ao ler erro da API do GitHub.",
-            cause,
-         }),
-   });
-
-   return Result.err(
-      new PrReviewAgentError({
-         message: `GitHub retornou ${responseResult.value.status} ao publicar comentário.`,
-         cause: Result.isOk(bodyResult) ? bodyResult.value : bodyResult.error,
-      }),
-   );
 }
 
 async function publishReview({
@@ -314,46 +296,28 @@ async function publishReview({
       })),
    };
 
-   const responseResult = await Result.tryPromise({
-      try: () =>
-         fetch(
-            `https://api.github.com/repos/${repo}/pulls/${prNumber}/reviews`,
+   const [owner, repoName] = repo.split("/");
+   const octokit = new Octokit({ auth: token });
+   return Result.tryPromise({
+      try: async () => {
+         await octokit.request(
+            "POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews",
             {
-               method: "POST",
-               headers: {
-                  Accept: "application/vnd.github+json",
-                  Authorization: `Bearer ${token}`,
-                  "Content-Type": "application/json",
-                  "X-GitHub-Api-Version": "2022-11-28",
-               },
-               body: JSON.stringify(payload),
+               owner,
+               repo: repoName,
+               pull_number: prNumber,
+               body: payload.body,
+               event: payload.event,
+               comments: payload.comments,
             },
-         ),
+         );
+      },
       catch: (cause) =>
          new PrReviewAgentError({
             message: "Falha ao publicar review inline no GitHub.",
             cause,
          }),
    });
-   if (Result.isError(responseResult)) return Result.err(responseResult.error);
-
-   if (responseResult.value.ok) return Result.ok(undefined);
-
-   const bodyResult = await Result.tryPromise({
-      try: () => responseResult.value.text(),
-      catch: (cause) =>
-         new PrReviewAgentError({
-            message: "Falha ao ler erro da API do GitHub.",
-            cause,
-         }),
-   });
-
-   return Result.err(
-      new PrReviewAgentError({
-         message: `GitHub retornou ${responseResult.value.status} ao publicar review.`,
-         cause: Result.isOk(bodyResult) ? bodyResult.value : bodyResult.error,
-      }),
-   );
 }
 
 export default async function ({ init, payload, env }: FlueContext) {

--- a/.flue/agents/security-audit.ts
+++ b/.flue/agents/security-audit.ts
@@ -76,12 +76,13 @@ async function publishIssueComment({
    repo,
    prNumber,
    body,
+   token,
 }: {
    repo: string;
    prNumber: number;
    body: string;
+   token: string | undefined;
 }) {
-   const token = process.env.GH_TOKEN;
    if (!token) {
       return Result.err(
          new SecurityAuditAgentError({
@@ -233,6 +234,11 @@ export default async function ({ init, payload, env }: FlueContext) {
    } = parsedPayload.data;
    const prNumber = payloadPrNumber ?? Number(env.PR_NUMBER);
    const repo = payloadRepo ?? env.GITHUB_REPOSITORY;
+   const githubToken =
+      env.GH_TOKEN ??
+      env.GITHUB_TOKEN ??
+      process.env.GH_TOKEN ??
+      process.env.GITHUB_TOKEN;
 
    if (!prNumber || Number.isNaN(prNumber)) {
       throw new SecurityAuditAgentError({
@@ -461,6 +467,7 @@ Retorne JSON válido, sem markdown fences, exatamente no schema da reference rep
       repo,
       prNumber,
       body: markdown,
+      token: githubToken,
    });
    if (Result.isError(commentResult)) throw commentResult.error;
 

--- a/.flue/agents/security-audit.ts
+++ b/.flue/agents/security-audit.ts
@@ -1,4 +1,5 @@
 import type { FlueContext } from "@flue/runtime";
+import { Octokit } from "@octokit/core";
 import { Result, TaggedError } from "better-result";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { z } from "zod";
@@ -91,45 +92,26 @@ async function publishIssueComment({
       );
    }
 
-   const responseResult = await Result.tryPromise({
-      try: () =>
-         fetch(
-            `https://api.github.com/repos/${repo}/issues/${prNumber}/comments`,
+   const [owner, repoName] = repo.split("/");
+   const octokit = new Octokit({ auth: token });
+   return Result.tryPromise({
+      try: async () => {
+         await octokit.request(
+            "POST /repos/{owner}/{repo}/issues/{num}/comments",
             {
-               method: "POST",
-               headers: {
-                  Accept: "application/vnd.github+json",
-                  Authorization: `Bearer ${token}`,
-                  "Content-Type": "application/json",
-                  "X-GitHub-Api-Version": "2022-11-28",
-               },
-               body: JSON.stringify({ body }),
+               owner,
+               repo: repoName,
+               num: prNumber,
+               body,
             },
-         ),
+         );
+      },
       catch: (cause) =>
          new SecurityAuditAgentError({
             message: "Falha ao publicar comentário no GitHub.",
             cause,
          }),
    });
-   if (Result.isError(responseResult)) return Result.err(responseResult.error);
-   if (responseResult.value.ok) return Result.ok(undefined);
-
-   const bodyResult = await Result.tryPromise({
-      try: () => responseResult.value.text(),
-      catch: (cause) =>
-         new SecurityAuditAgentError({
-            message: "Falha ao ler erro da API do GitHub.",
-            cause,
-         }),
-   });
-
-   return Result.err(
-      new SecurityAuditAgentError({
-         message: `GitHub retornou ${responseResult.value.status} ao publicar comentário.`,
-         cause: Result.isOk(bodyResult) ? bodyResult.value : bodyResult.error,
-      }),
-   );
 }
 
 function parseSecurityAuditResult(raw: string) {

--- a/.flue/agents/security-audit.ts
+++ b/.flue/agents/security-audit.ts
@@ -1,5 +1,4 @@
 import type { FlueContext } from "@flue/runtime";
-import { local } from "@flue/runtime/node";
 import { Result, TaggedError } from "better-result";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { z } from "zod";
@@ -18,6 +17,7 @@ const securityAuditPayloadSchema = z.object({
       .regex(/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u)
       .optional(),
    outputDir: z.string().default(".security-audit"),
+   contextDir: z.string().default(".agent-artifacts/security-audit/input"),
    failOn: failOnSchema.default("high"),
 });
 
@@ -48,8 +48,6 @@ const securityAuditResultSchema = z.object({
    discarded: z.array(discardedSchema).max(30).default([]),
 });
 
-type FlueHarness = Awaited<ReturnType<FlueContext["init"]>>;
-type FlueSession = Awaited<ReturnType<FlueHarness["session"]>>;
 type SecurityAuditResult = z.infer<typeof securityAuditResultSchema>;
 type Finding = z.infer<typeof findingSchema>;
 type FailOn = z.infer<typeof failOnSchema>;
@@ -59,32 +57,78 @@ class SecurityAuditAgentError extends TaggedError("SecurityAuditAgentError")<{
    cause?: unknown;
 }>() {}
 
-async function runRequiredCommand(
-   session: FlueSession,
-   command: string,
-   failureMessage: string,
-) {
-   const commandResult = await Result.tryPromise({
-      try: () => Promise.resolve(session.shell(command)),
+async function readPreparedContext(filePath: string, failureMessage: string) {
+   return Result.tryPromise({
+      try: async () => ({
+         stdout: await readFile(filePath, "utf8"),
+         stderr: "",
+         exitCode: 0,
+      }),
       catch: (cause) =>
          new SecurityAuditAgentError({
             message: failureMessage,
             cause,
          }),
    });
-   if (Result.isError(commandResult)) return Result.err(commandResult.error);
+}
 
-   if (commandResult.value.exitCode !== 0) {
-      const stderr = commandResult.value.stderr?.trim();
+async function publishIssueComment({
+   repo,
+   prNumber,
+   body,
+}: {
+   repo: string;
+   prNumber: number;
+   body: string;
+}) {
+   const token = process.env.GH_TOKEN;
+   if (!token) {
       return Result.err(
          new SecurityAuditAgentError({
-            message: stderr ? `${failureMessage}\n${stderr}` : failureMessage,
-            cause: commandResult.value.stderr,
+            message: "GH_TOKEN não configurado no ambiente.",
          }),
       );
    }
 
-   return Result.ok(commandResult.value);
+   const responseResult = await Result.tryPromise({
+      try: () =>
+         fetch(
+            `https://api.github.com/repos/${repo}/issues/${prNumber}/comments`,
+            {
+               method: "POST",
+               headers: {
+                  Accept: "application/vnd.github+json",
+                  Authorization: `Bearer ${token}`,
+                  "Content-Type": "application/json",
+                  "X-GitHub-Api-Version": "2022-11-28",
+               },
+               body: JSON.stringify({ body }),
+            },
+         ),
+      catch: (cause) =>
+         new SecurityAuditAgentError({
+            message: "Falha ao publicar comentário no GitHub.",
+            cause,
+         }),
+   });
+   if (Result.isError(responseResult)) return Result.err(responseResult.error);
+   if (responseResult.value.ok) return Result.ok(undefined);
+
+   const bodyResult = await Result.tryPromise({
+      try: () => responseResult.value.text(),
+      catch: (cause) =>
+         new SecurityAuditAgentError({
+            message: "Falha ao ler erro da API do GitHub.",
+            cause,
+         }),
+   });
+
+   return Result.err(
+      new SecurityAuditAgentError({
+         message: `GitHub retornou ${responseResult.value.status} ao publicar comentário.`,
+         cause: Result.isOk(bodyResult) ? bodyResult.value : bodyResult.error,
+      }),
+   );
 }
 
 function parseSecurityAuditResult(raw: string) {
@@ -184,6 +228,7 @@ export default async function ({ init, payload, env }: FlueContext) {
       prNumber: payloadPrNumber,
       repo: payloadRepo,
       outputDir,
+      contextDir,
       failOn,
    } = parsedPayload.data;
    const prNumber = payloadPrNumber ?? Number(env.PR_NUMBER);
@@ -201,38 +246,6 @@ export default async function ({ init, payload, env }: FlueContext) {
       });
    }
 
-   const harnessResult = await Result.tryPromise({
-      try: () =>
-         init({
-            name: "security-audit-context",
-            sandbox: local({
-               env: {
-                  GH_TOKEN: process.env.GH_TOKEN,
-               },
-            }),
-            model: false,
-         }),
-      catch: (cause) =>
-         new SecurityAuditAgentError({
-            message:
-               "Falha ao inicializar Flue para contexto de security audit.",
-            cause,
-         }),
-   });
-   if (Result.isError(harnessResult)) throw harnessResult.error;
-
-   const sessionResult = await Result.tryPromise({
-      try: () => harnessResult.value.session(),
-      catch: (cause) =>
-         new SecurityAuditAgentError({
-            message: "Falha ao abrir sessão Flue para security audit.",
-            cause,
-         }),
-   });
-   if (Result.isError(sessionResult)) throw sessionResult.error;
-
-   const session = sessionResult.value;
-
    const outputDirResult = await Result.tryPromise({
       try: () => mkdir(outputDir, { recursive: true }),
       catch: (cause) =>
@@ -246,30 +259,25 @@ export default async function ({ init, payload, env }: FlueContext) {
    const contextResult = await Result.tryPromise({
       try: () =>
          Promise.all([
-            runRequiredCommand(
-               session,
-               `gh pr view ${prNumber} --repo ${repo} --json number,title,author,state,isDraft,reviewDecision,additions,deletions,changedFiles,labels,url,body,baseRefName,headRefName,isCrossRepository`,
-               "Falha ao coletar metadados da PR.",
+            readPreparedContext(
+               `${contextDir}/pr-metadata.json`,
+               "Falha ao ler metadados preparados da PR.",
             ),
-            runRequiredCommand(
-               session,
-               "printf '%s\\n' 'Listagem de arquivos omitida; consulte o diff completo abaixo.'",
-               "Falha ao preparar lista de arquivos alterados da PR.",
+            readPreparedContext(
+               `${contextDir}/changed-files.md`,
+               "Falha ao ler lista preparada de arquivos da PR.",
             ),
-            runRequiredCommand(
-               session,
-               `gh pr diff ${prNumber} --repo ${repo}`,
-               "Falha ao coletar diff da PR.",
+            readPreparedContext(
+               `${contextDir}/pr.patch`,
+               "Falha ao ler diff preparado da PR.",
             ),
-            runRequiredCommand(
-               session,
-               `gh pr view ${prNumber} --repo ${repo} --json commits --jq '.commits[].message'`,
-               "Falha ao coletar commits da PR.",
+            readPreparedContext(
+               `${contextDir}/commits.md`,
+               "Falha ao ler commits preparados da PR.",
             ),
-            runRequiredCommand(
-               session,
-               `gh pr checks ${prNumber} --repo ${repo} --json name,status,conclusion || true`,
-               "Falha ao coletar checks da PR.",
+            readPreparedContext(
+               `${contextDir}/checks.json`,
+               "Falha ao ler checks preparados da PR.",
             ),
             readFile("AGENTS.md", "utf8"),
             readFile(".agents/skills/implementation/SKILL.md", "utf8"),
@@ -449,11 +457,11 @@ Retorne JSON válido, sem markdown fences, exatamente no schema da reference rep
       writeFile(markdownOutputFile, markdown),
    ]);
 
-   const commentResult = await runRequiredCommand(
-      session,
-      `gh pr comment ${prNumber} --repo ${repo} --body-file ${markdownOutputFile}`,
-      "Falha ao comentar security audit na PR.",
-   );
+   const commentResult = await publishIssueComment({
+      repo,
+      prNumber,
+      body: markdown,
+   });
    if (Result.isError(commentResult)) throw commentResult.error;
 
    if (shouldFailAudit(auditResult.value.findings, failOn)) {

--- a/.github/workflows/pr-review-ai.yml
+++ b/.github/workflows/pr-review-ai.yml
@@ -147,6 +147,39 @@ jobs:
            if: steps.pr.outputs.requested == 'true' && steps.pr.outputs.authorized == 'true' && steps.pr.outputs.is_cross_repository != 'true'
            run: bun install --frozen-lockfile
 
+         - name: Collect PR review context
+           if: steps.pr.outputs.requested == 'true' && steps.pr.outputs.authorized == 'true' && steps.pr.outputs.is_cross_repository != 'true'
+           env:
+              GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              PR_NUMBER: ${{ steps.pr.outputs.number }}
+              REPO: ${{ github.repository }}
+           run: |
+              set -euo pipefail
+              CONTEXT_DIR=".agent-artifacts/pr-review/input"
+              mkdir -p "$CONTEXT_DIR"
+
+              gh pr view "$PR_NUMBER" --repo "$REPO" --json number,title,author,state,isDraft,reviewDecision,additions,deletions,changedFiles,labels,url,body > "$CONTEXT_DIR/pr-metadata.json"
+
+              gh pr view "$PR_NUMBER" --repo "$REPO" --json files --jq '.files[] | "- " + .path + " (+" + (.additions|tostring) + " -" + (.deletions|tostring) + ")"' > "$CONTEXT_DIR/changed-files.md" \
+                || printf '%s\n' 'Listagem de arquivos indisponível; consulte o diff completo.' > "$CONTEXT_DIR/changed-files.md"
+
+              gh pr diff "$PR_NUMBER" --repo "$REPO" > "$CONTEXT_DIR/pr.patch"
+
+              gh pr view "$PR_NUMBER" --repo "$REPO" --json commits --jq '.commits[].message' > "$CONTEXT_DIR/commits.md" \
+                || : > "$CONTEXT_DIR/commits.md"
+
+              gh pr checks "$PR_NUMBER" --repo "$REPO" --json name,state,bucket,workflow,link > "$CONTEXT_DIR/checks.json" \
+                || printf '[]\n' > "$CONTEXT_DIR/checks.json"
+
+              gh pr view "$PR_NUMBER" --repo "$REPO" --json reviews --jq '.reviews[] | "- " + .state + " - " + .author.login + " - " + .body' > "$CONTEXT_DIR/reviews.md" \
+                || : > "$CONTEXT_DIR/reviews.md"
+
+              gh api "repos/$REPO/pulls/$PR_NUMBER/comments" --paginate --jq '.[] | "- " + .path + ":" + ((.line // 0)|tostring) + " - " + .user.login + " - " + .body' > "$CONTEXT_DIR/inline-review-comments.md" \
+                || : > "$CONTEXT_DIR/inline-review-comments.md"
+
+              gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate --jq '.[] | "- " + .user.login + " - " + .body' > "$CONTEXT_DIR/general-pr-comments.md" \
+                || : > "$CONTEXT_DIR/general-pr-comments.md"
+
          - name: Run PR Review Agent
            if: steps.pr.outputs.requested == 'true' && steps.pr.outputs.authorized == 'true' && steps.pr.outputs.is_cross_repository != 'true'
            env:
@@ -157,7 +190,7 @@ jobs:
               PR_NUMBER: ${{ steps.pr.outputs.number }}
               REPO: ${{ github.repository }}
            run: |
-              PAYLOAD=$(jq -c -n --argjson prNumber "${PR_NUMBER}" --arg repo "${REPO}" '{prNumber: $prNumber, repo: $repo}')
+              PAYLOAD=$(jq -c -n --argjson prNumber "${PR_NUMBER}" --arg repo "${REPO}" --arg contextDir ".agent-artifacts/pr-review/input" '{prNumber: $prNumber, repo: $repo, contextDir: $contextDir}')
               bunx flue run pr-review --target node --id "pr-review-${PR_NUMBER}" --payload "$PAYLOAD"
 
          - name: Upload review artifacts

--- a/.github/workflows/pr-review-ai.yml
+++ b/.github/workflows/pr-review-ai.yml
@@ -187,6 +187,7 @@ jobs:
               OPENCODE_GO_BASE_URL: ${{ vars.OPENCODE_GO_BASE_URL }}
               OPENCODE_GO_GATEWAY_KEY: ${{ secrets.OPENCODE_GO_GATEWAY_KEY }}
               GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               PR_NUMBER: ${{ steps.pr.outputs.number }}
               REPO: ${{ github.repository }}
            run: |

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -198,6 +198,7 @@ jobs:
               OPENCODE_GO_BASE_URL: ${{ vars.OPENCODE_GO_BASE_URL }}
               OPENCODE_GO_GATEWAY_KEY: ${{ secrets.OPENCODE_GO_GATEWAY_KEY }}
               GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               PR_NUMBER: ${{ steps.pr.outputs.number }}
               REPO: ${{ github.repository }}
               FAIL_ON: ${{ steps.pr.outputs.fail_on }}

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -167,6 +167,30 @@ jobs:
            if: steps.pr.outputs.requested == 'true' && steps.pr.outputs.authorized == 'true' && steps.pr.outputs.is_cross_repository != 'true'
            run: bun install --frozen-lockfile
 
+         - name: Collect security audit context
+           if: steps.pr.outputs.requested == 'true' && steps.pr.outputs.authorized == 'true' && steps.pr.outputs.is_cross_repository != 'true'
+           env:
+              GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              PR_NUMBER: ${{ steps.pr.outputs.number }}
+              REPO: ${{ github.repository }}
+           run: |
+              set -euo pipefail
+              CONTEXT_DIR=".agent-artifacts/security-audit/input"
+              mkdir -p "$CONTEXT_DIR"
+
+              gh pr view "$PR_NUMBER" --repo "$REPO" --json number,title,author,state,isDraft,reviewDecision,additions,deletions,changedFiles,labels,url,body,baseRefName,headRefName,isCrossRepository > "$CONTEXT_DIR/pr-metadata.json"
+
+              gh pr view "$PR_NUMBER" --repo "$REPO" --json files --jq '.files[] | "- " + .path + " (+" + (.additions|tostring) + " -" + (.deletions|tostring) + ")"' > "$CONTEXT_DIR/changed-files.md" \
+                || printf '%s\n' 'Listagem de arquivos indisponível; consulte o diff completo.' > "$CONTEXT_DIR/changed-files.md"
+
+              gh pr diff "$PR_NUMBER" --repo "$REPO" > "$CONTEXT_DIR/pr.patch"
+
+              gh pr view "$PR_NUMBER" --repo "$REPO" --json commits --jq '.commits[].message' > "$CONTEXT_DIR/commits.md" \
+                || : > "$CONTEXT_DIR/commits.md"
+
+              gh pr checks "$PR_NUMBER" --repo "$REPO" --json name,state,bucket,workflow,link > "$CONTEXT_DIR/checks.json" \
+                || printf '[]\n' > "$CONTEXT_DIR/checks.json"
+
          - name: Run Security Audit Agent
            if: steps.pr.outputs.requested == 'true' && steps.pr.outputs.authorized == 'true' && steps.pr.outputs.is_cross_repository != 'true'
            env:
@@ -178,7 +202,7 @@ jobs:
               REPO: ${{ github.repository }}
               FAIL_ON: ${{ steps.pr.outputs.fail_on }}
            run: |
-              PAYLOAD=$(jq -c -n --argjson prNumber "$PR_NUMBER" --arg repo "$REPO" --arg failOn "$FAIL_ON" '{prNumber: $prNumber, repo: $repo, failOn: $failOn}')
+              PAYLOAD=$(jq -c -n --argjson prNumber "$PR_NUMBER" --arg repo "$REPO" --arg failOn "$FAIL_ON" --arg contextDir ".agent-artifacts/security-audit/input" '{prNumber: $prNumber, repo: $repo, failOn: $failOn, contextDir: $contextDir}')
               bunx flue run security-audit --target node --id "security-audit-${PR_NUMBER}" --payload "$PAYLOAD"
 
          - name: Upload security audit artifacts

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@arcjet/node": "^1.4.0",
         "@flue/runtime": "^0.7.0",
+        "@octokit/core": "^7.0.6",
         "better-result": "catalog:validation",
         "zod": "catalog:validation",
       },
@@ -1829,6 +1830,22 @@
 
     "@nx/workspace": ["@nx/workspace@22.6.5", "", { "dependencies": { "@nx/devkit": "22.6.5", "@zkochan/js-yaml": "0.0.7", "chalk": "^4.1.0", "enquirer": "~2.3.6", "nx": "22.6.5", "picomatch": "4.0.4", "semver": "^7.6.3", "tslib": "^2.3.0", "yargs-parser": "21.1.1" } }, "sha512-/CZtv1ESSfZ1MVqSlCsmnBWysU1z5VdNlwANlqL6BV2X6RUHKDPVj4YuNPvCK+0LsqyzfJdUt3pcnBYxnT5TIg=="],
 
+    "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
+
+    "@octokit/core": ["@octokit/core@7.0.6", "", { "dependencies": { "@octokit/auth-token": "^6.0.0", "@octokit/graphql": "^9.0.3", "@octokit/request": "^10.0.6", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "before-after-hook": "^4.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q=="],
+
+    "@octokit/endpoint": ["@octokit/endpoint@11.0.3", "", { "dependencies": { "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag=="],
+
+    "@octokit/graphql": ["@octokit/graphql@9.0.3", "", { "dependencies": { "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA=="],
+
+    "@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
+
+    "@octokit/request": ["@octokit/request@10.0.9", "", { "dependencies": { "@octokit/endpoint": "^11.0.3", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "content-type": "^2.0.0", "fast-content-type-parse": "^3.0.0", "json-with-bigint": "^3.5.3", "universal-user-agent": "^7.0.2" } }, "sha512-o8Bi3f608eyM+7BmBiUWxFsdjLb3/ym1cQek5LZOv9KkZcxRrHCPhhRzm6xjO6HVZ85ItD6+sTsjxo821SVa/A=="],
+
+    "@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
+
+    "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
+
     "@oozcitak/dom": ["@oozcitak/dom@2.0.2", "", { "dependencies": { "@oozcitak/infra": "^2.0.2", "@oozcitak/url": "^3.0.0", "@oozcitak/util": "^10.0.0" } }, "sha512-GjpKhkSYC3Mj4+lfwEyI1dqnsKTgwGy48ytZEhm4A/xnH/8z9M3ZVXKr/YGQi3uCLs1AEBS+x5T2JPiueEDW8w=="],
 
     "@oozcitak/infra": ["@oozcitak/infra@2.0.2", "", { "dependencies": { "@oozcitak/util": "^10.0.0" } }, "sha512-2g+E7hoE2dgCz/APPOEK5s3rMhJvNxSMBrP+U+j1OWsIbtSpWxxlUjq1lU8RIsFJNYv7NMlnVsCuHcUzJW+8vA=="],
@@ -2991,6 +3008,8 @@
 
     "bcp-47-normalize": ["bcp-47-normalize@2.3.0", "", { "dependencies": { "bcp-47": "^2.0.0", "bcp-47-match": "^2.0.0" } }, "sha512-8I/wfzqQvttUFz7HVJgIZ7+dj3vUaIyIxYXaTRP1YWoSDfzt6TUmxaKZeuXR62qBmYr+nvuWINFRl6pZ5DlN4Q=="],
 
+    "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
+
     "better-auth": ["better-auth@1.6.5", "", { "dependencies": { "@better-auth/core": "1.6.5", "@better-auth/drizzle-adapter": "1.6.5", "@better-auth/kysely-adapter": "1.6.5", "@better-auth/memory-adapter": "1.6.5", "@better-auth/mongo-adapter": "1.6.5", "@better-auth/prisma-adapter": "1.6.5", "@better-auth/telemetry": "1.6.5", "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21", "@noble/ciphers": "^2.1.1", "@noble/hashes": "^2.0.1", "better-call": "1.3.5", "defu": "^6.1.4", "jose": "^6.1.3", "kysely": "^0.28.14", "nanostores": "^1.1.1", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": "^0.45.2", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-rSt8JtJOJK0MqPShXINCmM6DV30GsDvnCTlIxQIzP9OpUx/umA40nUc4ALZHQyqAPbw1ib/a549kIWw/WyxxKA=="],
 
     "better-call": ["better-call@1.3.5", "", { "dependencies": { "@better-auth/utils": "^0.4.0", "@better-fetch/fetch": "^1.1.21", "rou3": "^0.7.12", "set-cookie-parser": "^3.0.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA=="],
@@ -3485,6 +3504,8 @@
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
+    "fast-content-type-parse": ["fast-content-type-parse@3.0.0", "", {}, "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-json-patch": ["fast-json-patch@3.1.1", "", {}, "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="],
@@ -3824,6 +3845,8 @@
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "json-with-bigint": ["json-with-bigint@3.5.8", "", {}, "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
@@ -4875,6 +4898,8 @@
 
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
+    "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
+
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
     "unplugin": ["unplugin@3.0.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg=="],
@@ -5184,6 +5209,8 @@
     "@modelcontextprotocol/sdk/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@nx/eslint/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "@octokit/request/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "@opentelemetry/configuration/@opentelemetry/core": ["@opentelemetry/core@2.7.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ=="],
 

--- a/package.json
+++ b/package.json
@@ -274,6 +274,7 @@
    "dependencies": {
       "@arcjet/node": "^1.4.0",
       "@flue/runtime": "^0.7.0",
+      "@octokit/core": "^7.0.6",
       "better-result": "catalog:validation",
       "zod": "catalog:validation"
    },


### PR DESCRIPTION
## Summary
- Move a coleta de contexto da PR (`gh pr view`, `gh pr diff`, comentários e checks) para steps normais do GitHub Actions
- Os agentes Flue passam a ler arquivos preparados via `contextDir`, evitando `session.shell('gh ...')` para coleta
- Remove exposição de `GH_TOKEN` para o sandbox local; publicação usa API do GitHub no host do agente
- Mantém o diff completo como fonte principal de review/audit

## Checks
- flue build --target node via binário local
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pré-coletamos o contexto das PRs nos workflows do Actions e passamos as escritas no GitHub para `@octokit/core`, removendo qualquer uso de `gh` dentro do sandbox. O token do GitHub agora só é usado no host, e a lista de arquivos voltou a ser gerada e lida corretamente.

- **Refactors**
  - Agentes (`.flue/agents/pr-review.ts`, `.flue/agents/security-audit.ts`)
    - Removido `local`/`session.shell('gh ...')`; novo `readPreparedContext(...)`.
    - Novo `contextDir` no payload (defaults: `.agent-artifacts/pr-review/input` e `.agent-artifacts/security-audit/input`).
    - Publicação via GitHub com `@octokit/core` (`publishReview` e fallback `publishIssueComment`); token lido de `GH_TOKEN`/`GITHUB_TOKEN` no host.
  - Workflows (`.github/workflows/pr-review-ai.yml`, `.github/workflows/security-audit.yml`)
    - Step “Collect ... context” grava `pr-metadata.json`, `changed-files.md`, `pr.patch`, `commits.md`, `checks.json` (campos: `name,state,bucket,workflow,link`); no review também `reviews.md`, `inline-review-comments.md`, `general-pr-comments.md`.
    - Passa `contextDir` ao payload e exporta `GH_TOKEN`/`GITHUB_TOKEN` para os jobs (fora do sandbox).
    - Correção: `changed-files.md` volta a ser gerado e utilizado.
  - Dependências
    - Adiciona `@octokit/core`.
  - Impacto por camadas (AGENTS.md)
    - Router: orquestra coleta determinística via Actions.
    - Repositório: lê do `contextDir`, usando `pr.patch` como fonte principal.
    - Componente: apenas parse e publicação via Octokit, sem `gh`.
    - Store: recebe `.agent-artifacts/*/input`.

- **Checklist de teste**
  - Executar “Collect ... context” e confirmar arquivos no `contextDir`.
  - Rodar `bunx flue run pr-review` e `security-audit` com `contextDir`; verificar comentários/review na PR.
  - Garantir que nenhum `gh` roda no sandbox e que a publicação usa Octokit com `GH_TOKEN`/`GITHUB_TOKEN` do host.
  - Validar PRs grandes e os novos campos em `checks.json`.
  - `git diff --check` limpo e `flue build --target node` ok.

<sup>Written for commit 2c2fd032668c9779092fa484196a1c35b0ff42c1. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/996?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

