### PR TITLE
Corrigir checkout dos workflows de AI para base atual

### DIFF
--- a/.github/workflows/pr-review-ai.yml
+++ b/.github/workflows/pr-review-ai.yml
@@ -133,7 +133,7 @@ jobs:
            if: steps.pr.outputs.requested == 'true' && steps.pr.outputs.authorized == 'true' && steps.pr.outputs.is_cross_repository != 'true'
            uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
            with:
-              ref: ${{ steps.pr.outputs.base_sha }}
+              ref: ${{ steps.pr.outputs.base_ref }}
               fetch-depth: 0
               persist-credentials: false
 

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -153,7 +153,7 @@ jobs:
            if: steps.pr.outputs.requested == 'true' && steps.pr.outputs.authorized == 'true' && steps.pr.outputs.is_cross_repository != 'true'
            uses: actions/checkout@v6
            with:
-              ref: ${{ steps.pr.outputs.base_sha }}
+              ref: ${{ steps.pr.outputs.base_ref }}
               fetch-depth: 0
               persist-credentials: false
 


### PR DESCRIPTION
## Summary
- Troca checkout de `base_sha` para `base_ref` nos workflows de PR Review e Security Audit
- Evita executar agentes antigos quando a PR está com `baseRefOid` stale após novos merges em `master`
- Mantém checkout da branch base confiável, não do head da PR

## Evidência
- PR #990 ainda aponta `baseRefOid=d37bd99`, antes dos fixes #995/#996
- Run #25 já usa workflow novo, mas faz checkout desse SHA antigo e roda agente antigo com `session.shell(gh ...)`

## Checks
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrige os workflows de PR Review e Security Audit para sempre fazer checkout da base atual da PR, evitando usar um SHA de base desatualizado. O objetivo é garantir que a análise rode contra o estado mais recente da branch base, sem trocar para o head da PR.

- **Bug Fixes**
  - Troca `${{ steps.pr.outputs.base_sha }}` por `${{ steps.pr.outputs.base_ref }}` no `actions/checkout` em `pr-review-ai.yml` e `security-audit.yml`.
  - Evita executar lógica antiga quando a base avança após novos merges (sem usar `baseRefOid` stale).
  - Impacto nas camadas: apenas CI/workflows; nenhuma mudança em router, repositório, componente ou store.

- **Verificação**
  - Abrir uma PR cuja base (ex.: `master`) recebeu merges após a abertura e rodar os workflows.
  - Conferir nos logs do step de checkout que o ref aponta para a branch base atual (ponta de `master`), não para um SHA antigo.
  - Garantir que o head da PR não é checado e que `git diff --check` não acusa problemas.

<sup>Written for commit 9baa41d835565236343fbe26229f24c36c056e43. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/997?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

