### PR TITLE
Limitar contexto enviado aos agentes de AI

### DIFF
--- a/.flue/agents/pr-review.ts
+++ b/.flue/agents/pr-review.ts
@@ -60,6 +60,23 @@ async function readPreparedContext(filePath: string, failureMessage: string) {
    });
 }
 
+function truncateForPrompt(value: string, maxChars: number, label: string) {
+   if (value.length <= maxChars) return value;
+
+   return `${value.slice(0, maxChars)}\n\n[${label} truncado: ${value.length} caracteres totais; exibindo primeiros ${maxChars}. Consulte o artefato completo para validação.]`;
+}
+
+function formatCause(cause: unknown) {
+   if (cause instanceof Error) return cause.stack ?? cause.message;
+   if (typeof cause === "string") return cause;
+
+   try {
+      return JSON.stringify(cause);
+   } catch {
+      return String(cause);
+   }
+}
+
 function parseReviewResult(raw: string) {
    const trimmed = raw.trim();
    const withoutFence = trimmed
@@ -481,6 +498,45 @@ export default async function ({ init, payload, env }: FlueContext) {
       ),
    ]);
 
+   const promptFullDiff = truncateForPrompt(
+      fullDiff.value.stdout,
+      180_000,
+      "Full diff",
+   );
+   const promptGeneralReviews = truncateForPrompt(
+      generalReviews.value.stdout,
+      12_000,
+      "Reviews gerais",
+   );
+   const promptInlineReviewComments = truncateForPrompt(
+      inlineReviewComments.value.stdout,
+      18_000,
+      "Inline review comments",
+   );
+   const promptGeneralPrComments = truncateForPrompt(
+      generalPrComments.value.stdout,
+      18_000,
+      "General PR comments",
+   );
+
+   await writeFile(
+      `${outputDir}/prompt-context-size.json`,
+      JSON.stringify(
+         {
+            fullDiff: fullDiff.value.stdout.length,
+            promptFullDiff: promptFullDiff.length,
+            generalReviews: generalReviews.value.stdout.length,
+            promptGeneralReviews: promptGeneralReviews.length,
+            inlineReviewComments: inlineReviewComments.value.stdout.length,
+            promptInlineReviewComments: promptInlineReviewComments.length,
+            generalPrComments: generalPrComments.value.stdout.length,
+            promptGeneralPrComments: promptGeneralPrComments.length,
+         },
+         null,
+         2,
+      ),
+   );
+
    const context = `
 # Revisão PR #${prNumber}
 
@@ -491,7 +547,7 @@ ${prMetadata.value.stdout}
 ${changedFiles.value.stdout}
 
 ## Full diff
-${fullDiff.value.stdout}
+${promptFullDiff}
 
 ## Commits
 ${commits.value.stdout}
@@ -500,13 +556,13 @@ ${commits.value.stdout}
 ${ciChecks.value.stdout}
 
 ## Reviews gerais
-${generalReviews.value.stdout}
+${promptGeneralReviews}
 
 ## Inline review comments
-${inlineReviewComments.value.stdout}
+${promptInlineReviewComments}
 
 ## General PR comments
-${generalPrComments.value.stdout}
+${promptGeneralPrComments}
 `;
 
    const prompt = `
@@ -607,7 +663,7 @@ Regras para comments:
          ),
       catch: (cause) =>
          new PrReviewAgentError({
-            message: "Falha ao executar prompt de review via Flue.",
+            message: `Falha ao executar prompt de review via Flue: ${formatCause(cause)}`,
             cause,
          }),
    });

--- a/.flue/agents/pr-review.ts
+++ b/.flue/agents/pr-review.ts
@@ -1,6 +1,8 @@
 import type { FlueContext } from "@flue/runtime";
+import { local } from "@flue/runtime/node";
 import { Octokit } from "@octokit/core";
 import { Result, TaggedError } from "better-result";
+import { defineErrorCatalog } from "evlog";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import * as v from "valibot";
 import {
@@ -47,9 +49,54 @@ const reviewResultSchema = v.object({
 
 type ReviewComment = v.InferOutput<typeof reviewCommentSchema>;
 
+const prReviewAgentErrors = defineErrorCatalog("flue.pr-review.agent", {
+   BAD_PAYLOAD: {
+      status: 400,
+      message: "Payload inválido para agente de revisão de PR.",
+      tags: ["flue", "pr-review"],
+   },
+   MISSING_INPUT: {
+      status: 400,
+      message: "Entrada obrigatória ausente para revisão de PR.",
+      tags: ["flue", "pr-review"],
+   },
+   IO_FAILED: {
+      status: 500,
+      message: "Falha de IO no agente de revisão de PR.",
+      tags: ["flue", "pr-review"],
+   },
+   MODEL_FAILED: {
+      status: 500,
+      message: "Falha ao executar modelo de revisão de PR.",
+      tags: ["flue", "pr-review"],
+   },
+   GITHUB_FAILED: {
+      status: 500,
+      message: "Falha ao publicar revisão no GitHub.",
+      tags: ["flue", "pr-review", "github"],
+   },
+});
+
+declare module "evlog" {
+   interface RegisteredErrorCatalogs {
+      "flue.pr-review.agent": typeof prReviewAgentErrors;
+   }
+}
+
+type PrReviewAgentCatalogError =
+   | ReturnType<typeof prReviewAgentErrors.BAD_PAYLOAD>
+   | ReturnType<typeof prReviewAgentErrors.MISSING_INPUT>
+   | ReturnType<typeof prReviewAgentErrors.IO_FAILED>
+   | ReturnType<typeof prReviewAgentErrors.MODEL_FAILED>
+   | ReturnType<typeof prReviewAgentErrors.GITHUB_FAILED>;
+
 class PrReviewAgentError extends TaggedError("PrReviewAgentError")<{
+   error: PrReviewAgentCatalogError;
    message: string;
-   cause?: unknown;
+   repo?: string;
+   prNumber?: number;
+   outputFile?: string;
+   detail?: string;
 }>() {}
 
 function formatInlineComment(comment: ReviewComment) {
@@ -200,7 +247,10 @@ async function publishReview({
    if (!token) {
       return Result.err(
          new PrReviewAgentError({
+            error: prReviewAgentErrors.MISSING_INPUT(),
             message: "GH_TOKEN não configurado no ambiente.",
+            repo,
+            prNumber,
          }),
       );
    }
@@ -234,8 +284,11 @@ async function publishReview({
       },
       catch: (cause) =>
          new PrReviewAgentError({
+            error: prReviewAgentErrors.GITHUB_FAILED(),
             message: "Falha ao publicar review inline no GitHub.",
-            cause,
+            repo,
+            prNumber,
+            detail: formatCause(cause),
          }),
    });
 }
@@ -244,8 +297,9 @@ export default async function ({ init, payload, env }: FlueContext) {
    const parsedPayload = v.safeParse(prPayloadSchema, payload);
    if (!parsedPayload.success) {
       throw new PrReviewAgentError({
+         error: prReviewAgentErrors.BAD_PAYLOAD(),
          message: "Payload inválido para agente de revisão de PR.",
-         cause: parsedPayload.issues,
+         detail: formatCause(parsedPayload.issues),
       });
    }
 
@@ -269,6 +323,7 @@ export default async function ({ init, payload, env }: FlueContext) {
 
    if (!prNumber || prNumber <= 0) {
       throw new PrReviewAgentError({
+         error: prReviewAgentErrors.MISSING_INPUT(),
          message:
             "Informe prNumber positivo no payload ou PR_NUMBER no ambiente.",
       });
@@ -276,8 +331,10 @@ export default async function ({ init, payload, env }: FlueContext) {
 
    if (!repoResult.success) {
       throw new PrReviewAgentError({
+         error: prReviewAgentErrors.BAD_PAYLOAD(),
          message: "repo inválido ou não informado. Use owner/repo.",
-         cause: repoResult.issues,
+         prNumber,
+         detail: formatCause(repoResult.issues),
       });
    }
 
@@ -288,8 +345,10 @@ export default async function ({ init, payload, env }: FlueContext) {
       try: () => mkdir(outputDir, { recursive: true }),
       catch: (cause) =>
          new PrReviewAgentError({
+            error: prReviewAgentErrors.IO_FAILED(),
             message: "Falha ao criar diretório de artefatos da revisão.",
-            cause,
+            outputFile: outputDir,
+            detail: formatCause(cause),
          }),
    });
    if (Result.isError(outputDirResult)) throw outputDirResult.error;
@@ -300,42 +359,34 @@ export default async function ({ init, payload, env }: FlueContext) {
             readPreparedContext(
                `${contextDir}/pr-metadata.json`,
                "Falha ao ler metadados preparados da PR.",
-               (message, cause) => new PrReviewAgentError({ message, cause }),
             ),
             readPreparedContext(
                `${contextDir}/changed-files.md`,
                "Falha ao ler lista preparada de arquivos da PR.",
-               (message, cause) => new PrReviewAgentError({ message, cause }),
             ),
             readPreparedContext(
                `${contextDir}/pr.patch`,
                "Falha ao ler diff preparado da PR.",
-               (message, cause) => new PrReviewAgentError({ message, cause }),
             ),
             readPreparedContext(
                `${contextDir}/commits.md`,
                "Falha ao ler commits preparados da PR.",
-               (message, cause) => new PrReviewAgentError({ message, cause }),
             ),
             readPreparedContext(
                `${contextDir}/checks.json`,
                "Falha ao ler checks preparados da PR.",
-               (message, cause) => new PrReviewAgentError({ message, cause }),
             ),
             readPreparedContext(
                `${contextDir}/reviews.md`,
                "Falha ao ler reviews preparados da PR.",
-               (message, cause) => new PrReviewAgentError({ message, cause }),
             ),
             readPreparedContext(
                `${contextDir}/inline-review-comments.md`,
                "Falha ao ler comentários inline preparados da PR.",
-               (message, cause) => new PrReviewAgentError({ message, cause }),
             ),
             readPreparedContext(
                `${contextDir}/general-pr-comments.md`,
                "Falha ao ler comentários gerais preparados da PR.",
-               (message, cause) => new PrReviewAgentError({ message, cause }),
             ),
             readFile("AGENTS.md", "utf8"),
             readFile(".agents/skills/code-review/SKILL.md", "utf8"),
@@ -354,8 +405,9 @@ export default async function ({ init, payload, env }: FlueContext) {
          ]),
       catch: (cause) =>
          new PrReviewAgentError({
+            error: prReviewAgentErrors.IO_FAILED(),
             message: "Falha ao coletar contexto da PR ou carregar skill.",
-            cause,
+            detail: formatCause(cause),
          }),
    });
    if (Result.isError(contextResult)) throw contextResult.error;
@@ -544,13 +596,16 @@ Regras para comments:
       try: () =>
          init({
             name: "pr-review-model",
-            sandbox: false,
+            sandbox: local({ env: {} }),
             model: process.env.FLUE_MODEL ?? DEFAULT_FLUE_MODEL,
          }),
       catch: (cause) =>
          new PrReviewAgentError({
+            error: prReviewAgentErrors.MODEL_FAILED(),
             message: "Falha ao inicializar Flue para modelo de review.",
-            cause,
+            repo,
+            prNumber,
+            detail: formatCause(cause),
          }),
    });
    if (Result.isError(modelHarnessResult)) throw modelHarnessResult.error;
@@ -559,8 +614,11 @@ Regras para comments:
       try: () => modelHarnessResult.value.session(),
       catch: (cause) =>
          new PrReviewAgentError({
+            error: prReviewAgentErrors.MODEL_FAILED(),
             message: "Falha ao abrir sessão de modelo para review.",
-            cause,
+            repo,
+            prNumber,
+            detail: formatCause(cause),
          }),
    });
    if (Result.isError(modelSessionResult)) throw modelSessionResult.error;
@@ -568,15 +626,23 @@ Regras para comments:
    const outputResult = await Result.tryPromise({
       try: () =>
          Promise.resolve(
-            modelSessionResult.value.prompt(prompt, {
+            modelSessionResult.value.skill("code-review/SKILL.md", {
+               args: {
+                  task: prompt,
+                  repo,
+                  prNumber,
+               },
                thinkingLevel: "off",
                result: reviewResultSchema,
             }),
          ),
       catch: (cause) =>
          new PrReviewAgentError({
-            message: `Falha ao executar prompt de review via Flue: ${formatCause(cause)}`,
-            cause,
+            error: prReviewAgentErrors.MODEL_FAILED(),
+            message: `Falha ao executar skill de review via Flue: ${formatCause(cause)}`,
+            repo,
+            prNumber,
+            detail: formatCause(cause),
          }),
    });
    if (Result.isError(outputResult)) throw outputResult.error;
@@ -602,8 +668,10 @@ Regras para comments:
       try: () => writeFile(outputFile, reviewResult.summary),
       catch: (cause) =>
          new PrReviewAgentError({
+            error: prReviewAgentErrors.IO_FAILED(),
             message: "Falha ao escrever summary.md.",
-            cause,
+            outputFile,
+            detail: formatCause(cause),
          }),
    });
    if (Result.isError(writeResult)) throw writeResult.error;
@@ -629,7 +697,7 @@ Regras para comments:
    if (Result.isError(publishResult)) {
       await writeFile(
          `${outputDir}/publish-error.txt`,
-         String(publishResult.error.cause ?? publishResult.error.message),
+         publishResult.error.detail ?? publishResult.error.message,
       );
 
       const fallbackCommentResult = await publishIssueComment({
@@ -637,8 +705,6 @@ Regras para comments:
          prNumber,
          body: reviewResult.summary,
          token: githubToken,
-         makeError: (message, cause) =>
-            new PrReviewAgentError({ message, cause }),
       });
       if (Result.isError(fallbackCommentResult))
          throw fallbackCommentResult.error;

--- a/.flue/agents/pr-review.ts
+++ b/.flue/agents/pr-review.ts
@@ -3,7 +3,7 @@ import { local } from "@flue/runtime/node";
 import { Octokit } from "@octokit/core";
 import { Result, TaggedError } from "better-result";
 import { defineErrorCatalog } from "evlog";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import * as v from "valibot";
 import {
    formatCause,
@@ -388,20 +388,6 @@ export default async function ({ init, payload, env }: FlueContext) {
                `${contextDir}/general-pr-comments.md`,
                "Falha ao ler comentários gerais preparados da PR.",
             ),
-            readFile("AGENTS.md", "utf8"),
-            readFile(".agents/skills/code-review/SKILL.md", "utf8"),
-            readFile(
-               ".agents/skills/code-review/references/pr-review.md",
-               "utf8",
-            ),
-            readFile(
-               ".agents/skills/code-review/references/review-comments.md",
-               "utf8",
-            ),
-            readFile(
-               ".agents/skills/code-review/references/tests-validation.md",
-               "utf8",
-            ),
          ]),
       catch: (cause) =>
          new PrReviewAgentError({
@@ -421,11 +407,6 @@ export default async function ({ init, payload, env }: FlueContext) {
       generalReviews,
       inlineReviewComments,
       generalPrComments,
-      agentInstructions,
-      skillInstruction,
-      automatedReviewReference,
-      reviewCommentsReference,
-      testsValidationReference,
    ] = contextResult.value;
 
    const commandResults = [
@@ -479,123 +460,31 @@ export default async function ({ init, payload, env }: FlueContext) {
       "General PR comments",
    );
 
+   const promptContextSize = {
+      fullDiff: fullDiff.value.stdout.length,
+      promptFullDiff: promptFullDiff.length,
+      generalReviews: generalReviews.value.stdout.length,
+      promptGeneralReviews: promptGeneralReviews.length,
+      inlineReviewComments: inlineReviewComments.value.stdout.length,
+      promptInlineReviewComments: promptInlineReviewComments.length,
+      generalPrComments: generalPrComments.value.stdout.length,
+      promptGeneralPrComments: promptGeneralPrComments.length,
+   };
+
    await writeFile(
       `${outputDir}/prompt-context-size.json`,
-      JSON.stringify(
-         {
-            fullDiff: fullDiff.value.stdout.length,
-            promptFullDiff: promptFullDiff.length,
-            generalReviews: generalReviews.value.stdout.length,
-            promptGeneralReviews: promptGeneralReviews.length,
-            inlineReviewComments: inlineReviewComments.value.stdout.length,
-            promptInlineReviewComments: promptInlineReviewComments.length,
-            generalPrComments: generalPrComments.value.stdout.length,
-            promptGeneralPrComments: promptGeneralPrComments.length,
-         },
-         null,
-         2,
-      ),
+      JSON.stringify(promptContextSize, null, 2),
    );
 
-   const context = `
-# Revisão PR #${prNumber}
-
-## PR metadata
-${prMetadata.value.stdout}
-
-## Changed files (metric)
-${changedFiles.value.stdout}
-
-## Full diff
-${promptFullDiff}
-
-## Commits
-${commits.value.stdout}
-
-## CI checks
-${ciChecks.value.stdout}
-
-## Reviews gerais
-${promptGeneralReviews}
-
-## Inline review comments
-${promptInlineReviewComments}
-
-## General PR comments
-${promptGeneralPrComments}
-`;
-
-   const prompt = `
-Você é o agente automático de code review do Montte.
-Siga obrigatoriamente o AGENTS.md, o SKILL.md e as references carregadas abaixo.
-O SKILL.md é apenas o organizador; as references guiam o padrão de execução.
-
-AGENTS.md:
-${agentInstructions}
-
-SKILL.md de code review:
-${skillInstruction}
-
-Reference: pr-review
-${automatedReviewReference}
-
-Reference: review-comments
-${reviewCommentsReference}
-
-Reference: tests-validation
-${testsValidationReference}
-
-Contexto:
-${context}
-
-Tarefa:
-- não use ferramentas/read/bash; o repositório não está disponível no sandbox, use apenas o contexto fornecido neste prompt;
-- revise a PR com foco em bugs reais, regressões, contratos quebrados, segurança, dados incorretos e CI/testes;
-- verifique stale/duplicado contra comentários anteriores;
-- não faça nits cobertos por formatter/linter;
-- não invente fatos fora do contexto;
-- se não houver achados acionáveis, diga isso claramente.
-
-Restrição obrigatória:
-- cada comentário inline deve apontar para path e line exatos do diff;
-- use side "RIGHT" para linha adicionada ou contexto no arquivo novo;
-- use side "LEFT" apenas para linha removida no arquivo antigo;
-- não comente arquivo/linha fora do patch.
-
-Retorne JSON válido, sem markdown fences, neste formato:
-{
-  "summary": "Resumo curto do risco, CI/testes relevantes e validação recomendada.",
-  "comments": [
-    {
-      "path": "arquivo alterado",
-      "line": 123,
-      "side": "RIGHT",
-      "severity": "critical|major|minor|trivial|info",
-      "confidence": 0.82,
-      "actionable": true,
-      "suggestion": "Correção pequena opcional, ou omita o campo",
-      "reproSteps": "Passos de reprodução opcionais, ou omita o campo",
-      "title": "Título curto do achado",
-      "body": "Explique por que isso está errado, impacto concreto e correção pequena em pt-BR."
-    }
-  ]
-}
-
-Regras para comments:
-- cada comentário precisa estar em arquivo/linha do diff;
-- cada comentário precisa explicar por que está errado;
-- incluir severidade correta;
-- não limite artificialmente a quantidade de comentários; aplique apenas os gates de qualidade;
-- não inclua comentários trivial ou info;
-- cada comentário precisa ter confidence >= 0.7;
-- cada comentário precisa ter sugestão concreta, passos de reprodução ou actionable: true;
-- se não houver achados acionáveis, retorne "comments": [].
-`.trim();
+   const task = `Revise a PR #${prNumber} usando a skill de code review do Montte. Use apenas o contexto pré-coletado em args. Não rode comandos nem colete dados pelo GitHub. Retorne comentários inline somente para linhas existentes no patch, com severidade, confiança >= 0.7 e correção concreta.`;
 
    const modelHarnessResult = await Result.tryPromise({
       try: () =>
          init({
             name: "pr-review-model",
+            // local() lets Flue discover AGENTS.md and .agents/skills from cwd.
+            // GitHub writes stay on the host through Octokit; tokens are not
+            // exposed to the sandbox env and we do not collect context with gh.
             sandbox: local({ env: {} }),
             model: process.env.FLUE_MODEL ?? DEFAULT_FLUE_MODEL,
          }),
@@ -626,11 +515,20 @@ Regras para comments:
    const outputResult = await Result.tryPromise({
       try: () =>
          Promise.resolve(
-            modelSessionResult.value.skill("code-review/SKILL.md", {
+            modelSessionResult.value.skill("code-review", {
                args: {
-                  task: prompt,
+                  task,
                   repo,
                   prNumber,
+                  prMetadata: prMetadata.value.stdout,
+                  changedFiles: changedFiles.value.stdout,
+                  patch: promptFullDiff,
+                  commits: commits.value.stdout,
+                  checks: ciChecks.value.stdout,
+                  reviews: promptGeneralReviews,
+                  inlineReviewComments: promptInlineReviewComments,
+                  generalPrComments: promptGeneralPrComments,
+                  promptContextSize,
                },
                thinkingLevel: "off",
                result: reviewResultSchema,

--- a/.flue/agents/pr-review.ts
+++ b/.flue/agents/pr-review.ts
@@ -2,111 +2,57 @@ import type { FlueContext } from "@flue/runtime";
 import { Octokit } from "@octokit/core";
 import { Result, TaggedError } from "better-result";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { z } from "zod";
+import * as v from "valibot";
+import {
+   formatCause,
+   publishIssueComment,
+   readPreparedContext,
+   resolveGithubToken,
+   safePathSchema,
+   safeRepoSchema,
+   truncateForPrompt,
+} from "../lib/agent-utils.ts";
 import { DEFAULT_FLUE_MODEL } from "../lib/model.ts";
 
 export const triggers = {};
 
-const safeRepoSchema = z.string().regex(/^[\w.-]+\/[\w.-]+$/u);
-const safeOutputDirSchema = z
-   .string()
-   .regex(/^(?:\.\/[\w./-]+|\.[\w./-]*|[\w][\w./-]*)$/u)
-   .refine((value) => !value.split("/").includes(".."), {
-      message: "outputDir não pode conter segmentos '..'.",
-   });
-
-const prPayloadSchema = z.object({
-   prNumber: z.number().int().nonnegative().optional(),
-   repo: safeRepoSchema.optional(),
-   outputDir: safeOutputDirSchema.default(".agent-artifacts/pr-review"),
-   contextDir: safeOutputDirSchema.default(".agent-artifacts/pr-review/input"),
+const prPayloadSchema = v.object({
+   prNumber: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0))),
+   repo: v.optional(safeRepoSchema),
+   outputDir: v.optional(safePathSchema, ".agent-artifacts/pr-review"),
+   contextDir: v.optional(safePathSchema, ".agent-artifacts/pr-review/input"),
+   dryRun: v.optional(v.boolean(), false),
 });
 
-const reviewCommentSchema = z.object({
-   path: z.string().min(1),
-   line: z.number().int().positive(),
-   side: z.enum(["RIGHT", "LEFT"]).default("RIGHT"),
-   severity: z.enum(["critical", "major", "minor", "trivial", "info"]),
-   confidence: z.number().min(0).max(1).default(0.7),
-   actionable: z.boolean().default(false),
-   suggestion: z.string().min(1).optional(),
-   reproSteps: z.string().min(1).optional(),
-   title: z.string().min(1),
-   body: z.string().min(1),
+const reviewCommentSchema = v.object({
+   path: v.pipe(v.string(), v.minLength(1)),
+   line: v.pipe(v.number(), v.integer(), v.minValue(1)),
+   side: v.optional(v.picklist(["RIGHT", "LEFT"]), "RIGHT"),
+   severity: v.picklist(["critical", "major", "minor", "trivial", "info"]),
+   confidence: v.optional(
+      v.pipe(v.number(), v.minValue(0), v.maxValue(1)),
+      0.7,
+   ),
+   actionable: v.optional(v.boolean(), false),
+   suggestion: v.optional(v.pipe(v.string(), v.minLength(1))),
+   reproSteps: v.optional(v.pipe(v.string(), v.minLength(1))),
+   title: v.pipe(v.string(), v.minLength(1)),
+   body: v.pipe(v.string(), v.minLength(1)),
 });
 
-const reviewResultSchema = z.object({
-   summary: z.string().min(1),
-   comments: z.array(reviewCommentSchema).default([]),
+const reviewResultSchema = v.object({
+   summary: v.pipe(v.string(), v.minLength(1)),
+   comments: v.optional(v.array(reviewCommentSchema), []),
 });
+
+type ReviewComment = v.InferOutput<typeof reviewCommentSchema>;
 
 class PrReviewAgentError extends TaggedError("PrReviewAgentError")<{
    message: string;
    cause?: unknown;
 }>() {}
 
-async function readPreparedContext(filePath: string, failureMessage: string) {
-   return Result.tryPromise({
-      try: async () => ({
-         stdout: await readFile(filePath, "utf8"),
-         stderr: "",
-         exitCode: 0,
-      }),
-      catch: (cause) =>
-         new PrReviewAgentError({
-            message: failureMessage,
-            cause,
-         }),
-   });
-}
-
-function truncateForPrompt(value: string, maxChars: number, label: string) {
-   if (value.length <= maxChars) return value;
-
-   return `${value.slice(0, maxChars)}\n\n[${label} truncado: ${value.length} caracteres totais; exibindo primeiros ${maxChars}. Consulte o artefato completo para validação.]`;
-}
-
-function formatCause(cause: unknown) {
-   if (cause instanceof Error) return cause.stack ?? cause.message;
-   if (typeof cause === "string") return cause;
-
-   try {
-      return JSON.stringify(cause);
-   } catch {
-      return String(cause);
-   }
-}
-
-function parseReviewResult(raw: string) {
-   const trimmed = raw.trim();
-   const withoutFence = trimmed
-      .replace(/^```(?:json)?\s*/u, "")
-      .replace(/\s*```$/u, "");
-
-   const jsonResult = Result.try({
-      try: () => JSON.parse(withoutFence),
-      catch: (cause) =>
-         new PrReviewAgentError({
-            message: "Resposta do review agent não é JSON válido.",
-            cause,
-         }),
-   });
-   if (Result.isError(jsonResult)) return Result.err(jsonResult.error);
-
-   const parsed = reviewResultSchema.safeParse(jsonResult.value);
-   if (!parsed.success) {
-      return Result.err(
-         new PrReviewAgentError({
-            message: "Resposta do review agent não segue o schema esperado.",
-            cause: parsed.error,
-         }),
-      );
-   }
-
-   return Result.ok(parsed.data);
-}
-
-function formatInlineComment(comment: z.infer<typeof reviewCommentSchema>) {
+function formatInlineComment(comment: ReviewComment) {
    return `**Severidade:** ${comment.severity}
 
 **${comment.title}**
@@ -169,7 +115,7 @@ function parseDiffReviewLines(patch: string) {
    return allowed;
 }
 
-function hasActionableContent(comment: z.infer<typeof reviewCommentSchema>) {
+function hasActionableContent(comment: ReviewComment) {
    if (comment.actionable || comment.suggestion || comment.reproSteps)
       return true;
 
@@ -179,14 +125,12 @@ function hasActionableContent(comment: z.infer<typeof reviewCommentSchema>) {
 }
 
 function splitValidInlineComments(
-   comments: Array<z.infer<typeof reviewCommentSchema>>,
+   comments: Array<ReviewComment>,
    patch: string,
 ) {
    const allowed = parseDiffReviewLines(patch);
-   const valid: Array<z.infer<typeof reviewCommentSchema>> = [];
-   const skipped: Array<
-      z.infer<typeof reviewCommentSchema> & { reason: string }
-   > = [];
+   const valid: Array<ReviewComment> = [];
+   const skipped: Array<ReviewComment & { reason: string }> = [];
 
    for (const comment of comments) {
       if (comment.severity === "trivial" || comment.severity === "info") {
@@ -240,47 +184,6 @@ function splitValidInlineComments(
    return { valid, skipped };
 }
 
-async function publishIssueComment({
-   repo,
-   prNumber,
-   body,
-   token,
-}: {
-   repo: string;
-   prNumber: number;
-   body: string;
-   token: string | undefined;
-}) {
-   if (!token) {
-      return Result.err(
-         new PrReviewAgentError({
-            message: "GH_TOKEN não configurado no ambiente.",
-         }),
-      );
-   }
-
-   const [owner, repoName] = repo.split("/");
-   const octokit = new Octokit({ auth: token });
-   return Result.tryPromise({
-      try: async () => {
-         await octokit.request(
-            "POST /repos/{owner}/{repo}/issues/{num}/comments",
-            {
-               owner,
-               repo: repoName,
-               num: prNumber,
-               body,
-            },
-         );
-      },
-      catch: (cause) =>
-         new PrReviewAgentError({
-            message: "Falha ao publicar comentário no GitHub.",
-            cause,
-         }),
-   });
-}
-
 async function publishReview({
    repo,
    prNumber,
@@ -291,7 +194,7 @@ async function publishReview({
    repo: string;
    prNumber: number;
    body: string;
-   comments: Array<z.infer<typeof reviewCommentSchema>>;
+   comments: Array<ReviewComment>;
    token: string | undefined;
 }) {
    if (!token) {
@@ -338,11 +241,11 @@ async function publishReview({
 }
 
 export default async function ({ init, payload, env }: FlueContext) {
-   const parsedPayload = prPayloadSchema.safeParse(payload);
+   const parsedPayload = v.safeParse(prPayloadSchema, payload);
    if (!parsedPayload.success) {
       throw new PrReviewAgentError({
          message: "Payload inválido para agente de revisão de PR.",
-         cause: parsedPayload.error,
+         cause: parsedPayload.issues,
       });
    }
 
@@ -351,15 +254,16 @@ export default async function ({ init, payload, env }: FlueContext) {
       repo: payloadRepo,
       outputDir,
       contextDir,
-   } = parsedPayload.data;
-   const envPrNumber = z.coerce
-      .number()
-      .int()
-      .positive()
-      .safeParse(env.PR_NUMBER);
+      dryRun,
+   } = parsedPayload.output;
+   const envPrNumber = Number(env.PR_NUMBER);
    const prNumber =
-      payloadPrNumber ?? (envPrNumber.success ? envPrNumber.data : undefined);
-   const repoResult = safeRepoSchema.safeParse(
+      payloadPrNumber ??
+      (Number.isInteger(envPrNumber) && envPrNumber > 0
+         ? envPrNumber
+         : undefined);
+   const repoResult = v.safeParse(
+      safeRepoSchema,
       payloadRepo ?? env.GITHUB_REPOSITORY,
    );
 
@@ -373,16 +277,12 @@ export default async function ({ init, payload, env }: FlueContext) {
    if (!repoResult.success) {
       throw new PrReviewAgentError({
          message: "repo inválido ou não informado. Use owner/repo.",
-         cause: repoResult.error,
+         cause: repoResult.issues,
       });
    }
 
-   const repo = repoResult.data;
-   const githubToken =
-      env.GH_TOKEN ??
-      env.GITHUB_TOKEN ??
-      process.env.GH_TOKEN ??
-      process.env.GITHUB_TOKEN;
+   const repo = repoResult.output;
+   const githubToken = resolveGithubToken(env);
 
    const outputDirResult = await Result.tryPromise({
       try: () => mkdir(outputDir, { recursive: true }),
@@ -400,34 +300,42 @@ export default async function ({ init, payload, env }: FlueContext) {
             readPreparedContext(
                `${contextDir}/pr-metadata.json`,
                "Falha ao ler metadados preparados da PR.",
+               (message, cause) => new PrReviewAgentError({ message, cause }),
             ),
             readPreparedContext(
                `${contextDir}/changed-files.md`,
                "Falha ao ler lista preparada de arquivos da PR.",
+               (message, cause) => new PrReviewAgentError({ message, cause }),
             ),
             readPreparedContext(
                `${contextDir}/pr.patch`,
                "Falha ao ler diff preparado da PR.",
+               (message, cause) => new PrReviewAgentError({ message, cause }),
             ),
             readPreparedContext(
                `${contextDir}/commits.md`,
                "Falha ao ler commits preparados da PR.",
+               (message, cause) => new PrReviewAgentError({ message, cause }),
             ),
             readPreparedContext(
                `${contextDir}/checks.json`,
                "Falha ao ler checks preparados da PR.",
+               (message, cause) => new PrReviewAgentError({ message, cause }),
             ),
             readPreparedContext(
                `${contextDir}/reviews.md`,
                "Falha ao ler reviews preparados da PR.",
+               (message, cause) => new PrReviewAgentError({ message, cause }),
             ),
             readPreparedContext(
                `${contextDir}/inline-review-comments.md`,
                "Falha ao ler comentários inline preparados da PR.",
+               (message, cause) => new PrReviewAgentError({ message, cause }),
             ),
             readPreparedContext(
                `${contextDir}/general-pr-comments.md`,
                "Falha ao ler comentários gerais preparados da PR.",
+               (message, cause) => new PrReviewAgentError({ message, cause }),
             ),
             readFile("AGENTS.md", "utf8"),
             readFile(".agents/skills/code-review/SKILL.md", "utf8"),
@@ -589,6 +497,7 @@ Contexto:
 ${context}
 
 Tarefa:
+- não use ferramentas/read/bash; o repositório não está disponível no sandbox, use apenas o contexto fornecido neste prompt;
 - revise a PR com foco em bugs reais, regressões, contratos quebrados, segurança, dados incorretos e CI/testes;
 - verifique stale/duplicado contra comentários anteriores;
 - não faça nits cobertos por formatter/linter;
@@ -659,7 +568,10 @@ Regras para comments:
    const outputResult = await Result.tryPromise({
       try: () =>
          Promise.resolve(
-            modelSessionResult.value.prompt(prompt, { thinkingLevel: "off" }),
+            modelSessionResult.value.prompt(prompt, {
+               thinkingLevel: "off",
+               result: reviewResultSchema,
+            }),
          ),
       catch: (cause) =>
          new PrReviewAgentError({
@@ -669,11 +581,10 @@ Regras para comments:
    });
    if (Result.isError(outputResult)) throw outputResult.error;
 
-   const reviewResult = parseReviewResult(outputResult.value.text);
-   if (Result.isError(reviewResult)) throw reviewResult.error;
+   const reviewResult = outputResult.value.data;
 
    const inlineComments = splitValidInlineComments(
-      reviewResult.value.comments,
+      reviewResult.comments,
       fullDiff.value.stdout,
    );
 
@@ -688,7 +599,7 @@ Regras para comments:
 
    const outputFile = `${outputDir}/summary.md`;
    const writeResult = await Result.tryPromise({
-      try: () => writeFile(outputFile, reviewResult.value.summary),
+      try: () => writeFile(outputFile, reviewResult.summary),
       catch: (cause) =>
          new PrReviewAgentError({
             message: "Falha ao escrever summary.md.",
@@ -697,10 +608,20 @@ Regras para comments:
    });
    if (Result.isError(writeResult)) throw writeResult.error;
 
+   if (dryRun) {
+      return {
+         outputFile,
+         prNumber,
+         inlineComments: inlineComments.valid.length,
+         skippedInlineComments: inlineComments.skipped.length,
+         dryRun,
+      };
+   }
+
    const publishResult = await publishReview({
       repo,
       prNumber,
-      body: reviewResult.value.summary,
+      body: reviewResult.summary,
       comments: inlineComments.valid,
       token: githubToken,
    });
@@ -714,8 +635,10 @@ Regras para comments:
       const fallbackCommentResult = await publishIssueComment({
          repo,
          prNumber,
-         body: reviewResult.value.summary,
+         body: reviewResult.summary,
          token: githubToken,
+         makeError: (message, cause) =>
+            new PrReviewAgentError({ message, cause }),
       });
       if (Result.isError(fallbackCommentResult))
          throw fallbackCommentResult.error;
@@ -726,5 +649,6 @@ Regras para comments:
       prNumber,
       inlineComments: inlineComments.valid.length,
       skippedInlineComments: inlineComments.skipped.length,
+      dryRun,
    };
 }

--- a/.flue/agents/release-notes.ts
+++ b/.flue/agents/release-notes.ts
@@ -1,7 +1,10 @@
 import type { FlueContext } from "@flue/runtime";
+import { local } from "@flue/runtime/node";
 import { Result, TaggedError } from "better-result";
+import { defineErrorCatalog } from "evlog";
 import { readFile, writeFile } from "node:fs/promises";
 import * as v from "valibot";
+import { formatCause } from "../lib/agent-utils.ts";
 import { DEFAULT_FLUE_MODEL } from "../lib/model.ts";
 
 export const triggers = {};
@@ -32,9 +35,47 @@ const releaseNotesValidationSchema = v.object({
    warnings: v.array(v.string()),
 });
 
+const releaseNotesAgentErrors = defineErrorCatalog("flue.release-notes.agent", {
+   BAD_PAYLOAD: {
+      status: 400,
+      message: "Payload inválido para agente de release notes.",
+      tags: ["flue", "release-notes"],
+   },
+   IO_FAILED: {
+      status: 500,
+      message: "Falha de IO no agente de release notes.",
+      tags: ["flue", "release-notes"],
+   },
+   MODEL_FAILED: {
+      status: 500,
+      message: "Falha ao executar modelo de release notes.",
+      tags: ["flue", "release-notes"],
+   },
+   VALIDATION_FAILED: {
+      status: 422,
+      message: "Release notes falharam na validação estruturada.",
+      tags: ["flue", "release-notes"],
+   },
+});
+
+declare module "evlog" {
+   interface RegisteredErrorCatalogs {
+      "flue.release-notes.agent": typeof releaseNotesAgentErrors;
+   }
+}
+
+type ReleaseNotesAgentCatalogError =
+   | ReturnType<typeof releaseNotesAgentErrors.BAD_PAYLOAD>
+   | ReturnType<typeof releaseNotesAgentErrors.IO_FAILED>
+   | ReturnType<typeof releaseNotesAgentErrors.MODEL_FAILED>
+   | ReturnType<typeof releaseNotesAgentErrors.VALIDATION_FAILED>;
+
 class ReleaseNotesAgentError extends TaggedError("ReleaseNotesAgentError")<{
+   error: ReleaseNotesAgentCatalogError;
    message: string;
-   cause?: unknown;
+   releaseVersion?: string;
+   outputFile?: string;
+   detail?: string;
 }>() {}
 
 function validateReleaseNotes(markdown: string) {
@@ -69,8 +110,9 @@ export default async function ({ init, payload }: FlueContext) {
    const parsedPayload = v.safeParse(releasePayloadSchema, payload);
    if (!parsedPayload.success) {
       throw new ReleaseNotesAgentError({
+         error: releaseNotesAgentErrors.BAD_PAYLOAD(),
          message: "Payload inválido para agente de release notes.",
-         cause: parsedPayload.issues,
+         detail: formatCause(parsedPayload.issues),
       });
    }
 
@@ -88,13 +130,15 @@ export default async function ({ init, payload }: FlueContext) {
    const initResult = await Result.tryPromise({
       try: () =>
          init({
-            sandbox: false,
+            sandbox: local({ env: {} }),
             model: process.env.FLUE_MODEL ?? DEFAULT_FLUE_MODEL,
          }),
       catch: (cause) =>
          new ReleaseNotesAgentError({
+            error: releaseNotesAgentErrors.MODEL_FAILED(),
             message: "Falha ao inicializar Flue para release notes.",
-            cause,
+            releaseVersion,
+            detail: formatCause(cause),
          }),
    });
    if (Result.isError(initResult)) throw initResult.error;
@@ -111,9 +155,11 @@ export default async function ({ init, payload }: FlueContext) {
          ]),
       catch: (cause) =>
          new ReleaseNotesAgentError({
+            error: releaseNotesAgentErrors.IO_FAILED(),
             message:
                "Falha ao carregar AGENTS.md, skill ou referências de release.",
-            cause,
+            releaseVersion,
+            detail: formatCause(cause),
          }),
    });
    if (Result.isError(filesResult)) throw filesResult.error;
@@ -162,8 +208,10 @@ Retorne somente o Markdown do corpo da release, sem fences e sem explicações e
       try: () => harness.session(),
       catch: (cause) =>
          new ReleaseNotesAgentError({
+            error: releaseNotesAgentErrors.MODEL_FAILED(),
             message: "Falha ao abrir sessão Flue para release notes.",
-            cause,
+            releaseVersion,
+            detail: formatCause(cause),
          }),
    });
    if (Result.isError(sessionResult)) throw sessionResult.error;
@@ -175,8 +223,10 @@ Retorne somente o Markdown do corpo da release, sem fences e sem explicações e
          ),
       catch: (cause) =>
          new ReleaseNotesAgentError({
+            error: releaseNotesAgentErrors.MODEL_FAILED(),
             message: "Falha ao executar prompt de release notes via Flue.",
-            cause,
+            releaseVersion,
+            detail: formatCause(cause),
          }),
    });
    if (Result.isError(outputResult)) throw outputResult.error;
@@ -187,8 +237,11 @@ Retorne somente o Markdown do corpo da release, sem fences e sem explicações e
       try: () => writeFile(outputFile, markdown),
       catch: (cause) =>
          new ReleaseNotesAgentError({
+            error: releaseNotesAgentErrors.IO_FAILED(),
             message: "Falha ao escrever RELEASE_NOTES.md.",
-            cause,
+            releaseVersion,
+            outputFile,
+            detail: formatCause(cause),
          }),
    });
    if (Result.isError(writeResult)) throw writeResult.error;
@@ -201,16 +254,22 @@ Retorne somente o Markdown do corpo da release, sem fences e sem explicações e
       try: () => writeFile(validationFile, JSON.stringify(validation, null, 2)),
       catch: (cause) =>
          new ReleaseNotesAgentError({
+            error: releaseNotesAgentErrors.IO_FAILED(),
             message: "Falha ao escrever artefato de validação da release.",
-            cause,
+            releaseVersion,
+            outputFile: validationFile,
+            detail: formatCause(cause),
          }),
    });
    if (Result.isError(validationWriteResult)) throw validationWriteResult.error;
 
    if (!validation.valid) {
       throw new ReleaseNotesAgentError({
+         error: releaseNotesAgentErrors.VALIDATION_FAILED(),
          message: "Release notes falharam na validação estruturada.",
-         cause: validation.errors,
+         releaseVersion,
+         outputFile,
+         detail: validation.errors.join("\n"),
       });
    }
 

--- a/.flue/agents/release-notes.ts
+++ b/.flue/agents/release-notes.ts
@@ -1,32 +1,35 @@
 import type { FlueContext } from "@flue/runtime";
 import { Result, TaggedError } from "better-result";
 import { readFile, writeFile } from "node:fs/promises";
-import { z } from "zod";
+import * as v from "valibot";
 import { DEFAULT_FLUE_MODEL } from "../lib/model.ts";
 
 export const triggers = {};
 
-const releasePayloadSchema = z.object({
-   releaseVersion: z.string(),
-   changesFile: z.string().default("changes.md"),
-   skillFile: z.string().default(".agents/skills/release/SKILL.md"),
-   releaseNotesReference: z
-      .string()
-      .default(".agents/skills/release/references/release-notes.md"),
-   automatedReleaseNotesReference: z
-      .string()
-      .default(".agents/skills/release/references/automated-release-notes.md"),
-   validationReference: z
-      .string()
-      .default(".agents/skills/release/references/release-validation.md"),
-   outputFile: z.string().default("RELEASE_NOTES.md"),
-   validationFile: z.string().default("validation.json"),
+const releasePayloadSchema = v.object({
+   releaseVersion: v.pipe(v.string(), v.minLength(1)),
+   changesFile: v.optional(v.string(), "changes.md"),
+   skillFile: v.optional(v.string(), ".agents/skills/release/SKILL.md"),
+   releaseNotesReference: v.optional(
+      v.string(),
+      ".agents/skills/release/references/release-notes.md",
+   ),
+   automatedReleaseNotesReference: v.optional(
+      v.string(),
+      ".agents/skills/release/references/automated-release-notes.md",
+   ),
+   validationReference: v.optional(
+      v.string(),
+      ".agents/skills/release/references/release-validation.md",
+   ),
+   outputFile: v.optional(v.string(), "RELEASE_NOTES.md"),
+   validationFile: v.optional(v.string(), "validation.json"),
 });
 
-const releaseNotesValidationSchema = z.object({
-   valid: z.boolean(),
-   errors: z.array(z.string()),
-   warnings: z.array(z.string()),
+const releaseNotesValidationSchema = v.object({
+   valid: v.boolean(),
+   errors: v.array(v.string()),
+   warnings: v.array(v.string()),
 });
 
 class ReleaseNotesAgentError extends TaggedError("ReleaseNotesAgentError")<{
@@ -63,11 +66,11 @@ function validateReleaseNotes(markdown: string) {
 }
 
 export default async function ({ init, payload }: FlueContext) {
-   const parsedPayload = releasePayloadSchema.safeParse(payload);
+   const parsedPayload = v.safeParse(releasePayloadSchema, payload);
    if (!parsedPayload.success) {
       throw new ReleaseNotesAgentError({
          message: "Payload inválido para agente de release notes.",
-         cause: parsedPayload.error,
+         cause: parsedPayload.issues,
       });
    }
 
@@ -80,7 +83,7 @@ export default async function ({ init, payload }: FlueContext) {
       validationReference,
       outputFile,
       validationFile,
-   } = parsedPayload.data;
+   } = parsedPayload.output;
 
    const initResult = await Result.tryPromise({
       try: () =>
@@ -190,7 +193,8 @@ Retorne somente o Markdown do corpo da release, sem fences e sem explicações e
    });
    if (Result.isError(writeResult)) throw writeResult.error;
 
-   const validation = releaseNotesValidationSchema.parse(
+   const validation = v.parse(
+      releaseNotesValidationSchema,
       validateReleaseNotes(markdown),
    );
    const validationWriteResult = await Result.tryPromise({

--- a/.flue/agents/release-notes.ts
+++ b/.flue/agents/release-notes.ts
@@ -116,20 +116,14 @@ export default async function ({ init, payload }: FlueContext) {
       });
    }
 
-   const {
-      releaseVersion,
-      changesFile,
-      skillFile,
-      releaseNotesReference,
-      automatedReleaseNotesReference,
-      validationReference,
-      outputFile,
-      validationFile,
-   } = parsedPayload.output;
+   const { releaseVersion, changesFile, outputFile, validationFile } =
+      parsedPayload.output;
 
    const initResult = await Result.tryPromise({
       try: () =>
          init({
+            // local() lets Flue discover AGENTS.md and .agents/skills from cwd.
+            // GitHub tokens are intentionally not exposed to the sandbox env.
             sandbox: local({ env: {} }),
             model: process.env.FLUE_MODEL ?? DEFAULT_FLUE_MODEL,
          }),
@@ -144,64 +138,20 @@ export default async function ({ init, payload }: FlueContext) {
    if (Result.isError(initResult)) throw initResult.error;
 
    const filesResult = await Result.tryPromise({
-      try: () =>
-         Promise.all([
-            readFile("AGENTS.md", "utf8"),
-            readFile(changesFile, "utf8"),
-            readFile(skillFile, "utf8"),
-            readFile(releaseNotesReference, "utf8"),
-            readFile(automatedReleaseNotesReference, "utf8"),
-            readFile(validationReference, "utf8"),
-         ]),
+      try: () => readFile(changesFile, "utf8"),
       catch: (cause) =>
          new ReleaseNotesAgentError({
             error: releaseNotesAgentErrors.IO_FAILED(),
-            message:
-               "Falha ao carregar AGENTS.md, skill ou referências de release.",
+            message: "Falha ao carregar arquivo de mudanças da release.",
             releaseVersion,
             detail: formatCause(cause),
          }),
    });
    if (Result.isError(filesResult)) throw filesResult.error;
 
-   const [
-      agentInstructions,
-      changes,
-      skillInstruction,
-      notesReference,
-      automatedReleaseNotesReferenceContent,
-      validationReferenceContent,
-   ] = filesResult.value;
+   const changes = filesResult.value;
 
-   const prompt = `
-Você está rodando dentro de um agente Flue no repositório Montte.
-Siga obrigatoriamente o AGENTS.md e a skill carregada abaixo.
-
-AGENTS.md:
-${agentInstructions}
-
-Skill de release:
-${skillInstruction}
-
-Leia também estes arquivos de referência:
-
-## Estrutura da release notes
-${notesReference}
-
-## Automação de release notes
-${automatedReleaseNotesReferenceContent}
-
-## Diretrizes de validação
-${validationReferenceContent}
-
-Agora gere as release notes da versão ${releaseVersion} em Markdown (sem inventar links, números ou funcionalidades).
-
-Arquivo de mudanças:
-${changes}
-
-Saida deve ser escrita em pt-BR e obedecer à estrutura esperada pelo arquivo de referência de release notes.
-Retorne somente o Markdown do corpo da release, sem fences e sem explicações externas.
-`.trim();
+   const task = `Gere as release notes da versão ${releaseVersion} em Markdown, em pt-BR, sem inventar links, números ou funcionalidades. Use a skill de release e suas referências como fonte de verdade. Retorne somente o Markdown do corpo da release, sem fences e sem explicações externas.`;
 
    const harness = initResult.value;
    const sessionResult = await Result.tryPromise({
@@ -219,7 +169,10 @@ Retorne somente o Markdown do corpo da release, sem fences e sem explicações e
    const outputResult = await Result.tryPromise({
       try: () =>
          Promise.resolve(
-            sessionResult.value.prompt(prompt, { thinkingLevel: "off" }),
+            sessionResult.value.skill("release", {
+               args: { task, releaseVersion, changes },
+               thinkingLevel: "off",
+            }),
          ),
       catch: (cause) =>
          new ReleaseNotesAgentError({

--- a/.flue/agents/security-audit.ts
+++ b/.flue/agents/security-audit.ts
@@ -73,6 +73,23 @@ async function readPreparedContext(filePath: string, failureMessage: string) {
    });
 }
 
+function truncateForPrompt(value: string, maxChars: number, label: string) {
+   if (value.length <= maxChars) return value;
+
+   return `${value.slice(0, maxChars)}\n\n[${label} truncado: ${value.length} caracteres totais; exibindo primeiros ${maxChars}. Consulte o artefato completo para validação.]`;
+}
+
+function formatCause(cause: unknown) {
+   if (cause instanceof Error) return cause.stack ?? cause.message;
+   if (typeof cause === "string") return cause;
+
+   try {
+      return JSON.stringify(cause);
+   } catch {
+      return String(cause);
+   }
+}
+
 async function publishIssueComment({
    repo,
    prNumber,
@@ -333,6 +350,24 @@ export default async function ({ init, payload, env }: FlueContext) {
       writeFile(`${outputDir}/checks.json`, ciChecks.value.stdout),
    ]);
 
+   const promptFullDiff = truncateForPrompt(
+      fullDiff.value.stdout,
+      180_000,
+      "Full diff",
+   );
+
+   await writeFile(
+      `${outputDir}/prompt-context-size.json`,
+      JSON.stringify(
+         {
+            fullDiff: fullDiff.value.stdout.length,
+            promptFullDiff: promptFullDiff.length,
+         },
+         null,
+         2,
+      ),
+   );
+
    const context = `# PR #${prNumber}
 
 ## Metadata
@@ -342,7 +377,7 @@ ${prMetadata.value.stdout}
 ${changedFiles.value.stdout}
 
 ## Full diff
-${fullDiff.value.stdout}
+${promptFullDiff}
 
 ## Commits
 ${commits.value.stdout}
@@ -427,7 +462,7 @@ Retorne JSON válido, sem markdown fences, exatamente no schema da reference rep
          ),
       catch: (cause) =>
          new SecurityAuditAgentError({
-            message: "Falha ao executar prompt de security audit via Flue.",
+            message: `Falha ao executar prompt de security audit via Flue: ${formatCause(cause)}`,
             cause,
          }),
    });

--- a/.flue/agents/security-audit.ts
+++ b/.flue/agents/security-audit.ts
@@ -2,7 +2,7 @@ import type { FlueContext } from "@flue/runtime";
 import { local } from "@flue/runtime/node";
 import { Result, TaggedError } from "better-result";
 import { defineErrorCatalog } from "evlog";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import * as v from "valibot";
 import {
    formatCause,
@@ -253,29 +253,6 @@ export default async function ({ init, payload, env }: FlueContext) {
                `${contextDir}/checks.json`,
                "Falha ao ler checks preparados da PR.",
             ),
-            readFile("AGENTS.md", "utf8"),
-            readFile(".agents/skills/implementation/SKILL.md", "utf8"),
-            readFile(".agents/skills/security-audit/SKILL.md", "utf8"),
-            readFile(
-               ".agents/skills/security-audit/references/methodology.md",
-               "utf8",
-            ),
-            readFile(
-               ".agents/skills/security-audit/references/finding-validation.md",
-               "utf8",
-            ),
-            readFile(
-               ".agents/skills/security-audit/references/montte-attack-surface.md",
-               "utf8",
-            ),
-            readFile(
-               ".agents/skills/security-audit/references/github-actions-security.md",
-               "utf8",
-            ),
-            readFile(
-               ".agents/skills/security-audit/references/report-schema.md",
-               "utf8",
-            ),
          ]),
       catch: (cause) =>
          new SecurityAuditAgentError({
@@ -286,21 +263,8 @@ export default async function ({ init, payload, env }: FlueContext) {
    });
    if (Result.isError(contextResult)) throw contextResult.error;
 
-   const [
-      prMetadata,
-      changedFiles,
-      fullDiff,
-      commits,
-      ciChecks,
-      agentInstructions,
-      implementationSkill,
-      securityAuditSkill,
-      methodologyReference,
-      findingValidationReference,
-      montteAttackSurfaceReference,
-      githubActionsSecurityReference,
-      reportSchemaReference,
-   ] = contextResult.value;
+   const [prMetadata, changedFiles, fullDiff, commits, ciChecks] =
+      contextResult.value;
 
    const commandResults = [
       prMetadata,
@@ -326,85 +290,25 @@ export default async function ({ init, payload, env }: FlueContext) {
       "Full diff",
    );
 
+   const promptContextSize = {
+      fullDiff: fullDiff.value.stdout.length,
+      promptFullDiff: promptFullDiff.length,
+   };
+
    await writeFile(
       `${outputDir}/prompt-context-size.json`,
-      JSON.stringify(
-         {
-            fullDiff: fullDiff.value.stdout.length,
-            promptFullDiff: promptFullDiff.length,
-         },
-         null,
-         2,
-      ),
+      JSON.stringify(promptContextSize, null, 2),
    );
 
-   const context = `# PR #${prNumber}
-
-## Metadata
-${prMetadata.value.stdout}
-
-## Changed files
-${changedFiles.value.stdout}
-
-## Full diff
-${promptFullDiff}
-
-## Commits
-${commits.value.stdout}
-
-## CI checks
-${ciChecks.value.stdout}
-`;
-
-   const prompt = `Você é o agente de security audit do Montte.
-Siga obrigatoriamente AGENTS.md, implementation skill e security-audit skill/references abaixo.
-
-Objetivo: fazer uma auditoria de segurança CI-friendly da PR #${prNumber}, focada em achados reais Medium+.
-
-AGENTS.md:
-${agentInstructions}
-
-Implementation skill:
-${implementationSkill}
-
-Security audit skill:
-${securityAuditSkill}
-
-Reference: methodology
-${methodologyReference}
-
-Reference: finding-validation
-${findingValidationReference}
-
-Reference: montte-attack-surface
-${montteAttackSurfaceReference}
-
-Reference: github-actions-security
-${githubActionsSecurityReference}
-
-Reference: report-schema
-${reportSchemaReference}
-
-Contexto da PR:
-${context}
-
-Tarefa:
-- não use ferramentas/read/bash; o repositório não está disponível no sandbox, use apenas o contexto fornecido neste prompt;
-- audite o diff e callers/contratos evidentes;
-- procure regressões de authz, isolamento org/team, billing/usage, uploads/files, workers/jobs, AI tools, secrets e GitHub Actions;
-- tente refutar cada hipótese antes de reportar;
-- descarte Low/Info/teórico;
-- não invente arquivos, linhas, APIs ou contexto ausente;
-- não recomende mudanças genéricas sem finding concreto;
-- retorne no máximo 10 findings.
-
-Retorne JSON válido, sem markdown fences, exatamente no schema da reference report-schema.
-`.trim();
+   const task = `Audite a PR #${prNumber} usando a skill de security audit do Montte. Use apenas o contexto pré-coletado em args. Não rode comandos nem colete dados pelo GitHub. Foque em achados reais Medium+ e tente refutar hipóteses antes de reportar.`;
 
    const modelHarnessResult = await Result.tryPromise({
       try: () =>
          init({
             name: "security-audit-model",
+            // local() lets Flue discover AGENTS.md and .agents/skills from cwd.
+            // GitHub writes stay on the host through Octokit; tokens are not
+            // exposed to the sandbox env and we do not collect context with gh.
             sandbox: local({ env: {} }),
             model: process.env.FLUE_MODEL ?? DEFAULT_FLUE_MODEL,
          }),
@@ -435,12 +339,18 @@ Retorne JSON válido, sem markdown fences, exatamente no schema da reference rep
    const outputResult = await Result.tryPromise({
       try: () =>
          Promise.resolve(
-            modelSessionResult.value.skill("security-audit/SKILL.md", {
+            modelSessionResult.value.skill("security-audit", {
                args: {
-                  task: prompt,
+                  task,
                   repo,
                   prNumber,
                   failOn,
+                  prMetadata: prMetadata.value.stdout,
+                  changedFiles: changedFiles.value.stdout,
+                  patch: promptFullDiff,
+                  commits: commits.value.stdout,
+                  checks: ciChecks.value.stdout,
+                  promptContextSize,
                },
                thinkingLevel: "off",
                result: securityAuditResultSchema,

--- a/.flue/agents/security-audit.ts
+++ b/.flue/agents/security-audit.ts
@@ -1,166 +1,71 @@
 import type { FlueContext } from "@flue/runtime";
-import { Octokit } from "@octokit/core";
 import { Result, TaggedError } from "better-result";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { z } from "zod";
+import * as v from "valibot";
+import {
+   formatCause,
+   publishIssueComment,
+   readPreparedContext,
+   resolveGithubToken,
+   safePathSchema,
+   safeRepoSchema,
+   truncateForPrompt,
+} from "../lib/agent-utils.ts";
 import { DEFAULT_FLUE_MODEL } from "../lib/model.ts";
 
 export const triggers = {};
 
-const severitySchema = z.enum(["medium", "high", "critical"]);
-const riskLevelSchema = z.enum(["none", "medium", "high", "critical"]);
-const failOnSchema = z.enum(["none", "medium", "high", "critical"]);
+const failOnSchema = v.picklist(["none", "medium", "high", "critical"]);
 
-const securityAuditPayloadSchema = z.object({
-   prNumber: z.number().optional(),
-   repo: z
-      .string()
-      .regex(/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u)
-      .optional(),
-   outputDir: z.string().default(".security-audit"),
-   contextDir: z.string().default(".agent-artifacts/security-audit/input"),
-   failOn: failOnSchema.default("high"),
+const securityAuditPayloadSchema = v.object({
+   prNumber: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1))),
+   repo: v.optional(safeRepoSchema),
+   outputDir: v.optional(safePathSchema, ".security-audit"),
+   contextDir: v.optional(
+      safePathSchema,
+      ".agent-artifacts/security-audit/input",
+   ),
+   failOn: v.optional(failOnSchema, "high"),
+   dryRun: v.optional(v.boolean(), false),
 });
 
-const findingSchema = z.object({
-   id: z.string().min(1),
-   severity: severitySchema,
-   title: z.string().min(1),
-   path: z.string().min(1),
-   line: z.number().int().positive(),
-   evidence: z.string().min(1),
-   attackerControl: z.string().min(1),
-   reachablePath: z.string().min(1),
-   trustBoundary: z.string().min(1),
-   impact: z.string().min(1),
-   fix: z.string().min(1),
-   confidence: z.enum(["medium", "high"]),
+const findingSchema = v.object({
+   id: v.pipe(v.string(), v.minLength(1)),
+   severity: v.picklist(["medium", "high", "critical"]),
+   title: v.pipe(v.string(), v.minLength(1)),
+   path: v.pipe(v.string(), v.minLength(1)),
+   line: v.pipe(v.number(), v.integer(), v.minValue(1)),
+   evidence: v.pipe(v.string(), v.minLength(1)),
+   attackerControl: v.pipe(v.string(), v.minLength(1)),
+   reachablePath: v.pipe(v.string(), v.minLength(1)),
+   trustBoundary: v.pipe(v.string(), v.minLength(1)),
+   impact: v.pipe(v.string(), v.minLength(1)),
+   fix: v.pipe(v.string(), v.minLength(1)),
+   confidence: v.picklist(["medium", "high"]),
 });
 
-const discardedSchema = z.object({
-   title: z.string().min(1),
-   reason: z.string().min(1),
+const discardedSchema = v.object({
+   title: v.pipe(v.string(), v.minLength(1)),
+   reason: v.pipe(v.string(), v.minLength(1)),
 });
 
-const securityAuditResultSchema = z.object({
-   summary: z.string().min(1),
-   riskLevel: riskLevelSchema,
-   findings: z.array(findingSchema).max(20).default([]),
-   discarded: z.array(discardedSchema).max(30).default([]),
+const securityAuditResultSchema = v.object({
+   summary: v.pipe(v.string(), v.minLength(1)),
+   riskLevel: v.picklist(["none", "medium", "high", "critical"]),
+   findings: v.optional(v.pipe(v.array(findingSchema), v.maxLength(20)), []),
+   discarded: v.optional(v.pipe(v.array(discardedSchema), v.maxLength(30)), []),
 });
 
-type SecurityAuditResult = z.infer<typeof securityAuditResultSchema>;
-type Finding = z.infer<typeof findingSchema>;
-type FailOn = z.infer<typeof failOnSchema>;
+type SecurityAuditResult = v.InferOutput<typeof securityAuditResultSchema>;
+type Finding = v.InferOutput<typeof findingSchema>;
+type FailOn = v.InferOutput<typeof failOnSchema>;
 
 class SecurityAuditAgentError extends TaggedError("SecurityAuditAgentError")<{
    message: string;
    cause?: unknown;
 }>() {}
 
-async function readPreparedContext(filePath: string, failureMessage: string) {
-   return Result.tryPromise({
-      try: async () => ({
-         stdout: await readFile(filePath, "utf8"),
-         stderr: "",
-         exitCode: 0,
-      }),
-      catch: (cause) =>
-         new SecurityAuditAgentError({
-            message: failureMessage,
-            cause,
-         }),
-   });
-}
-
-function truncateForPrompt(value: string, maxChars: number, label: string) {
-   if (value.length <= maxChars) return value;
-
-   return `${value.slice(0, maxChars)}\n\n[${label} truncado: ${value.length} caracteres totais; exibindo primeiros ${maxChars}. Consulte o artefato completo para validação.]`;
-}
-
-function formatCause(cause: unknown) {
-   if (cause instanceof Error) return cause.stack ?? cause.message;
-   if (typeof cause === "string") return cause;
-
-   try {
-      return JSON.stringify(cause);
-   } catch {
-      return String(cause);
-   }
-}
-
-async function publishIssueComment({
-   repo,
-   prNumber,
-   body,
-   token,
-}: {
-   repo: string;
-   prNumber: number;
-   body: string;
-   token: string | undefined;
-}) {
-   if (!token) {
-      return Result.err(
-         new SecurityAuditAgentError({
-            message: "GH_TOKEN não configurado no ambiente.",
-         }),
-      );
-   }
-
-   const [owner, repoName] = repo.split("/");
-   const octokit = new Octokit({ auth: token });
-   return Result.tryPromise({
-      try: async () => {
-         await octokit.request(
-            "POST /repos/{owner}/{repo}/issues/{num}/comments",
-            {
-               owner,
-               repo: repoName,
-               num: prNumber,
-               body,
-            },
-         );
-      },
-      catch: (cause) =>
-         new SecurityAuditAgentError({
-            message: "Falha ao publicar comentário no GitHub.",
-            cause,
-         }),
-   });
-}
-
-function parseSecurityAuditResult(raw: string) {
-   const trimmed = raw.trim();
-   const withoutFence = trimmed
-      .replace(/^```(?:json)?\s*/u, "")
-      .replace(/\s*```$/u, "");
-
-   const jsonResult = Result.try({
-      try: () => JSON.parse(withoutFence),
-      catch: (cause) =>
-         new SecurityAuditAgentError({
-            message: "Resposta do security audit não é JSON válido.",
-            cause,
-         }),
-   });
-   if (Result.isError(jsonResult)) return Result.err(jsonResult.error);
-
-   const parsed = securityAuditResultSchema.safeParse(jsonResult.value);
-   if (!parsed.success) {
-      return Result.err(
-         new SecurityAuditAgentError({
-            message: "Resposta do security audit não segue o schema esperado.",
-            cause: parsed.error,
-         }),
-      );
-   }
-
-   return Result.ok(parsed.data);
-}
-
-function severityRank(severity: FailOn | z.infer<typeof severitySchema>) {
+function severityRank(severity: FailOn | Finding["severity"]) {
    return ["none", "medium", "high", "critical"].indexOf(severity);
 }
 
@@ -216,11 +121,11 @@ ${discarded}
 }
 
 export default async function ({ init, payload, env }: FlueContext) {
-   const parsedPayload = securityAuditPayloadSchema.safeParse(payload);
+   const parsedPayload = v.safeParse(securityAuditPayloadSchema, payload);
    if (!parsedPayload.success) {
       throw new SecurityAuditAgentError({
          message: "Payload inválido para agente de security audit.",
-         cause: parsedPayload.error,
+         cause: parsedPayload.issues,
       });
    }
 
@@ -230,14 +135,19 @@ export default async function ({ init, payload, env }: FlueContext) {
       outputDir,
       contextDir,
       failOn,
-   } = parsedPayload.data;
-   const prNumber = payloadPrNumber ?? Number(env.PR_NUMBER);
-   const repo = payloadRepo ?? env.GITHUB_REPOSITORY;
-   const githubToken =
-      env.GH_TOKEN ??
-      env.GITHUB_TOKEN ??
-      process.env.GH_TOKEN ??
-      process.env.GITHUB_TOKEN;
+      dryRun,
+   } = parsedPayload.output;
+   const envPrNumber = Number(env.PR_NUMBER);
+   const prNumber =
+      payloadPrNumber ??
+      (Number.isInteger(envPrNumber) && envPrNumber > 0
+         ? envPrNumber
+         : undefined);
+   const repoResult = v.safeParse(
+      safeRepoSchema,
+      payloadRepo ?? env.GITHUB_REPOSITORY,
+   );
+   const githubToken = resolveGithubToken(env);
 
    if (!prNumber || Number.isNaN(prNumber)) {
       throw new SecurityAuditAgentError({
@@ -245,11 +155,14 @@ export default async function ({ init, payload, env }: FlueContext) {
       });
    }
 
-   if (!repo || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(repo)) {
+   if (!repoResult.success) {
       throw new SecurityAuditAgentError({
          message: "repo inválido ou não informado.",
+         cause: repoResult.issues,
       });
    }
+
+   const repo = repoResult.output;
 
    const outputDirResult = await Result.tryPromise({
       try: () => mkdir(outputDir, { recursive: true }),
@@ -267,22 +180,32 @@ export default async function ({ init, payload, env }: FlueContext) {
             readPreparedContext(
                `${contextDir}/pr-metadata.json`,
                "Falha ao ler metadados preparados da PR.",
+               (message, cause) =>
+                  new SecurityAuditAgentError({ message, cause }),
             ),
             readPreparedContext(
                `${contextDir}/changed-files.md`,
                "Falha ao ler lista preparada de arquivos da PR.",
+               (message, cause) =>
+                  new SecurityAuditAgentError({ message, cause }),
             ),
             readPreparedContext(
                `${contextDir}/pr.patch`,
                "Falha ao ler diff preparado da PR.",
+               (message, cause) =>
+                  new SecurityAuditAgentError({ message, cause }),
             ),
             readPreparedContext(
                `${contextDir}/commits.md`,
                "Falha ao ler commits preparados da PR.",
+               (message, cause) =>
+                  new SecurityAuditAgentError({ message, cause }),
             ),
             readPreparedContext(
                `${contextDir}/checks.json`,
                "Falha ao ler checks preparados da PR.",
+               (message, cause) =>
+                  new SecurityAuditAgentError({ message, cause }),
             ),
             readFile("AGENTS.md", "utf8"),
             readFile(".agents/skills/implementation/SKILL.md", "utf8"),
@@ -419,6 +342,7 @@ Contexto da PR:
 ${context}
 
 Tarefa:
+- não use ferramentas/read/bash; o repositório não está disponível no sandbox, use apenas o contexto fornecido neste prompt;
 - audite o diff e callers/contratos evidentes;
 - procure regressões de authz, isolamento org/team, billing/usage, uploads/files, workers/jobs, AI tools, secrets e GitHub Actions;
 - tente refutar cada hipótese antes de reportar;
@@ -458,7 +382,10 @@ Retorne JSON válido, sem markdown fences, exatamente no schema da reference rep
    const outputResult = await Result.tryPromise({
       try: () =>
          Promise.resolve(
-            modelSessionResult.value.prompt(prompt, { thinkingLevel: "off" }),
+            modelSessionResult.value.prompt(prompt, {
+               thinkingLevel: "off",
+               result: securityAuditResultSchema,
+            }),
          ),
       catch: (cause) =>
          new SecurityAuditAgentError({
@@ -468,27 +395,30 @@ Retorne JSON válido, sem markdown fences, exatamente no schema da reference rep
    });
    if (Result.isError(outputResult)) throw outputResult.error;
 
-   const auditResult = parseSecurityAuditResult(outputResult.value.text);
-   if (Result.isError(auditResult)) throw auditResult.error;
+   const auditResult = outputResult.value.data;
 
    const jsonOutputFile = `${outputDir}/security-audit.json`;
    const markdownOutputFile = `${outputDir}/SECURITY_AUDIT.md`;
-   const markdown = formatMarkdownReport(auditResult.value, failOn);
+   const markdown = formatMarkdownReport(auditResult, failOn);
 
    await Promise.all([
-      writeFile(jsonOutputFile, JSON.stringify(auditResult.value, null, 2)),
+      writeFile(jsonOutputFile, JSON.stringify(auditResult, null, 2)),
       writeFile(markdownOutputFile, markdown),
    ]);
 
-   const commentResult = await publishIssueComment({
-      repo,
-      prNumber,
-      body: markdown,
-      token: githubToken,
-   });
-   if (Result.isError(commentResult)) throw commentResult.error;
+   if (!dryRun) {
+      const commentResult = await publishIssueComment({
+         repo,
+         prNumber,
+         body: markdown,
+         token: githubToken,
+         makeError: (message, cause) =>
+            new SecurityAuditAgentError({ message, cause }),
+      });
+      if (Result.isError(commentResult)) throw commentResult.error;
+   }
 
-   if (shouldFailAudit(auditResult.value.findings, failOn)) {
+   if (!dryRun && shouldFailAudit(auditResult.findings, failOn)) {
       throw new SecurityAuditAgentError({
          message: `Security audit encontrou findings >= ${failOn}.`,
       });
@@ -498,8 +428,9 @@ Retorne JSON válido, sem markdown fences, exatamente no schema da reference rep
       outputFile: markdownOutputFile,
       jsonOutputFile,
       prNumber,
-      findings: auditResult.value.findings.length,
-      riskLevel: auditResult.value.riskLevel,
+      findings: auditResult.findings.length,
+      riskLevel: auditResult.riskLevel,
       failOn,
+      dryRun,
    };
 }

--- a/.flue/agents/security-audit.ts
+++ b/.flue/agents/security-audit.ts
@@ -1,5 +1,7 @@
 import type { FlueContext } from "@flue/runtime";
+import { local } from "@flue/runtime/node";
 import { Result, TaggedError } from "better-result";
+import { defineErrorCatalog } from "evlog";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import * as v from "valibot";
 import {
@@ -60,9 +62,57 @@ type SecurityAuditResult = v.InferOutput<typeof securityAuditResultSchema>;
 type Finding = v.InferOutput<typeof findingSchema>;
 type FailOn = v.InferOutput<typeof failOnSchema>;
 
+const securityAuditAgentErrors = defineErrorCatalog(
+   "flue.security-audit.agent",
+   {
+      BAD_PAYLOAD: {
+         status: 400,
+         message: "Payload inválido para agente de security audit.",
+         tags: ["flue", "security-audit"],
+      },
+      MISSING_INPUT: {
+         status: 400,
+         message: "Entrada obrigatória ausente para security audit.",
+         tags: ["flue", "security-audit"],
+      },
+      IO_FAILED: {
+         status: 500,
+         message: "Falha de IO no agente de security audit.",
+         tags: ["flue", "security-audit"],
+      },
+      MODEL_FAILED: {
+         status: 500,
+         message: "Falha ao executar modelo de security audit.",
+         tags: ["flue", "security-audit"],
+      },
+      GATE_FAILED: {
+         status: 422,
+         message: "Security audit encontrou findings bloqueantes.",
+         tags: ["flue", "security-audit"],
+      },
+   },
+);
+
+declare module "evlog" {
+   interface RegisteredErrorCatalogs {
+      "flue.security-audit.agent": typeof securityAuditAgentErrors;
+   }
+}
+
+type SecurityAuditAgentCatalogError =
+   | ReturnType<typeof securityAuditAgentErrors.BAD_PAYLOAD>
+   | ReturnType<typeof securityAuditAgentErrors.MISSING_INPUT>
+   | ReturnType<typeof securityAuditAgentErrors.IO_FAILED>
+   | ReturnType<typeof securityAuditAgentErrors.MODEL_FAILED>
+   | ReturnType<typeof securityAuditAgentErrors.GATE_FAILED>;
+
 class SecurityAuditAgentError extends TaggedError("SecurityAuditAgentError")<{
+   error: SecurityAuditAgentCatalogError;
    message: string;
-   cause?: unknown;
+   repo?: string;
+   prNumber?: number;
+   outputFile?: string;
+   detail?: string;
 }>() {}
 
 function severityRank(severity: FailOn | Finding["severity"]) {
@@ -124,8 +174,9 @@ export default async function ({ init, payload, env }: FlueContext) {
    const parsedPayload = v.safeParse(securityAuditPayloadSchema, payload);
    if (!parsedPayload.success) {
       throw new SecurityAuditAgentError({
+         error: securityAuditAgentErrors.BAD_PAYLOAD(),
          message: "Payload inválido para agente de security audit.",
-         cause: parsedPayload.issues,
+         detail: formatCause(parsedPayload.issues),
       });
    }
 
@@ -151,14 +202,17 @@ export default async function ({ init, payload, env }: FlueContext) {
 
    if (!prNumber || Number.isNaN(prNumber)) {
       throw new SecurityAuditAgentError({
+         error: securityAuditAgentErrors.MISSING_INPUT(),
          message: "Informe prNumber no payload ou PR_NUMBER no ambiente.",
       });
    }
 
    if (!repoResult.success) {
       throw new SecurityAuditAgentError({
+         error: securityAuditAgentErrors.BAD_PAYLOAD(),
          message: "repo inválido ou não informado.",
-         cause: repoResult.issues,
+         prNumber,
+         detail: formatCause(repoResult.issues),
       });
    }
 
@@ -168,8 +222,10 @@ export default async function ({ init, payload, env }: FlueContext) {
       try: () => mkdir(outputDir, { recursive: true }),
       catch: (cause) =>
          new SecurityAuditAgentError({
+            error: securityAuditAgentErrors.IO_FAILED(),
             message: "Falha ao criar diretório de artefatos de security audit.",
-            cause,
+            outputFile: outputDir,
+            detail: formatCause(cause),
          }),
    });
    if (Result.isError(outputDirResult)) throw outputDirResult.error;
@@ -180,32 +236,22 @@ export default async function ({ init, payload, env }: FlueContext) {
             readPreparedContext(
                `${contextDir}/pr-metadata.json`,
                "Falha ao ler metadados preparados da PR.",
-               (message, cause) =>
-                  new SecurityAuditAgentError({ message, cause }),
             ),
             readPreparedContext(
                `${contextDir}/changed-files.md`,
                "Falha ao ler lista preparada de arquivos da PR.",
-               (message, cause) =>
-                  new SecurityAuditAgentError({ message, cause }),
             ),
             readPreparedContext(
                `${contextDir}/pr.patch`,
                "Falha ao ler diff preparado da PR.",
-               (message, cause) =>
-                  new SecurityAuditAgentError({ message, cause }),
             ),
             readPreparedContext(
                `${contextDir}/commits.md`,
                "Falha ao ler commits preparados da PR.",
-               (message, cause) =>
-                  new SecurityAuditAgentError({ message, cause }),
             ),
             readPreparedContext(
                `${contextDir}/checks.json`,
                "Falha ao ler checks preparados da PR.",
-               (message, cause) =>
-                  new SecurityAuditAgentError({ message, cause }),
             ),
             readFile("AGENTS.md", "utf8"),
             readFile(".agents/skills/implementation/SKILL.md", "utf8"),
@@ -233,8 +279,9 @@ export default async function ({ init, payload, env }: FlueContext) {
          ]),
       catch: (cause) =>
          new SecurityAuditAgentError({
+            error: securityAuditAgentErrors.IO_FAILED(),
             message: "Falha ao coletar contexto da PR ou carregar skill.",
-            cause,
+            detail: formatCause(cause),
          }),
    });
    if (Result.isError(contextResult)) throw contextResult.error;
@@ -358,13 +405,16 @@ Retorne JSON válido, sem markdown fences, exatamente no schema da reference rep
       try: () =>
          init({
             name: "security-audit-model",
-            sandbox: false,
+            sandbox: local({ env: {} }),
             model: process.env.FLUE_MODEL ?? DEFAULT_FLUE_MODEL,
          }),
       catch: (cause) =>
          new SecurityAuditAgentError({
+            error: securityAuditAgentErrors.MODEL_FAILED(),
             message: "Falha ao inicializar Flue para modelo de security audit.",
-            cause,
+            repo,
+            prNumber,
+            detail: formatCause(cause),
          }),
    });
    if (Result.isError(modelHarnessResult)) throw modelHarnessResult.error;
@@ -373,8 +423,11 @@ Retorne JSON válido, sem markdown fences, exatamente no schema da reference rep
       try: () => modelHarnessResult.value.session(),
       catch: (cause) =>
          new SecurityAuditAgentError({
+            error: securityAuditAgentErrors.MODEL_FAILED(),
             message: "Falha ao abrir sessão de modelo para security audit.",
-            cause,
+            repo,
+            prNumber,
+            detail: formatCause(cause),
          }),
    });
    if (Result.isError(modelSessionResult)) throw modelSessionResult.error;
@@ -382,15 +435,24 @@ Retorne JSON válido, sem markdown fences, exatamente no schema da reference rep
    const outputResult = await Result.tryPromise({
       try: () =>
          Promise.resolve(
-            modelSessionResult.value.prompt(prompt, {
+            modelSessionResult.value.skill("security-audit/SKILL.md", {
+               args: {
+                  task: prompt,
+                  repo,
+                  prNumber,
+                  failOn,
+               },
                thinkingLevel: "off",
                result: securityAuditResultSchema,
             }),
          ),
       catch: (cause) =>
          new SecurityAuditAgentError({
-            message: `Falha ao executar prompt de security audit via Flue: ${formatCause(cause)}`,
-            cause,
+            error: securityAuditAgentErrors.MODEL_FAILED(),
+            message: `Falha ao executar skill de security audit via Flue: ${formatCause(cause)}`,
+            repo,
+            prNumber,
+            detail: formatCause(cause),
          }),
    });
    if (Result.isError(outputResult)) throw outputResult.error;
@@ -412,15 +474,16 @@ Retorne JSON válido, sem markdown fences, exatamente no schema da reference rep
          prNumber,
          body: markdown,
          token: githubToken,
-         makeError: (message, cause) =>
-            new SecurityAuditAgentError({ message, cause }),
       });
       if (Result.isError(commentResult)) throw commentResult.error;
    }
 
    if (!dryRun && shouldFailAudit(auditResult.findings, failOn)) {
       throw new SecurityAuditAgentError({
+         error: securityAuditAgentErrors.GATE_FAILED(),
          message: `Security audit encontrou findings >= ${failOn}.`,
+         repo,
+         prNumber,
       });
    }
 

--- a/.flue/app.ts
+++ b/.flue/app.ts
@@ -12,9 +12,11 @@ type FlueExecutionContext = Parameters<FlueFetch>[2];
 
 function toProcessEnv(env: FlueEnv) {
    return {
-      OPENCODE_API_KEY: env.OPENCODE_API_KEY,
-      OPENCODE_GO_BASE_URL: env.OPENCODE_GO_BASE_URL,
-      OPENCODE_GO_GATEWAY_KEY: env.OPENCODE_GO_GATEWAY_KEY,
+      OPENCODE_API_KEY: env.OPENCODE_API_KEY ?? process.env.OPENCODE_API_KEY,
+      OPENCODE_GO_BASE_URL:
+         env.OPENCODE_GO_BASE_URL ?? process.env.OPENCODE_GO_BASE_URL,
+      OPENCODE_GO_GATEWAY_KEY:
+         env.OPENCODE_GO_GATEWAY_KEY ?? process.env.OPENCODE_GO_GATEWAY_KEY,
    };
 }
 

--- a/.flue/app.ts
+++ b/.flue/app.ts
@@ -1,28 +1,17 @@
 import { flue } from "@flue/runtime/app";
+import { validateFlueProviderEnv } from "./lib/agent-utils.ts";
 import { configureFlueProvidersFromEnv } from "./lib/providers.ts";
-
-interface FlueEnv {
-   OPENCODE_API_KEY?: string;
-   OPENCODE_GO_BASE_URL?: string;
-   OPENCODE_GO_GATEWAY_KEY?: string;
-}
 
 type FlueFetch = ReturnType<typeof flue>["fetch"];
 type FlueExecutionContext = Parameters<FlueFetch>[2];
 
-function toProcessEnv(env: FlueEnv) {
-   return {
-      OPENCODE_API_KEY: env.OPENCODE_API_KEY ?? process.env.OPENCODE_API_KEY,
-      OPENCODE_GO_BASE_URL:
-         env.OPENCODE_GO_BASE_URL ?? process.env.OPENCODE_GO_BASE_URL,
-      OPENCODE_GO_GATEWAY_KEY:
-         env.OPENCODE_GO_GATEWAY_KEY ?? process.env.OPENCODE_GO_GATEWAY_KEY,
-   };
-}
-
 export default {
-   fetch(req: Request, env: FlueEnv, ctx: FlueExecutionContext) {
-      configureFlueProvidersFromEnv(toProcessEnv(env));
+   fetch(
+      req: Request,
+      env: Record<string, unknown>,
+      ctx: FlueExecutionContext,
+   ) {
+      configureFlueProvidersFromEnv(validateFlueProviderEnv(env));
       return flue().fetch(req, env, ctx);
    },
 };

--- a/.flue/app.ts
+++ b/.flue/app.ts
@@ -1,3 +1,4 @@
+import { Result } from "better-result";
 import { flue } from "@flue/runtime/app";
 import { validateFlueProviderEnv } from "./lib/agent-utils.ts";
 import { configureFlueProvidersFromEnv } from "./lib/providers.ts";
@@ -11,7 +12,10 @@ export default {
       env: Record<string, unknown>,
       ctx: FlueExecutionContext,
    ) {
-      configureFlueProvidersFromEnv(validateFlueProviderEnv(env));
+      const providerEnvResult = validateFlueProviderEnv(env);
+      if (Result.isError(providerEnvResult)) throw providerEnvResult.error;
+
+      configureFlueProvidersFromEnv(providerEnvResult.value);
       return flue().fetch(req, env, ctx);
    },
 };

--- a/.flue/lib/agent-utils.ts
+++ b/.flue/lib/agent-utils.ts
@@ -1,7 +1,46 @@
 import { Octokit } from "@octokit/core";
-import { Result } from "better-result";
+import { Result, TaggedError } from "better-result";
+import { defineErrorCatalog } from "evlog";
 import { readFile } from "node:fs/promises";
 import * as v from "valibot";
+
+export const agentUtilsErrors = defineErrorCatalog("flue.agent-utils", {
+   MISSING_GITHUB_TOKEN: {
+      status: 401,
+      message: "Token do GitHub não configurado.",
+      tags: ["flue", "agent-utils", "github"],
+   },
+   READ_CONTEXT_FAILED: {
+      status: 500,
+      message: "Falha ao ler contexto preparado do agente.",
+      tags: ["flue", "agent-utils", "context"],
+   },
+   PUBLISH_COMMENT_FAILED: {
+      status: 500,
+      message: "Falha ao publicar comentário no GitHub.",
+      tags: ["flue", "agent-utils", "github"],
+   },
+});
+
+declare module "evlog" {
+   interface RegisteredErrorCatalogs {
+      "flue.agent-utils": typeof agentUtilsErrors;
+   }
+}
+
+type AgentUtilsCatalogError =
+   | ReturnType<typeof agentUtilsErrors.MISSING_GITHUB_TOKEN>
+   | ReturnType<typeof agentUtilsErrors.READ_CONTEXT_FAILED>
+   | ReturnType<typeof agentUtilsErrors.PUBLISH_COMMENT_FAILED>;
+
+export class AgentUtilsError extends TaggedError("AgentUtilsError")<{
+   error: AgentUtilsCatalogError;
+   message: string;
+   repo?: string;
+   prNumber?: number;
+   filePath?: string;
+   detail?: string;
+}>() {}
 
 export const safeRepoSchema = v.pipe(
    v.string(),
@@ -17,10 +56,25 @@ export const safePathSchema = v.pipe(
    ),
 );
 
-export type AgentErrorFactory<TError> = (
-   message: string,
-   cause?: unknown,
-) => TError;
+const envStringSchema = v.pipe(v.string(), v.minLength(1));
+
+export const flueProviderEnvSchema = v.object({
+   OPENCODE_API_KEY: v.optional(envStringSchema),
+   OPENCODE_GO_BASE_URL: v.optional(v.pipe(envStringSchema, v.url())),
+   OPENCODE_GO_GATEWAY_KEY: v.optional(envStringSchema),
+});
+
+export type FlueProviderEnv = v.InferOutput<typeof flueProviderEnvSchema>;
+
+export function validateFlueProviderEnv(env: Record<string, unknown>) {
+   return v.parse(flueProviderEnvSchema, {
+      OPENCODE_API_KEY: env.OPENCODE_API_KEY ?? process.env.OPENCODE_API_KEY,
+      OPENCODE_GO_BASE_URL:
+         env.OPENCODE_GO_BASE_URL ?? process.env.OPENCODE_GO_BASE_URL,
+      OPENCODE_GO_GATEWAY_KEY:
+         env.OPENCODE_GO_GATEWAY_KEY ?? process.env.OPENCODE_GO_GATEWAY_KEY,
+   });
+}
 
 export function formatCause(cause: unknown) {
    if (cause instanceof Error) return cause.stack ?? cause.message;
@@ -46,10 +100,9 @@ export function truncateForPrompt(
    return `${value.slice(0, maxChars)}\n\n[${label} truncado: ${value.length} caracteres totais; exibindo primeiros ${maxChars}. Consulte o artefato completo para validação.]`;
 }
 
-export async function readPreparedContext<TError>(
+export async function readPreparedContext(
    filePath: string,
    failureMessage: string,
-   makeError: AgentErrorFactory<TError>,
 ) {
    return Result.tryPromise({
       try: async () => ({
@@ -57,7 +110,13 @@ export async function readPreparedContext<TError>(
          stderr: "",
          exitCode: 0,
       }),
-      catch: (cause) => makeError(failureMessage, cause),
+      catch: (cause) =>
+         new AgentUtilsError({
+            error: agentUtilsErrors.READ_CONTEXT_FAILED(),
+            message: failureMessage,
+            filePath,
+            detail: formatCause(cause),
+         }),
    });
 }
 
@@ -75,21 +134,26 @@ export function resolveGithubToken(env: Record<string, unknown>) {
    );
 }
 
-export async function publishIssueComment<TError>({
+export async function publishIssueComment({
    repo,
    prNumber,
    body,
    token,
-   makeError,
 }: {
    repo: string;
    prNumber: number;
    body: string;
    token: string | undefined;
-   makeError: AgentErrorFactory<TError>;
 }) {
    if (!token) {
-      return Result.err(makeError("GH_TOKEN não configurado no ambiente."));
+      return Result.err(
+         new AgentUtilsError({
+            error: agentUtilsErrors.MISSING_GITHUB_TOKEN(),
+            message: "GH_TOKEN não configurado no ambiente.",
+            repo,
+            prNumber,
+         }),
+      );
    }
 
    const [owner, repoName] = repo.split("/");
@@ -107,6 +171,12 @@ export async function publishIssueComment<TError>({
          );
       },
       catch: (cause) =>
-         makeError("Falha ao publicar comentário no GitHub.", cause),
+         new AgentUtilsError({
+            error: agentUtilsErrors.PUBLISH_COMMENT_FAILED(),
+            message: "Falha ao publicar comentário no GitHub.",
+            repo,
+            prNumber,
+            detail: formatCause(cause),
+         }),
    });
 }

--- a/.flue/lib/agent-utils.ts
+++ b/.flue/lib/agent-utils.ts
@@ -20,6 +20,11 @@ export const agentUtilsErrors = defineErrorCatalog("flue.agent-utils", {
       message: "Falha ao publicar comentário no GitHub.",
       tags: ["flue", "agent-utils", "github"],
    },
+   INVALID_PROVIDER_ENV: {
+      status: 500,
+      message: "Ambiente de providers Flue inválido.",
+      tags: ["flue", "agent-utils", "env"],
+   },
 });
 
 declare module "evlog" {
@@ -31,7 +36,8 @@ declare module "evlog" {
 type AgentUtilsCatalogError =
    | ReturnType<typeof agentUtilsErrors.MISSING_GITHUB_TOKEN>
    | ReturnType<typeof agentUtilsErrors.READ_CONTEXT_FAILED>
-   | ReturnType<typeof agentUtilsErrors.PUBLISH_COMMENT_FAILED>;
+   | ReturnType<typeof agentUtilsErrors.PUBLISH_COMMENT_FAILED>
+   | ReturnType<typeof agentUtilsErrors.INVALID_PROVIDER_ENV>;
 
 export class AgentUtilsError extends TaggedError("AgentUtilsError")<{
    error: AgentUtilsCatalogError;
@@ -67,13 +73,23 @@ export const flueProviderEnvSchema = v.object({
 export type FlueProviderEnv = v.InferOutput<typeof flueProviderEnvSchema>;
 
 export function validateFlueProviderEnv(env: Record<string, unknown>) {
-   return v.parse(flueProviderEnvSchema, {
+   const parsed = v.safeParse(flueProviderEnvSchema, {
       OPENCODE_API_KEY: env.OPENCODE_API_KEY ?? process.env.OPENCODE_API_KEY,
       OPENCODE_GO_BASE_URL:
          env.OPENCODE_GO_BASE_URL ?? process.env.OPENCODE_GO_BASE_URL,
       OPENCODE_GO_GATEWAY_KEY:
          env.OPENCODE_GO_GATEWAY_KEY ?? process.env.OPENCODE_GO_GATEWAY_KEY,
    });
+
+   if (parsed.success) return Result.ok(parsed.output);
+
+   return Result.err(
+      new AgentUtilsError({
+         error: agentUtilsErrors.INVALID_PROVIDER_ENV(),
+         message: "Ambiente de providers Flue inválido.",
+         detail: formatCause(parsed.issues),
+      }),
+   );
 }
 
 export function formatCause(cause: unknown) {

--- a/.flue/lib/agent-utils.ts
+++ b/.flue/lib/agent-utils.ts
@@ -1,0 +1,112 @@
+import { Octokit } from "@octokit/core";
+import { Result } from "better-result";
+import { readFile } from "node:fs/promises";
+import * as v from "valibot";
+
+export const safeRepoSchema = v.pipe(
+   v.string(),
+   v.regex(/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u),
+);
+
+export const safePathSchema = v.pipe(
+   v.string(),
+   v.regex(/^(?:\.\/[\w./-]+|\.[\w./-]*|[\w][\w./-]*)$/u),
+   v.check(
+      (value) => !value.split("/").includes(".."),
+      "path não pode conter segmentos '..'.",
+   ),
+);
+
+export type AgentErrorFactory<TError> = (
+   message: string,
+   cause?: unknown,
+) => TError;
+
+export function formatCause(cause: unknown) {
+   if (cause instanceof Error) return cause.stack ?? cause.message;
+   if (typeof cause === "string") return cause;
+
+   const jsonResult = Result.try({
+      try: () => JSON.stringify(cause),
+      catch: () => undefined,
+   });
+
+   return Result.isOk(jsonResult) && jsonResult.value
+      ? jsonResult.value
+      : String(cause);
+}
+
+export function truncateForPrompt(
+   value: string,
+   maxChars: number,
+   label: string,
+) {
+   if (value.length <= maxChars) return value;
+
+   return `${value.slice(0, maxChars)}\n\n[${label} truncado: ${value.length} caracteres totais; exibindo primeiros ${maxChars}. Consulte o artefato completo para validação.]`;
+}
+
+export async function readPreparedContext<TError>(
+   filePath: string,
+   failureMessage: string,
+   makeError: AgentErrorFactory<TError>,
+) {
+   return Result.tryPromise({
+      try: async () => ({
+         stdout: await readFile(filePath, "utf8"),
+         stderr: "",
+         exitCode: 0,
+      }),
+      catch: (cause) => makeError(failureMessage, cause),
+   });
+}
+
+export function resolveGithubToken(env: Record<string, unknown>) {
+   const envGhToken =
+      typeof env.GH_TOKEN === "string" ? env.GH_TOKEN : undefined;
+   const envGithubToken =
+      typeof env.GITHUB_TOKEN === "string" ? env.GITHUB_TOKEN : undefined;
+
+   return (
+      envGhToken ??
+      envGithubToken ??
+      process.env.GH_TOKEN ??
+      process.env.GITHUB_TOKEN
+   );
+}
+
+export async function publishIssueComment<TError>({
+   repo,
+   prNumber,
+   body,
+   token,
+   makeError,
+}: {
+   repo: string;
+   prNumber: number;
+   body: string;
+   token: string | undefined;
+   makeError: AgentErrorFactory<TError>;
+}) {
+   if (!token) {
+      return Result.err(makeError("GH_TOKEN não configurado no ambiente."));
+   }
+
+   const [owner, repoName] = repo.split("/");
+   const octokit = new Octokit({ auth: token });
+   return Result.tryPromise({
+      try: async () => {
+         await octokit.request(
+            "POST /repos/{owner}/{repo}/issues/{num}/comments",
+            {
+               owner,
+               repo: repoName,
+               num: prNumber,
+               body,
+            },
+         );
+      },
+      catch: (cause) =>
+         makeError("Falha ao publicar comentário no GitHub.", cause),
+   });
+}

--- a/.flue/lib/providers.ts
+++ b/.flue/lib/providers.ts
@@ -1,14 +1,9 @@
 import { configureProvider } from "@flue/runtime/app";
+import type { FlueProviderEnv } from "./agent-utils.ts";
 
 const DEFAULT_OPENCODE_GO_BASE_URL = "https://opencode.ai/zen/go/v1";
 
-interface ProviderEnv {
-   OPENCODE_API_KEY?: string;
-   OPENCODE_GO_BASE_URL?: string;
-   OPENCODE_GO_GATEWAY_KEY?: string;
-}
-
-export function configureFlueProvidersFromEnv(env: ProviderEnv) {
+export function configureFlueProvidersFromEnv(env: FlueProviderEnv) {
    if (env.OPENCODE_GO_GATEWAY_KEY) {
       configureProvider("opencode-go", {
          baseUrl: env.OPENCODE_GO_BASE_URL ?? DEFAULT_OPENCODE_GO_BASE_URL,

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@flue/runtime": "^0.7.0",
         "@octokit/core": "^7.0.6",
         "better-result": "catalog:validation",
+        "evlog": "catalog:logging",
         "valibot": "^1.4.1",
         "zod": "catalog:validation",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@flue/runtime": "^0.7.0",
         "@octokit/core": "^7.0.6",
         "better-result": "catalog:validation",
+        "valibot": "^1.4.1",
         "zod": "catalog:validation",
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -276,6 +276,7 @@
       "@flue/runtime": "^0.7.0",
       "@octokit/core": "^7.0.6",
       "better-result": "catalog:validation",
+      "evlog": "catalog:logging",
       "valibot": "^1.4.1",
       "zod": "catalog:validation"
    },

--- a/package.json
+++ b/package.json
@@ -276,6 +276,7 @@
       "@flue/runtime": "^0.7.0",
       "@octokit/core": "^7.0.6",
       "better-result": "catalog:validation",
+      "valibot": "^1.4.1",
       "zod": "catalog:validation"
    },
    "devDependencies": {


### PR DESCRIPTION
## Summary
- Trunca diff/comentários no prompt para evitar falha do modelo com contexto grande
- Mantém artefatos completos (`pr.patch`, comentários etc.) para auditoria e validação posterior
- Registra `prompt-context-size.json` nos artefatos
- Inclui causa formatada nos erros de prompt para diagnóstico futuro

## Evidência
- Run #29 já usa os fixes de checkout/contextDir, mas falha em `modelSession.prompt`
- Artefato da PR #990 tem `pr.patch` com ~778KB, além de comentários/reviews, gerando prompt grande demais

## Checks
- flue build --target node via binário local
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limita o contexto dos prompts e migra os agentes para skills do Flue com outputs estruturados e erros padronizados, reduzindo falhas em PRs grandes e alinhando a execução ao AGENTS.md.

- **Bug Fixes**
  - Novo `truncateForPrompt` (diff: 180k; reviews gerais: 12k; inline review: 18k; general PR comments: 18k) + métrica em `prompt-context-size.json`.
  - `pr-review`, `security-audit` e `release-notes` passam a usar skills do Flue (não carregam mais `AGENTS.md`/references no prompt); outputs via `valibot` e remoção do parsing manual de JSON.
  - Padronização de erros com `evlog` (+ `detail` via `formatCause`); catálogos por agente e util.
  - Fatoração: `lib/agent-utils.ts` com `safeRepoSchema`, `safePathSchema`, `truncateForPrompt`, `readPreparedContext`, `resolveGithubToken`, `publishIssueComment`, `formatCause`, `flueProviderEnvSchema`, `validateFlueProviderEnv`.
  - Infra: agentes usam sandbox `local` do `@flue/runtime/node`; `.flue/app.ts` valida `OPENCODE_*` e configura providers; `providers.ts` tipado com `FlueProviderEnv`.
  - `dryRun` em `pr-review` e `security-audit` (não publica comentários/não falha gate); tarefas instruem a não usar ferramentas externas.

- **Impacto e Testes**
  - Router/Repositório: sem mudanças; apenas truncamento e validação estruturada do contexto.
  - Componente: `pr-review`/`security-audit` chamam skills com args (patch truncado, checks, commits); catálogos `evlog`, `dryRun` e publicação via util; `release-notes` usa skill `release` e validação estruturada.
  - Store: preserva artefatos (`pr.patch`, comentários, `SECURITY_AUDIT.md`, `security-audit.json`, `summary.md`); novos `prompt-context-size.json` e `publish-error.txt` quando aplicável.
  - Checklist: `flue build --target node`; `git diff --check`; rodar agentes com `dryRun: true`; validar truncamento/artefatos e outputs `valibot`; confirmar providers via `OPENCODE_*`; verificar resolução de skills no sandbox local.

<sup>Written for commit 24a7fd91331080757b8f633c4ff52ae200a3048b. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/998?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

