### PR TITLE
docs: atualizar README e CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,13 @@ Se o ambiente falhar antes de iniciar os apps, rode:
 bun run doctor
 ```
 
+Gotchas do workspace:
+
+- `bun dev` executa `scripts/dev-init.ts`; se containers locais falharem, ele avisa e continua.
+- Erro `Module has no exported member` no typecheck geralmente indica `dist` stale. Rode build do pacote `core/<pkg>` citado.
+- Nunca edite `apps/web/src/routeTree.gen.ts`; ele e gerado.
+- Nao aumente `NODE_OPTIONS` para contornar memoria; corrija a causa raiz.
+
 ## Comandos
 
 ```bash
@@ -59,7 +66,7 @@ bun run clean            # limpeza segura
 bun run clean:cache      # limpa cache
 bun run auth:generate    # regenera schema do Better Auth
 bun run landing:build    # build da landing Astro
-bun run landing:start    # preview da landing
+bun run landing:start    # preview da landing em host/port compativel com Railway
 ```
 
 Scripts de workspace ficam em `scripts/`: `setup.ts`, `dev-init.ts`, `doctor.ts`, `clean.ts`, `db-push.ts`, `ensure-database.ts`, `ensure-schemas.ts`, `check-env.ts`, `env-setup.ts`, `set-bucket-cors.ts`, `backfill-category-icons.ts` e scripts auxiliares similares.
@@ -129,38 +136,29 @@ As integracoes oficiais sao PostHog e Twenty. Nao adicione outra integracao ofic
 - Tags no produto sao sempre chamadas de **Centro de Custo**.
 - `apps/web/src/routeTree.gen.ts` e gerado; nao edite manualmente.
 
-## Skills
+## Skills e agentes
 
-Antes de mexer em um dominio, abra o skill correspondente. O conteudo do skill tem precedencia sobre instrucoes antigas.
+`AGENTS.md` e a fonte de verdade para agentes. Antes de mexer em uma area, abra o skill correspondente; o conteudo do skill tem precedencia sobre instrucoes antigas.
 
 Skills do repositorio ficam em `.agents/skills/<nome>/SKILL.md`.
 
-Mapa rapido:
+| Area | Abra este skill |
+| :-- | :-- |
+| Implementacao em `apps/`, `modules/`, `core/`, `packages/` ou `tooling/` | [`implementation`](.agents/skills/implementation/SKILL.md) |
+| Review comments, PR findings, bugs reportados, diffs e CI | [`code-review`](.agents/skills/code-review/SKILL.md) |
+| UI, UX, copy de produto, layout, dashboards, forms, sheets e surfaces autenticadas | [`design`](.agents/skills/design/SKILL.md) |
+| Release workflows, release notes, tags, GitHub Releases, Linear Releases e recuperacao | [`release`](.agents/skills/release/SKILL.md) |
+| Documentacao tecnica, `docs/project` e automacao de docs | [`docs`](.agents/skills/docs/SKILL.md) |
+| Blog, LinkedIn, X, release blog posts e marketing drafts | [`marketing`](.agents/skills/marketing/SKILL.md) |
 
-- Novo dominio, Payments/Vault ou erro de dominio: `better-result`
-- Codigo legado oRPC/erros ainda em `neverthrow`: `neverthrow`
-- oRPC client e TanStack Query: `tanstack-query`
-- Banco, schemas e queries: `postgres-drizzle`
-- Busca/BM25: `paradedb-skill`
-- Redis: `redis-best-practices`
-- DBOS e workflows: `dbos-typescript`
-- Better Auth: `better-auth-best-practices`
-- Formularios: `tanstack-form`
-- Rotas e loaders: `tanstack-router`, `tanstack-start`
-- Tabelas: `tanstack-table`, `tanstack-virtual`
-- shadcn e UI primitives: `shadcn`
-- UI/UX e acessibilidade: `ui-ux-expert`, `wcag-audit-patterns`
-- Nx workspace: `nx-workspace`
-- Geradores Nx: `nx-generate`
-- Tarefas Nx: `nx-run-tasks`
-- CI Nx Cloud: `monitor-ci`
-- Linear: `linear-cli`
+Quando uma tarefa cruzar areas, abra todos os skills relevantes. Exemplo: bug visual usa `code-review`, `implementation` e `design`; automacao de post de release usa `release`, `marketing` e `implementation`.
 
-Para skills TanStack Intent, siga o bloco de mapeamento em `AGENTS.md` e carregue com:
+Ferramentas operacionais:
 
-```bash
-npx @tanstack/intent@latest load <use>
-```
+- CI checks: `monitor-ci`
+- Linear (`MON-*`): `linear-cli`
+
+Skills especificos de framework ou biblioteca podem existir, mas siga primeiro o roteamento de `AGENTS.md`.
 
 ## Testes e verificacao
 
@@ -202,6 +200,12 @@ Commits devem ser curtos e descritivos, por exemplo:
 ```text
 docs: atualizar readme e contributing
 ```
+
+## Releases
+
+O produto unico (`apps/web`) usa CalVer `YYYY.MM.DD` com tag `vYYYY.MM.DD`. O workflow `.github/workflows/release-weekly.yml` coleta commits e PRs desde a ultima tag, gera release notes em pt-BR e cria GitHub Release + Linear Release. O workflow `.github/workflows/blog-post-from-release.yml` gera PR de post a partir de releases publicadas, e `.github/workflows/project-documentation.yml` atualiza `docs/project`.
+
+Alteracoes nesses fluxos devem seguir os skills `release`, `marketing`, `docs` e/ou `implementation`, conforme a area tocada.
 
 ## Problemas e sugestoes
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ Veja [CONTRIBUTING.md](CONTRIBUTING.md) para comandos, validacoes e padroes de c
 
 ---
 
+## Agentes e skills
+
+`AGENTS.md` e a fonte de verdade para agentes trabalhando no repositorio. Antes de alterar uma area, abra o skill correspondente em `.agents/skills/<nome>/SKILL.md`.
+
+| Area | Skill |
+| :-- | :-- |
+| Implementacao em `apps/`, `modules/`, `core/`, `packages/` ou `tooling/` | [`implementation`](.agents/skills/implementation/SKILL.md) |
+| Review comments, PRs, bugs, diffs e CI | [`code-review`](.agents/skills/code-review/SKILL.md) |
+| UI, UX, copy de produto, dashboards, forms e surfaces autenticadas | [`design`](.agents/skills/design/SKILL.md) |
+| Releases, tags, GitHub Releases, Linear Releases e recuperacao | [`release`](.agents/skills/release/SKILL.md) |
+| Documentacao tecnica e `docs/project` | [`docs`](.agents/skills/docs/SKILL.md) |
+| Blog, LinkedIn, X e marketing | [`marketing`](.agents/skills/marketing/SKILL.md) |
+
+Ferramentas operacionais: CI via `monitor-ci`; Linear (`MON-*`) via `linear-cli`.
+
+---
+
 ## O que existe hoje
 
 ### Web app (`apps/web`)
@@ -190,20 +207,33 @@ montte-nx/
 ```bash
 bun dev                  # dev-init + web + worker + landing
 bun run dev:desktop      # dev-init + desktop Tauri + worker + landing
-bun dev:all              # todos os apps/pacotes com target dev
-bun run build            # build via Nx
+bun dev:all              # todos os apps e pacotes com target dev
+bun run build            # build via Nx cache
 bun run typecheck        # typecheck via Nx
 bun run check            # oxlint
 bun run format           # oxfmt --write
 bun run test             # testes via Nx
 bun run db:push          # aplica schema local
-bun run doctor           # diagnostico do ambiente
+bun run db:studio:local  # Drizzle Studio local
+bun run db:studio:prod   # Drizzle Studio producao
 bun run check-boundaries # valida regras de importacao
+bun run clean            # limpeza segura
+bun run clean:cache      # limpa cache
+bun run auth:generate    # regenera schema do Better Auth
 bun run landing:build    # build da landing Astro
+bun run landing:start    # preview da landing
+bun run doctor           # diagnostico do ambiente
 bun run e2e              # Playwright
 ```
 
 Scripts operacionais ficam em `scripts/`, incluindo `setup.ts`, `dev-init.ts`, `doctor.ts`, `clean.ts`, `db-push.ts`, `ensure-database.ts`, `ensure-schemas.ts`, `check-env.ts`, `env-setup.ts`, `set-bucket-cors.ts` e `backfill-category-icons.ts`.
+
+Gotchas:
+
+- `bun dev` executa `scripts/dev-init.ts`; se containers locais falharem, o script avisa e continua. Confirme o ambiente com `bun run doctor`.
+- Erro `Module has no exported member` no typecheck costuma indicar `dist` stale. Rode build do pacote `core/<pkg>` citado.
+- Nunca edite `apps/web/src/routeTree.gen.ts`; o arquivo e gerado.
+- Nao aumente `NODE_OPTIONS` para contornar memoria; corrija a causa raiz.
 
 ---
 
@@ -224,6 +254,10 @@ Para chamadas programaticas, crie uma chave em Configuracoes do projeto -> API K
 Leia [CONTRIBUTING.md](CONTRIBUTING.md) antes de abrir PR. O projeto usa padroes fortes para oRPC, Drizzle, TanStack Query, DBOS, UI e boundaries.
 
 Roadmap e trabalho ativo vivem no Linear do Montte. Issues no GitHub sao bem-vindas para bugs e sugestoes publicas.
+
+## Releases
+
+O produto unico (`apps/web`) usa CalVer `YYYY.MM.DD` com tag `vYYYY.MM.DD`. O workflow `.github/workflows/release-weekly.yml` gera release notes em pt-BR, tag, GitHub Release e Linear Release. `.github/workflows/blog-post-from-release.yml` transforma releases publicadas em PR de post. `.github/workflows/project-documentation.yml` atualiza `docs/project`.
 
 ## Licenca
 

--- a/docs/research/self-updating-docs.md
+++ b/docs/research/self-updating-docs.md
@@ -1,0 +1,438 @@
+# Deep research — docs/wiki autoatualizadas para o Flue
+
+Data: 2026-05-25
+
+## Objetivo
+
+Entender como cubic e Dosu mantêm documentação/wiki gerada por IA e desenhar uma versão nativa para o **Flue — The Agent Harness Framework**: documentação pública autoatualizada semanalmente, versionada no GitHub, usada como fonte do `/docs` da landing, e também consumível por agentes.
+
+## Contexto do Flue usado neste research
+
+Flue é um framework TypeScript para construir agentes headless/programáveis com agent harness embutido. A DX é parecida com Claude Code/Codex/OpenCode/Pi, mas sem TUI/GUI e sem pressupor operador humano.
+
+Elementos importantes para docs:
+
+- agentes vivem em `.flue/agents/<name>.ts`;
+- lógica operacional fica majoritariamente em Markdown: `AGENTS.md`, `.agents/skills/`, roles e contexto;
+- `init()` cria harnesses com modelo, sandbox, tools, filesystem e sessões;
+- `harness.session()` abre sessões persistentes;
+- `session.prompt()`, `session.skill()` e `session.task()` são primitivas centrais;
+- `flue run <agent>` executa agentes localmente/CI;
+- `local()` é ideal para CI porque dá acesso a git, gh, npm e filesystem do runner;
+- Flue é runtime-agnostic: Node.js, Cloudflare, GitHub Actions, GitLab CI/CD etc.;
+- MCP é suportado como tool adapter via `connectMcpServer()`;
+- sandboxes podem ser virtuais, locais, Cloudflare/cf-shell ou remotas via conectores como Daytona.
+
+Conclusão: a feature de docs deve **dogfoodar Flue**. Em vez de chamar só um bot externo no workflow, criar um agente Flue `docs-refresh` que coleta contexto, invoca skills e escreve Markdown.
+
+## Resumo executivo
+
+- **cubic**: wiki externa/searchable gerada a partir do codebase. Foco em indexação completa, links para código, diagramas, chat e MCP. Atualiza por regeneração manual/semanal/mensal.
+- **Dosu**: knowledge base com lifecycle. Gera drafts a partir de código, PRs, issues e conversas; publica com revisão; monitora documentos publicados contra PRs/MRs e atualiza docs relacionadas.
+- **Flue deve combinar os dois padrões**, mas com GitHub como fonte auditável e a landing como superfície pública:
+  - conteúdo Markdown/MDX versionado no repo;
+  - rota `/docs` na landing renderizando esse conteúdo;
+  - mesmas docs usadas pelo Montte AI como base confiável para explicar o produto;
+  - agente Flue semanal rodando em CI;
+  - PR automático para revisão humana;
+  - índice LLM-readable tipo `llms.txt`;
+  - no futuro, staleness check em PRs e MCP/read API.
+
+Complemento obrigatório: a estratégia editorial para `/docs` está em `docs/research/user-facing-technical-docs-strategy.md`. O agente `docs-refresh` deve seguir esse documento para equilibrar explicações para iniciantes, profundidade técnica para usuários avançados e uso seguro pelo Montte AI em respostas ao usuário.
+
+## Como o cubic parece implementar
+
+Fontes principais:
+
+- `https://docs.cubic.dev/wiki/ai-wiki`
+- `https://www.cubic.dev/blog/ai-wiki-and-mcp-support-for-code-review`
+- `https://www.cubic.dev/blog/ai-generated-documentation`
+- `https://docs.cubic.dev/ide/mcp-server`
+
+Padrões observados:
+
+- indexa o codebase e produz wiki pesquisável;
+- páginas têm links para código-fonte e podem incluir diagramas;
+- suporta perguntas em linguagem natural;
+- permite custom instructions por repositório;
+- tem auto-refresh semanal ou mensal;
+- expõe a wiki via MCP para IDEs/agentes;
+- não promete atualização em tempo real: é necessário regenerar para refletir mudanças recentes.
+
+O que copiar para Flue:
+
+- índice pesquisável/agent-readable;
+- páginas com paths reais do código;
+- refresh semanal;
+- instructions por repo/domínio;
+- futuro MCP para consultar docs geradas.
+
+O que não copiar no início:
+
+- knowledge base externa como única fonte;
+- regeneração opaca sem PR/diff;
+- dependência de UI para gerar ou revisar.
+
+## Como o Dosu parece implementar
+
+Fontes principais:
+
+- `https://dosu.dev/blog/using-ai-to-generate-and-maintain-documentation`
+- `https://app.dosu.dev/9affd04a-e6a9-452c-b927-c639e979994c/documents/a02d84e2-6162-4c9e-bb14-4eeb063c2e40`
+- `https://app.dosu.dev/9affd04a-e6a9-452c-b927-c639e979994c/documents/13015099-253a-4ec5-8791-5ac9e17b8379`
+- `https://app.dosu.dev/9affd04a-e6a9-452c-b927-c639e979994c/documents/8d46c36e-d383-4738-b8c2-c6b7cd27da8f`
+
+Padrões observados:
+
+- usa código, diffs, PRs, issues, tickets e conversas como sinais;
+- gera drafts antes de publicar;
+- aplica templates e style guidelines;
+- monitora apenas documentos publicados;
+- quando PR abre, comenta docs relacionadas;
+- quando PR mergeia, atualiza docs relacionadas;
+- permite monitored paths/globs;
+- permite `/dosu-refresh` manual;
+- Self-Documenting PRs atualiza a knowledge base e comenta no PR; não necessariamente abre PR alterando arquivos do repo.
+
+O que copiar para Flue:
+
+- draft/review via PR;
+- templates em Markdown/skills;
+- monitored paths;
+- PR-aware staleness check;
+- vínculo entre doc gerada, commit/ref e PRs.
+
+O que adaptar:
+
+- em Flue, a saída principal deve ser arquivo Markdown versionado, não knowledge base fechada;
+- o mecanismo deve ser um agente Flue executável por `flue run`, não só um app SaaS.
+
+## Comparação prática
+
+| Dimensão | cubic | Dosu | Flue recomendado |
+|---|---|---|---|
+| Fonte | Codebase indexado | Code + PRs + issues + docs publicadas | Repo + git diff + PR metadata + skills |
+| Saída | Wiki externa | Knowledge base; pode publicar GitHub/Confluence | Conteúdo da landing `/docs` + índice agent-readable |
+| Atualização | Manual/semanal/mensal | PR/MR-aware | Semanal primeiro; PR-aware depois |
+| Revisão | Não claro nas fontes públicas | Draft/publicação | PR obrigatório no início |
+| Agent DX | MCP | Q&A/integrações | `llms.txt` primeiro; MCP depois |
+| Guardrails | Custom instructions | Templates/style/paths | `AGENTS.md`, skills, templates, validação |
+
+## Arquitetura recomendada para Flue
+
+### Visão geral
+
+Criar um agente nativo:
+
+```text
+.flue/agents/docs-refresh.ts
+```
+
+Rodado por GitHub Actions:
+
+```bash
+flue run docs-refresh --target node --id weekly-docs --payload '{"mode":"weekly","target":"landing-docs"}'
+```
+
+O output principal não é uma wiki interna solta: é o conteúdo que a landing renderiza em `/docs` e que o Montte AI usa como knowledge base canônica para explicar o produto. O diretório exato depende da estrutura da landing, mas o contrato deve ser algo como:
+
+```text
+apps/landing/src/content/docs/**/*.mdx
+```
+
+ou, se a landing consumir conteúdo compartilhado:
+
+```text
+docs/content/**/*.mdx
+```
+
+Com sandbox local em CI:
+
+```ts
+import { local } from '@flue/runtime/node';
+
+const harness = await init({
+  sandbox: local({ env: { GH_TOKEN: process.env.GH_TOKEN } }),
+  model: 'anthropic/claude-sonnet-4-6',
+});
+```
+
+O agente lê o repo, coleta contexto determinístico, chama uma skill de documentação e escreve apenas no diretório de conteúdo público configurado, além do índice `docs/llms.txt`. Artifacts internos como `documentation-context.md` não devem ser publicados em `/docs` nem usados como resposta direta pelo Montte AI.
+
+### Arquivos propostos
+
+```text
+.flue/agents/docs-refresh.ts
+.agents/skills/docs/SKILL.md
+.agents/skills/docs/references/public-docs-pages.md
+.agents/skills/docs/references/style.md
+.agents/skills/docs/references/validation.md
+.github/workflows/docs-refresh.yml
+apps/landing/src/content/docs/index.mdx
+apps/landing/src/content/docs/quickstart.mdx
+apps/landing/src/content/docs/concepts/agents-harness-sessions.mdx
+apps/landing/src/content/docs/concepts/sandboxes.mdx
+apps/landing/src/content/docs/guides/support-agent.mdx
+apps/landing/src/content/docs/guides/issue-triage-ci.mdx
+apps/landing/src/content/docs/guides/coding-agent-remote-sandbox.mdx
+apps/landing/src/content/docs/guides/mcp-tools.mdx
+apps/landing/src/content/docs/reference/runtime.mdx
+apps/landing/src/content/docs/reference/cli.mdx
+apps/landing/src/content/docs/reference/cloudflare.mdx
+apps/landing/src/content/docs/reference/connectors.mdx
+docs/llms.txt
+```
+
+Se a landing não usar `apps/landing/src/content/docs`, adaptar o path ao content system real. O importante é: **o agente atualiza a fonte renderizada por `/docs`**, não uma documentação paralela.
+
+### IA inicial para `/docs`
+
+Cada página deve servir dois públicos ao mesmo tempo:
+
+- **iniciante**: quer entender o conceito e copiar um exemplo funcional rápido;
+- **avançado**: quer saber limites, runtime behavior, trade-offs, APIs e deploy details.
+
+A estrutura recomendada por página:
+
+```mdx
+# Title
+
+Short plain-English explanation.
+
+## Quick example
+
+## How it works
+
+## When to use this
+
+## Advanced details
+
+## API/reference
+
+## Next steps
+```
+
+| Rota pública | Fonte sugerida | Escopo |
+|---|---|---|
+| `/docs` | `index.mdx` | overview, mental model e navegação |
+| `/docs/quickstart` | `quickstart.mdx` | primeiro agente mínimo com typed result |
+| `/docs/concepts/agents-harness-sessions` | `concepts/agents-harness-sessions.mdx` | agent instance, harnesses, sessions, state |
+| `/docs/concepts/sandboxes` | `concepts/sandboxes.mdx` | virtual sandbox, `local()`, Cloudflare shell/cf-shell, Daytona/remotos |
+| `/docs/guides/support-agent` | `guides/support-agent.mdx` | support agent em Cloudflare/cf-shell |
+| `/docs/guides/issue-triage-ci` | `guides/issue-triage-ci.mdx` | agente rodando em CI com `flue run` |
+| `/docs/guides/coding-agent-remote-sandbox` | `guides/coding-agent-remote-sandbox.mdx` | coding agent com sandbox remoto |
+| `/docs/guides/mcp-tools` | `guides/mcp-tools.mdx` | `connectMcpServer()` e ferramentas remotas |
+| `/docs/reference/runtime` | `reference/runtime.mdx` | API de `@flue/runtime` |
+| `/docs/reference/cli` | `reference/cli.mdx` | `flue dev`, `flue run`, `flue build`, `flue add` |
+| `/docs/reference/cloudflare` | `reference/cloudflare.mdx` | Cloudflare target, Durable Objects, cf-shell |
+| `/docs/reference/connectors` | `reference/connectors.mdx` | modelo de conectores |
+
+### Coleta de contexto
+
+O agente deve produzir um arquivo temporário/artifact:
+
+```text
+documentation-context.md
+```
+
+Conteúdo mínimo:
+
+- repo, branch, commit atual e tag base;
+- árvore relevante;
+- `package.json`, workspace config, tsconfig, build config;
+- arquivos em `.flue/agents/**`;
+- arquivos em `.agents/skills/**`;
+- roles/context files;
+- docs existentes e conteúdo atual da landing `/docs`;
+- commits desde última tag;
+- PRs mergeados desde última tag via `gh` quando `GH_TOKEN` existir;
+- paths alterados agrupados por domínio;
+- lista de arquivos ignorados por segurança.
+
+Não incluir:
+
+- `.env`;
+- tokens;
+- valores reais de secrets;
+- arquivos grandes gerados;
+- `node_modules`, `dist`, coverage, lockfile gigante salvo integralmente.
+
+### Prompt/skill contract
+
+A skill de docs deve impor:
+
+- usar só fatos presentes no contexto ou em arquivos reais lidos;
+- escrever para documentação **user-facing** da landing: fácil para usuários leigos, mas com profundidade suficiente para usuários avançados;
+- usar inglês claro e técnico quando necessário, porque o `/docs` da landing é documentação pública de um framework/devtool global;
+- organizar cada página em camadas:
+  1. explicação simples do conceito;
+  2. exemplo mínimo copiável;
+  3. detalhes técnicos e trade-offs;
+  4. referência/API quando aplicável;
+- sempre citar APIs, comandos e paths reais quando o assunto for implementação;
+- declarar lacunas como “Not identified in collected context.”;
+- não gerar API inexistente;
+- não escrever fora do diretório de conteúdo público da landing e `docs/llms.txt`;
+- manter páginas pequenas, navegáveis e revisáveis.
+
+### Workflow semanal
+
+```yaml
+name: Docs Refresh
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - run: bunx flue run docs-refresh --target node --id weekly-docs --payload '{"mode":"weekly","target":"landing-docs"}'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      - run: git diff --check -- apps/landing docs .agents .flue
+      - run: bun run landing:build
+      - name: Open PR
+        if: inputs.dry_run != true
+        run: |
+          # criar branch automation/docs-refresh-YYYY.MM.DD
+          # commit docs/wiki docs/llms.txt
+          # abrir/atualizar PR
+```
+
+## PR-aware staleness check
+
+Depois do semanal estar estável, criar segundo agente:
+
+```text
+.flue/agents/docs-staleness.ts
+```
+
+Disparos:
+
+- `pull_request opened/synchronize/ready_for_review`;
+- comentário `/docs-refresh`.
+
+Comportamento:
+
+1. ler arquivos alterados no PR;
+2. mapear paths para páginas de docs;
+3. comentar links das páginas relacionadas;
+4. opcionalmente label `docs-needed`;
+5. não editar docs automaticamente no PR até a acurácia estar boa.
+
+Exemplo:
+
+```text
+This PR changes `.flue/agents/**` and `@flue/runtime` session behavior.
+Likely public docs to review:
+- /docs/concepts/agents-harness-sessions
+- /docs/reference/runtime
+```
+
+## Guardrails contra documentação falsa
+
+- Docs geradas via PR, não commit direto.
+- Cada página inclui “Last generated from: `<commit>`”.
+- Cada seção técnica aponta paths reais.
+- Lacunas ficam explícitas.
+- Validação bloqueia criação de arquivos fora do allowlist.
+- O agente não recebe secrets além do necessário (`GH_TOKEN` para metadata).
+- `local()` sandbox em CI herda env mínimo; passar secrets explicitamente.
+- Ignorar `.env`, logs, artifacts, fixtures sensíveis.
+
+## Estratégia de dogfooding
+
+Essa feature é uma vitrine perfeita do Flue:
+
+- mostra `flue run` em CI;
+- usa `local()` sandbox;
+- usa skills como lógica principal;
+- usa `session.task()` para pesquisa paralela por domínio;
+- usa typed result para resumo/estatísticas;
+- pode evoluir para Cloudflare/Node deploy se virar produto;
+- pode usar MCP depois para publicar/consultar docs.
+
+Exemplo de decomposição interna:
+
+```ts
+const runtimeResearch = await session.task('Research @flue/runtime docs and changed files.', {
+  role: 'docs-researcher',
+});
+
+const cliResearch = await session.task('Research @flue/cli docs and changed files.', {
+  role: 'docs-researcher',
+});
+
+await session.skill('docs', {
+  args: { contextFile: 'documentation-context.md', outputDir: 'docs/wiki' },
+});
+```
+
+## Plano de implementação
+
+### Fase 1 — MVP semanal
+
+- Criar `.flue/agents/docs-refresh.ts`.
+- Criar skill `.agents/skills/docs/SKILL.md`.
+- Criar templates/regras para docs públicas.
+- Criar `.github/workflows/docs-refresh.yml`.
+- Gerar/atualizar conteúdo MDX usado pela landing em `/docs` e `docs/llms.txt` usado pelo Montte AI.
+- Rodar build da landing.
+- Abrir PR semanal.
+
+### Fase 2 — Melhor contexto
+
+- Adicionar PR metadata via `gh`.
+- Agrupar diffs por domínio.
+- Gerar changelog técnico em `recent-changes.md`.
+- Incluir citações/paths por seção.
+
+### Fase 3 — Staleness em PR
+
+- Criar `docs-staleness`.
+- Comentar docs relacionadas no PR.
+- Adicionar comando `/docs-refresh`.
+
+### Fase 4 — Wiki/API para agentes
+
+- Publicar `/docs` na landing e manter `docs/llms.txt` como índice para agentes.
+- Adicionar endpoint ou MCP server para consultar páginas.
+- Opcional: sincronizar com site público.
+
+## Decisão recomendada
+
+Implementar primeiro como **Flue agent + GitHub Action semanal + PR de conteúdo da landing `/docs`**.
+
+Isso entrega o valor central de cubic/Dosu sem criar uma knowledge base paralela:
+
+- auditável no Git;
+- revisável por PR;
+- publicado automaticamente pela landing;
+- dogfooda Flue;
+- útil para usuários humanos e para o Montte AI;
+- fácil de estender para staleness/MCP depois.
+
+## Perguntas abertas
+
+- Qual será o content system da landing: Astro content collections, MDX direto, ou outro?
+- O diretório final será `apps/landing/src/content/docs` ou um pacote compartilhado de conteúdo?
+- Qual modelo será padrão no CI?
+- O workflow deve rodar só semanalmente ou também após release?
+- PR de docs pode auto-mergear após checks ou sempre precisa review humano?

--- a/docs/research/user-facing-technical-docs-strategy.md
+++ b/docs/research/user-facing-technical-docs-strategy.md
@@ -1,0 +1,551 @@
+# Deep research — user-facing technical docs strategy for Flue
+
+Data: 2026-05-25
+
+## Objetivo
+
+Definir como escrever a documentação pública do Flue em `/docs`: simples o bastante para usuários leigos entenderem e começarem, mas precisa e profunda o bastante para usuários avançados confiarem como referência técnica.
+
+Essas docs têm dois consumidores principais:
+
+- **usuários humanos**, que vão ler `/docs` para entender o produto e se virar sozinhos;
+- **Montte AI**, que vai usar as mesmas docs como base confiável para explicar ao usuário como as coisas funcionam.
+
+Essa estratégia deve orientar:
+
+- conteúdo gerado pelo agente semanal `docs-refresh`;
+- revisão humana dos PRs de documentação;
+- arquitetura de informação da landing `/docs`;
+- tom, templates e guardrails para docs geradas por IA;
+- estrutura de conteúdo que funcione bem para leitura humana e retrieval/grounding por IA.
+
+## Fontes pesquisadas
+
+- Diátaxis — `https://diataxis.fr/` e `https://www.diataxis.fr/map/`
+- Google Developer Documentation Style Guide — `https://developers.google.com/style/tone`
+- Google Technical Writing — Audience/Documents — `https://developers.google.com/tech-writing/one/audience`, `https://developers.google.com/tech-writing/one/documents`
+- MDN — Creating effective technical documentation — `https://developer.mozilla.org/en-US/blog/technical-writing/`
+- Write the Docs — Software documentation guide — `https://www.writethedocs.org/guide/`
+- Stripe Docs/API reference — `https://docs.stripe.com/api`
+
+## Achados principais
+
+### 1. Documentação precisa responder a intenções diferentes
+
+Diátaxis separa documentação em quatro modos:
+
+| Modo | Pergunta do usuário | Uso no Flue |
+|---|---|---|
+| Tutorial | “Can you teach me?” | Quickstart, primeiro agente, primeiro deploy |
+| How-to guide | “How do I do X?” | suporte, triagem em CI, MCP, Cloudflare, Daytona |
+| Reference | “What is the exact API/command?” | `@flue/runtime`, `@flue/cli`, config, options |
+| Explanation | “Why does it work this way?” | harness/session model, sandbox trade-offs, runtime-agnostic design |
+
+Para Flue, isso significa que `/docs` não deve ser só uma lista de APIs nem só um tutorial longo. Precisa ter rotas e seções que deixem claro o tipo de ajuda que o usuário está buscando.
+
+### 2. A mesma página pode ter camadas, mas não pode misturar intenções sem controle
+
+Como a docs será user-facing, muitas páginas precisam servir dois públicos:
+
+- iniciante: quer entender “o que é isso?” e copiar um exemplo;
+- avançado: quer detalhes de runtime, limites, trade-offs e API.
+
+O padrão recomendado é **progressive disclosure**:
+
+1. explicar em linguagem simples;
+2. mostrar um exemplo mínimo;
+3. explicar como funciona;
+4. mostrar detalhes avançados;
+5. fechar com referência ou próximos passos.
+
+Isso evita dois extremos ruins:
+
+- docs fáceis, mas superficiais demais para produção;
+- docs completas, mas intimidadoras para quem chegou agora.
+
+### 3. Usuário vem com tarefa, não com vontade de ler arquitetura
+
+Google Technical Writing define boa documentação como:
+
+> conhecimento e habilidades que o público precisa para realizar uma tarefa, menos o que ele já sabe.
+
+Aplicação para Flue:
+
+- começar páginas com o objetivo prático;
+- declarar pré-requisitos;
+- não assumir que todo usuário conhece agent harness, sandboxes, Durable Objects, MCP ou CI;
+- introduzir termos antes de usá-los em profundidade;
+- explicar conceitos comparando com ferramentas que o público conhece: Claude Code, Codex, OpenCode, Pi, Next.js/Astro.
+
+### 4. Tom deve ser claro, direto e respeitoso
+
+Google recomenda voz conversacional, amigável e respeitosa, sem gírias, sem exagerar no informal e sem soar pedante.
+
+Para Flue:
+
+- usar inglês simples e global;
+- evitar idioms/culture-specific jokes;
+- evitar “simply”, “easy”, “just” quando isso pode diminuir a dificuldade real;
+- falar como um engenheiro experiente sentado ao lado do usuário;
+- não misturar marketing agressivo dentro das páginas de docs.
+
+### 5. Clareza, concisão e consistência são mais importantes que estilo bonito
+
+MDN resume o núcleo da escrita técnica em:
+
+- clarity;
+- conciseness;
+- consistency.
+
+Aplicação:
+
+- uma ideia por frase quando possível;
+- parágrafos curtos;
+- termos consistentes: não alternar “agent instance”, “agent run”, “session” e “thread” se significam coisas diferentes;
+- exemplos curtos, reais e copiáveis;
+- headings descritivos;
+- links com texto descritivo.
+
+### 6. Reference precisa ser seca, completa e confiável
+
+Stripe é bom exemplo de docs que combinam:
+
+- visão simples no topo;
+- exemplos executáveis;
+- referência precisa;
+- status codes/errors/limites;
+- avisos de segurança sobre API keys.
+
+Para Flue:
+
+- páginas reference devem ser menos narrativas;
+- cada opção/config deve ter tipo, default, quando usar, exemplo e limitações;
+- comandos CLI devem ter flags, exemplos e efeitos;
+- API docs devem distinguir Node-only, Cloudflare-only e runtime-agnostic.
+
+## Princípio central para Flue
+
+> Every public docs page should start beginner-friendly, end production-useful, and be safe for Montte AI to quote.
+
+Tradução prática:
+
+- a abertura deve ser compreensível para alguém novo em agentes;
+- o exemplo deve funcionar sem contexto excessivo;
+- o meio deve explicar o modelo mental;
+- o final deve dar detalhes que um usuário avançado precisa para usar em produção;
+- cada seção deve poder ser recuperada por IA sem induzir uma resposta errada ou incompleta.
+
+## Dual-use docs: humanos e Montte AI
+
+As páginas de `/docs` devem ser a fonte canônica tanto para self-service quanto para respostas do Montte AI. Isso muda o jeito de escrever.
+
+### Requisitos para humanos
+
+- A página precisa responder rapidamente: “isso resolve meu problema?”
+- O usuário deve conseguir copiar um exemplo e adaptar.
+- Conceitos novos precisam ser explicados antes do uso técnico.
+- Troubleshooting deve cobrir erros comuns sem obrigar contato com suporte.
+- Próximos passos devem guiar o usuário para a próxima ação.
+
+### Requisitos para Montte AI
+
+- Seções devem ser pequenas, focadas e com headings estáveis.
+- Cada seção deve ter contexto suficiente para ser citada isoladamente.
+- Termos precisam ser consistentes para melhorar retrieval.
+- Limitações, pré-requisitos e exceções precisam ser explícitos.
+- Evitar frases vagas ou promocionais, porque a IA pode repeti-las como se fossem instruções.
+- Incluir perguntas comuns e respostas canônicas quando possível.
+
+### Estrutura AI-friendly por página
+
+Cada página importante deve responder:
+
+| Pergunta | Por que importa |
+|---|---|
+| What is it? | Ajuda iniciante e AI a definir o conceito sem inventar. |
+| When should I use it? | Ajuda decisão e recomendação. |
+| How do I use it? | Dá caminho prático para usuário self-service. |
+| What can go wrong? | Alimenta troubleshooting e respostas de suporte. |
+| What are the limits? | Evita promessas erradas em respostas da IA. |
+| What should I read next? | Ajuda navegação humana e AI follow-up. |
+
+### Índice para Montte AI
+
+Além do conteúdo renderizado pela landing, manter um índice legível por agentes:
+
+```text
+docs/llms.txt
+```
+
+Fase futura opcional:
+
+```text
+docs/ai-docs-index.json
+```
+
+Formato sugerido:
+
+```json
+{
+  "pages": [
+    {
+      "title": "Agents, harnesses, and sessions",
+      "route": "/docs/concepts/agents-harness-sessions",
+      "source": "apps/landing/src/content/docs/concepts/agents-harness-sessions.mdx",
+      "summary": "Explains the lifecycle of agent instances, harnesses, and sessions.",
+      "topics": ["agents", "harness", "sessions", "state"],
+      "commonQuestions": [
+        "What is the difference between a harness and a session?",
+        "How do I continue the same conversation?"
+      ],
+      "lastUpdatedCommit": "<commit-sha>"
+    }
+  ]
+}
+```
+
+Esse índice não substitui `/docs`; ele ajuda Montte AI a encontrar a página certa e citar a fonte correta.
+
+## Arquitetura de informação recomendada para `/docs`
+
+### Camada 1 — Getting started
+
+Objetivo: levar o usuário de zero para “rodei meu primeiro agente”.
+
+Rotas:
+
+```text
+/docs
+/docs/quickstart
+/docs/installation
+/docs/project-structure
+```
+
+Conteúdo:
+
+- o que é Flue em linguagem simples;
+- como criar um agente mínimo;
+- como rodar com `flue dev` e `flue run`;
+- onde ficam `.flue/agents`, `.agents/skills`, `AGENTS.md`.
+
+### Camada 2 — Core concepts
+
+Objetivo: construir modelo mental.
+
+Rotas:
+
+```text
+/docs/concepts/agents-harnesses-sessions
+/docs/concepts/sandboxes
+/docs/concepts/skills-roles-context
+/docs/concepts/tasks
+/docs/concepts/runtime-targets
+```
+
+Conteúdo:
+
+- agent instance vs harness vs session;
+- sandbox virtual, local, Cloudflare, remoto;
+- skills/roles/context como lógica em Markdown;
+- `session.task()` para trabalho focado/paralelo;
+- diferenças Node/Cloudflare/CI.
+
+### Camada 3 — Guides
+
+Objetivo: resolver tarefas concretas.
+
+Rotas:
+
+```text
+/docs/guides/support-agent
+/docs/guides/issue-triage-ci
+/docs/guides/coding-agent-remote-sandbox
+/docs/guides/mcp-tools
+/docs/guides/cloudflare-support-agent
+/docs/guides/github-actions-agent
+```
+
+Conteúdo:
+
+- receita passo a passo;
+- código completo ou quase completo;
+- pré-requisitos;
+- troubleshooting;
+- próximos passos.
+
+### Camada 4 — Reference
+
+Objetivo: responder “qual é a API exata?”.
+
+Rotas:
+
+```text
+/docs/reference/runtime
+/docs/reference/cli
+/docs/reference/cloudflare
+/docs/reference/node
+/docs/reference/connectors
+/docs/reference/provider-settings
+```
+
+Conteúdo:
+
+- assinaturas;
+- opções;
+- defaults;
+- runtime support;
+- exemplos mínimos;
+- erros comuns.
+
+### Camada 5 — Advanced/architecture
+
+Objetivo: ajudar usuários construindo agentes em produção.
+
+Rotas:
+
+```text
+/docs/advanced/session-persistence
+/docs/advanced/sandbox-strategy
+/docs/advanced/security-and-secrets
+/docs/advanced/deploying-at-scale
+/docs/advanced/mcp-and-external-tools
+```
+
+Conteúdo:
+
+- trade-offs;
+- segurança;
+- estado/persistência;
+- performance/custo;
+- deploy em ambientes diferentes.
+
+## Template recomendado por página
+
+### Para páginas de conceito
+
+```mdx
+# <Concept name>
+
+One-paragraph explanation in plain English.
+
+## Why it matters
+
+Explain the problem this concept solves.
+
+## Quick example
+
+Show the smallest useful example.
+
+## How it works
+
+Explain the mechanism without assuming deep prior knowledge.
+
+## Common mistakes
+
+List confusing parts and how to avoid them.
+
+## Advanced details
+
+Runtime behavior, lifecycle, persistence, limitations, trade-offs.
+
+## Related APIs
+
+Link to reference pages.
+
+## Next steps
+
+Link to guides that use the concept.
+```
+
+### Para how-to guides
+
+```mdx
+# <Do the task>
+
+Short outcome-focused summary.
+
+## What you'll build
+
+State the final result.
+
+## Before you start
+
+Prerequisites and assumptions.
+
+## Step 1: ...
+
+Numbered steps with code.
+
+## Step 2: ...
+
+Continue until the user gets a working result.
+
+## Troubleshooting
+
+Common errors and fixes.
+
+## How it works
+
+Explain the relevant concepts after the user has seen the result.
+
+## Production notes
+
+Security, deployment, persistence, cost, scaling.
+
+## Next steps
+```
+
+### Para reference
+
+```mdx
+# <API or command>
+
+Brief description.
+
+## Signature / command
+
+## Parameters / flags
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+
+## Returns / output
+
+## Examples
+
+## Runtime support
+
+| Runtime | Supported | Notes |
+|---|---|---|
+
+## Errors and edge cases
+
+## Related guides
+```
+
+## Regras de estilo para Flue `/docs`
+
+### Voz
+
+- Clear, direct, calm.
+- Friendly, but not cute.
+- Confident, but not salesy.
+- Technical where needed, but never needlessly abstract.
+
+### Linguagem
+
+- Inglês simples para público global.
+- Introduzir termos antes de usá-los.
+- Preferir frases curtas.
+- Evitar idioms, memes e referências culturais.
+- Evitar “just”, “simply”, “obviously”, “easy”.
+- Evitar hype de landing dentro da doc.
+
+### Estrutura
+
+- Começar com resultado/benefício prático.
+- Colocar exemplo cedo.
+- Dividir iniciante/intermediário/avançado por seções.
+- Usar tabelas para comparação e opções.
+- Usar bullets para listas escaneáveis.
+- Cada página deve ter próximos passos.
+
+### Código
+
+- Exemplos devem ser copiáveis.
+- Preferir exemplos pequenos e completos.
+- Não inventar APIs.
+- Mostrar imports.
+- Mostrar onde o arquivo vive, por exemplo `.flue/agents/hello-world.ts`.
+- Marcar runtime target quando importa: Node, Cloudflare, CI, remote sandbox.
+- Evitar placeholders vagos; quando precisar, explicar.
+
+## Como balancear leigo e avançado na mesma página
+
+Use esta ordem:
+
+1. **Plain-English intro** — o que é e por que existe.
+2. **Tiny working example** — menor coisa útil.
+3. **Mental model** — como pensar sobre isso.
+4. **Practical variations** — quando usar alternativas.
+5. **Advanced mechanics** — lifecycle, state, runtime behavior.
+6. **Reference links** — detalhes exatos.
+
+Exemplo para “Harnesses and sessions”:
+
+- Iniciante: “A harness is the configured environment your agent uses to think and act. A session is one conversation inside that environment.”
+- Intermediário: mostrar `const harness = await init(...); const session = await harness.session();`.
+- Avançado: explicar default harness, named harnesses, session persistence, Cloudflare Durable Objects, Node memory default, `session(threadName)`.
+
+## Regras para docs geradas por IA
+
+O agente `docs-refresh` deve obedecer:
+
+- não publicar contexto interno como `documentation-context.md`;
+- não vazar secrets, env values, tokens, URLs privadas ou metadados irrelevantes de CI;
+- não inventar APIs, flags, defaults ou runtime behavior;
+- se uma informação não está confirmada, omitir ou marcar como desconhecida;
+- manter exemplos alinhados ao código real e docs oficiais do repo;
+- preservar frontmatter/metadata exigida pela landing;
+- evitar reescrever páginas inteiras quando só uma seção mudou;
+- incluir camadas iniciante + avançado nas páginas principais;
+- escrever seções chunkáveis, com headings específicos e contexto suficiente para Montte AI usar em respostas;
+- incluir limitações, pré-requisitos e troubleshooting quando existirem;
+- manter reference mais precisa que narrativa;
+- atualizar `docs/llms.txt` junto com o conteúdo público;
+- rodar build/typecheck da landing antes de abrir PR.
+
+## Checklist de review humano
+
+Antes de mergear PR de docs:
+
+- [ ] A página ajuda um iniciante a entender o conceito?
+- [ ] Um usuário consegue resolver a tarefa sem pedir suporte?
+- [ ] Existe um exemplo copiável cedo na página?
+- [ ] As APIs/comandos existem de verdade?
+- [ ] O texto diferencia Node, Cloudflare, CI e sandbox remoto quando necessário?
+- [ ] A seção avançada explica trade-offs reais?
+- [ ] Limitações, pré-requisitos e erros comuns estão explícitos?
+- [ ] Montte AI poderia citar esta seção sem enganar o usuário?
+- [ ] Headings são estáveis, específicos e bons para retrieval?
+- [ ] Não há secrets, dados internos ou contexto de CI publicado?
+- [ ] Links e rotas funcionam?
+- [ ] `docs/llms.txt` aponta para a página correta?
+- [ ] O build da landing passou?
+- [ ] O texto não parece marketing ou hype?
+- [ ] O próximo passo está claro?
+
+## Como isso entra no `docs-refresh`
+
+O agente semanal deve receber essa estratégia como referência obrigatória.
+
+Contrato sugerido:
+
+```text
+Read:
+- docs/research/user-facing-technical-docs-strategy.md
+- .agents/skills/docs/SKILL.md
+- documentation-context.md
+
+Write only public docs content consumed by landing /docs and docs/llms.txt.
+Every page must serve beginners first, advanced users by the end, and Montte AI retrieval safely.
+```
+
+O workflow deve validar:
+
+```bash
+git diff --check -- apps/landing docs .agents .flue
+bun run landing:build
+```
+
+## Decisão recomendada
+
+Para Flue, `/docs` deve seguir um modelo híbrido:
+
+- **Diátaxis na navegação**: tutorials, guides, concepts/explanations, reference.
+- **Progressive disclosure dentro das páginas**: simples primeiro, técnico depois.
+- **Docs as code no processo**: PR, review, build e versionamento.
+- **AI-readable by design**: headings estáveis, seções focadas, limitações explícitas e `docs/llms.txt`.
+- **AI-assisted, not AI-published**: agente gera atualização, humano revisa.
+
+Isso cria docs que vendem confiança sem virar marketing, ajudam iniciantes sem esconder complexidade, continuam úteis quando o usuário chega em produção e dão ao Montte AI uma base segura para responder dúvidas.


### PR DESCRIPTION
## Resumo
- Alinha README e CONTRIBUTING com o AGENTS.md
- Documenta skills, gotchas do workspace e fluxos de release
- Atualiza comandos principais e ferramentas operacionais

## Validação
- git diff --check -- README.md CONTRIBUTING.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Atualiza README e CONTRIBUTING para alinhar com `AGENTS.md`, formalizando roteamento de skills, gotchas do workspace e fluxos de release. Adiciona pesquisas e estratégia de documentação pública autoatualizada do Flue, preparando a automação via agente dedicado.

- Sem impacto em router, repositório, componentes ou stores; apenas documentação e DX.

- **New Features**
  - README: nova seção “Agentes e skills” alinhada ao `AGENTS.md`; inclusão de ferramentas operacionais (`monitor-ci`, `linear-cli`); gotchas do workspace; comandos atualizados (`dev`, `build`, `db:studio:*`, `landing:*`, `doctor`).
  - CONTRIBUTING: gotchas do workspace; mapeamento de skills por área (abrir skills corretos por domínio); seção de releases (CalVer `vYYYY.MM.DD`, workflows de release e blog); ajuste do `landing:start` para host/port compatível com Railway.
  - Docs de pesquisa: adiciona `docs/research/self-updating-docs.md` (plano do agente `docs-refresh`, CI semanal e PR automático para `/docs`) e `docs/research/user-facing-technical-docs-strategy.md` (arquitetura de informação, templates e guardrails para `/docs`).

- Checklist de teste
  - git diff --check -- README.md CONTRIBUTING.md
  - Validar links internos para `.agents/skills/**` e referências a `AGENTS.md`
  - bun run landing:build (garante que referências e rotas documentadas não quebram a landing)
  - bun run doctor (sanidade do ambiente conforme gotchas)

<sup>Written for commit 72f1a9075ce5f6eb5511b062403a687f2d92ad11. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/999?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

