### PR TITLE
feat: add public docs refresh agent

### DIFF
--- a/.agents/skills/public-docs/SKILL.md
+++ b/.agents/skills/public-docs/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: public-docs
+description: Gera e atualiza a documentação pública user-facing usada pela landing /docs e pelo Montte AI como knowledge base confiável.
+---
+
+# Public Docs
+
+Use esta skill para gerar ou atualizar documentação pública renderizada em `/docs` e índices consumíveis pelo Montte AI.
+
+## Regra principal
+
+A documentação tem dois consumidores oficiais:
+
+1. usuários humanos que precisam entender o produto e resolver tarefas sozinhos;
+2. Montte AI, que usa as mesmas páginas como base confiável para explicar como as coisas funcionam.
+
+Toda página deve começar simples, terminar útil para produção e ser segura para Montte AI citar.
+
+## Referências obrigatórias
+
+Leia antes de escrever:
+
+- [Estratégia editorial](references/user-facing-technical-docs.md)
+- [Páginas públicas](references/public-docs-pages.md)
+- [Validação](references/public-docs-validation.md)
+
+Leia também o arquivo de contexto informado em `$CONTEXT_FILE` ou nos argumentos da chamada.
+
+## Regras de conteúdo
+
+- Escreva em pt-BR claro, direto e acessível.
+- Explique conceitos novos antes de usar detalhe técnico.
+- Use progressive disclosure: simples primeiro, técnico depois.
+- Inclua exemplos ou fluxos práticos cedo nas páginas principais.
+- Use nomes de telas, recursos, comandos e paths reais encontrados no contexto.
+- Não invente funcionalidades, planos, permissões, rotas, defaults, arquivos ou comportamento do produto.
+- Se algo não estiver confirmado, escreva `Não identificado no contexto coletado.` ou omita.
+- Não publique metadados internos de CI, tokens, secrets ou valores reais de env.
+- Não transforme docs em marketing; seja claro, prático e confiável.
+- Mantenha headings estáveis, específicos e bons para retrieval.
+- Atualize o índice LLM-readable junto com as páginas públicas.
+
+## Output permitido
+
+Escreva somente dentro dos caminhos recebidos por argumento:
+
+- diretório público de docs da landing, por exemplo `apps/landing/src/content/docs`;
+- índice LLM-readable, por exemplo `docs/llms.txt`.
+
+Não escreva artefatos internos como `documentation-context.md` no diretório público.
+
+## Fechamento
+
+Retorne um resumo curto com:
+
+- páginas criadas/alteradas;
+- lacunas relevantes;
+- validações recomendadas.

--- a/.agents/skills/public-docs/references/public-docs-pages.md
+++ b/.agents/skills/public-docs/references/public-docs-pages.md
@@ -1,0 +1,51 @@
+# Páginas públicas de documentação
+
+Diretório padrão de docs públicas: `apps/landing/src/content/docs`.
+
+Índice LLM-readable padrão: `docs/llms.txt`.
+
+## Arquitetura inicial recomendada
+
+| Rota                        | Fonte                     | Propósito                                                  |
+| --------------------------- | ------------------------- | ---------------------------------------------------------- |
+| `/docs`                     | `index.mdx`               | Visão geral, modelo mental e navegação.                    |
+| `/docs/primeiros-passos`    | `primeiros-passos.mdx`    | Introdução para usuários novos.                            |
+| `/docs/financeiro`          | `financeiro.mdx`          | Contas, categorias, lançamentos e organização financeira.  |
+| `/docs/clientes-e-servicos` | `clientes-e-servicos.mdx` | Clientes, serviços, benefícios e contexto comercial.       |
+| `/docs/cobrancas`           | `cobrancas.mdx`           | Cobranças recorrentes, assinaturas, invoices e pendências. |
+| `/docs/montte-ai`           | `montte-ai.mdx`           | Como o Montte AI usa contexto e ajuda o usuário.           |
+| `/docs/configuracoes`       | `configuracoes.mdx`       | Organização, times, permissões e preferências.             |
+
+Gere primeiro as páginas confirmadas pelo contexto. Não crie páginas para áreas que não aparecem nos arquivos coletados.
+
+## Frontmatter obrigatório
+
+Cada página deve incluir apenas campos aceitos por `apps/landing/src/content.config.ts`:
+
+```yaml
+---
+title: "Título da página"
+description: "Descrição clara entre 80 e 240 caracteres."
+category: "Comece aqui"
+order: 10
+updatedAt: "YYYY-MM-DD"
+aiSummary: "Resumo curto usado pelo Montte AI para encontrar esta página."
+commonQuestions:
+   - "Pergunta comum do usuário?"
+---
+```
+
+## `docs/llms.txt`
+
+O índice deve resumir as docs para retrieval:
+
+```text
+# Montte docs
+
+> Documentação pública canônica do Montte para usuários e grounding do Montte AI.
+
+## Comece aqui
+- [Primeiros passos](/docs/primeiros-passos) — Entenda o modelo mental do Montte.
+```
+
+Não inclua contexto privado de CI, prompts crus ou valores sensíveis em `docs/llms.txt`.

--- a/.agents/skills/public-docs/references/public-docs-validation.md
+++ b/.agents/skills/public-docs/references/public-docs-validation.md
@@ -1,0 +1,32 @@
+# Public docs validation
+
+Run these checks after generating docs.
+
+## Required files
+
+The exact content directory can vary, but the default is:
+
+```bash
+test -s apps/landing/src/content/docs/index.mdx
+test -s apps/landing/src/content/docs/quickstart.mdx
+test -s docs/llms.txt
+```
+
+## Content checks
+
+- No secrets, tokens, env values or private CI metadata.
+- No TODO placeholders in published pages.
+- Every page has a clear title and first paragraph.
+- Main pages have a quick example or a clear next step.
+- Limitations and prerequisites are explicit when relevant.
+- Headings are stable and specific enough for retrieval.
+- `docs/llms.txt` links to public routes, not internal artifact paths only.
+
+## Commands
+
+```bash
+git diff --check -- apps/landing docs .agents .flue
+bun run landing:build
+```
+
+If the landing docs content collection is not implemented yet, document that `bun run landing:build` cannot validate the new pages until `/docs` exists.

--- a/.agents/skills/public-docs/references/user-facing-technical-docs.md
+++ b/.agents/skills/public-docs/references/user-facing-technical-docs.md
@@ -1,0 +1,77 @@
+# Documentação técnica user-facing
+
+## Princípio central
+
+Toda página pública deve começar fácil para iniciantes, terminar útil para uso real e ser segura para o Montte AI citar.
+
+## Público
+
+As docs têm dois consumidores:
+
+- usuários lendo `/docs` para entender o Montte e resolver tarefas sem suporte;
+- Montte AI recuperando seções para responder dúvidas com precisão.
+
+## Modelo de conteúdo
+
+Use Diátaxis como modelo de navegação:
+
+| Tipo       | Pergunta do usuário     | Propósito                                       |
+| ---------- | ----------------------- | ----------------------------------------------- |
+| Tutorial   | Você pode me ensinar?   | Levar de zero até um resultado claro.           |
+| Guia       | Como eu faço X?         | Passos orientados a uma tarefa.                 |
+| Referência | Qual é a regra exata?   | Fatos, campos, opções, limites e comportamento. |
+| Explicação | Por que funciona assim? | Modelos mentais, contexto e trade-offs.         |
+
+Dentro das páginas, use progressive disclosure:
+
+1. introdução em linguagem simples;
+2. exemplo, cenário ou fluxo mínimo;
+3. modelo mental;
+4. variações práticas;
+5. detalhes avançados;
+6. próximos passos e links relacionados.
+
+## Tom
+
+- Claro, direto e calmo.
+- Amigável, mas não infantil.
+- Confiante, mas sem hype.
+- Técnico quando necessário, mas nunca abstrato sem necessidade.
+- Evite piadas internas, memes e referências culturais.
+- Evite dizer que algo é “simples”, “óbvio” ou “fácil” quando a tarefa pode ser difícil.
+
+## Regras para retrieval por IA
+
+- Use headings estáveis e específicos.
+- Mantenha seções focadas e pequenas.
+- Defina termos uma vez e reutilize os mesmos nomes.
+- Deixe pré-requisitos, limites e exceções explícitos.
+- Inclua erros comuns e troubleshooting quando relevante.
+- Prefira tabelas para opções, permissões, estados e trade-offs.
+- Evite linguagem vaga de marketing porque a IA pode repetir como orientação.
+
+## Template de seção
+
+```mdx
+# Título da página
+
+Resumo em linguagem simples.
+
+## O que você vai aprender
+
+## Antes de começar
+
+## Exemplo ou fluxo rápido
+
+## Como funciona
+
+## Erros comuns
+
+## Detalhes avançados
+
+## Referência
+
+## Próximos passos
+```
+
+Páginas de referência podem ser mais diretas, com campos, estados, permissões, efeitos, erros e guias relacionados.

--- a/.flue/agents/docs-refresh.ts
+++ b/.flue/agents/docs-refresh.ts
@@ -1,0 +1,527 @@
+import type { FlueContext } from "@flue/runtime";
+import { local } from "@flue/runtime/node";
+import { Result, TaggedError } from "better-result";
+import { defineErrorCatalog } from "evlog";
+import { execFile } from "node:child_process";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+import * as v from "valibot";
+import {
+   buildLocalSandboxEnv,
+   formatCause,
+   resolveGithubToken,
+   safePathSchema,
+   truncateForPrompt,
+} from "../lib/agent-utils.ts";
+import { DEFAULT_FLUE_MODEL } from "../lib/model.ts";
+
+export const triggers = {};
+
+const execFileAsync = promisify(execFile);
+
+const docsRefreshPayloadSchema = v.object({
+   mode: v.optional(v.picklist(["weekly", "manual"]), "manual"),
+   target: v.optional(v.picklist(["landing-docs"]), "landing-docs"),
+   outputDir: v.optional(safePathSchema, "apps/landing/src/content/docs"),
+   llmsFile: v.optional(safePathSchema, "docs/llms.txt"),
+   contextFile: v.optional(
+      safePathSchema,
+      ".agent-artifacts/docs-refresh/documentation-context.md",
+   ),
+   maxContextChars: v.optional(
+      v.pipe(v.number(), v.integer(), v.minValue(20_000), v.maxValue(200_000)),
+      80_000,
+   ),
+   dryRun: v.optional(v.boolean(), false),
+});
+
+const generatedPageSchema = v.object({
+   path: v.pipe(v.string(), v.minLength(1)),
+   status: v.picklist(["created", "updated", "unchanged"]),
+   summary: v.pipe(v.string(), v.minLength(1)),
+});
+
+const docsRefreshResultSchema = v.object({
+   summary: v.pipe(v.string(), v.minLength(1)),
+   pages: v.optional(v.array(generatedPageSchema), []),
+   gaps: v.optional(v.array(v.string()), []),
+   validationNotes: v.optional(v.array(v.string()), []),
+});
+
+const docsRefreshValidationSchema = v.object({
+   valid: v.boolean(),
+   errors: v.array(v.string()),
+   warnings: v.array(v.string()),
+});
+
+const docsRefreshAgentErrors = defineErrorCatalog("flue.docs-refresh.agent", {
+   BAD_PAYLOAD: {
+      status: 400,
+      message: "Payload inválido para agente de documentação pública.",
+      tags: ["flue", "docs-refresh"],
+   },
+   IO_FAILED: {
+      status: 500,
+      message: "Falha de IO no agente de documentação pública.",
+      tags: ["flue", "docs-refresh"],
+   },
+   MODEL_FAILED: {
+      status: 500,
+      message: "Falha ao executar modelo de documentação pública.",
+      tags: ["flue", "docs-refresh"],
+   },
+   VALIDATION_FAILED: {
+      status: 422,
+      message: "Documentação pública falhou na validação estruturada.",
+      tags: ["flue", "docs-refresh"],
+   },
+});
+
+declare module "evlog" {
+   interface RegisteredErrorCatalogs {
+      "flue.docs-refresh.agent": typeof docsRefreshAgentErrors;
+   }
+}
+
+type DocsRefreshAgentCatalogError =
+   | ReturnType<typeof docsRefreshAgentErrors.BAD_PAYLOAD>
+   | ReturnType<typeof docsRefreshAgentErrors.IO_FAILED>
+   | ReturnType<typeof docsRefreshAgentErrors.MODEL_FAILED>
+   | ReturnType<typeof docsRefreshAgentErrors.VALIDATION_FAILED>;
+
+class DocsRefreshAgentError extends TaggedError("DocsRefreshAgentError")<{
+   error: DocsRefreshAgentCatalogError;
+   message: string;
+   outputFile?: string;
+   detail?: string;
+}>() {}
+
+type CommandSpec = {
+   title: string;
+   command: string;
+   args: string[];
+   maxChars: number;
+};
+
+async function collectCommandSection(spec: CommandSpec) {
+   const result = await Result.tryPromise({
+      try: () => execFileAsync(spec.command, spec.args, { cwd: process.cwd() }),
+      catch: (cause) => formatCause(cause),
+   });
+
+   if (Result.isError(result)) {
+      return `## ${spec.title}\n\nUnavailable: ${result.error}\n`;
+   }
+
+   const stdout = truncateForPrompt(
+      result.value.stdout.trim(),
+      spec.maxChars,
+      spec.title,
+   );
+   const stderr = result.value.stderr.trim();
+   const stderrBlock =
+      stderr.length > 0 ? `\n\nStderr:\n\n\`\`\`text\n${stderr}\n\`\`\`` : "";
+
+   return `## ${spec.title}\n\n\`\`\`text\n${stdout}\n\`\`\`${stderrBlock}\n`;
+}
+
+async function collectOptionalGithubSection(githubToken: string | undefined) {
+   if (!githubToken) {
+      return "## Recently merged PRs\n\nUnavailable: GH_TOKEN/GITHUB_TOKEN not configured.\n";
+   }
+
+   const result = await Result.tryPromise({
+      try: () =>
+         execFileAsync(
+            "gh",
+            [
+               "pr",
+               "list",
+               "--state",
+               "merged",
+               "--limit",
+               "40",
+               "--json",
+               "number,title,url,mergedAt,labels",
+            ],
+            {
+               cwd: process.cwd(),
+               env: { ...process.env, GH_TOKEN: githubToken },
+            },
+         ),
+      catch: (cause) => formatCause(cause),
+   });
+
+   if (Result.isError(result)) {
+      return `## Recently merged PRs\n\nUnavailable: ${result.error}\n`;
+   }
+
+   return `## Recently merged PRs\n\n\`\`\`json\n${truncateForPrompt(
+      result.value.stdout.trim(),
+      30_000,
+      "recently merged PRs",
+   )}\n\`\`\`\n`;
+}
+
+async function collectDocumentationContext({
+   contextFile,
+   outputDir,
+   llmsFile,
+   githubToken,
+}: {
+   contextFile: string;
+   outputDir: string;
+   llmsFile: string;
+   githubToken: string | undefined;
+}) {
+   const specs: CommandSpec[] = [
+      {
+         title: "Current ref",
+         command: "git",
+         args: ["rev-parse", "--short", "HEAD"],
+         maxChars: 2_000,
+      },
+      {
+         title: "Current branch",
+         command: "git",
+         args: ["branch", "--show-current"],
+         maxChars: 2_000,
+      },
+      {
+         title: "Latest tags",
+         command: "git",
+         args: ["tag", "--sort=-version:refname"],
+         maxChars: 10_000,
+      },
+      {
+         title: "Top-level structure",
+         command: "git",
+         args: ["ls-tree", "-d", "--name-only", "HEAD"],
+         maxChars: 10_000,
+      },
+      {
+         title: "Relevant package and config files",
+         command: "bash",
+         args: [
+            "-lc",
+            "git ls-files | grep -E '(^package.json$|/package.json$|^nx.json$|tsconfig.*json$|astro.config.mjs$|content.config.ts$|project.json$|wrangler.jsonc$|^AGENTS.md$|^README.md$)' | head -n 300",
+         ],
+         maxChars: 30_000,
+      },
+      {
+         title: "Flue agents, skills and app files",
+         command: "bash",
+         args: [
+            "-lc",
+            "git ls-files .flue .agents/skills AGENTS.md README.md | head -n 400",
+         ],
+         maxChars: 40_000,
+      },
+      {
+         title: "Landing docs and content files",
+         command: "bash",
+         args: [
+            "-lc",
+            `git ls-files apps/landing/src/content apps/landing/src/pages apps/landing/src/components ${outputDir} ${llmsFile} | head -n 500`,
+         ],
+         maxChars: 50_000,
+      },
+      {
+         title: "Changed files in working tree",
+         command: "git",
+         args: ["status", "--short"],
+         maxChars: 20_000,
+      },
+      {
+         title: "Recent commits",
+         command: "git",
+         args: ["log", "--pretty=format:- %s (%h)", "-n", "80"],
+         maxChars: 30_000,
+      },
+      {
+         title: "Existing docs skill files",
+         command: "bash",
+         args: ["-lc", "find .agents/skills -maxdepth 3 -type f | sort"],
+         maxChars: 40_000,
+      },
+   ];
+
+   const sections: string[] = [];
+   sections.push("# Montte public docs refresh context");
+   sections.push("");
+   sections.push(`- outputDir: ${outputDir}`);
+   sections.push(`- llmsFile: ${llmsFile}`);
+   sections.push("- public surface: landing /docs");
+   sections.push("- AI consumer: Montte AI");
+   sections.push("");
+
+   for (const spec of specs) {
+      sections.push(await collectCommandSection(spec));
+   }
+
+   sections.push(await collectOptionalGithubSection(githubToken));
+
+   const markdown = sections.join("\n");
+   const mkdirResult = await Result.tryPromise({
+      try: () => mkdir(dirname(contextFile), { recursive: true }),
+      catch: (cause) =>
+         new DocsRefreshAgentError({
+            error: docsRefreshAgentErrors.IO_FAILED(),
+            message: "Falha ao criar diretório do contexto de documentação.",
+            outputFile: contextFile,
+            detail: formatCause(cause),
+         }),
+   });
+   if (Result.isError(mkdirResult)) return mkdirResult;
+
+   const writeResult = await Result.tryPromise({
+      try: () => writeFile(contextFile, markdown),
+      catch: (cause) =>
+         new DocsRefreshAgentError({
+            error: docsRefreshAgentErrors.IO_FAILED(),
+            message: "Falha ao escrever contexto de documentação.",
+            outputFile: contextFile,
+            detail: formatCause(cause),
+         }),
+   });
+   if (Result.isError(writeResult)) return writeResult;
+
+   return Result.ok(markdown);
+}
+
+async function listMarkdownFiles(dir: string) {
+   const result = await Result.tryPromise({
+      try: () => readdir(dir, { recursive: true, withFileTypes: true }),
+      catch: (cause) =>
+         new DocsRefreshAgentError({
+            error: docsRefreshAgentErrors.IO_FAILED(),
+            message: "Falha ao listar páginas geradas de documentação.",
+            outputFile: dir,
+            detail: formatCause(cause),
+         }),
+   });
+   if (Result.isError(result)) return result;
+
+   const files: string[] = [];
+   for (const entry of result.value) {
+      if (!entry.isFile()) continue;
+      if (!entry.name.endsWith(".md") && !entry.name.endsWith(".mdx")) continue;
+
+      files.push(join(entry.parentPath, entry.name));
+   }
+
+   return Result.ok(files.sort());
+}
+
+async function validateGeneratedDocs({
+   outputDir,
+   llmsFile,
+}: {
+   outputDir: string;
+   llmsFile: string;
+}) {
+   const errors: string[] = [];
+   const warnings: string[] = [];
+
+   const filesResult = await listMarkdownFiles(outputDir);
+   if (Result.isError(filesResult)) return filesResult;
+
+   if (filesResult.value.length === 0) {
+      errors.push(`Nenhuma página Markdown/MDX encontrada em ${outputDir}.`);
+   }
+
+   const llmsResult = await Result.tryPromise({
+      try: () => readFile(llmsFile, "utf8"),
+      catch: (cause) =>
+         new DocsRefreshAgentError({
+            error: docsRefreshAgentErrors.IO_FAILED(),
+            message: "Falha ao ler índice LLM-readable de documentação.",
+            outputFile: llmsFile,
+            detail: formatCause(cause),
+         }),
+   });
+   if (Result.isError(llmsResult)) return llmsResult;
+
+   if (llmsResult.value.trim().length === 0) {
+      errors.push(`${llmsFile} está vazio.`);
+   }
+
+   const scannedFiles = [...filesResult.value, llmsFile];
+   for (const file of scannedFiles) {
+      const readResult = await Result.tryPromise({
+         try: () => readFile(file, "utf8"),
+         catch: (cause) =>
+            new DocsRefreshAgentError({
+               error: docsRefreshAgentErrors.IO_FAILED(),
+               message: "Falha ao ler arquivo de documentação gerado.",
+               outputFile: file,
+               detail: formatCause(cause),
+            }),
+      });
+      if (Result.isError(readResult)) return readResult;
+
+      if (
+         /TODO|CHANGE_ME|INSERT_|not implemented yet/iu.test(readResult.value)
+      ) {
+         warnings.push(`${file} contém possível placeholder.`);
+      }
+      if (
+         /sk_live_|sk_test_|BEGIN PRIVATE KEY|GITHUB_TOKEN|OPENCODE_API_KEY/iu.test(
+            readResult.value,
+         )
+      ) {
+         errors.push(`${file} contém possível segredo ou nome de secret.`);
+      }
+   }
+
+   return Result.ok(
+      v.parse(docsRefreshValidationSchema, {
+         valid: errors.length === 0,
+         errors,
+         warnings,
+      }),
+   );
+}
+
+export default async function ({ init, payload, env }: FlueContext) {
+   const parsedPayload = v.safeParse(docsRefreshPayloadSchema, payload);
+   if (!parsedPayload.success) {
+      throw new DocsRefreshAgentError({
+         error: docsRefreshAgentErrors.BAD_PAYLOAD(),
+         message: "Payload inválido para agente de documentação pública.",
+         detail: formatCause(parsedPayload.issues),
+      });
+   }
+
+   const { mode, outputDir, llmsFile, contextFile, maxContextChars, dryRun } =
+      parsedPayload.output;
+   const githubToken = resolveGithubToken(env);
+
+   const dirsResult = await Result.tryPromise({
+      try: () =>
+         Promise.all([
+            mkdir(outputDir, { recursive: true }),
+            mkdir(dirname(llmsFile), { recursive: true }),
+         ]),
+      catch: (cause) =>
+         new DocsRefreshAgentError({
+            error: docsRefreshAgentErrors.IO_FAILED(),
+            message: "Falha ao preparar diretórios de documentação pública.",
+            detail: formatCause(cause),
+         }),
+   });
+   if (Result.isError(dirsResult)) throw dirsResult.error;
+
+   const contextResult = await collectDocumentationContext({
+      contextFile,
+      outputDir,
+      llmsFile,
+      githubToken,
+   });
+   if (Result.isError(contextResult)) throw contextResult.error;
+
+   const initResult = await Result.tryPromise({
+      try: () =>
+         init({
+            sandbox: local({
+               env: buildLocalSandboxEnv({
+                  GH_TOKEN: githubToken,
+                  GITHUB_REPOSITORY: process.env.GITHUB_REPOSITORY,
+               }),
+            }),
+            model: process.env.FLUE_MODEL ?? DEFAULT_FLUE_MODEL,
+         }),
+      catch: (cause) =>
+         new DocsRefreshAgentError({
+            error: docsRefreshAgentErrors.MODEL_FAILED(),
+            message: "Falha ao inicializar Flue para documentação pública.",
+            detail: formatCause(cause),
+         }),
+   });
+   if (Result.isError(initResult)) throw initResult.error;
+
+   const sessionResult = await Result.tryPromise({
+      try: () => initResult.value.session(),
+      catch: (cause) =>
+         new DocsRefreshAgentError({
+            error: docsRefreshAgentErrors.MODEL_FAILED(),
+            message: "Falha ao abrir sessão Flue para documentação pública.",
+            detail: formatCause(cause),
+         }),
+   });
+   if (Result.isError(sessionResult)) throw sessionResult.error;
+
+   const task = `Update the public Montte documentation for landing /docs.
+
+Mode: ${mode}
+Output directory: ${outputDir}
+LLM index file: ${llmsFile}
+Context file: ${contextFile}
+Dry run: ${dryRun ? "yes" : "no"}
+
+Use the public-docs skill and its references. Write in pt-BR. The docs have two consumers: humans reading /docs and Montte AI using the same content as grounding. Keep pages beginner-friendly at the start, production-useful by the end, and safe for AI retrieval.
+
+Read the collected context below. Use only confirmed facts from the context and files you inspect. Do not publish private CI metadata or secrets. Write only inside ${outputDir} and ${llmsFile}. Do not write raw context into public docs.
+
+Collected context:
+
+${truncateForPrompt(contextResult.value, maxContextChars, "documentation context")}`;
+
+   const generationResult = await Result.tryPromise({
+      try: () =>
+         Promise.resolve(
+            sessionResult.value.skill("public-docs", {
+               args: {
+                  task,
+                  contextFile,
+                  outputDir,
+                  llmsFile,
+                  dryRun,
+               },
+               result: docsRefreshResultSchema,
+               thinkingLevel: "off",
+            }),
+         ),
+      catch: (cause) =>
+         new DocsRefreshAgentError({
+            error: docsRefreshAgentErrors.MODEL_FAILED(),
+            message: "Falha ao gerar documentação pública via Flue.",
+            detail: formatCause(cause),
+         }),
+   });
+   if (Result.isError(generationResult)) throw generationResult.error;
+
+   if (dryRun) {
+      return {
+         contextFile,
+         outputDir,
+         llmsFile,
+         dryRun,
+         result: generationResult.value.data,
+      };
+   }
+
+   const validationResult = await validateGeneratedDocs({
+      outputDir,
+      llmsFile,
+   });
+   if (Result.isError(validationResult)) throw validationResult.error;
+
+   if (!validationResult.value.valid) {
+      throw new DocsRefreshAgentError({
+         error: docsRefreshAgentErrors.VALIDATION_FAILED(),
+         message: "Documentação pública falhou na validação estruturada.",
+         detail: validationResult.value.errors.join("\n"),
+      });
+   }
+
+   return {
+      contextFile,
+      outputDir,
+      llmsFile,
+      dryRun,
+      result: generationResult.value.data,
+      validation: validationResult.value,
+   };
+}

--- a/.flue/agents/pr-review.ts
+++ b/.flue/agents/pr-review.ts
@@ -255,16 +255,12 @@ async function publishReview({
       );
    }
 
-   const payload = {
-      body,
-      event: "COMMENT",
-      comments: comments.map((comment) => ({
-         path: comment.path,
-         line: comment.line,
-         side: comment.side,
-         body: formatInlineComment(comment),
-      })),
-   };
+   const commentsPayload = comments.map((comment) => ({
+      path: comment.path,
+      line: comment.line,
+      side: comment.side,
+      body: formatInlineComment(comment),
+   }));
 
    const [owner, repoName] = repo.split("/");
    const octokit = new Octokit({ auth: token });
@@ -276,9 +272,9 @@ async function publishReview({
                owner,
                repo: repoName,
                pull_number: prNumber,
-               body: payload.body,
-               event: payload.event,
-               comments: payload.comments,
+               body,
+               event: "COMMENT",
+               comments: commentsPayload,
             },
          );
       },
@@ -409,18 +405,14 @@ export default async function ({ init, payload, env }: FlueContext) {
       generalPrComments,
    ] = contextResult.value;
 
-   const commandResults = [
-      prMetadata,
-      changedFiles,
-      fullDiff,
-      commits,
-      ciChecks,
-      generalReviews,
-      inlineReviewComments,
-      generalPrComments,
-   ];
-   const failedCommand = commandResults.find(Result.isError);
-   if (failedCommand) throw failedCommand.error;
+   if (Result.isError(prMetadata)) throw prMetadata.error;
+   if (Result.isError(changedFiles)) throw changedFiles.error;
+   if (Result.isError(fullDiff)) throw fullDiff.error;
+   if (Result.isError(commits)) throw commits.error;
+   if (Result.isError(ciChecks)) throw ciChecks.error;
+   if (Result.isError(generalReviews)) throw generalReviews.error;
+   if (Result.isError(inlineReviewComments)) throw inlineReviewComments.error;
+   if (Result.isError(generalPrComments)) throw generalPrComments.error;
 
    await Promise.all([
       writeFile(`${outputDir}/pr-metadata.json`, prMetadata.value.stdout),

--- a/.flue/agents/security-audit.ts
+++ b/.flue/agents/security-audit.ts
@@ -266,15 +266,11 @@ export default async function ({ init, payload, env }: FlueContext) {
    const [prMetadata, changedFiles, fullDiff, commits, ciChecks] =
       contextResult.value;
 
-   const commandResults = [
-      prMetadata,
-      changedFiles,
-      fullDiff,
-      commits,
-      ciChecks,
-   ];
-   const failedCommand = commandResults.find(Result.isError);
-   if (failedCommand) throw failedCommand.error;
+   if (Result.isError(prMetadata)) throw prMetadata.error;
+   if (Result.isError(changedFiles)) throw changedFiles.error;
+   if (Result.isError(fullDiff)) throw fullDiff.error;
+   if (Result.isError(commits)) throw commits.error;
+   if (Result.isError(ciChecks)) throw ciChecks.error;
 
    await Promise.all([
       writeFile(`${outputDir}/pr-metadata.json`, prMetadata.value.stdout),

--- a/.flue/lib/agent-utils.ts
+++ b/.flue/lib/agent-utils.ts
@@ -106,6 +106,18 @@ export function formatCause(cause: unknown) {
       : String(cause);
 }
 
+function isDefinedEnvEntry(
+   entry: [string, string | undefined],
+): entry is [string, string] {
+   return typeof entry[1] === "string" && entry[1].length > 0;
+}
+
+export function buildLocalSandboxEnv(
+   values: Record<string, string | undefined>,
+) {
+   return Object.fromEntries(Object.entries(values).filter(isDefinedEnvEntry));
+}
+
 export function truncateForPrompt(
    value: string,
    maxChars: number,

--- a/.github/workflows/docs-refresh.yml
+++ b/.github/workflows/docs-refresh.yml
@@ -1,0 +1,105 @@
+name: Docs Refresh
+
+on:
+   schedule:
+      - cron: "0 9 * * 1"
+   workflow_dispatch:
+      inputs:
+         dry_run:
+            description: "Generate docs without opening a PR"
+            required: false
+            type: boolean
+            default: false
+
+permissions:
+   contents: write
+   pull-requests: write
+
+jobs:
+   docs-refresh:
+      runs-on: ubuntu-latest
+      steps:
+         - name: Checkout
+           uses: actions/checkout@v4
+           with:
+              fetch-depth: 0
+              fetch-tags: true
+              persist-credentials: false
+
+         - name: Setup Bun
+           uses: oven-sh/setup-bun@v2
+
+         - name: Install dependencies
+           run: bun install --frozen-lockfile
+
+         - name: Generate public docs
+           env:
+              GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+              OPENCODE_GO_BASE_URL: ${{ vars.OPENCODE_GO_BASE_URL }}
+              OPENCODE_GO_GATEWAY_KEY: ${{ secrets.OPENCODE_GO_GATEWAY_KEY }}
+              DRY_RUN: ${{ inputs.dry_run || false }}
+           run: |
+              PAYLOAD=$(jq -c -n \
+                --argjson dryRun "$DRY_RUN" \
+                '{mode: "weekly", target: "landing-docs", dryRun: $dryRun}'
+              )
+
+              bunx flue run docs-refresh \
+                --target node \
+                --id weekly-docs \
+                --payload "$PAYLOAD"
+
+         - name: Validate landing docs
+           env:
+              PUBLIC_POSTHOG_KEY: ${{ vars.PUBLIC_POSTHOG_KEY || 'phc_docs_refresh' }}
+              PUBLIC_POSTHOG_HOST: ${{ vars.PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com' }}
+           run: |
+              bun run landing:build
+              git diff --check -- apps/landing/src/content/docs apps/landing/src/pages/docs apps/landing/src/content.config.ts apps/landing/src/pages/llms.txt.ts docs/llms.txt .flue/agents/docs-refresh.ts .agents/skills/public-docs
+
+         - name: Open documentation pull request
+           if: github.event_name == 'schedule' || inputs.dry_run != true
+           env:
+              GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              GH_REPO: ${{ github.repository }}
+           run: |
+              VERSION=$(date -u '+%Y.%m.%d')
+              BRANCH="automation/docs-refresh-${VERSION}"
+              BASE_BRANCH="${GITHUB_REF_NAME}"
+
+              git config user.name "github-actions[bot]"
+              git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+              git checkout -B "$BRANCH"
+              git add apps/landing/src/content/docs docs/llms.txt
+
+              if git diff --cached --quiet; then
+                echo "No documentation changes to publish"
+                exit 0
+              fi
+
+              git commit -m "docs: update public documentation"
+              git push "https://x-access-token:${GH_TOKEN}@github.com/${GH_REPO}.git" "$BRANCH" --force-with-lease
+
+              PR_URL=$(gh pr list --repo "$GH_REPO" --head "$BRANCH" --json url --jq '.[0].url')
+              if [ -n "$PR_URL" ]; then
+                gh pr edit "$PR_URL" --repo "$GH_REPO" \
+                  --title "docs: atualizar documentação pública" \
+                  --body "Atualiza a documentação pública renderizada em /docs e o índice usado pelo Montte AI."
+              else
+                gh pr create --repo "$GH_REPO" \
+                  --base "$BASE_BRANCH" \
+                  --head "$BRANCH" \
+                  --title "docs: atualizar documentação pública" \
+                  --body "Atualiza a documentação pública renderizada em /docs e o índice usado pelo Montte AI."
+              fi
+
+         - name: Upload docs artifact
+           uses: actions/upload-artifact@v4
+           with:
+              name: docs-refresh
+              path: |
+                 .agent-artifacts/docs-refresh/documentation-context.md
+                 apps/landing/src/content/docs/**/*.mdx
+                 docs/llms.txt

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -151,7 +151,7 @@ jobs:
 
          - name: Checkout trusted base
            if: steps.pr.outputs.requested == 'true' && steps.pr.outputs.authorized == 'true' && steps.pr.outputs.is_cross_repository != 'true'
-           uses: actions/checkout@v6
+           uses: actions/checkout@v4
            with:
               ref: ${{ steps.pr.outputs.base_ref }}
               fetch-depth: 0

--- a/apps/landing/src/blocks/footer-block.astro
+++ b/apps/landing/src/blocks/footer-block.astro
@@ -38,6 +38,12 @@ const year = dayjs().year();
                Blog
             </a>
             <a
+               href="/docs"
+               class="text-foreground/80 transition-colors hover:text-foreground"
+            >
+               Docs
+            </a>
+            <a
                href="/privacidade"
                class="text-foreground/80 transition-colors hover:text-foreground"
             >

--- a/apps/landing/src/content.config.ts
+++ b/apps/landing/src/content.config.ts
@@ -32,4 +32,17 @@ const blog = defineCollection({
       }),
 });
 
-export const collections = { blog };
+const docs = defineCollection({
+   loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/docs" }),
+   schema: z.object({
+      title: z.string().max(90),
+      description: z.string().min(80).max(240),
+      category: z.string().default("Guia"),
+      order: z.number().int().nonnegative().default(999),
+      updatedAt: z.coerce.date(),
+      aiSummary: z.string().min(40).max(240),
+      commonQuestions: z.array(z.string()).max(8).default([]),
+   }),
+});
+
+export const collections = { blog, docs };

--- a/apps/landing/src/content/docs/index.mdx
+++ b/apps/landing/src/content/docs/index.mdx
@@ -1,0 +1,56 @@
+---
+title: "Documentação do Montte"
+description: "Aprenda como o Montte organiza financeiro, clientes, serviços, cobranças e automações com IA para operações recorrentes."
+category: "Comece aqui"
+order: 0
+updatedAt: "2026-05-25"
+aiSummary: "Página inicial da documentação pública do Montte, com visão geral, navegação e explicação de como as docs também orientam o Montte AI."
+commonQuestions:
+   - "O que é o Montte?"
+   - "Como eu começo a usar a documentação?"
+   - "Como o Montte AI usa estas páginas?"
+---
+
+O Montte é uma infraestrutura AI-native para negócios com serviços recorrentes. Ele reúne financeiro, clientes, serviços, cobrança e automações em um lugar só para reduzir trabalho manual e deixar a operação mais previsível.
+
+Esta documentação foi escrita para dois usos ao mesmo tempo:
+
+- ajudar você a entender o Montte e resolver tarefas sozinho;
+- servir como base confiável para o Montte AI explicar como as coisas funcionam.
+
+## Como usar esta documentação
+
+Se você está começando, leia primeiro [Primeiros passos](/docs/primeiros-passos). Essa página apresenta os conceitos principais sem assumir conhecimento técnico.
+
+Se você já usa o Montte, procure pela área que quer entender melhor:
+
+- financeiro;
+- clientes e serviços;
+- cobranças recorrentes;
+- automações e IA;
+- configurações da operação.
+
+## Como as páginas são organizadas
+
+Cada página segue a mesma lógica:
+
+1. uma explicação simples do assunto;
+2. um exemplo ou fluxo prático;
+3. detalhes importantes para uso avançado;
+4. limitações, cuidados e próximos passos.
+
+Esse formato ajuda usuários novos sem esconder os detalhes que importam em produção.
+
+## Como o Montte AI usa estas docs
+
+O Montte AI usa estas páginas como fonte de contexto. Quando você faz uma pergunta, ele pode consultar a documentação para responder com mais precisão e apontar o caminho correto.
+
+Isso significa que as páginas evitam promessas vagas. Sempre que um comportamento depende de configuração, permissão ou etapa anterior, a documentação deve deixar isso explícito.
+
+## O que fazer quando algo não bater
+
+Se a documentação disser uma coisa e a tela mostrar outra, trate a tela atual do produto como fonte imediata e entre em contato com suporte. A documentação é atualizada continuamente, mas pode existir uma diferença temporária entre uma mudança recente e a próxima atualização publicada.
+
+## Próximo passo
+
+Comece por [Primeiros passos](/docs/primeiros-passos).

--- a/apps/landing/src/content/docs/primeiros-passos.mdx
+++ b/apps/landing/src/content/docs/primeiros-passos.mdx
@@ -1,0 +1,86 @@
+---
+title: "Primeiros passos"
+description: "Entenda os conceitos básicos do Montte e saiba por onde começar para organizar sua operação recorrente com menos trabalho manual."
+category: "Comece aqui"
+order: 10
+updatedAt: "2026-05-25"
+aiSummary: "Guia inicial para usuários novos entenderem o Montte, seus conceitos principais e o caminho recomendado para começar."
+commonQuestions:
+   - "Por onde eu começo no Montte?"
+   - "Quais áreas o Montte organiza?"
+   - "O que preciso configurar primeiro?"
+---
+
+Use esta página para entender o básico antes de entrar nas áreas específicas do Montte.
+
+## O que você vai aprender
+
+Ao final, você deve saber:
+
+- quais partes da operação o Montte organiza;
+- por que financeiro, clientes, serviços e cobranças ficam conectados;
+- como usar a documentação para resolver dúvidas comuns;
+- quando pedir ajuda ao Montte AI.
+
+## O modelo mental
+
+Pense no Montte como a camada operacional do seu negócio recorrente.
+
+Em vez de tratar financeiro, clientes e cobranças como planilhas ou ferramentas separadas, o Montte conecta essas áreas para que a operação tenha mais contexto.
+
+Por exemplo:
+
+- um cliente pode estar ligado a serviços contratados;
+- um serviço pode gerar cobrança recorrente;
+- uma cobrança pode afetar o financeiro;
+- o Montte AI pode usar esse contexto para explicar pendências e próximos passos.
+
+## Caminho recomendado
+
+Comece nesta ordem:
+
+1. entenda sua organização e time;
+2. revise clientes e serviços;
+3. configure categorias, contas e preferências financeiras;
+4. acompanhe cobranças e pendências;
+5. use o Montte AI para tirar dúvidas sobre fluxos e próximos passos.
+
+Nem toda conta terá todas as áreas ativadas. Se uma página mencionar um recurso que não aparece para você, isso pode depender do plano, permissão ou etapa de configuração.
+
+## Exemplo prático
+
+Imagine que você vende um serviço mensal.
+
+No Montte, o fluxo esperado é:
+
+1. cadastrar ou revisar o cliente;
+2. associar o serviço ou contrato recorrente;
+3. acompanhar a cobrança;
+4. conferir o reflexo financeiro;
+5. usar o Montte AI para entender pendências, inconsistências ou próximos passos.
+
+Esse fluxo evita que a informação fique espalhada entre atendimento, financeiro e gestão.
+
+## Erros comuns
+
+- Começar pelo financeiro sem revisar clientes e serviços.
+- Criar categorias sem um padrão claro para análise depois.
+- Ignorar permissões de organização e time ao procurar uma tela.
+- Esperar que a IA corrija dados incompletos sem contexto suficiente.
+
+## Quando usar o Montte AI
+
+Use o Montte AI quando quiser entender uma situação ou decidir o próximo passo.
+
+Boas perguntas:
+
+- “Por que esta cobrança aparece como pendente?”
+- “O que falta para organizar este cliente?”
+- “Como este lançamento afeta meu financeiro?”
+- “Qual é o próximo passo para configurar cobranças recorrentes?”
+
+O Montte AI deve responder com base no produto e nesta documentação. Quando uma informação não estiver confirmada, a resposta deve deixar a limitação clara.
+
+## Próximos passos
+
+Volte para a [documentação principal](/docs) e escolha a área que melhor representa sua dúvida atual.

--- a/apps/landing/src/lib/docs.ts
+++ b/apps/landing/src/lib/docs.ts
@@ -1,0 +1,33 @@
+import type { CollectionEntry } from "astro:content";
+
+export function sortDocs(docs: CollectionEntry<"docs">[]) {
+   return docs.toSorted((a, b) => {
+      const categoryCompare = a.data.category.localeCompare(b.data.category);
+      if (categoryCompare !== 0) return categoryCompare;
+
+      const orderCompare = a.data.order - b.data.order;
+      if (orderCompare !== 0) return orderCompare;
+
+      return a.data.title.localeCompare(b.data.title);
+   });
+}
+
+export function getDocPath(doc: CollectionEntry<"docs">) {
+   if (doc.id === "index") return "/docs";
+   return `/docs/${doc.id}`;
+}
+
+export function groupDocsByCategory(docs: CollectionEntry<"docs">[]) {
+   const groups = new Map<string, CollectionEntry<"docs">[]>();
+
+   for (const doc of docs) {
+      const existing = groups.get(doc.data.category) ?? [];
+      existing.push(doc);
+      groups.set(doc.data.category, existing);
+   }
+
+   return Array.from(groups.entries()).map(([category, items]) => ({
+      category,
+      items,
+   }));
+}

--- a/apps/landing/src/pages/docs/[...slug].astro
+++ b/apps/landing/src/pages/docs/[...slug].astro
@@ -1,0 +1,144 @@
+---
+export const prerender = true;
+import { getCollection, render } from "astro:content";
+import dayjs from "dayjs";
+import BaseLayout from "../../layouts/base-layout.astro";
+import FooterBlock from "../../blocks/footer-block.astro";
+import { getDocPath, groupDocsByCategory, sortDocs } from "../../lib/docs";
+
+export async function getStaticPaths() {
+   const docs = sortDocs(await getCollection("docs"));
+   return docs
+      .filter((doc) => doc.id !== "index")
+      .map((doc) => ({
+         params: { slug: doc.id },
+         props: { doc, docs },
+      }));
+}
+
+const { doc: currentDoc, docs } = Astro.props;
+const { Content, headings } = await render(currentDoc);
+const tocHeadings = headings.filter((heading) => heading.depth === 2);
+const groups = groupDocsByCategory(docs);
+const siteUrl = "https://montte.co";
+const canonical = new URL(getDocPath(currentDoc), siteUrl).toString();
+
+const docsLd = {
+   "@context": "https://schema.org",
+   "@type": "TechArticle",
+   headline: currentDoc.data.title,
+   description: currentDoc.data.description,
+   dateModified: currentDoc.data.updatedAt.toISOString(),
+   inLanguage: "pt-BR",
+   mainEntityOfPage: { "@type": "WebPage", "@id": canonical },
+};
+
+const breadcrumbLd = {
+   "@context": "https://schema.org",
+   "@type": "BreadcrumbList",
+   itemListElement: [
+      {
+         "@type": "ListItem",
+         position: 1,
+         name: "Documentação",
+         item: new URL("/docs", siteUrl).toString(),
+      },
+      {
+         "@type": "ListItem",
+         position: 2,
+         name: currentDoc.data.title,
+         item: canonical,
+      },
+   ],
+};
+---
+
+<BaseLayout
+   title={`${currentDoc.data.title} — Documentação Montte`}
+   description={currentDoc.data.description}
+   canonicalOverride={canonical}
+   jsonLd={[docsLd, breadcrumbLd]}
+>
+   <article class="relative bg-background">
+      <header class="relative isolate overflow-hidden border-b border-border/60 pt-32 pb-12">
+         <div
+            class="absolute inset-0 -z-10"
+            style="background: linear-gradient(to bottom, color-mix(in oklch, var(--secondary) 22%, var(--background)) 0%, var(--background) 100%);"
+            aria-hidden="true"
+         >
+         </div>
+         <div class="mx-auto flex w-full max-w-6xl flex-col gap-4 px-4 sm:px-4">
+            <a
+               href="/docs"
+               class="text-xs font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
+            >
+               ← Documentação
+            </a>
+            <h1 class="font-serif text-4xl leading-tight font-black text-foreground text-balance sm:text-5xl md:text-6xl">
+               {currentDoc.data.title}
+            </h1>
+            <p class="max-w-2xl text-base leading-relaxed text-foreground/80 sm:text-lg">
+               {currentDoc.data.description}
+            </p>
+            <p class="text-sm text-muted-foreground">
+               Atualizado em {dayjs(currentDoc.data.updatedAt).format("DD/MM/YYYY")}
+            </p>
+         </div>
+      </header>
+
+      <div class="mx-auto grid w-full max-w-6xl grid-cols-1 gap-8 px-4 py-12 sm:px-4 lg:grid-cols-[220px_1fr_220px]">
+         <aside class="hidden lg:block">
+            <nav class="sticky top-24 flex flex-col gap-4" aria-label="Documentação">
+               {groups.map((group) => (
+                  <div class="flex flex-col gap-2">
+                     <p class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                        {group.category}
+                     </p>
+                     <div class="flex flex-col gap-2">
+                        {group.items.map((item) => (
+                           <a
+                              href={getDocPath(item)}
+                              class:list={[
+                                 "rounded-lg px-3 py-2 text-sm transition-colors",
+                                 item.id === currentDoc.id
+                                    ? "bg-primary/10 text-primary"
+                                    : "text-foreground/80 hover:bg-muted hover:text-foreground",
+                              ]}
+                           >
+                              {item.data.title}
+                           </a>
+                        ))}
+                     </div>
+                  </div>
+               ))}
+            </nav>
+         </aside>
+
+         <div class="prose-invert flex min-w-0 flex-col gap-6 text-foreground/90 [&_a]:font-semibold [&_a]:text-primary [&_a]:underline-offset-4 [&_a]:hover:underline [&_code]:rounded [&_code]:bg-muted [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:text-sm [&_h2]:pt-4 [&_h2]:font-serif [&_h2]:text-2xl [&_h2]:font-bold [&_h2]:text-foreground [&_h2]:scroll-mt-32 [&_h3]:text-lg [&_h3]:font-semibold [&_h3]:text-foreground [&_li]:leading-relaxed [&_ol]:flex [&_ol]:list-decimal [&_ol]:flex-col [&_ol]:gap-2 [&_ol]:pl-6 [&_p]:leading-relaxed [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-muted [&_pre]:p-4 [&_ul]:flex [&_ul]:list-disc [&_ul]:flex-col [&_ul]:gap-2 [&_ul]:pl-6 [&_hr]:my-8 [&_hr]:border-border/60">
+            <Content />
+         </div>
+
+         <aside class="hidden xl:block">
+            {tocHeadings.length > 0 && (
+               <nav class="sticky top-24 flex flex-col gap-3" aria-label="Nesta página">
+                  <p class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                     Nesta página
+                  </p>
+                  <div class="flex flex-col gap-2">
+                     {tocHeadings.map((heading) => (
+                        <a
+                           href={`#${heading.slug}`}
+                           class="text-sm text-foreground/70 transition-colors hover:text-foreground"
+                        >
+                           {heading.text}
+                        </a>
+                     ))}
+                  </div>
+               </nav>
+            )}
+         </aside>
+      </div>
+   </article>
+
+   <FooterBlock />
+</BaseLayout>

--- a/apps/landing/src/pages/docs/index.astro
+++ b/apps/landing/src/pages/docs/index.astro
@@ -1,0 +1,126 @@
+---
+export const prerender = true;
+import { getCollection, render } from "astro:content";
+import dayjs from "dayjs";
+import BaseLayout from "../../layouts/base-layout.astro";
+import FooterBlock from "../../blocks/footer-block.astro";
+import { getDocPath, groupDocsByCategory, sortDocs } from "../../lib/docs";
+
+const docs = sortDocs(await getCollection("docs"));
+const currentDoc = docs.find((doc) => doc.id === "index") ?? docs[0];
+const { Content, headings } = await render(currentDoc);
+const tocHeadings = headings.filter((heading) => heading.depth === 2);
+const groups = groupDocsByCategory(docs);
+const siteUrl = "https://montte.co";
+const canonical = new URL("/docs", siteUrl).toString();
+
+const docsLd = {
+   "@context": "https://schema.org",
+   "@type": "TechArticle",
+   headline: currentDoc.data.title,
+   description: currentDoc.data.description,
+   dateModified: currentDoc.data.updatedAt.toISOString(),
+   inLanguage: "pt-BR",
+   mainEntityOfPage: { "@type": "WebPage", "@id": canonical },
+};
+
+const breadcrumbLd = {
+   "@context": "https://schema.org",
+   "@type": "BreadcrumbList",
+   itemListElement: [
+      {
+         "@type": "ListItem",
+         position: 1,
+         name: "Documentação",
+         item: canonical,
+      },
+   ],
+};
+---
+
+<BaseLayout
+   title={`${currentDoc.data.title} — Montte`}
+   description={currentDoc.data.description}
+   canonicalOverride={canonical}
+   jsonLd={[docsLd, breadcrumbLd]}
+>
+   <article class="relative bg-background">
+      <header class="relative isolate overflow-hidden border-b border-border/60 pt-32 pb-12">
+         <div
+            class="absolute inset-0 -z-10"
+            style="background: linear-gradient(to bottom, color-mix(in oklch, var(--secondary) 22%, var(--background)) 0%, var(--background) 100%);"
+            aria-hidden="true"
+         >
+         </div>
+         <div class="mx-auto flex w-full max-w-6xl flex-col gap-4 px-4 sm:px-4">
+            <p class="text-xs font-medium uppercase tracking-wider text-primary">
+               Documentação
+            </p>
+            <h1 class="font-serif text-4xl leading-tight font-black text-foreground text-balance sm:text-5xl md:text-6xl">
+               {currentDoc.data.title}
+            </h1>
+            <p class="max-w-2xl text-base leading-relaxed text-foreground/80 sm:text-lg">
+               {currentDoc.data.description}
+            </p>
+            <p class="text-sm text-muted-foreground">
+               Atualizado em {dayjs(currentDoc.data.updatedAt).format("DD/MM/YYYY")}
+            </p>
+         </div>
+      </header>
+
+      <div class="mx-auto grid w-full max-w-6xl grid-cols-1 gap-8 px-4 py-12 sm:px-4 lg:grid-cols-[220px_1fr_220px]">
+         <aside class="hidden lg:block">
+            <nav class="sticky top-24 flex flex-col gap-4" aria-label="Documentação">
+               {groups.map((group) => (
+                  <div class="flex flex-col gap-2">
+                     <p class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                        {group.category}
+                     </p>
+                     <div class="flex flex-col gap-2">
+                        {group.items.map((doc) => (
+                           <a
+                              href={getDocPath(doc)}
+                              class:list={[
+                                 "rounded-lg px-3 py-2 text-sm transition-colors",
+                                 doc.id === currentDoc.id
+                                    ? "bg-primary/10 text-primary"
+                                    : "text-foreground/80 hover:bg-muted hover:text-foreground",
+                              ]}
+                           >
+                              {doc.data.title}
+                           </a>
+                        ))}
+                     </div>
+                  </div>
+               ))}
+            </nav>
+         </aside>
+
+         <div class="prose-invert flex min-w-0 flex-col gap-6 text-foreground/90 [&_a]:font-semibold [&_a]:text-primary [&_a]:underline-offset-4 [&_a]:hover:underline [&_code]:rounded [&_code]:bg-muted [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:text-sm [&_h2]:pt-4 [&_h2]:font-serif [&_h2]:text-2xl [&_h2]:font-bold [&_h2]:text-foreground [&_h2]:scroll-mt-32 [&_h3]:text-lg [&_h3]:font-semibold [&_h3]:text-foreground [&_li]:leading-relaxed [&_ol]:flex [&_ol]:list-decimal [&_ol]:flex-col [&_ol]:gap-2 [&_ol]:pl-6 [&_p]:leading-relaxed [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-muted [&_pre]:p-4 [&_ul]:flex [&_ul]:list-disc [&_ul]:flex-col [&_ul]:gap-2 [&_ul]:pl-6 [&_hr]:my-8 [&_hr]:border-border/60">
+            <Content />
+         </div>
+
+         <aside class="hidden xl:block">
+            {tocHeadings.length > 0 && (
+               <nav class="sticky top-24 flex flex-col gap-3" aria-label="Nesta página">
+                  <p class="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                     Nesta página
+                  </p>
+                  <div class="flex flex-col gap-2">
+                     {tocHeadings.map((heading) => (
+                        <a
+                           href={`#${heading.slug}`}
+                           class="text-sm text-foreground/70 transition-colors hover:text-foreground"
+                        >
+                           {heading.text}
+                        </a>
+                     ))}
+                  </div>
+               </nav>
+            )}
+         </aside>
+      </div>
+   </article>
+
+   <FooterBlock />
+</BaseLayout>

--- a/apps/landing/src/pages/llms.txt.ts
+++ b/apps/landing/src/pages/llms.txt.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from "astro";
 import { getCollection } from "astro:content";
 import dayjs from "dayjs";
+import { getDocPath, sortDocs } from "../lib/docs";
 
 export const prerender = true;
 
@@ -10,6 +11,7 @@ export const GET: APIRoute = async () => {
    const posts = (await getCollection("blog")).sort(
       (a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime(),
    );
+   const docs = sortDocs(await getCollection("docs"));
 
    const lines: string[] = [];
    lines.push("# Montte");
@@ -20,6 +22,23 @@ export const GET: APIRoute = async () => {
    lines.push("");
    lines.push(`Site: ${SITE}`);
    lines.push(`Repositório: https://github.com/Montte-erp/montte-nx`);
+   lines.push("");
+   lines.push("## Documentação");
+   lines.push("");
+
+   for (const doc of docs) {
+      const url = `${SITE}${getDocPath(doc)}`;
+      const date = dayjs(doc.data.updatedAt).format("YYYY-MM-DD");
+      lines.push(
+         `- [${doc.data.title}](${url}) — ${doc.data.category} — atualizado em ${date} — ${doc.data.aiSummary}`,
+      );
+      if (doc.data.commonQuestions.length > 0) {
+         for (const question of doc.data.commonQuestions) {
+            lines.push(`  - Pergunta comum: ${question}`);
+         }
+      }
+   }
+
    lines.push("");
    lines.push("## Blog");
    lines.push("");
@@ -39,6 +58,7 @@ export const GET: APIRoute = async () => {
 
    lines.push("");
    lines.push("## Links principais");
+   lines.push(`- Documentação: ${SITE}/docs`);
    lines.push(`- Waitlist: ${SITE}/#waitlist`);
    lines.push(`- Sitemap: ${SITE}/sitemap-index.xml`);
    lines.push("");

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,16 @@
+# Montte docs
+
+> Documentação pública canônica do Montte para usuários e grounding do Montte AI.
+
+Site: https://montte.co
+Documentação: https://montte.co/docs
+Repositório: https://github.com/Montte-erp/montte-nx
+
+## Comece aqui
+
+- [Documentação do Montte](https://montte.co/docs) — visão geral, modelo mental e como usar as docs.
+- [Primeiros passos](https://montte.co/docs/primeiros-passos) — conceitos básicos para organizar a operação recorrente no Montte.
+
+## Uso pelo Montte AI
+
+O Montte AI deve usar estas páginas como base confiável para explicar o produto. Quando uma informação não estiver confirmada na documentação, a resposta deve deixar a limitação clara em vez de inventar comportamento.


### PR DESCRIPTION
## Resumo

- adiciona `/docs` na landing com collection Astro, páginas iniciais e navegação
- adiciona agente Flue `docs-refresh` para atualizar docs públicas do Montte via CI
- adiciona skill `public-docs` em pt-BR para orientar geração segura para humanos e Montte AI
- adiciona `docs/llms.txt` e inclui docs no `/llms.txt`
- corrige problemas de tipagem/CI nos agents Flue existentes (`pr-review`, `security-audit`) e alinha sandbox env ao guia do Flue

## Validação

- `bunx tsc --ignoreConfig --noEmit --module esnext --target es2022 --moduleResolution bundler --skipLibCheck --allowImportingTsExtensions .flue/agents/*.ts`
- `bunx tsc --ignoreConfig --noEmit --module esnext --target es2022 --moduleResolution bundler --skipLibCheck --allowImportingTsExtensions .flue/app.ts .flue/lib/*.ts`
- `bunx flue build --target node --output .flue-dist-check`
- `PUBLIC_POSTHOG_KEY=phc_test PUBLIC_POSTHOG_HOST=https://us.i.posthog.com bun run landing:build`
- `bunx oxlint .flue apps/landing/src/content.config.ts apps/landing/src/lib/docs.ts apps/landing/src/pages/docs apps/landing/src/pages/llms.txt.ts`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adiciona a seção pública de documentação em /docs na landing e um agente Flue `docs-refresh` com CI para gerar/atualizar essas páginas e o índice `docs/llms.txt`. Também corrige tipagem e fluxo dos agentes `pr-review` e `security-audit`, e adiciona link de Docs no rodapé.

- **Novidades**
  - Landing (/docs): coleção `docs` no Astro, páginas `index.astro` e `[...slug].astro` com navegação lateral, TOC, SEO e ordenação; conteúdo inicial `index.mdx` e `primeiros-passos.mdx`; link “Docs” no rodapé.
  - Índice LLM: novo `docs/llms.txt` e atualização de `/llms.txt` para listar docs com `aiSummary` e perguntas comuns.
  - Flue: agente `.flue/agents/docs-refresh.ts` que coleta contexto, usa skill `public-docs`, valida saída (páginas + `llms.txt`) e suporta `dryRun`; referências e regras em `.agents/skills/public-docs/**`. Implementado conforme AGENTS.md (nomenclatura, skill isolada, sandbox env).
  - CI: workflow `docs-refresh.yml` (semanal/dispatch) roda agente, valida build da landing e abre PR com mudanças de docs.
  - Ajustes: `pr-review` e `security-audit` com checagens de erro explícitas e payload de comentários simplificado; util `buildLocalSandboxEnv` em `.flue/lib/agent-utils.ts`; `actions/checkout` fixado para `v4` no `security-audit.yml`.

- **Impacto por camadas e validação**
  - Router: novas rotas `/docs` e `/docs/[...slug]` (prerender), e `/llms.txt` incluindo docs.
  - Componente: `FooterBlock` inclui link “Docs”.
  - Repositório: utilidades do agente (coleta/validação/exec) e ajustes de agentes existentes; nenhum “store” alterado.
  - Por quê: centralizar documentação user-facing e base canônica para grounding do Montte, com atualização automática via agente/CI.
  - Checklist de teste:
    - Compilação/CI dos agentes: `bunx tsc ... .flue/agents/*.ts .flue/app.ts .flue/lib/*.ts && bunx flue build --target node --output .flue-dist-check`
    - Lint: `bunx oxlint .flue apps/landing/src/content.config.ts apps/landing/src/lib/docs.ts apps/landing/src/pages/docs apps/landing/src/pages/llms.txt.ts`
    - Build da landing: `PUBLIC_POSTHOG_KEY=phc_test PUBLIC_POSTHOG_HOST=https://us.i.posthog.com bun run landing:build`
    - Docs-refresh local (opcional): `bunx flue run docs-refresh --target node --id local --payload '{"mode":"manual","dryRun":true}'`
    - Checagem de diffs: `git diff --check`

<sup>Written for commit 7b560c1c487163c4122a9fb381e0a87f6e62f9c9. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/1000?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

