### PR TITLE
Otimiza tabela de lançamentos e importação

### DIFF
--- a/apps/web/src/blocks/data-table/column-meta.ts
+++ b/apps/web/src/blocks/data-table/column-meta.ts
@@ -12,6 +12,7 @@ declare module "@tanstack/react-table" {
       align?: "left" | "center" | "right";
       bulkEditAction?: string;
       bulkEditIcon?: ComponentType<{ className?: string }>;
+      bulkEditPatch?: (option: DataTableOption) => Record<string, unknown>;
       cellComponent?:
          | "combobox"
          | "date"

--- a/apps/web/src/blocks/data-table/data-import/data-import-bulk-edit.tsx
+++ b/apps/web/src/blocks/data-table/data-import/data-import-bulk-edit.tsx
@@ -20,7 +20,10 @@ import { useState } from "react";
 interface DataImportBulkEditProps<TData> {
    table: Table<TData>;
    selectedIndices: Set<number>;
-   onUpdate: (key: string, value: unknown) => void;
+   onUpdate: (
+      keyOrPatch: string | Record<string, unknown>,
+      value?: unknown,
+   ) => void;
 }
 
 export function DataImportBulkEdit<TData>({
@@ -122,7 +125,9 @@ export function DataImportBulkEdit<TData>({
                               className="w-full justify-start text-xs"
                               key={opt.value}
                               onClick={() => {
-                                 onUpdate(accKey, opt.value);
+                                 const patch = meta.bulkEditPatch?.(opt);
+                                 if (patch) onUpdate(patch);
+                                 else onUpdate(accKey, opt.value);
                                  setOpenCol(null);
                               }}
                               size="sm"
@@ -161,7 +166,9 @@ export function DataImportBulkEdit<TData>({
                                     keywords={[opt.label]}
                                     value={opt.value}
                                     onSelect={() => {
-                                       onUpdate(accKey, opt.value);
+                                       const patch = meta.bulkEditPatch?.(opt);
+                                       if (patch) onUpdate(patch);
+                                       else onUpdate(accKey, opt.value);
                                        setOpenCol(null);
                                     }}
                                  >

--- a/apps/web/src/blocks/data-table/data-import/data-import-section.tsx
+++ b/apps/web/src/blocks/data-table/data-import/data-import-section.tsx
@@ -1,5 +1,6 @@
 import type { Column, Table } from "@tanstack/react-table";
 import { flexRender } from "@tanstack/react-table";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { Badge } from "@packages/ui/components/badge";
 import { Button } from "@packages/ui/components/button";
 import { Checkbox } from "@packages/ui/components/checkbox";
@@ -55,6 +56,7 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
    const { openAlertDialog } = useAlertDialog();
    const [editingColKey, setEditingColKey] = useState<string | null>(null);
    const [isSubmitting, setSubmitting] = useState(false);
+   const [scrollElement, setScrollElement] = useState<HTMLElement | null>(null);
 
    const { rawHeaders, rawRows, mapping, importRows } = state;
    const { selectedIndices, ignoredIndices } = api;
@@ -126,6 +128,27 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
    const allSelected =
       rawRows.length > 0 && selectedIndices.size === rawRows.length;
    const someSelected = selectedIndices.size > 0 && !allSelected;
+   const virtualizer = useVirtualizer({
+      count: rawRows.length,
+      estimateSize: () => 44,
+      getScrollElement: () => scrollElement,
+      overscan: 12,
+   });
+   const virtualRows = virtualizer.getVirtualItems();
+   const topPadding = virtualRows[0]?.start ?? 0;
+   const bottomPadding =
+      virtualRows.length > 0
+         ? virtualizer.getTotalSize() -
+           (virtualRows[virtualRows.length - 1]?.end ?? 0)
+         : 0;
+   const handleImportBodyRef = useCallback(
+      (node: HTMLTableSectionElement | null) => {
+         if (!node) return;
+         const viewport = node.closest('[data-slot="scroll-area-viewport"]');
+         if (viewport instanceof HTMLElement) setScrollElement(viewport);
+      },
+      [],
+   );
 
    const buildRowToImport = useCallback(
       (rowIdx: number, currentMapping: Record<string, string>) => {
@@ -226,7 +249,7 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
    }, [duplicateIndices, ignoredIndices, openAlertDialog, submit]);
 
    return (
-      <TableBody>
+      <TableBody ref={handleImportBodyRef}>
          <TableRow className="sticky top-10 z-30 bg-muted hover:bg-transparent">
             <TableCell className="bg-muted px-4 py-2" colSpan={colCount}>
                <div className="flex items-center justify-between gap-4">
@@ -399,12 +422,23 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
             ))}
          </TableRow>
 
-         {rawRows.map((row, rowIdx) => {
+         {topPadding > 0 && (
+            <TableRow aria-hidden="true">
+               <TableCell colSpan={colCount} style={{ height: topPadding }} />
+            </TableRow>
+         )}
+
+         {virtualRows.map((virtualRow) => {
+            const rowIdx = virtualRow.index;
+            const row = rawRows[rowIdx];
+            if (!row) return null;
             const isSelected = selectedIndices.has(rowIdx);
             const isIgnored = ignoredIndices.has(rowIdx);
             const isDuplicate = duplicateIndices.has(rowIdx);
             return (
                <TableRow
+                  ref={virtualizer.measureElement}
+                  data-index={virtualRow.index}
                   className={cn(
                      "border-l-2 transition-colors",
                      isIgnored
@@ -593,6 +627,15 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
                </TableRow>
             );
          })}
+
+         {bottomPadding > 0 && (
+            <TableRow aria-hidden="true">
+               <TableCell
+                  colSpan={colCount}
+                  style={{ height: bottomPadding }}
+               />
+            </TableRow>
+         )}
       </TableBody>
    );
 }

--- a/apps/web/src/blocks/data-table/data-import/data-import-section.tsx
+++ b/apps/web/src/blocks/data-table/data-import/data-import-section.tsx
@@ -9,7 +9,7 @@ import { TableBody, TableCell, TableRow } from "@packages/ui/components/table";
 import { cn } from "@packages/ui/lib/utils";
 import { Check, Loader2, TriangleAlert, X } from "lucide-react";
 import { fromPromise } from "neverthrow";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useLayoutEffect, useMemo, useState } from "react";
 import { toast } from "@packages/ui/hooks/use-toast";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
 import { InlineEditMoney } from "../inline-edit/inline-edit-money";
@@ -57,6 +57,9 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
    const [editingColKey, setEditingColKey] = useState<string | null>(null);
    const [isSubmitting, setSubmitting] = useState(false);
    const [scrollElement, setScrollElement] = useState<HTMLElement | null>(null);
+   const [sentinelElement, setSentinelElement] =
+      useState<HTMLTableRowElement | null>(null);
+   const [scrollMargin, setScrollMargin] = useState(0);
 
    const { rawHeaders, rawRows, mapping, importRows } = state;
    const { selectedIndices, ignoredIndices } = api;
@@ -66,15 +69,7 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
       () => visibleCols.filter(isImportableColumn),
       [visibleCols],
    );
-   const montteColumns = useMemo(() => {
-      const requiredColumns = importableColumns.filter(
-         (col) => col.columnDef.meta?.required,
-      );
-      const optionalColumns = importableColumns.filter(
-         (col) => !col.columnDef.meta?.required,
-      );
-      return [...requiredColumns, ...optionalColumns];
-   }, [importableColumns]);
+   const montteColumns = importableColumns;
    const hasSelectColumn = visibleCols.some((col) => col.id === "__select");
    const hasActionsColumn = visibleCols.some((col) => col.id === "__actions");
    const mappedHeaders = useMemo(
@@ -96,6 +91,15 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
       (hasActionsColumn ? 1 : 0) +
       extraHeaders.length;
    const activeCount = rawRows.length - ignoredIndices.size;
+   const typeCounts = useMemo(() => {
+      let income = 0;
+      let expense = 0;
+      for (const row of importRows) {
+         if (row.type === "income") income += 1;
+         if (row.type === "expense") expense += 1;
+      }
+      return { income, expense };
+   }, [importRows]);
 
    const duplicateIndices = useMemo(() => {
       if (!hasImportRows) return new Set<number>();
@@ -130,25 +134,63 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
    const someSelected = selectedIndices.size > 0 && !allSelected;
    const virtualizer = useVirtualizer({
       count: rawRows.length,
-      estimateSize: () => 44,
+      estimateSize: () => 54,
+      getItemKey: (index) => `__import_${index}`,
       getScrollElement: () => scrollElement,
-      overscan: 12,
+      overscan: 5,
+      scrollMargin,
    });
    const virtualRows = virtualizer.getVirtualItems();
-   const topPadding = virtualRows[0]?.start ?? 0;
-   const bottomPadding =
-      virtualRows.length > 0
-         ? virtualizer.getTotalSize() -
-           (virtualRows[virtualRows.length - 1]?.end ?? 0)
-         : 0;
+   const topPadding = Math.max(
+      0,
+      virtualRows[0] ? virtualRows[0].start - scrollMargin : 0,
+   );
+   const lastVirtualRow = virtualRows[virtualRows.length - 1];
+   const bottomPadding = Math.max(
+      0,
+      lastVirtualRow
+         ? virtualizer.getTotalSize() - (lastVirtualRow.end - scrollMargin)
+         : 0,
+   );
    const handleImportBodyRef = useCallback(
       (node: HTMLTableSectionElement | null) => {
-         if (!node) return;
+         if (!node) {
+            setScrollElement(null);
+            return;
+         }
          const viewport = node.closest('[data-slot="scroll-area-viewport"]');
-         if (viewport instanceof HTMLElement) setScrollElement(viewport);
+         setScrollElement(viewport instanceof HTMLElement ? viewport : null);
       },
       [],
    );
+
+   const updateScrollMargin = useCallback(() => {
+      if (!sentinelElement || !scrollElement) return;
+      const sentinelRect = sentinelElement.getBoundingClientRect();
+      const scrollRect = scrollElement.getBoundingClientRect();
+      const next = Math.max(
+         0,
+         sentinelRect.top - scrollRect.top + scrollElement.scrollTop,
+      );
+      setScrollMargin((current) =>
+         Math.abs(current - next) > 1 ? next : current,
+      );
+   }, [scrollElement, sentinelElement]);
+
+   useLayoutEffect(() => {
+      if (!sentinelElement || !scrollElement) return;
+      updateScrollMargin();
+      const frame = window.requestAnimationFrame(updateScrollMargin);
+      const resizeObserver = new ResizeObserver(updateScrollMargin);
+      resizeObserver.observe(sentinelElement);
+      if (scrollElement.firstElementChild) {
+         resizeObserver.observe(scrollElement.firstElementChild);
+      }
+      return () => {
+         window.cancelAnimationFrame(frame);
+         resizeObserver.disconnect();
+      };
+   }, [scrollElement, sentinelElement, updateScrollMargin]);
 
    const buildRowToImport = useCallback(
       (rowIdx: number, currentMapping: Record<string, string>) => {
@@ -250,8 +292,11 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
 
    return (
       <TableBody ref={handleImportBodyRef}>
-         <TableRow className="sticky top-10 z-30 bg-muted hover:bg-transparent">
-            <TableCell className="bg-muted px-4 py-2" colSpan={colCount}>
+         <TableRow className="sticky top-10 z-40 border-y border-border bg-secondary/90 hover:bg-secondary/90">
+            <TableCell
+               className="bg-secondary/90 px-4 py-2 text-foreground"
+               colSpan={colCount}
+            >
                <div className="flex items-center justify-between gap-4">
                   <div className="flex items-center gap-2">
                      <span className="text-sm font-medium">Importando</span>
@@ -266,6 +311,19 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
                            {duplicateIndices.size} duplicado(s)
                         </Badge>
                      )}
+                     {typeCounts.income > 0 && (
+                        <Badge className="border-emerald-500/30 bg-emerald-500/[0.08] text-emerald-300 text-xs font-normal">
+                           A receber → Receita · {typeCounts.income}
+                        </Badge>
+                     )}
+                     {typeCounts.expense > 0 && (
+                        <Badge className="border-rose-500/30 bg-rose-500/[0.08] text-rose-300 text-xs font-normal">
+                           A pagar → Despesa · {typeCounts.expense}
+                        </Badge>
+                     )}
+                     <span className="text-muted-foreground text-xs">
+                        De/para: campo Montte → coluna da planilha
+                     </span>
                   </div>
                   <div className="flex items-center gap-2">
                      <Button
@@ -317,45 +375,9 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
             </TableCell>
          </TableRow>
 
-         <TableRow className="sticky top-20 z-20 bg-muted/20 hover:bg-muted/20">
-            {hasSelectColumn && <TableCell className="w-10 px-2" />}
-            {montteColumns.map((col) => {
-               const label = col.columnDef.meta?.label ?? col.id;
-               const required = col.columnDef.meta?.required;
-               return (
-                  <TableCell
-                     className="bg-muted/20 py-1 pr-2"
-                     key={`montte-label-${col.id}`}
-                  >
-                     <span className="text-xs font-medium">
-                        {label}
-                        {required && (
-                           <span
-                              aria-label="Campo obrigatório"
-                              className="ml-0.5 text-destructive"
-                           >
-                              *
-                           </span>
-                        )}
-                     </span>
-                  </TableCell>
-               );
-            })}
-            {hasActionsColumn && <TableCell key="montte-label-actions" />}
-            {extraHeaders.map((header, index) => (
-               <TableCell
-                  className="bg-muted/20 py-1 pr-2"
-                  key={`montte-label-extra-${header}-${index}`}
-               >
-                  <span className="text-xs text-muted-foreground/60">
-                     &nbsp;
-                  </span>
-               </TableCell>
-            ))}
-         </TableRow>
-         <TableRow className="sticky top-32 z-20 bg-muted/20 hover:bg-muted/20">
+         <TableRow className="sticky top-20 z-30 border-b border-border bg-secondary/40 shadow-[0_8px_12px_-12px_rgb(0_0_0/0.45)] hover:bg-secondary/40">
             {hasSelectColumn && (
-               <TableCell className="w-10 px-2">
+               <TableCell className="w-10 bg-secondary/40 px-2 align-bottom">
                   <Checkbox
                      aria-label="Selecionar todos"
                      checked={someSelected ? "indeterminate" : allSelected}
@@ -364,67 +386,124 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
                </TableCell>
             )}
             {montteColumns.map((col) => {
+               const label = col.columnDef.meta?.label ?? col.id;
+               const required = col.columnDef.meta?.required;
                const accKey = getColumnAccessorKey(col);
                const currentHeader = mapping[accKey] ?? "";
                const isEditing = editingColKey === accKey;
                return (
-                  <TableCell className="py-1 pr-2" key={`montte-map-${col.id}`}>
-                     {isEditing ? (
-                        <Combobox
-                           defaultOpen
-                           emptyMessage="Nenhuma coluna encontrada."
-                           options={headerOptions}
-                           placeholder="Não mapeado"
-                           searchPlaceholder="Buscar coluna..."
-                           value={currentHeader || "__none__"}
-                           onValueChange={(v) => {
-                              api.updateMapping({
-                                 ...mapping,
-                                 [accKey]: v === "__none__" ? "" : v,
-                              });
-                              setEditingColKey(null);
-                           }}
-                        />
-                     ) : (
-                        <Button
-                           className="flex w-full items-center justify-start gap-2 px-2 py-2 text-left text-xs"
-                           data-testid={
-                              col.columnDef.meta?.required
-                                 ? "unmapped-required"
-                                 : undefined
-                           }
-                           onClick={() => setEditingColKey(accKey)}
-                           type="button"
-                           variant="ghost"
-                        >
-                           {currentHeader ? (
-                              <span className="flex-1 truncate font-medium text-foreground">
-                                 {currentHeader}
+                  <TableCell
+                     className="bg-secondary/40 py-2 pr-2 align-top"
+                     key={`montte-map-${col.id}`}
+                  >
+                     <div className="flex min-w-0 flex-col gap-2">
+                        <div className="flex min-w-0 items-center gap-2">
+                           <span className="text-muted-foreground text-[10px] font-medium uppercase tracking-wide">
+                              Montte
+                           </span>
+                           <span className="truncate text-xs font-medium text-foreground">
+                              {label}
+                              {required && (
+                                 <span
+                                    aria-label="Campo obrigatório"
+                                    className="ml-0.5 text-destructive"
+                                 >
+                                    *
+                                 </span>
+                              )}
+                           </span>
+                        </div>
+                        {isEditing ? (
+                           <Combobox
+                              className="h-8 w-full border-dashed bg-card/70 text-xs"
+                              defaultOpen
+                              emptyMessage="Nenhuma coluna encontrada."
+                              options={headerOptions}
+                              placeholder="Não mapeado"
+                              searchPlaceholder="Buscar coluna..."
+                              value={currentHeader || "__none__"}
+                              onValueChange={(v) => {
+                                 api.updateMapping({
+                                    ...mapping,
+                                    [accKey]: v === "__none__" ? "" : v,
+                                 });
+                                 setEditingColKey(null);
+                              }}
+                           />
+                        ) : (
+                           <Button
+                              className={cn(
+                                 "h-8 w-full justify-start gap-2 rounded-md border border-dashed border-border/80 bg-card/70 px-2 text-left text-xs shadow-none hover:bg-card",
+                                 !currentHeader &&
+                                    required &&
+                                    "border-destructive/40 bg-destructive/[0.04]",
+                              )}
+                              data-testid={
+                                 required ? "unmapped-required" : undefined
+                              }
+                              onClick={() => setEditingColKey(accKey)}
+                              type="button"
+                              variant="ghost"
+                           >
+                              <span className="shrink-0 text-muted-foreground">
+                                 Planilha:
                               </span>
-                           ) : (
-                              <span className="flex-1 truncate italic text-muted-foreground/50">
-                                 Não mapeado
-                              </span>
-                           )}
-                        </Button>
-                     )}
+                              {currentHeader ? (
+                                 <span className="truncate font-medium text-foreground">
+                                    {currentHeader}
+                                 </span>
+                              ) : (
+                                 <span className="truncate italic text-muted-foreground">
+                                    Não mapeado
+                                 </span>
+                              )}
+                           </Button>
+                        )}
+                     </div>
                   </TableCell>
                );
             })}
-            {hasActionsColumn && <TableCell key="montte-mapping-actions" />}
+            {hasActionsColumn && (
+               <TableCell
+                  className="bg-secondary/40"
+                  key="montte-mapping-actions"
+               />
+            )}
             {extraHeaders.map((header, index) => (
                <TableCell
-                  className="py-1 pr-2"
+                  className="bg-secondary/40 py-2 pr-2 align-top"
                   key={`montte-extra-${header}-${index}`}
                >
-                  <span className="text-xs font-medium">{header}</span>
+                  <div className="flex min-w-0 flex-col gap-2">
+                     <span className="text-[11px] font-medium leading-none text-muted-foreground">
+                        Planilha
+                     </span>
+                     <span className="truncate rounded-md border border-dashed border-border px-2 py-2 text-xs text-muted-foreground">
+                        {header}
+                     </span>
+                  </div>
                </TableCell>
             ))}
          </TableRow>
 
+         <TableRow
+            ref={setSentinelElement}
+            aria-hidden="true"
+            className="border-0 hover:bg-transparent"
+         >
+            <TableCell className="border-0 p-0" colSpan={colCount} />
+         </TableRow>
+
          {topPadding > 0 && (
-            <TableRow aria-hidden="true">
-               <TableCell colSpan={colCount} style={{ height: topPadding }} />
+            <TableRow
+               aria-hidden="true"
+               className="border-0 hover:bg-transparent"
+            >
+               <TableCell
+                  className="border-0 p-0"
+                  colSpan={colCount}
+                  style={{ height: topPadding }}
+               />
             </TableRow>
          )}
 
@@ -435,9 +514,12 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
             const isSelected = selectedIndices.has(rowIdx);
             const isIgnored = ignoredIndices.has(rowIdx);
             const isDuplicate = duplicateIndices.has(rowIdx);
+            const importedRow = hasImportRows
+               ? (importRows[rowIdx] ?? null)
+               : null;
+            const rowType = importedRow?.type;
             return (
                <TableRow
-                  ref={virtualizer.measureElement}
                   data-index={virtualRow.index}
                   className={cn(
                      "border-l-2 transition-colors",
@@ -447,7 +529,11 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
                           ? "border-l-destructive/50 bg-destructive/[0.03] hover:bg-destructive/[0.07]"
                           : isSelected
                             ? "border-l-primary/40 bg-primary/10 hover:bg-primary/10"
-                            : "border-l-primary/40 bg-primary/[0.03] hover:bg-primary/[0.07]",
+                            : rowType === "income"
+                              ? "border-l-primary/70 bg-transparent hover:bg-muted/40"
+                              : rowType === "expense"
+                                ? "border-l-destructive/70 bg-transparent hover:bg-muted/40"
+                                : "border-l-border bg-transparent hover:bg-muted/40",
                   )}
                   key={`__import_${rowIdx}`}
                >
@@ -465,9 +551,6 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
                      const accKey = getColumnAccessorKey(col);
                      const fileHeader = mapping[accKey];
                      const rawVal = getRawValue(row, fileHeader ?? "");
-                     const importedRow = hasImportRows
-                        ? (importRows[rowIdx] ?? null)
-                        : null;
                      const val = importedRow ? importedRow[accKey] : rawVal;
                      const meta = col.columnDef.meta;
                      const ariaLabel = meta?.label ?? accKey;
@@ -629,8 +712,12 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
          })}
 
          {bottomPadding > 0 && (
-            <TableRow aria-hidden="true">
+            <TableRow
+               aria-hidden="true"
+               className="border-0 hover:bg-transparent"
+            >
                <TableCell
+                  className="border-0 p-0"
                   colSpan={colCount}
                   style={{ height: bottomPadding }}
                />

--- a/apps/web/src/blocks/data-table/data-import/use-data-import.tsx
+++ b/apps/web/src/blocks/data-table/data-import/use-data-import.tsx
@@ -70,6 +70,30 @@ function normalizeHeader(s: string) {
       .replace(/[^a-z0-9]/g, "");
 }
 
+function canAutoMatchHeader(col: ImportableColumn, normalizedHeader: string) {
+   const normalizedKey = normalizeHeader(col.key);
+   const normalizedLabel = normalizeHeader(col.label);
+   if (
+      (normalizedKey === "amount" || normalizedLabel === "valor") &&
+      /saldo/.test(normalizedHeader)
+   ) {
+      return false;
+   }
+   if (
+      (normalizedKey === "bankaccountname" || normalizedLabel === "conta") &&
+      /(receber|pagar|saldo)/.test(normalizedHeader)
+   ) {
+      return false;
+   }
+   if (
+      (normalizedKey === "categoryname" || normalizedLabel === "categoria") &&
+      /(despesa|receita|tipo)/.test(normalizedHeader)
+   ) {
+      return false;
+   }
+   return true;
+}
+
 function autoMatch(
    fileHeaders: string[],
    cols: ImportableColumn[],
@@ -78,13 +102,22 @@ function autoMatch(
    for (const col of cols) {
       const normLabel = normalizeHeader(col.label);
       const normKey = normalizeHeader(col.key);
+      const exactMatch = fileHeaders.find((h) => {
+         const normH = normalizeHeader(h);
+         if (!canAutoMatchHeader(col, normH)) return false;
+         return normH === normLabel || normH === normKey;
+      });
+      if (exactMatch) {
+         mapping[col.key] = exactMatch;
+         continue;
+      }
+
       const match = fileHeaders.find((h) => {
          const normH = normalizeHeader(h);
+         if (!canAutoMatchHeader(col, normH)) return false;
          return (
-            normH === normLabel ||
-            normH === normKey ||
-            normH.includes(normLabel) ||
-            normH.includes(normKey)
+            (normLabel.length >= 6 && normH.includes(normLabel)) ||
+            (normKey.length >= 6 && normH.includes(normKey))
          );
       });
       if (match) mapping[col.key] = match;

--- a/apps/web/src/blocks/data-table/data-table-body.tsx
+++ b/apps/web/src/blocks/data-table/data-table-body.tsx
@@ -7,10 +7,18 @@ import {
    type Row,
    type Table,
 } from "@tanstack/react-table";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { ChevronDown, ChevronRight } from "lucide-react";
-import { Fragment } from "react";
+import {
+   Fragment,
+   useCallback,
+   useLayoutEffect,
+   useMemo,
+   useState,
+} from "react";
+import type { CSSProperties, ReactNode } from "react";
 
-function getPinStyles<TData>(column: Column<TData>): React.CSSProperties {
+function getPinStyles<TData>(column: Column<TData>): CSSProperties {
    const pin = column.getIsPinned();
    if (!pin) return {};
    const isLeft = pin === "left";
@@ -27,11 +35,18 @@ interface DataTableBodyProps<TData> {
    table: Table<TData>;
    getRowClassName?: (props: { row: Row<TData> }) => string | undefined;
    renderRow?: (props: { row: Row<TData> }) => React.ReactNode;
-   renderExpandedRow?: (props: { row: Row<TData> }) => React.ReactNode;
-   renderGroupLabel?: (props: { row: Row<TData> }) => React.ReactNode;
+   renderExpandedRow?: (props: { row: Row<TData> }) => ReactNode;
+   renderGroupLabel?: (props: { row: Row<TData> }) => ReactNode;
+   virtualized?: boolean;
+   estimateRowHeight?: number;
+   overscan?: number;
 }
 
-function defaultGroupLabel<TData>(row: Row<TData>): React.ReactNode {
+type RenderItem<TData> =
+   | { kind: "row"; row: Row<TData> }
+   | { kind: "expanded"; row: Row<TData> };
+
+function defaultGroupLabel<TData>(row: Row<TData>): ReactNode {
    const groupingColumnId = row.groupingColumnId;
    const groupColumn = groupingColumnId
       ? row.getAllCells().find((c) => c.column.id === groupingColumnId)?.column
@@ -66,92 +81,234 @@ export function DataTableBody<TData>({
    renderRow,
    renderExpandedRow,
    renderGroupLabel,
+   virtualized = false,
+   estimateRowHeight = 48,
+   overscan = 5,
 }: DataTableBodyProps<TData>) {
    const rows = table.getRowModel().rows;
    const colSpan = table.getVisibleLeafColumns().length;
+   const [scrollElement, setScrollElement] = useState<HTMLElement | null>(null);
+   const [bodyElement, setBodyElement] =
+      useState<HTMLTableSectionElement | null>(null);
+   const [scrollMargin, setScrollMargin] = useState(0);
+
+   const renderItems = useMemo(() => {
+      const items: RenderItem<TData>[] = [];
+      for (const row of rows) {
+         items.push({ kind: "row", row });
+         if (!row.getIsGrouped() && row.getIsExpanded() && renderExpandedRow) {
+            items.push({ kind: "expanded", row });
+         }
+      }
+      return items;
+   }, [renderExpandedRow, rows]);
+
+   const handleBodyRef = useCallback((node: HTMLTableSectionElement | null) => {
+      setBodyElement(node);
+      if (!node) {
+         setScrollElement(null);
+         return;
+      }
+      const viewport = node.closest('[data-slot="scroll-area-viewport"]');
+      setScrollElement(viewport instanceof HTMLElement ? viewport : null);
+   }, []);
+
+   const updateScrollMargin = useCallback(() => {
+      if (!bodyElement || !scrollElement) return;
+      const bodyRect = bodyElement.getBoundingClientRect();
+      const scrollRect = scrollElement.getBoundingClientRect();
+      const next = Math.max(
+         0,
+         bodyRect.top - scrollRect.top + scrollElement.scrollTop,
+      );
+      setScrollMargin((current) =>
+         Math.abs(current - next) > 1 ? next : current,
+      );
+   }, [bodyElement, scrollElement]);
+
+   useLayoutEffect(() => {
+      if (!virtualized || !bodyElement || !scrollElement) return;
+      updateScrollMargin();
+      const frame = window.requestAnimationFrame(updateScrollMargin);
+      const resizeObserver = new ResizeObserver(updateScrollMargin);
+      resizeObserver.observe(bodyElement);
+      if (scrollElement.firstElementChild) {
+         resizeObserver.observe(scrollElement.firstElementChild);
+      }
+      return () => {
+         window.cancelAnimationFrame(frame);
+         resizeObserver.disconnect();
+      };
+   }, [bodyElement, scrollElement, updateScrollMargin, virtualized]);
+
+   const rowVirtualizer = useVirtualizer({
+      count: virtualized ? renderItems.length : 0,
+      estimateSize: (index) =>
+         renderItems[index]?.kind === "expanded" ? 160 : estimateRowHeight,
+      getItemKey: (index) => {
+         const item = renderItems[index];
+         if (!item) return index;
+         return item.kind === "expanded"
+            ? `${item.row.id}__expanded`
+            : item.row.id;
+      },
+      getScrollElement: () => scrollElement,
+      overscan,
+      scrollMargin,
+   });
+
+   const renderGroupRow = useCallback(
+      (row: Row<TData>) => (
+         <TableRow
+            key={row.id}
+            className="border-y border-border bg-accent/50 hover:bg-accent/60"
+         >
+            <TableCell className="py-2 text-foreground" colSpan={colSpan}>
+               <div className="flex items-center gap-2">
+                  <Button
+                     aria-label={
+                        row.getIsExpanded()
+                           ? "Recolher grupo"
+                           : "Expandir grupo"
+                     }
+                     onClick={row.getToggleExpandedHandler()}
+                     size="icon-sm"
+                     variant="ghost"
+                  >
+                     {row.getIsExpanded() ? <ChevronDown /> : <ChevronRight />}
+                  </Button>
+                  {renderGroupLabel
+                     ? renderGroupLabel({ row })
+                     : defaultGroupLabel(row)}
+               </div>
+            </TableCell>
+         </TableRow>
+      ),
+      [colSpan, renderGroupLabel],
+   );
+
+   const renderDataRow = useCallback(
+      (row: Row<TData>) => {
+         if (row.getIsGrouped()) return renderGroupRow(row);
+         if (renderRow) return renderRow({ row });
+         return (
+            <TableRow
+               className={getRowClassName?.({ row })}
+               data-selected={row.getIsSelected()}
+               data-state={row.getIsSelected() ? "selected" : undefined}
+               key={row.id}
+            >
+               {row.getVisibleCells().map((cell) => {
+                  const col = cell.column;
+                  const align = col.columnDef.meta?.align ?? "left";
+                  return (
+                     <TableCell
+                        key={cell.id}
+                        style={{
+                           width: cell.column.getSize(),
+                           textAlign: align,
+                           ...getPinStyles(col),
+                        }}
+                        className={cn(
+                           col.getIsPinned() &&
+                              "shadow-[inset_-1px_0_0_var(--border)]",
+                        )}
+                     >
+                        {flexRender(col.columnDef.cell, cell.getContext())}
+                     </TableCell>
+                  );
+               })}
+            </TableRow>
+         );
+      },
+      [getRowClassName, renderGroupRow, renderRow],
+   );
+
+   const renderExpanded = useCallback(
+      (row: Row<TData>) => {
+         if (!renderExpandedRow) return null;
+         return (
+            <TableRow data-expanded key={`${row.id}__expanded`}>
+               <TableCell
+                  className="bg-muted/20"
+                  colSpan={row.getVisibleCells().length}
+               >
+                  {renderExpandedRow({ row })}
+               </TableCell>
+            </TableRow>
+         );
+      },
+      [renderExpandedRow],
+   );
+
+   const renderItem = useCallback(
+      (item: RenderItem<TData>) =>
+         item.kind === "expanded"
+            ? renderExpanded(item.row)
+            : renderDataRow(item.row),
+      [renderDataRow, renderExpanded],
+   );
+
+   if (!virtualized) {
+      return (
+         <TableBody>
+            {rows.map((row) => (
+               <Fragment key={row.id}>
+                  {renderDataRow(row)}
+                  {!row.getIsGrouped() &&
+                     row.getIsExpanded() &&
+                     renderExpanded(row)}
+               </Fragment>
+            ))}
+         </TableBody>
+      );
+   }
+
+   const virtualRows = rowVirtualizer.getVirtualItems();
+   const firstVirtualRow = virtualRows[0];
+   const lastVirtualRow = virtualRows[virtualRows.length - 1];
+   const topPadding = Math.max(
+      0,
+      firstVirtualRow ? firstVirtualRow.start - scrollMargin : 0,
+   );
+   const bottomPadding = Math.max(
+      0,
+      lastVirtualRow
+         ? rowVirtualizer.getTotalSize() - (lastVirtualRow.end - scrollMargin)
+         : 0,
+   );
 
    return (
-      <TableBody>
-         {rows.map((row) => {
-            if (row.getIsGrouped()) {
-               return (
-                  <TableRow key={row.id} className="bg-muted/40">
-                     <TableCell className="py-2" colSpan={colSpan}>
-                        <div className="flex items-center gap-2">
-                           <Button
-                              aria-label={
-                                 row.getIsExpanded()
-                                    ? "Recolher grupo"
-                                    : "Expandir grupo"
-                              }
-                              onClick={row.getToggleExpandedHandler()}
-                              size="icon-sm"
-                              variant="ghost"
-                           >
-                              {row.getIsExpanded() ? (
-                                 <ChevronDown />
-                              ) : (
-                                 <ChevronRight />
-                              )}
-                           </Button>
-                           {renderGroupLabel
-                              ? renderGroupLabel({ row })
-                              : defaultGroupLabel(row)}
-                        </div>
-                     </TableCell>
-                  </TableRow>
-               );
-            }
-
-            const expanded = row.getIsExpanded();
-            const body = renderRow ? (
-               renderRow({ row })
-            ) : (
-               <TableRow
-                  className={getRowClassName?.({ row })}
-                  data-selected={row.getIsSelected()}
-                  data-state={row.getIsSelected() ? "selected" : undefined}
-                  key={row.id}
-               >
-                  {row.getVisibleCells().map((cell) => {
-                     const col = cell.column;
-                     const align = col.columnDef.meta?.align ?? "left";
-                     return (
-                        <TableCell
-                           key={cell.id}
-                           style={{
-                              width: cell.column.getSize(),
-                              textAlign: align,
-                              ...getPinStyles(col),
-                           }}
-                           className={cn(
-                              col.getIsPinned() &&
-                                 "shadow-[inset_-1px_0_0_var(--border)]",
-                           )}
-                        >
-                           {flexRender(col.columnDef.cell, cell.getContext())}
-                        </TableCell>
-                     );
-                  })}
-               </TableRow>
-            );
-
-            return (
-               <Fragment key={row.id}>
-                  {body}
-                  {expanded && renderExpandedRow && (
-                     <TableRow data-expanded>
-                        <TableCell
-                           className="bg-muted/20"
-                           colSpan={row.getVisibleCells().length}
-                        >
-                           {renderExpandedRow({ row })}
-                        </TableCell>
-                     </TableRow>
-                  )}
-               </Fragment>
-            );
+      <TableBody ref={handleBodyRef}>
+         {topPadding > 0 ? (
+            <TableRow
+               aria-hidden="true"
+               className="border-0 hover:bg-transparent"
+            >
+               <TableCell
+                  className="border-0 p-0"
+                  colSpan={colSpan}
+                  style={{ height: topPadding }}
+               />
+            </TableRow>
+         ) : null}
+         {virtualRows.map((virtualRow) => {
+            const item = renderItems[virtualRow.index];
+            if (!item) return null;
+            return <Fragment key={virtualRow.key}>{renderItem(item)}</Fragment>;
          })}
+         {bottomPadding > 0 ? (
+            <TableRow
+               aria-hidden="true"
+               className="border-0 hover:bg-transparent"
+            >
+               <TableCell
+                  className="border-0 p-0"
+                  colSpan={colSpan}
+                  style={{ height: bottomPadding }}
+               />
+            </TableRow>
+         ) : null}
       </TableBody>
    );
 }

--- a/apps/web/src/blocks/data-table/inline-edit/inline-edit-combobox.tsx
+++ b/apps/web/src/blocks/data-table/inline-edit/inline-edit-combobox.tsx
@@ -23,11 +23,13 @@ export function InlineEditCombobox({
    options,
    onSave,
    onCreate,
+   ariaLabel,
    placeholder,
    className,
    startContent,
    renderSelected,
 }: InlineEditComboboxProps) {
+   const [editing, setEditing] = useState(false);
    const [pending, setPending] = useState<string | null>(null);
    const lastCommittedRef = useRef(value);
 
@@ -41,6 +43,7 @@ export function InlineEditCombobox({
    const displayed = pending ?? value;
 
    async function commit(next: string) {
+      setEditing(false);
       if (next === value) return;
       setPending(next);
       const result = await fromPromise(onSave(next), (e) => e);
@@ -53,13 +56,47 @@ export function InlineEditCombobox({
       if (result.isOk()) commit(result.value);
    }
 
+   const selectedOption = options.find((option) => option.value === displayed);
+
+   if (!editing) {
+      return (
+         <button
+            aria-label={ariaLabel}
+            className={cn(
+               "flex h-8 w-full min-w-0 cursor-pointer items-center gap-2 rounded-md border border-dashed border-transparent bg-muted/20 px-2 text-left text-sm transition-colors hover:border-border hover:bg-muted/50 focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none",
+               className,
+            )}
+            onClick={() => setEditing(true)}
+            type="button"
+         >
+            {selectedOption ? (
+               (renderSelected?.(selectedOption) ?? (
+                  <>
+                     {startContent}
+                     <span className="truncate">{selectedOption.label}</span>
+                  </>
+               ))
+            ) : (
+               <>
+                  {startContent}
+                  <span className="truncate text-muted-foreground">
+                     {placeholder ?? "—"}
+                  </span>
+               </>
+            )}
+         </button>
+      );
+   }
+
    return (
       <Combobox
          className={cn(
             "h-8 w-full border-0 bg-transparent px-1 shadow-none focus-visible:ring-1 focus-visible:ring-ring",
             className,
          )}
+         defaultOpen
          onCreate={onCreate ? handleCreate : undefined}
+         onOpenChange={setEditing}
          onValueChange={commit}
          options={options}
          placeholder={placeholder ?? "—"}

--- a/apps/web/src/blocks/data-table/inline-edit/inline-edit-date.tsx
+++ b/apps/web/src/blocks/data-table/inline-edit/inline-edit-date.tsx
@@ -15,9 +15,11 @@ interface InlineEditDateProps {
 export function InlineEditDate({
    value,
    onSave,
+   ariaLabel,
    placeholder,
    className,
 }: InlineEditDateProps) {
+   const [editing, setEditing] = useState(false);
    const [pending, setPending] = useState<string | null>(null);
    const lastCommittedRef = useRef(value);
 
@@ -32,11 +34,34 @@ export function InlineEditDate({
    const dateValue = displayed ? dayjs(displayed).toDate() : undefined;
 
    async function commit(next: Date | undefined) {
+      setEditing(false);
       const formatted = next ? dayjs(next).format("YYYY-MM-DD") : "";
       if (formatted === (value ?? "")) return;
       setPending(formatted);
       const result = await fromPromise(onSave(formatted), (e) => e);
       if (result.isErr()) setPending(null);
+   }
+
+   if (!editing) {
+      return (
+         <button
+            aria-label={ariaLabel}
+            className={cn(
+               "flex h-8 w-full min-w-0 cursor-pointer items-center rounded-md border border-dashed border-transparent bg-muted/20 px-2 text-left text-sm tabular-nums transition-colors hover:border-border hover:bg-muted/50 focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none",
+               className,
+            )}
+            onClick={() => setEditing(true)}
+            type="button"
+         >
+            <span
+               className={cn("truncate", !displayed && "text-muted-foreground")}
+            >
+               {displayed
+                  ? dayjs(displayed).format("DD/MM/YYYY")
+                  : placeholder || "—"}
+            </span>
+         </button>
+      );
    }
 
    return (
@@ -46,7 +71,9 @@ export function InlineEditDate({
             className,
          )}
          date={dateValue}
+         onOpenChange={setEditing}
          onSelect={commit}
+         open={editing}
          placeholder={placeholder ?? "—"}
       />
    );

--- a/apps/web/src/blocks/data-table/inline-edit/inline-edit-money.tsx
+++ b/apps/web/src/blocks/data-table/inline-edit/inline-edit-money.tsx
@@ -33,7 +33,8 @@ export function InlineEditMoney({
       }
    }, [value]);
 
-   const displayed = pending ?? draft ?? 0;
+   const displayed = pending ?? draft;
+   const displayValue = displayed ?? 0;
 
    async function commit(next: number | undefined) {
       setEditing(false);
@@ -50,7 +51,7 @@ export function InlineEditMoney({
    const formatted = new Intl.NumberFormat("pt-BR", {
       currency: "BRL",
       style: "currency",
-   }).format(valueInCents ? displayed / 100 : displayed);
+   }).format(valueInCents ? displayValue / 100 : displayValue);
 
    if (!editing) {
       return (
@@ -64,9 +65,12 @@ export function InlineEditMoney({
             type="button"
          >
             <span
-               className={cn("truncate", !displayed && "text-muted-foreground")}
+               className={cn(
+                  "truncate",
+                  displayed == null && "text-muted-foreground",
+               )}
             >
-               {displayed ? formatted : (placeholder ?? formatted)}
+               {displayed == null ? (placeholder ?? formatted) : formatted}
             </span>
          </button>
       );
@@ -83,7 +87,7 @@ export function InlineEditMoney({
          onBlur={() => commit(draft)}
          onChange={(next) => setDraft(next)}
          placeholder={placeholder}
-         value={displayed}
+         value={displayValue}
          valueInCents={valueInCents}
       />
    );

--- a/apps/web/src/blocks/data-table/inline-edit/inline-edit-money.tsx
+++ b/apps/web/src/blocks/data-table/inline-edit/inline-edit-money.tsx
@@ -20,6 +20,7 @@ export function InlineEditMoney({
    className,
    valueInCents = true,
 }: InlineEditMoneyProps) {
+   const [editing, setEditing] = useState(false);
    const [draft, setDraft] = useState<number | undefined>(value);
    const [pending, setPending] = useState<number | null>(null);
    const lastCommittedRef = useRef(value);
@@ -35,6 +36,7 @@ export function InlineEditMoney({
    const displayed = pending ?? draft ?? 0;
 
    async function commit(next: number | undefined) {
+      setEditing(false);
       const normalized = next ?? 0;
       if (normalized === value) return;
       setPending(normalized);
@@ -45,9 +47,35 @@ export function InlineEditMoney({
       }
    }
 
+   const formatted = new Intl.NumberFormat("pt-BR", {
+      currency: "BRL",
+      style: "currency",
+   }).format(valueInCents ? displayed / 100 : displayed);
+
+   if (!editing) {
+      return (
+         <button
+            aria-label={ariaLabel}
+            className={cn(
+               "flex h-8 w-full min-w-0 cursor-pointer items-center rounded-md border border-dashed border-transparent bg-muted/20 px-2 text-left text-sm tabular-nums transition-colors hover:border-border hover:bg-muted/50 focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none",
+               className,
+            )}
+            onClick={() => setEditing(true)}
+            type="button"
+         >
+            <span
+               className={cn("truncate", !displayed && "text-muted-foreground")}
+            >
+               {displayed ? formatted : (placeholder ?? formatted)}
+            </span>
+         </button>
+      );
+   }
+
    return (
       <MoneyInput
          aria-label={ariaLabel}
+         autoFocus
          className={cn(
             "[&_input]:h-8 [&_input]:border-0 [&_input]:bg-transparent [&_input]:px-1 [&_input]:shadow-none focus-within:[&_input]:ring-1 focus-within:[&_input]:ring-ring",
             className,

--- a/apps/web/src/blocks/data-table/inline-edit/inline-edit-number.tsx
+++ b/apps/web/src/blocks/data-table/inline-edit/inline-edit-number.tsx
@@ -22,6 +22,7 @@ export function InlineEditNumber({
    step,
    className,
 }: InlineEditNumberProps) {
+   const [editing, setEditing] = useState(false);
    const [draft, setDraft] = useState(value);
    const lastCommittedRef = useRef(value);
    const latestSaveIdRef = useRef(0);
@@ -46,6 +47,22 @@ export function InlineEditNumber({
       [onSave, value],
    );
 
+   if (!editing) {
+      return (
+         <button
+            aria-label={ariaLabel}
+            className={cn(
+               "flex h-8 w-full min-w-0 cursor-pointer items-center rounded-md border border-dashed border-transparent bg-muted/20 px-2 text-left text-sm tabular-nums transition-colors hover:border-border hover:bg-muted/50 focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none",
+               className,
+            )}
+            onClick={() => setEditing(true)}
+            type="button"
+         >
+            <span className="truncate">{draft}</span>
+         </button>
+      );
+   }
+
    return (
       <NumberInput
          aria-label={ariaLabel}
@@ -55,6 +72,7 @@ export function InlineEditNumber({
          )}
          max={max}
          min={min}
+         onBlur={() => setEditing(false)}
          onChange={commit}
          step={step}
          value={draft}

--- a/apps/web/src/blocks/data-table/inline-edit/inline-edit-select.tsx
+++ b/apps/web/src/blocks/data-table/inline-edit/inline-edit-select.tsx
@@ -35,6 +35,7 @@ export function InlineEditSelect({
    startContent,
    hideValue,
 }: InlineEditSelectProps) {
+   const [editing, setEditing] = useState(false);
    const [pending, setPending] = useState<string | null>(null);
    const lastCommittedRef = useRef(value);
 
@@ -48,14 +49,48 @@ export function InlineEditSelect({
    const displayed = pending ?? value;
 
    async function commit(next: string) {
+      setEditing(false);
       if (next === value) return;
       setPending(next);
       const result = await fromPromise(onSave(next), (e) => e);
       if (result.isErr()) setPending(null);
    }
 
+   const selectedOption = options.find((option) => option.value === displayed);
+
+   if (!editing) {
+      return (
+         <button
+            aria-label={ariaLabel}
+            className={cn(
+               "flex h-8 w-full min-w-0 cursor-pointer items-center gap-2 rounded-md border border-dashed border-transparent bg-muted/20 px-2 text-left text-sm transition-colors hover:border-border hover:bg-muted/50 focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none",
+               className,
+            )}
+            onClick={() => setEditing(true)}
+            type="button"
+         >
+            {startContent}
+            {!hideValue && (
+               <span
+                  className={cn(
+                     "truncate",
+                     !selectedOption && "text-muted-foreground",
+                  )}
+               >
+                  {selectedOption?.label ?? placeholder ?? "—"}
+               </span>
+            )}
+         </button>
+      );
+   }
+
    return (
-      <Select onValueChange={commit} value={displayed}>
+      <Select
+         onOpenChange={(open) => setEditing(open)}
+         onValueChange={commit}
+         open={editing}
+         value={displayed}
+      >
          <SelectTrigger
             aria-label={ariaLabel}
             className={cn(

--- a/apps/web/src/blocks/data-table/inline-edit/inline-edit-text.tsx
+++ b/apps/web/src/blocks/data-table/inline-edit/inline-edit-text.tsx
@@ -32,6 +32,7 @@ export function InlineEditText({
    className,
    startContent,
 }: InlineEditTextProps) {
+   const [editing, setEditing] = useState(false);
    const [draft, setDraft] = useState(value);
    const [pending, setPending] = useState<string | null>(null);
    const lastCommittedRef = useRef(value);
@@ -50,6 +51,7 @@ export function InlineEditText({
    const commit = useCallback(
       async (next: string) => {
          const trimmed = next.trim();
+         setEditing(false);
          if (trimmed === value.trim()) return;
          setPending(trimmed);
          const result = await fromPromise(onSave(trimmed), (e) => e);
@@ -78,12 +80,34 @@ export function InlineEditText({
       (e: FocusEvent<HTMLInputElement>) => {
          if (cancelledRef.current) {
             cancelledRef.current = false;
+            setEditing(false);
             return;
          }
          commit(e.target.value);
       },
       [commit],
    );
+
+   if (!editing) {
+      return (
+         <button
+            aria-label={ariaLabel}
+            className={cn(
+               "flex h-8 w-full min-w-0 cursor-pointer items-center gap-2 rounded-md border border-dashed border-transparent bg-muted/20 px-2 text-left text-sm transition-colors hover:border-border hover:bg-muted/50 focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none",
+               className,
+            )}
+            onClick={() => setEditing(true)}
+            type="button"
+         >
+            {startContent}
+            <span
+               className={cn("truncate", !displayed && "text-muted-foreground")}
+            >
+               {displayed || placeholder || "—"}
+            </span>
+         </button>
+      );
+   }
 
    if (startContent) {
       return (
@@ -98,6 +122,7 @@ export function InlineEditText({
             </InputGroupAddon>
             <InputGroupInput
                aria-label={ariaLabel}
+               autoFocus
                onBlur={handleBlur}
                onChange={(e) => setDraft(e.target.value)}
                onKeyDown={handleKeyDown}
@@ -111,6 +136,7 @@ export function InlineEditText({
    return (
       <Input
          aria-label={ariaLabel}
+         autoFocus
          className={cn(
             "h-8 w-full border-0 bg-transparent px-1 shadow-none focus-visible:ring-1 focus-visible:ring-ring",
             className,

--- a/apps/web/src/hooks/use-xlsx-file.ts
+++ b/apps/web/src/hooks/use-xlsx-file.ts
@@ -16,9 +16,61 @@ function cellToString(cell: unknown): string {
    return String(cell);
 }
 
+function normalizeHtmlCellText(value: string): string {
+   return value
+      .replace(/\u00a0/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+}
+
+function isHtmlSpreadsheet(prefix: string): boolean {
+   const normalized = prefix.trimStart().toLowerCase();
+   return (
+      normalized.startsWith("<!doctype html") ||
+      normalized.startsWith("<html") ||
+      normalized.includes("<table")
+   );
+}
+
+function parseHtmlSpreadsheet(text: string): XlsxData {
+   const document = new DOMParser().parseFromString(text, "text/html");
+   const tables = Array.from(document.querySelectorAll("table"));
+   if (tables.length === 0) throw new Error("Planilha vazia");
+
+   let bestRows: string[][] = [];
+   for (const table of tables) {
+      const rows = Array.from(table.querySelectorAll("tr"))
+         .map((row) =>
+            Array.from(row.children)
+               .filter((cell) =>
+                  ["TD", "TH"].includes(cell.tagName.toUpperCase()),
+               )
+               .map((cell) => normalizeHtmlCellText(cell.textContent ?? "")),
+         )
+         .filter((row) => row.some((cell) => cell !== ""));
+      if (rows.length > bestRows.length) bestRows = rows;
+   }
+
+   if (bestRows.length < 2) throw new Error("Planilha sem dados");
+   const [headerRow = [], ...bodyRows] = bestRows;
+   return {
+      headers: headerRow,
+      rows: bodyRows,
+   };
+}
+
 export function useXlsxFile() {
    const parse = useCallback(async (file: File): Promise<XlsxData> => {
-      const wb = xlsxRead(new Uint8Array(await file.arrayBuffer()), {
+      const buffer = await file.arrayBuffer();
+      const bytes = new Uint8Array(buffer);
+      const prefix = new TextDecoder("utf-8").decode(
+         bytes.subarray(0, Math.min(bytes.byteLength, 4096)),
+      );
+      if (isHtmlSpreadsheet(prefix)) {
+         return parseHtmlSpreadsheet(new TextDecoder("utf-8").decode(bytes));
+      }
+
+      const wb = xlsxRead(bytes, {
          type: "array",
          cellDates: true,
       });

--- a/apps/web/src/integrations/tanstack-db/transactions.ts
+++ b/apps/web/src/integrations/tanstack-db/transactions.ts
@@ -69,6 +69,7 @@ type TransactionUpdateActionInput = {
             | "bankAccountName"
             | "categoryName"
             | "creditCardName"
+            | "relationshipName"
             | "suggestedCategoryName"
             | "suggestedTagName"
             | "tagName"
@@ -177,6 +178,7 @@ function parseTransactionSortId(value: string): TransactionSortId | undefined {
       case "date":
       case "dueDate":
       case "name":
+      case "relationshipName":
       case "status":
       case "type":
          return value;
@@ -265,6 +267,7 @@ export function buildOptimisticTransactionRow({
    bankAccountName,
    categoryName,
    creditCardName,
+   relationshipName,
    tagName,
 }: {
    id: string;
@@ -273,6 +276,7 @@ export function buildOptimisticTransactionRow({
    bankAccountName?: string | null;
    categoryName?: string | null;
    creditCardName?: string | null;
+   relationshipName?: string | null;
    tagName?: string | null;
 }): TransactionsCollectionRow {
    const now = dayjs().toDate();
@@ -303,12 +307,13 @@ export function buildOptimisticTransactionRow({
       statementPeriod: input.statementPeriod ?? null,
       tagId: input.tagId ?? null,
       suggestedTagId: null,
-      relationshipId: null,
+      relationshipId: input.relationshipId ?? null,
       createdAt: now,
       updatedAt: now,
       categoryName: categoryName ?? null,
       creditCardName: creditCardName ?? null,
       bankAccountName: bankAccountName ?? null,
+      relationshipName: relationshipName ?? null,
       suggestedCategoryName: null,
       tagName: tagName ?? null,
       suggestedTagName: null,
@@ -464,6 +469,10 @@ export function updateTransactionAction(collection: TransactionsCollection) {
             if (patch.dueDate !== undefined) draft.dueDate = patch.dueDate;
             if (patch.ignored !== undefined) draft.ignored = patch.ignored;
             if (patch.name !== undefined) draft.name = patch.name;
+            if (patch.relationshipId !== undefined)
+               draft.relationshipId = patch.relationshipId;
+            if (patch.relationshipName !== undefined)
+               draft.relationshipName = patch.relationshipName;
             if (patch.paidAt !== undefined) draft.paidAt = patch.paidAt;
             if (patch.paymentMethod !== undefined)
                draft.paymentMethod = patch.paymentMethod;

--- a/apps/web/src/integrations/tanstack-db/transactions.ts
+++ b/apps/web/src/integrations/tanstack-db/transactions.ts
@@ -469,10 +469,12 @@ export function updateTransactionAction(collection: TransactionsCollection) {
             if (patch.dueDate !== undefined) draft.dueDate = patch.dueDate;
             if (patch.ignored !== undefined) draft.ignored = patch.ignored;
             if (patch.name !== undefined) draft.name = patch.name;
-            if (patch.relationshipId !== undefined)
+            if (patch.relationshipId !== undefined) {
                draft.relationshipId = patch.relationshipId;
-            if (patch.relationshipName !== undefined)
+               draft.relationshipName = patch.relationshipName ?? null;
+            } else if (patch.relationshipName !== undefined) {
                draft.relationshipName = patch.relationshipName;
+            }
             if (patch.paidAt !== undefined) draft.paidAt = patch.paidAt;
             if (patch.paymentMethod !== undefined)
                draft.paymentMethod = patch.paymentMethod;
@@ -530,6 +532,10 @@ export function bulkUpdateTransactionsAction(
                if (patch.date !== undefined) draft.date = patch.date;
                if (patch.dueDate !== undefined) draft.dueDate = patch.dueDate;
                if (patch.ignored !== undefined) draft.ignored = patch.ignored;
+               if (patch.relationshipId !== undefined) {
+                  draft.relationshipId = patch.relationshipId;
+                  draft.relationshipName = null;
+               }
                if (patch.status !== undefined) draft.status = patch.status;
                draft.updatedAt = dayjs().toDate();
             }

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-sorting.ts
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-sorting.ts
@@ -9,6 +9,7 @@ export const transactionSortIdSchema = z.enum([
    "date",
    "dueDate",
    "name",
+   "relationshipName",
    "status",
    "type",
 ]);

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-columns.tsx
@@ -43,6 +43,7 @@ export type BankAccountOption = {
 };
 export type CategoryOption = { id: string; name: string };
 export type CreditCardOption = { id: string; name: string };
+export type RelationshipOption = { id: string; name: string };
 
 export function formatBRL(value: string | number): string {
    const raw = String(value).trim();
@@ -134,10 +135,14 @@ export function buildTransactionColumns(options?: {
    bankAccounts?: BankAccountOption[];
    categories?: CategoryOption[];
    creditCards?: CreditCardOption[];
+   customers?: RelationshipOption[];
+   suppliers?: RelationshipOption[];
    onUpdate?: (id: string, patch: Record<string, unknown>) => Promise<void>;
    onUpdateImport?: (index: number, patch: Record<string, unknown>) => void;
    onCreateBankAccount?: (name: string) => Promise<string>;
    onCreateCategory?: (name: string) => Promise<string>;
+   onCreateCustomer?: (name: string) => Promise<string>;
+   onCreateSupplier?: (name: string) => Promise<string>;
    onAcceptSuggestedCategory?: (id: string) => void | Promise<void>;
    onDismissSuggestedCategory?: (id: string) => void | Promise<void>;
    getRowStatus?: (id: string) => string | undefined;
@@ -179,6 +184,14 @@ export function buildTransactionColumns(options?: {
    const creditCardOptions = (options?.creditCards ?? []).map((c) => ({
       value: c.id,
       label: c.name,
+   }));
+   const customerOptions = (options?.customers ?? []).map((c) => ({
+      value: c.id,
+      label: c.name,
+   }));
+   const supplierOptions = (options?.suppliers ?? []).map((s) => ({
+      value: s.id,
+      label: s.name,
    }));
 
    return [
@@ -383,6 +396,88 @@ export function buildTransactionColumns(options?: {
                />
             );
          },
+      },
+      {
+         id: "customerName",
+         header: "Cliente",
+         meta: {
+            label: "Cliente",
+            cellComponent: "combobox",
+            isEditable: true,
+            editMode: "inline",
+            editOptions: customerOptions,
+            onCreateOption: options?.onCreateCustomer,
+         },
+         cell: ({ row }) => (
+            <InlineEditCombobox
+               ariaLabel="Cliente"
+               onCreate={options?.onCreateCustomer}
+               onSave={async (value) => {
+                  const label =
+                     customerOptions.find((o) => o.value === value)?.label ??
+                     "";
+                  const importIdx = isImportRow(row);
+                  if (importIdx !== null) {
+                     options?.onUpdateImport?.(importIdx, {
+                        customerName: label,
+                        relationshipId: value || null,
+                        relationshipName: label,
+                     });
+                     return;
+                  }
+                  await options?.onUpdate?.(row.original.id, {
+                     relationshipId: value || null,
+                  });
+               }}
+               options={customerOptions}
+               value={
+                  customerOptions.find(
+                     (option) => option.value === row.original.relationshipId,
+                  )?.value ?? ""
+               }
+            />
+         ),
+      },
+      {
+         id: "supplierName",
+         header: "Fornecedor",
+         meta: {
+            label: "Fornecedor",
+            cellComponent: "combobox",
+            isEditable: true,
+            editMode: "inline",
+            editOptions: supplierOptions,
+            onCreateOption: options?.onCreateSupplier,
+         },
+         cell: ({ row }) => (
+            <InlineEditCombobox
+               ariaLabel="Fornecedor"
+               onCreate={options?.onCreateSupplier}
+               onSave={async (value) => {
+                  const label =
+                     supplierOptions.find((o) => o.value === value)?.label ??
+                     "";
+                  const importIdx = isImportRow(row);
+                  if (importIdx !== null) {
+                     options?.onUpdateImport?.(importIdx, {
+                        supplierName: label,
+                        relationshipId: value || null,
+                        relationshipName: label,
+                     });
+                     return;
+                  }
+                  await options?.onUpdate?.(row.original.id, {
+                     relationshipId: value || null,
+                  });
+               }}
+               options={supplierOptions}
+               value={
+                  supplierOptions.find(
+                     (option) => option.value === row.original.relationshipId,
+                  )?.value ?? ""
+               }
+            />
+         ),
       },
       {
          accessorKey: "bankAccountName",

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-columns.tsx
@@ -21,8 +21,10 @@ import {
    CalendarDays,
    CircleDot,
    CreditCard,
+   Handshake,
    Landmark,
    Tag,
+   Users,
 } from "lucide-react";
 import { InlineEditCombobox } from "@/blocks/data-table/inline-edit/inline-edit-combobox";
 import { InlineEditDate } from "@/blocks/data-table/inline-edit/inline-edit-date";
@@ -405,6 +407,13 @@ export function buildTransactionColumns(options?: {
             cellComponent: "combobox",
             isEditable: true,
             editMode: "inline",
+            bulkEditIcon: Users,
+            bulkEditAction: "Definir cliente",
+            bulkEditPatch: (option) => ({
+               customerName: option.label,
+               relationshipId: option.value || null,
+               relationshipName: option.label,
+            }),
             editOptions: customerOptions,
             onCreateOption: options?.onCreateCustomer,
          },
@@ -446,6 +455,13 @@ export function buildTransactionColumns(options?: {
             cellComponent: "combobox",
             isEditable: true,
             editMode: "inline",
+            bulkEditIcon: Handshake,
+            bulkEditAction: "Definir fornecedor",
+            bulkEditPatch: (option) => ({
+               supplierName: option.label,
+               relationshipId: option.value || null,
+               relationshipName: option.label,
+            }),
             editOptions: supplierOptions,
             onCreateOption: options?.onCreateSupplier,
          },

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
@@ -182,6 +182,7 @@ const IMPORT_HEADER_LABELS: Record<string, string> = {
    detalhe: "Nome",
    tipo: "Tipo",
    type: "Tipo",
+   despesareceita: "Tipo",
    status: "Status",
    conta: "Conta",
    bankaccountname: "Conta",
@@ -201,6 +202,7 @@ const IMPORT_HEADER_LABELS: Record<string, string> = {
    vencimento: "Vencimento",
    contaareceberrs: "Conta a receber",
    contaapagarrs: "Conta a pagar",
+   saldors: "Saldo",
    fitid: "Identificador",
    reference: "Referência",
 };
@@ -1298,17 +1300,16 @@ export function TransactionsList() {
             const receivableAmount = String(row.receivableAmount ?? "").trim();
             const payableAmount = String(row.payableAmount ?? "").trim();
             const amountSource = (() => {
-               if (String(row.amount ?? "").trim()) return row.amount;
                if (receivableAmount) return receivableAmount;
-               return payableAmount;
+               if (payableAmount) return payableAmount;
+               return row.amount;
             })();
             const parsedAmount = parseImportAmount(amountSource);
-            const type = parseImportType(
-               row.type,
-               receivableAmount
-                  ? parsedAmount.signedAmount
-                  : -parsedAmount.signedAmount,
-            );
+            const type = receivableAmount
+               ? "income"
+               : payableAmount
+                 ? "expense"
+                 : parseImportType(row.type, parsedAmount.signedAmount);
             const parsedStatus = parseImportStatus(row.status);
 
             return {
@@ -1959,18 +1960,21 @@ export function TransactionsList() {
                      style={{ minWidth: table.getTotalSize() }}
                   >
                      <DataTableHeader table={table} />
+                     <DataImportSection
+                        api={importApi}
+                        config={importConfig}
+                        table={table}
+                     />
                      <DataTableBody<TransactionRow>
+                        estimateRowHeight={48}
+                        overscan={5}
+                        virtualized
                         getRowClassName={({ row }) =>
                            cn(
                               row.original.ignored &&
                                  "bg-muted/20 text-muted-foreground opacity-60",
                            )
                         }
-                        table={table}
-                     />
-                     <DataImportSection
-                        api={importApi}
-                        config={importConfig}
                         table={table}
                      />
                   </Table>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
@@ -101,6 +101,13 @@ import {
 } from "@/integrations/tanstack-db/categories";
 import { creditCardsCollectionOptions } from "@/integrations/tanstack-db/credit-cards";
 import {
+   buildOptimisticRelationshipRow,
+   buildOptimisticRelationshipRowId,
+   createRelationshipAction,
+   relationshipsCollectionOptions,
+   type RelationshipCreateInput,
+} from "@/integrations/tanstack-db/relationships";
+import {
    buildOptimisticTransactionRow,
    buildOptimisticTransactionRowId,
    acceptSuggestedTransactionCategoryAction,
@@ -162,6 +169,7 @@ const IMPORT_HEADER_LABELS: Record<string, string> = {
    data: "Data",
    date: "Data",
    datetxn: "Data",
+   pagamento: "Data",
    duedate: "Vencimento",
    valor: "Valor",
    amount: "Valor",
@@ -180,6 +188,8 @@ const IMPORT_HEADER_LABELS: Record<string, string> = {
    bankaccount: "Conta",
    contaid: "Conta",
    banco: "Conta",
+   cliente: "Cliente",
+   fornecedor: "Fornecedor",
    cartao: "Cartão",
    card: "Cartão",
    creditcard: "Cartão",
@@ -189,6 +199,8 @@ const IMPORT_HEADER_LABELS: Record<string, string> = {
    categoryname: "Categoria",
    categoriaid: "Categoria",
    vencimento: "Vencimento",
+   contaareceberrs: "Conta a receber",
+   contaapagarrs: "Conta a pagar",
    fitid: "Identificador",
    reference: "Referência",
 };
@@ -288,6 +300,11 @@ function parseImportType(
    return signedAmount < 0 ? "expense" : "income";
 }
 
+function cleanImportText(value: unknown): string {
+   const text = String(value ?? "").trim();
+   return text === "-" ? "" : text;
+}
+
 function parseImportStatus(value: unknown): {
    status: "pending" | "paid";
    ignored: boolean;
@@ -300,7 +317,11 @@ function parseImportStatus(value: unknown): {
    ) {
       return { status: "pending", ignored: true };
    }
-   if (normalized === "paid" || normalized.includes("efetivado")) {
+   if (
+      normalized === "paid" ||
+      normalized.includes("efetivado") ||
+      normalized.includes("pago")
+   ) {
       return { status: "paid", ignored: false };
    }
    return { status: "pending", ignored: false };
@@ -354,6 +375,46 @@ function buildInlineCategoryRow({
       createdAt: now,
       updatedAt: now,
    };
+}
+
+function getColumnDefId(column: ColumnDef<TransactionRow>): string | null {
+   if (column.id) return column.id;
+   if ("accessorKey" in column && typeof column.accessorKey === "string") {
+      return column.accessorKey;
+   }
+   return null;
+}
+
+function normalizeTransactionsColumnOrder(
+   order: string[] | undefined,
+   defaultOrder: string[],
+): string[] {
+   const known = new Set(defaultOrder);
+   const middle = (order ?? []).filter(
+      (id) => known.has(id) && id !== "__select" && id !== "__actions",
+   );
+
+   const ensureBefore = (id: string, beforeId: string) => {
+      const currentIndex = middle.indexOf(id);
+      if (currentIndex >= 0) middle.splice(currentIndex, 1);
+      const beforeIndex = middle.indexOf(beforeId);
+      if (beforeIndex >= 0) {
+         middle.splice(beforeIndex, 0, id);
+         return;
+      }
+      middle.push(id);
+   };
+
+   ensureBefore("customerName", "bankAccountName");
+   ensureBefore("supplierName", "bankAccountName");
+
+   for (const id of defaultOrder) {
+      if (id !== "__select" && id !== "__actions" && !middle.includes(id)) {
+         middle.push(id);
+      }
+   }
+
+   return ["__select", ...middle, "__actions"];
 }
 
 export function TransactionsList() {
@@ -491,6 +552,32 @@ export function TransactionsList() {
             creditCardsCollectionOptions({
                queryClient,
                teamId: collectionTeamId,
+            }),
+         ),
+      [collectionTeamId, queryClient],
+   );
+
+   const customersCollection = useMemo(
+      () =>
+         createCollection(
+            relationshipsCollectionOptions({
+               queryClient,
+               teamId: collectionTeamId,
+               role: "customer",
+               archived: false,
+            }),
+         ),
+      [collectionTeamId, queryClient],
+   );
+
+   const suppliersCollection = useMemo(
+      () =>
+         createCollection(
+            relationshipsCollectionOptions({
+               queryClient,
+               teamId: collectionTeamId,
+               role: "supplier",
+               archived: false,
             }),
          ),
       [collectionTeamId, queryClient],
@@ -658,6 +745,12 @@ export function TransactionsList() {
                         rule.desc ? "desc" : "asc",
                      );
                      break;
+                  case "relationshipName":
+                     query = query.orderBy(
+                        ({ transaction }) => transaction.relationshipName,
+                        rule.desc ? "desc" : "asc",
+                     );
+                     break;
                   case "status":
                      query = query.orderBy(
                         ({ transaction }) => transaction.status,
@@ -731,6 +824,22 @@ export function TransactionsList() {
       [creditCardsCollection],
    );
 
+   const { data: customersResult } = useLiveQuery(
+      (q) =>
+         q
+            .from({ customer: customersCollection })
+            .select(({ customer }) => customer),
+      [customersCollection],
+   );
+
+   const { data: suppliersResult } = useLiveQuery(
+      (q) =>
+         q
+            .from({ supplier: suppliersCollection })
+            .select(({ supplier }) => supplier),
+      [suppliersCollection],
+   );
+
    const safeTransactions = useMemo(
       () => liveTransactions ?? [],
       [liveTransactions],
@@ -743,6 +852,14 @@ export function TransactionsList() {
    const safeCreditCards = useMemo(
       () => creditCardsResult ?? [],
       [creditCardsResult],
+   );
+   const safeCustomers = useMemo(
+      () => customersResult ?? [],
+      [customersResult],
+   );
+   const safeSuppliers = useMemo(
+      () => suppliersResult ?? [],
+      [suppliersResult],
    );
 
    const selectedBankAccount = useMemo(
@@ -838,6 +955,82 @@ export function TransactionsList() {
       [activeTeamId, categoriesCollection],
    );
 
+   const handleCreateCustomer = useCallback(
+      async (name: string): Promise<string> => {
+         if (!activeTeamId) {
+            toast.error("Time ativo não encontrado.");
+            return "";
+         }
+         const input: RelationshipCreateInput = {
+            name,
+            role: "customer",
+            kind: "company",
+            documentNumber: null,
+            email: null,
+            phone: null,
+         };
+         const createCustomer = createRelationshipAction(customersCollection);
+         const transaction = createCustomer({
+            row: buildOptimisticRelationshipRow({
+               id: buildOptimisticRelationshipRowId(),
+               input,
+               teamId: activeTeamId,
+            }),
+            input,
+         });
+         const result = await Result.tryPromise({
+            try: () => transaction.isPersisted.promise,
+            catch: (error) => error,
+         });
+         if (Result.isError(result)) {
+            toast.error(
+               getErrorMessage(result.error, "Erro ao criar cliente."),
+            );
+            return "";
+         }
+         return result.value.id;
+      },
+      [activeTeamId, customersCollection],
+   );
+
+   const handleCreateSupplier = useCallback(
+      async (name: string): Promise<string> => {
+         if (!activeTeamId) {
+            toast.error("Time ativo não encontrado.");
+            return "";
+         }
+         const input: RelationshipCreateInput = {
+            name,
+            role: "supplier",
+            kind: "company",
+            documentNumber: null,
+            email: null,
+            phone: null,
+         };
+         const createSupplier = createRelationshipAction(suppliersCollection);
+         const transaction = createSupplier({
+            row: buildOptimisticRelationshipRow({
+               id: buildOptimisticRelationshipRowId(),
+               input,
+               teamId: activeTeamId,
+            }),
+            input,
+         });
+         const result = await Result.tryPromise({
+            try: () => transaction.isPersisted.promise,
+            catch: (error) => error,
+         });
+         if (Result.isError(result)) {
+            toast.error(
+               getErrorMessage(result.error, "Erro ao criar fornecedor."),
+            );
+            return "";
+         }
+         return result.value.id;
+      },
+      [activeTeamId, suppliersCollection],
+   );
+
    const handleCreateTransaction = useCallback(
       async (input: TransactionCreateInput) => {
          if (!activeTeamId) {
@@ -863,6 +1056,14 @@ export function TransactionsList() {
                creditCardName:
                   safeCreditCards.find((card) => card.id === input.creditCardId)
                      ?.name ?? null,
+               relationshipName:
+                  safeCustomers.find(
+                     (customer) => customer.id === input.relationshipId,
+                  )?.name ??
+                  safeSuppliers.find(
+                     (supplier) => supplier.id === input.relationshipId,
+                  )?.name ??
+                  null,
             }),
             input,
          });
@@ -883,6 +1084,8 @@ export function TransactionsList() {
          safeBankAccounts,
          safeCategories,
          safeCreditCards,
+         safeCustomers,
+         safeSuppliers,
          transactionsCollection,
       ],
    );
@@ -1067,6 +1270,10 @@ export function TransactionsList() {
 
    const importConfig: DataImportConfig = useMemo(
       () => ({
+         importColumns: [
+            { key: "receivableAmount", label: "Conta a receber" },
+            { key: "payableAmount", label: "Conta a pagar" },
+         ],
          accept: {
             "text/csv": [".csv"],
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
@@ -1088,27 +1295,49 @@ export function TransactionsList() {
             return localizeImportHeaders(parsed);
          },
          mapRow: (row, i) => {
-            const parsedAmount = parseImportAmount(row.amount);
-            const type = parseImportType(row.type, parsedAmount.signedAmount);
+            const receivableAmount = String(row.receivableAmount ?? "").trim();
+            const payableAmount = String(row.payableAmount ?? "").trim();
+            const amountSource = (() => {
+               if (String(row.amount ?? "").trim()) return row.amount;
+               if (receivableAmount) return receivableAmount;
+               return payableAmount;
+            })();
+            const parsedAmount = parseImportAmount(amountSource);
+            const type = parseImportType(
+               row.type,
+               receivableAmount
+                  ? parsedAmount.signedAmount
+                  : -parsedAmount.signedAmount,
+            );
             const parsedStatus = parseImportStatus(row.status);
 
             return {
                id: `__import_${i}`,
-               date: parseImportDate(row.date),
+               date: parseImportDate(row.date) || parseImportDate(row.dueDate),
                amount: parsedAmount.amount,
                type,
-               name: String(row.name ?? "").trim() || null,
+               name: cleanImportText(row.name) || null,
                status: parsedStatus.status,
                ignored: parsedStatus.ignored,
                dueDate: row.dueDate ? parseImportDate(row.dueDate) : null,
-               bankAccountName: String(row.bankAccountName ?? "").trim(),
+               bankAccountName: cleanImportText(row.bankAccountName),
                bankAccountId: resolveImportId(
                   safeBankAccounts,
                   row.bankAccountName,
                ),
-               categoryName: String(row.categoryName ?? "").trim(),
+               customerName: cleanImportText(row.customerName),
+               supplierName: cleanImportText(row.supplierName),
+               relationshipName:
+                  type === "income"
+                     ? cleanImportText(row.customerName)
+                     : cleanImportText(row.supplierName),
+               relationshipId:
+                  type === "income"
+                     ? resolveImportId(safeCustomers, row.customerName)
+                     : resolveImportId(safeSuppliers, row.supplierName),
+               categoryName: cleanImportText(row.categoryName),
                categoryId: resolveImportId(safeCategories, row.categoryName),
-               creditCardName: String(row.creditCardName ?? "").trim(),
+               creditCardName: cleanImportText(row.creditCardName),
                creditCardId: resolveImportId(
                   safeCreditCards,
                   row.creditCardName,
@@ -1233,6 +1462,15 @@ export function TransactionsList() {
                const categoryId =
                   resolveImportId(safeCategories, r.categoryId) ??
                   resolveImportId(safeCategories, r.categoryName);
+               const parsedType = parseImportType(r.type, 1);
+               const relationshipId =
+                  resolveImportId(safeCustomers, r.relationshipId) ??
+                  resolveImportId(safeSuppliers, r.relationshipId) ??
+                  (parsedType === "income"
+                     ? (resolveImportId(safeCustomers, r.customerName) ??
+                       resolveImportId(safeCustomers, r.relationshipName))
+                     : (resolveImportId(safeSuppliers, r.supplierName) ??
+                       resolveImportId(safeSuppliers, r.relationshipName)));
 
                if (!date) {
                   invalidDateValueRows.push(line);
@@ -1253,13 +1491,14 @@ export function TransactionsList() {
 
                return [
                   {
-                     type: parseImportType(r.type, 1),
+                     type: parsedType,
                      amount,
                      date,
                      name: r.name ? String(r.name) : null,
                      bankAccountId,
                      destinationBankAccountId: null,
                      categoryId,
+                     relationshipId,
                      attachments: [],
                      description: null,
                      creditCardId,
@@ -1325,6 +1564,14 @@ export function TransactionsList() {
                         safeCreditCards.find(
                            (card) => card.id === input.creditCardId,
                         )?.name ?? null,
+                     relationshipName:
+                        safeCustomers.find(
+                           (customer) => customer.id === input.relationshipId,
+                        )?.name ??
+                        safeSuppliers.find(
+                           (supplier) => supplier.id === input.relationshipId,
+                        )?.name ??
+                        null,
                   }),
                ),
             });
@@ -1352,6 +1599,8 @@ export function TransactionsList() {
          safeBankAccounts,
          safeCategories,
          safeCreditCards,
+         safeCustomers,
+         safeSuppliers,
          transactionsCollection,
       ],
    );
@@ -1365,10 +1614,14 @@ export function TransactionsList() {
          bankAccounts: safeBankAccounts,
          categories: safeCategories,
          creditCards: safeCreditCards,
+         customers: safeCustomers,
+         suppliers: safeSuppliers,
          onUpdate: handleUpdate,
          onUpdateImport: (idx, patch) => importUpdateRef.current?.(idx, patch),
          onCreateBankAccount: handleCreateBankAccount,
          onCreateCategory: handleCreateCategory,
+         onCreateCustomer: handleCreateCustomer,
+         onCreateSupplier: handleCreateSupplier,
          onAcceptSuggestedCategory: handleAcceptSuggestedCategory,
          onDismissSuggestedCategory: handleDismissSuggestedCategory,
          getRowStatus: (id) => transactionData.find((t) => t.id === id)?.status,
@@ -1475,11 +1728,15 @@ export function TransactionsList() {
       safeBankAccounts,
       safeCategories,
       safeCreditCards,
+      safeCustomers,
+      safeSuppliers,
       transactionData,
       publicEnv?.LOGO_DEV_TOKEN,
       handleUpdate,
       handleCreateBankAccount,
       handleCreateCategory,
+      handleCreateCustomer,
+      handleCreateSupplier,
       handleAcceptSuggestedCategory,
       handleDismissSuggestedCategory,
       handleMarkPaid,
@@ -1499,6 +1756,21 @@ export function TransactionsList() {
       totalRows: total,
    });
 
+   const defaultColumnOrder = useMemo(
+      () => columns.map(getColumnDefId).filter((id): id is string => !!id),
+      [columns],
+   );
+   const normalizedLayoutState = useMemo(
+      () => ({
+         ...layout.state,
+         columnOrder: normalizeTransactionsColumnOrder(
+            layout.state.columnOrder,
+            defaultColumnOrder,
+         ),
+      }),
+      [defaultColumnOrder, layout.state],
+   );
+
    const table = useReactTable({
       data: transactionData,
       columns,
@@ -1509,7 +1781,7 @@ export function TransactionsList() {
       manualFiltering: true,
       columnResizeMode: "onChange",
       defaultColumn: { minSize: 80, size: 160, maxSize: 600 },
-      state: { ...urlState.state, ...layout.state },
+      state: { ...urlState.state, ...normalizedLayoutState },
       onSortingChange: urlState.onSortingChange,
       onColumnFiltersChange: urlState.onColumnFiltersChange,
       onPaginationChange: urlState.onPaginationChange,
@@ -1681,7 +1953,11 @@ export function TransactionsList() {
             </div>
             <TooltipProvider>
                <ScrollArea className="flex-1 min-h-0 rounded-md border bg-card">
-                  <Table>
+                  <Table
+                     className="min-w-max"
+                     wrapperClassName="w-max min-w-full overflow-visible"
+                     style={{ minWidth: table.getTotalSize() }}
+                  >
                      <DataTableHeader table={table} />
                      <DataTableBody<TransactionRow>
                         getRowClassName={({ row }) =>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
@@ -319,10 +319,14 @@ function parseImportStatus(value: unknown): {
    ) {
       return { status: "pending", ignored: true };
    }
+   const isNegativePaid =
+      /\bnao\s+(pago|efetivado)\b/.test(normalized) ||
+      /\bnão\s+(pago|efetivado)\b/.test(normalized);
    if (
-      normalized === "paid" ||
-      normalized.includes("efetivado") ||
-      normalized.includes("pago")
+      !isNegativePaid &&
+      (normalized === "paid" ||
+         /\befetivado\b/.test(normalized) ||
+         /\bpago\b/.test(normalized))
    ) {
       return { status: "paid", ignored: false };
    }

--- a/core/database/src/schemas/transactions.ts
+++ b/core/database/src/schemas/transactions.ts
@@ -241,6 +241,7 @@ const baseTransactionSchema = createInsertSchema(transactions).pick({
    categoryId: true,
    creditCardId: true,
    tagId: true,
+   relationshipId: true,
    paymentMethod: true,
    attachments: true,
    statementPeriod: true,
@@ -274,6 +275,7 @@ export const createTransactionSchema = baseTransactionSchema
       destinationBankAccountId: z.string().uuid().nullable().optional(),
       creditCardId: z.string().uuid().nullable().optional(),
       categoryId: z.string().uuid().nullable().optional(),
+      relationshipId: z.string().uuid().nullable().optional(),
       attachments: z.array(attachmentSchema).nullable().optional(),
       status: z
          .enum(["pending", "paid", "cancelled"])
@@ -354,6 +356,7 @@ export const updateTransactionSchema = baseTransactionSchema
       destinationBankAccountId: z.string().uuid().nullable().optional(),
       creditCardId: z.string().uuid().nullable().optional(),
       categoryId: z.string().uuid().nullable().optional(),
+      relationshipId: z.string().uuid().nullable().optional(),
       attachments: z.array(attachmentSchema).nullable().optional(),
       status: z.enum(["pending", "paid", "cancelled"]).optional(),
       ignored: z.boolean().optional(),

--- a/modules/cashbook/src/router/imports.ts
+++ b/modules/cashbook/src/router/imports.ts
@@ -258,6 +258,7 @@ export const importBulk = protectedProcedure
                destinationBankAccountId: data.destinationBankAccountId,
                categoryId: data.categoryId,
                tagId,
+               relationshipId: data.relationshipId,
                date: data.date,
             }),
          ),

--- a/modules/cashbook/src/router/middlewares.ts
+++ b/modules/cashbook/src/router/middlewares.ts
@@ -184,6 +184,7 @@ export type FinancialReferences = {
    destinationBankAccountId?: string | null;
    categoryId?: string | null;
    tagId?: string | null;
+   relationshipId?: string | null;
    date?: Date | string | null;
 };
 
@@ -299,6 +300,27 @@ export async function requireValidFinancialReferences(
          throw new CashbookMiddlewareError({
             error: cashbookMiddlewareErrors.BAD_REQUEST(),
             message: "Centro de Custo inválido.",
+         });
+      }
+   }
+
+   if (refs.relationshipId) {
+      const relationship = await Result.tryPromise({
+         try: () =>
+            db.query.parties.findFirst({
+               where: (f, { eq }) => eq(f.id, refs.relationshipId ?? ""),
+            }),
+         catch: () =>
+            new CashbookMiddlewareError({
+               error: cashbookMiddlewareErrors.INTERNAL(),
+               message: "Falha ao verificar cliente.",
+            }),
+      });
+      if (Result.isError(relationship)) throw relationship.error;
+      if (!relationship.value || relationship.value.teamId !== teamId) {
+         throw new CashbookMiddlewareError({
+            error: cashbookMiddlewareErrors.BAD_REQUEST(),
+            message: "Cliente inválido.",
          });
       }
    }

--- a/modules/cashbook/src/router/middlewares.ts
+++ b/modules/cashbook/src/router/middlewares.ts
@@ -313,14 +313,14 @@ export async function requireValidFinancialReferences(
          catch: () =>
             new CashbookMiddlewareError({
                error: cashbookMiddlewareErrors.INTERNAL(),
-               message: "Falha ao verificar cliente.",
+               message: "Falha ao verificar relacionamento.",
             }),
       });
       if (Result.isError(relationship)) throw relationship.error;
       if (!relationship.value || relationship.value.teamId !== teamId) {
          throw new CashbookMiddlewareError({
             error: cashbookMiddlewareErrors.BAD_REQUEST(),
-            message: "Cliente inválido.",
+            message: "Relacionamento inválido.",
          });
       }
    }

--- a/modules/cashbook/src/router/transactions-list.ts
+++ b/modules/cashbook/src/router/transactions-list.ts
@@ -24,6 +24,7 @@ const sortIdSchema = z.enum([
    "date",
    "dueDate",
    "name",
+   "relationshipName",
    "status",
    "type",
 ]);

--- a/modules/cashbook/src/router/transactions.ts
+++ b/modules/cashbook/src/router/transactions.ts
@@ -216,6 +216,7 @@ export const create = protectedProcedure
             return transactionData.categoryId;
          })(),
          tagId,
+         relationshipId: transactionData.relationshipId,
          date: transactionData.date,
       });
 
@@ -592,6 +593,7 @@ export const update = protectedProcedure
             input.destinationBankAccountId ?? existing.destinationBankAccountId,
          categoryId: input.categoryId ?? existing.categoryId,
          tagId: input.tagId ?? existing.tagId,
+         relationshipId: input.relationshipId ?? existing.relationshipId,
          date: input.date ?? existing.date,
       });
       const { id, tagId, items, ...data } = input;
@@ -713,6 +715,10 @@ export const bulkUpdate = protectedProcedure
          categoryId:
             data.categoryId !== undefined ? data.categoryId : row.categoryId,
          tagId: tagId !== undefined ? tagId : row.tagId,
+         relationshipId:
+            data.relationshipId !== undefined
+               ? data.relationshipId
+               : row.relationshipId,
          date: data.date !== undefined ? data.date : row.date,
       }));
 

--- a/modules/cashbook/src/router/transactions.ts
+++ b/modules/cashbook/src/router/transactions.ts
@@ -724,6 +724,7 @@ export const bulkUpdate = protectedProcedure
 
       const bankAccountIds = new Set<string>();
       const categoryIds = new Set<string>();
+      const relationshipIds = new Set<string>();
       const tagIds = new Set<string>();
       for (const refs of finalReferences) {
          if (refs.bankAccountId) bankAccountIds.add(refs.bankAccountId);
@@ -731,6 +732,7 @@ export const bulkUpdate = protectedProcedure
             bankAccountIds.add(refs.destinationBankAccountId);
          }
          if (refs.categoryId) categoryIds.add(refs.categoryId);
+         if (refs.relationshipId) relationshipIds.add(refs.relationshipId);
          if (refs.tagId) tagIds.add(refs.tagId);
       }
 
@@ -782,6 +784,22 @@ export const bulkUpdate = protectedProcedure
       });
       if (tagRowsResult.isErr()) throw tagRowsResult.error;
 
+      const relationshipRowsResult = await Result.tryPromise({
+         try: () =>
+            relationshipIds.size > 0
+               ? context.db.query.parties.findMany({
+                    where: (f, { inArray }) =>
+                       inArray(f.id, Array.from(relationshipIds)),
+                 })
+               : Promise.resolve([]),
+         catch: () =>
+            new TransactionRouterError({
+               error: transactionRouterErrors.INTERNAL(),
+               message: "Falha ao verificar relacionamentos.",
+            }),
+      });
+      if (relationshipRowsResult.isErr()) throw relationshipRowsResult.error;
+
       const bankAccountRows = new Map(
          bankAccountRowsResult.value.map((account) => [account.id, account]),
       );
@@ -789,6 +807,12 @@ export const bulkUpdate = protectedProcedure
          categoryRowsResult.value.map((category) => [category.id, category]),
       );
       const tagRows = new Map(tagRowsResult.value.map((tag) => [tag.id, tag]));
+      const relationshipRows = new Map(
+         relationshipRowsResult.value.map((relationship) => [
+            relationship.id,
+            relationship,
+         ]),
+      );
 
       for (const refs of finalReferences) {
          if (refs.bankAccountId) {
@@ -853,6 +877,16 @@ export const bulkUpdate = protectedProcedure
                throw new TransactionRouterError({
                   error: transactionRouterErrors.BAD_REQUEST(),
                   message: "Centro de Custo inválido.",
+               });
+            }
+         }
+
+         if (refs.relationshipId) {
+            const relationship = relationshipRows.get(refs.relationshipId);
+            if (!relationship || relationship.teamId !== context.teamId) {
+               throw new TransactionRouterError({
+                  error: transactionRouterErrors.BAD_REQUEST(),
+                  message: "Relacionamento inválido.",
                });
             }
          }

--- a/modules/cashbook/src/transactions.ts
+++ b/modules/cashbook/src/transactions.ts
@@ -30,6 +30,7 @@ import { bankAccounts } from "@core/database/schemas/bank-accounts";
 import { categories } from "@core/database/schemas/categories";
 import { creditCards } from "@core/database/schemas/credit-cards";
 import { tags } from "@core/database/schemas/tags";
+import { parties } from "@core/database/schemas/relationships";
 import {
    transactions,
    type TransactionRecurrenceFrequency,
@@ -70,6 +71,7 @@ export type TransactionSortId =
    | "date"
    | "dueDate"
    | "name"
+   | "relationshipName"
    | "status"
    | "type";
 
@@ -114,6 +116,9 @@ function buildTransactionOrderBy(
          case "name":
             orderBy.push(direction(transactions.name));
             break;
+         case "relationshipName":
+            orderBy.push(direction(parties.name));
+            break;
          case "status":
             orderBy.push(direction(transactions.status));
             break;
@@ -142,6 +147,7 @@ export function selectTransactionsWithJoins(
          categoryName: categories.name,
          creditCardName: creditCards.name,
          bankAccountName: bankAccounts.name,
+         relationshipName: parties.name,
          suggestedCategoryName: suggestedCategories.name,
          tagName: tagAlias.name,
          suggestedTagName: suggestedTags.name,
@@ -154,6 +160,7 @@ export function selectTransactionsWithJoins(
       )
       .leftJoin(creditCards, eq(transactions.creditCardId, creditCards.id))
       .leftJoin(bankAccounts, eq(transactions.bankAccountId, bankAccounts.id))
+      .leftJoin(parties, eq(transactions.relationshipId, parties.id))
       .leftJoin(tagAlias, eq(transactions.tagId, tagAlias.id))
       .leftJoin(
          suggestedTags,

--- a/packages/ui/src/components/combobox.tsx
+++ b/packages/ui/src/components/combobox.tsx
@@ -91,12 +91,20 @@ export function Combobox({
       }
    }, []);
 
+   const handleOpenChange = React.useCallback(
+      (nextOpen: boolean) => {
+         setOpen(nextOpen);
+         onOpenChange?.(nextOpen);
+      },
+      [onOpenChange],
+   );
+
    const handleCreate = () => {
       const trimmedSearch = search.trim();
       if (trimmedSearch && onCreate) {
          onCreate(trimmedSearch);
          setSearch("");
-         setOpen(false);
+         handleOpenChange(false);
       }
    };
 
@@ -106,14 +114,6 @@ export function Combobox({
       !filteredOptions.some(
          (o) => o.label.toLowerCase() === search.trim().toLowerCase(),
       );
-
-   const handleOpenChange = React.useCallback(
-      (nextOpen: boolean) => {
-         setOpen(nextOpen);
-         onOpenChange?.(nextOpen);
-      },
-      [onOpenChange],
-   );
 
    return (
       <Popover onOpenChange={handleOpenChange} open={open}>
@@ -197,7 +197,7 @@ export function Combobox({
                                                 ? ""
                                                 : currentValue,
                                           );
-                                          setOpen(false);
+                                          handleOpenChange(false);
                                        }}
                                        ref={virtualizer.measureElement}
                                        value={option.value}

--- a/packages/ui/src/components/combobox.tsx
+++ b/packages/ui/src/components/combobox.tsx
@@ -34,6 +34,7 @@ interface ComboboxProps {
    className?: string;
    disabled?: boolean;
    defaultOpen?: boolean;
+   onOpenChange?: (open: boolean) => void;
    id?: string;
    onBlur?: React.FocusEventHandler<HTMLButtonElement>;
    onCreate?: (name: string) => void;
@@ -52,6 +53,7 @@ export function Combobox({
    className,
    disabled = false,
    defaultOpen = false,
+   onOpenChange,
    id,
    onBlur,
    onCreate,
@@ -105,8 +107,16 @@ export function Combobox({
          (o) => o.label.toLowerCase() === search.trim().toLowerCase(),
       );
 
+   const handleOpenChange = React.useCallback(
+      (nextOpen: boolean) => {
+         setOpen(nextOpen);
+         onOpenChange?.(nextOpen);
+      },
+      [onOpenChange],
+   );
+
    return (
-      <Popover onOpenChange={setOpen} open={open}>
+      <Popover onOpenChange={handleOpenChange} open={open}>
          <PopoverTrigger asChild>
             <Button
                aria-expanded={open}

--- a/packages/ui/src/components/date-picker.tsx
+++ b/packages/ui/src/components/date-picker.tsx
@@ -32,6 +32,9 @@ export interface DatePickerProps {
    className?: string;
    /** Placeholder text shown when no date is selected */
    placeholder?: string;
+   open?: boolean;
+   defaultOpen?: boolean;
+   onOpenChange?: (open: boolean) => void;
 }
 
 export const DatePicker = ({
@@ -39,6 +42,9 @@ export const DatePicker = ({
    onSelect,
    className,
    placeholder,
+   open,
+   defaultOpen,
+   onOpenChange,
 }: DatePickerProps = {}) => {
    const isControlled = dateProp !== undefined || onSelect !== undefined;
    const [internalDate, setInternalDate] = useState<Date | undefined>(
@@ -72,7 +78,11 @@ export const DatePicker = ({
    };
 
    return (
-      <Popover>
+      <Popover
+         defaultOpen={defaultOpen}
+         onOpenChange={onOpenChange}
+         open={open}
+      >
          <PopoverTrigger asChild>
             <Button
                className={cn(

--- a/packages/ui/src/components/scroll-area.tsx
+++ b/packages/ui/src/components/scroll-area.tsx
@@ -22,6 +22,7 @@ function ScrollArea({
             {children}
          </ScrollAreaPrimitive.Viewport>
          <ScrollBar />
+         <ScrollBar orientation="horizontal" />
          <ScrollAreaPrimitive.Corner />
       </ScrollAreaPrimitive.Root>
    );


### PR DESCRIPTION
## Resumo

- Virtualiza linhas da tabela de lançamentos com TanStack Virtual, usando o viewport real do ScrollArea, chaves estáveis e `scrollMargin`.
- Ajusta a prévia de importação para arquivos grandes/HTML `.xls`, mantendo cabeçalho e mapeamento fixos enquanto só as linhas importadas rolam.
- Melhora o mapeamento do `Fluxo_de_Caixa.xls`: `Pagamento` como data, `Conta a receber` como receita, `Conta a pagar` como despesa e `Saldo` fora do valor.
- Adiciona suporte a cliente/fornecedor no fluxo de importação de lançamentos.
- Evita montar editores inline pesados até o usuário clicar e deixa campos textuais visualmente clicáveis.
- Ajusta scroll horizontal, ordem das colunas e hierarquia visual neutra da tabela/importação.

## Validação

- `bun nx run @packages/ui:build`
- `bun --filter web typecheck`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Virtualiza a tabela de lançamentos e a prévia de importação para evitar travamentos em listas grandes, e adiciona Cliente/Fornecedor (UI, API e ordenação) com validação por time. Também melhora o parsing de planilhas HTML “.xls”, o auto‑mapeamento e a UX dos editores inline.

- **New Features**
  - Virtualização: corpo da tabela e prévia de importação com `@tanstack/react-virtual` usando o viewport real do `ScrollArea`, `scrollMargin` dinâmico, padding top/bottom e overscan 5; suporta linhas expandidas; cabeçalhos/mapeamento fixos.
  - Importação mais robusta: lê `.xls` em HTML (tabelas), escolhe a maior e normaliza células; suporta colunas “Conta a receber/Conta a pagar” (vira Receita/Despesa e mostra contadores), “Cliente” e “Fornecedor”; melhor auto‑match (prioriza match exato e evita mapear “Saldo”→Valor, “Receber/Pagar/Saldo”→Conta e “Despesa/Receita/Tipo”→Categoria); trata “-” como vazio; status “pago/efetivado” com detecção de negação (“não/nao pago/efetivado”); data com fallback para Vencimento.
  - Cliente/Fornecedor: novas colunas com edição inline via `Combobox` (criação on‑the‑fly) e bulk edit com `bulkEditPatch` para aplicar `relationshipId`/`relationshipName`; import resolve `relationshipId` conforme tipo; ordenação por `relationshipName`.
  - Editores inline unificados: só montam ao clicar; `Combobox`/`DatePicker` controlam `open`/`onOpenChange`; `MoneyInput` exibe valor formatado fora de edição; botões clicáveis com ARIA.
  - UX/layout: “Montte → Planilha” nos mapeamentos; cores por tipo na prévia; Cliente/Fornecedor antes de Conta; `ScrollArea` com barra horizontal; tabela com largura mínima para evitar quebra.
  - Camadas: Router — cria/atualiza/importa `relationshipId`, ordena por `relationshipName` e valida relacionamento do mesmo time; Repositório — `tanstack-db` aceita `relationshipName`/sort e updates otimistas de relacionamento; Componentes — `DataTableBody`/`DataImportSection` virtualizados e editores atualizados; UI — `Combobox`, `DatePicker` e `ScrollArea` expostos com novos controles; Store/estado — normaliza `columnOrder` para posicionar Cliente/Fornecedor e adiciona campos de import (`receivableAmount`/`payableAmount`).

- **Testes**
  - Build/typecheck: `bun nx run @packages/ui:build`, `bun --filter web typecheck`, `git diff --check`.
  - Virtualização: rolagem fluida, cabeçalhos/mapeamento fixos, linhas expandidas e alturas corretas.
  - Importação: `.xls` em HTML carrega; “Conta a receber/pagar” define tipo/valor; data cai para Vencimento quando “Data” ausente; “Saldo” não mapeia para Valor; deduplicação/ignorados corretos; contadores de Receita/Despesa visíveis; “não/nao pago/efetivado” não marca como pago.
  - Cliente/Fornecedor: criar via inline, atribuir na linha/import, refletir `relationshipId`/`relationshipName`, ordenar por `relationshipName`; backend rejeita relacionamento de outro time.
  - Editores inline: abrem ao clicar, fecham ao salvar/cancelar; `Combobox`/`DatePicker` respeitam `open`; valores persistem.

<sup>Written for commit b26d1f34655bcc69ce116f88e09497459a882c4c. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/1001?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

