### PR TITLE
fix(flue): simplify env — only OPENCODE_API_KEY needed

### DIFF
--- a/.flue/app.ts
+++ b/.flue/app.ts
@@ -1,7 +1,7 @@
 import { Result } from "better-result";
 import { flue } from "@flue/runtime/app";
-import { validateFlueProviderEnv } from "./lib/agent-utils.ts";
-import { configureFlueProvidersFromEnv } from "./lib/providers.ts";
+import { requireEnv } from "./lib/agent-utils.ts";
+import { configureFlueProvider } from "./lib/providers.ts";
 
 type FlueFetch = ReturnType<typeof flue>["fetch"];
 type FlueExecutionContext = Parameters<FlueFetch>[2];
@@ -12,10 +12,10 @@ export default {
       env: Record<string, unknown>,
       ctx: FlueExecutionContext,
    ) {
-      const providerEnvResult = validateFlueProviderEnv(env);
-      if (Result.isError(providerEnvResult)) throw providerEnvResult.error;
+      const apiKeyResult = requireEnv(env, "OPENCODE_API_KEY");
+      if (Result.isError(apiKeyResult)) throw apiKeyResult.error;
 
-      configureFlueProvidersFromEnv(providerEnvResult.value);
+      configureFlueProvider(apiKeyResult.value);
       return flue().fetch(req, env, ctx);
    },
 };

--- a/.flue/lib/agent-utils.ts
+++ b/.flue/lib/agent-utils.ts
@@ -62,32 +62,25 @@ export const safePathSchema = v.pipe(
    ),
 );
 
-const envStringSchema = v.pipe(v.string(), v.minLength(1));
+function nonEmpty(value: unknown): string | undefined {
+   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
 
-export const flueProviderEnvSchema = v.object({
-   OPENCODE_API_KEY: v.optional(envStringSchema),
-   OPENCODE_GO_BASE_URL: v.optional(v.pipe(envStringSchema, v.url())),
-   OPENCODE_GO_GATEWAY_KEY: v.optional(envStringSchema),
-});
+export function resolveEnv(
+   env: Record<string, unknown>,
+   key: string,
+): string | undefined {
+   return nonEmpty(env[key]) ?? nonEmpty(process.env[key]);
+}
 
-export type FlueProviderEnv = v.InferOutput<typeof flueProviderEnvSchema>;
-
-export function validateFlueProviderEnv(env: Record<string, unknown>) {
-   const parsed = v.safeParse(flueProviderEnvSchema, {
-      OPENCODE_API_KEY: env.OPENCODE_API_KEY ?? process.env.OPENCODE_API_KEY,
-      OPENCODE_GO_BASE_URL:
-         env.OPENCODE_GO_BASE_URL ?? process.env.OPENCODE_GO_BASE_URL,
-      OPENCODE_GO_GATEWAY_KEY:
-         env.OPENCODE_GO_GATEWAY_KEY ?? process.env.OPENCODE_GO_GATEWAY_KEY,
-   });
-
-   if (parsed.success) return Result.ok(parsed.output);
+export function requireEnv(env: Record<string, unknown>, key: string) {
+   const value = resolveEnv(env, key);
+   if (value) return Result.ok(value);
 
    return Result.err(
       new AgentUtilsError({
          error: agentUtilsErrors.INVALID_PROVIDER_ENV(),
-         message: "Ambiente de providers Flue inválido.",
-         detail: formatCause(parsed.issues),
+         message: `${key} não configurada.`,
       }),
    );
 }

--- a/.flue/lib/providers.ts
+++ b/.flue/lib/providers.ts
@@ -1,20 +1,10 @@
 import { configureProvider } from "@flue/runtime/app";
-import type { FlueProviderEnv } from "./agent-utils.ts";
 
-const DEFAULT_OPENCODE_GO_BASE_URL = "https://opencode.ai/zen/go/v1";
+const OPENCODE_GO_BASE_URL = "https://opencode.ai/zen/go/v1";
 
-export function configureFlueProvidersFromEnv(env: FlueProviderEnv) {
-   if (env.OPENCODE_GO_GATEWAY_KEY) {
-      configureProvider("opencode-go", {
-         baseUrl: env.OPENCODE_GO_BASE_URL ?? DEFAULT_OPENCODE_GO_BASE_URL,
-         apiKey: env.OPENCODE_API_KEY ?? "dummy",
-         headers: { "X-Custom-Auth": env.OPENCODE_GO_GATEWAY_KEY },
-      });
-      return;
-   }
-
+export function configureFlueProvider(apiKey: string) {
    configureProvider("opencode-go", {
-      baseUrl: env.OPENCODE_GO_BASE_URL ?? DEFAULT_OPENCODE_GO_BASE_URL,
-      apiKey: env.OPENCODE_API_KEY ?? "dummy",
+      baseUrl: OPENCODE_GO_BASE_URL,
+      apiKey,
    });
 }

--- a/.github/workflows/docs-refresh.yml
+++ b/.github/workflows/docs-refresh.yml
@@ -36,8 +36,6 @@ jobs:
            env:
               GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-              OPENCODE_GO_BASE_URL: ${{ vars.OPENCODE_GO_BASE_URL }}
-              OPENCODE_GO_GATEWAY_KEY: ${{ secrets.OPENCODE_GO_GATEWAY_KEY }}
               DRY_RUN: ${{ inputs.dry_run || false }}
            run: |
               PAYLOAD=$(jq -c -n \

--- a/.github/workflows/pr-review-ai.yml
+++ b/.github/workflows/pr-review-ai.yml
@@ -184,8 +184,6 @@ jobs:
            if: steps.pr.outputs.requested == 'true' && steps.pr.outputs.authorized == 'true' && steps.pr.outputs.is_cross_repository != 'true'
            env:
               OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-              OPENCODE_GO_BASE_URL: ${{ vars.OPENCODE_GO_BASE_URL }}
-              OPENCODE_GO_GATEWAY_KEY: ${{ secrets.OPENCODE_GO_GATEWAY_KEY }}
               GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               PR_NUMBER: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -81,8 +81,6 @@ jobs:
            if: steps.version.outputs.skip != 'true'
            env:
               OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-              OPENCODE_GO_BASE_URL: ${{ vars.OPENCODE_GO_BASE_URL }}
-              OPENCODE_GO_GATEWAY_KEY: ${{ secrets.OPENCODE_GO_GATEWAY_KEY }}
               RELEASE_VERSION: ${{ steps.version.outputs.version }}
               RELEASE_TAG: ${{ steps.version.outputs.tag }}
            run: |

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -195,8 +195,6 @@ jobs:
            if: steps.pr.outputs.requested == 'true' && steps.pr.outputs.authorized == 'true' && steps.pr.outputs.is_cross_repository != 'true'
            env:
               OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-              OPENCODE_GO_BASE_URL: ${{ vars.OPENCODE_GO_BASE_URL }}
-              OPENCODE_GO_GATEWAY_KEY: ${{ secrets.OPENCODE_GO_GATEWAY_KEY }}
               GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               PR_NUMBER: ${{ steps.pr.outputs.number }}


### PR DESCRIPTION
## Summary
- Empty string env vars (`OPENCODE_GO_BASE_URL=""`, `OPENCODE_GO_GATEWAY_KEY=""`) in CI bypassed `??` and hit valibot `minLength(1)` → HTTP 500 on all flue agents
- Removed both vars — base URL hardcoded, gateway key unused
- Added generic `resolveEnv`/`requireEnv` helpers that treat empty strings as `undefined`
- Cleaned all 4 workflows (pr-review, security-audit, release-weekly, docs-refresh)

## Test plan
- [ ] Trigger `/review` on a PR and confirm no HTTP 500
- [ ] Verify `OPENCODE_API_KEY` alone is sufficient for flue agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifica a configuração dos agentes Flue: agora só `OPENCODE_API_KEY` é exigida. Corrige HTTP 500 em CI causados por envs vazias para `OPENCODE_GO_BASE_URL`/`OPENCODE_GO_GATEWAY_KEY`.

- **Bug Fixes**
  - Motivo: strings vazias em CI passavam no `??` e falhavam no `minLength(1)` → 500 nos agentes.
  - Utils: adiciona `resolveEnv`/`requireEnv` que tratam string vazia como `undefined` e exigem `OPENCODE_API_KEY`.
  - Router (.flue/app.ts): usa `requireEnv` para validar `OPENCODE_API_KEY` e aborta cedo com erro claro.
  - Providers (.flue/lib/providers.ts): remove `OPENCODE_GO_GATEWAY_KEY` e URL dinâmica; fixa base `https://opencode.ai/zen/go/v1` e configura `opencode-go` com a chave única via `@flue/runtime/app`.
  - Workflows (CI): remove `OPENCODE_GO_BASE_URL` e `OPENCODE_GO_GATEWAY_KEY` dos jobs.
  - Impacto por camada (AGENTS.md):
    - Router: alterado (validação de env simplificada).
    - Providers/infra: alterado (configuração única por API key).
    - Repositório, Componente, Store: sem impacto.

Checklist de teste
- Disparar `/review` em um PR e confirmar ausência de HTTP 500.
- Rodar os jobs de CI afetados com apenas `OPENCODE_API_KEY` e verificar execução bem-sucedida.

<sup>Written for commit 4f518b349844ea562c34eb17b7f402219e75ddf7. Summary will update on new commits. <a href="https://cubic.dev/pr/Montte-erp/montte-nx/pull/1002?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

