### PR TITLE
feat: adicionar importação CSV/XLSX em relacionamentos

### DIFF
--- a/apps/web-e2e/helpers/db.ts
+++ b/apps/web-e2e/helpers/db.ts
@@ -16,6 +16,7 @@ import {
 import { bankAccounts } from "@core/database/schemas/bank-accounts";
 import { creditCards } from "@core/database/schemas/credit-cards";
 import { categories } from "@core/database/schemas/categories";
+import { parties } from "@core/database/schemas/relationships";
 import { tags } from "@core/database/schemas/tags";
 import {
    transactionRecurrences,
@@ -220,6 +221,33 @@ export async function deleteBankAccountById(teamId: string, id: string) {
    await db()
       .delete(bankAccounts)
       .where(and(eq(bankAccounts.teamId, teamId), eq(bankAccounts.id, id)));
+}
+
+export async function findPartyByName(teamId: string, name: string) {
+   return db().query.parties.findFirst({
+      where: (f, { and, eq }) => and(eq(f.teamId, teamId), eq(f.name, name)),
+   });
+}
+
+export async function findPartiesByDocument(
+   teamId: string,
+   role: "customer" | "supplier",
+   documentNumber: string,
+) {
+   return db().query.parties.findMany({
+      where: (f, { and, eq }) =>
+         and(
+            eq(f.teamId, teamId),
+            eq(f.role, role),
+            eq(f.documentNumber, documentNumber),
+         ),
+   });
+}
+
+export async function deletePartyById(teamId: string, id: string) {
+   await db()
+      .delete(parties)
+      .where(and(eq(parties.teamId, teamId), eq(parties.id, id)));
 }
 
 export async function findCreditCardByName(teamId: string, name: string) {

--- a/apps/web-e2e/tests/import-templates.spec.ts
+++ b/apps/web-e2e/tests/import-templates.spec.ts
@@ -1,13 +1,54 @@
 import fs from "node:fs";
 import type { Page } from "@playwright/test";
-import { read as readXlsx, utils as xlsxUtils } from "xlsx";
+import { read as readXlsx, utils as xlsxUtils, write as writeXlsx } from "xlsx";
 import { expect, test, type E2ESession } from "../fixtures";
+import {
+   deletePartyById,
+   findPartiesByDocument,
+   findPartyByName,
+   findTeamByOrgAndSlug,
+} from "../helpers/db";
 
 type TemplateCase = {
    path: string;
    heading: string;
    filenameBase: string;
    headers: string[];
+};
+
+const createdPartyIds: string[] = [];
+const stamp = () => `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+
+function cpfDigit(values: string, weights: readonly number[]) {
+   const total = values
+      .split("")
+      .reduce(
+         (acc, digit, index) => acc + Number(digit) * (weights[index] ?? 0),
+         0,
+      );
+   const remainder = total % 11;
+   return remainder < 2 ? 0 : 11 - remainder;
+}
+
+function generateCpf() {
+   const body = String(Math.floor(100_000_000 + Math.random() * 899_999_999));
+   const first = cpfDigit(body, [10, 9, 8, 7, 6, 5, 4, 3, 2]);
+   const second = cpfDigit(`${body}${first}`, [11, 10, 9, 8, 7, 6, 5, 4, 3, 2]);
+   return `${body}${first}${second}`;
+}
+
+const customersTemplateCase: TemplateCase = {
+   path: "customers",
+   heading: "Clientes",
+   filenameBase: "modelo-relacionamentos",
+   headers: ["Tipo", "Nome", "CPF/CNPJ", "E-mail", "Telefone"],
+};
+
+const suppliersTemplateCase: TemplateCase = {
+   path: "suppliers",
+   heading: "Fornecedores",
+   filenameBase: "modelo-relacionamentos",
+   headers: ["Tipo", "Nome", "CPF/CNPJ", "E-mail", "Telefone"],
 };
 
 const cases: TemplateCase[] = [
@@ -54,6 +95,8 @@ const cases: TemplateCase[] = [
          "Status",
       ],
    },
+   customersTemplateCase,
+   suppliersTemplateCase,
 ];
 
 async function gotoImportFlow(
@@ -109,6 +152,65 @@ async function expectXlsxTemplate(page: Page, item: TemplateCase) {
    }
 }
 
+async function uploadCsv(page: Page, filename: string, csv: string) {
+   await page.getByRole("button", { name: "Importar dados" }).click();
+   await page
+      .locator('input[type="file"]')
+      .first()
+      .setInputFiles({
+         name: filename,
+         mimeType: "text/csv",
+         buffer: Buffer.from(csv, "utf8"),
+      });
+   await expect(page.getByText("Importando")).toBeVisible();
+}
+
+async function uploadXlsx(
+   page: Page,
+   filename: string,
+   rows: Record<string, string>[],
+) {
+   await page.getByRole("button", { name: "Importar dados" }).click();
+   const worksheet = xlsxUtils.json_to_sheet(rows, {
+      header: ["Tipo", "Nome", "CPF/CNPJ", "E-mail", "Telefone"],
+   });
+   const workbook = xlsxUtils.book_new();
+   xlsxUtils.book_append_sheet(workbook, worksheet, "Modelo");
+   await page
+      .locator('input[type="file"]')
+      .first()
+      .setInputFiles({
+         name: filename,
+         mimeType:
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+         buffer: Buffer.from(writeXlsx(workbook, { type: "buffer" })),
+      });
+   await expect(page.getByText("Importando")).toBeVisible();
+}
+
+async function rememberParty(session: E2ESession, name: string) {
+   const team = await findTeamByOrgAndSlug(session.orgSlug, session.teamSlug);
+   if (!team) return;
+   const party = await findPartyByName(team.id, name);
+   if (party) createdPartyIds.push(party.id);
+}
+
+async function expectRelationshipRow(page: Page, name: string) {
+   await page.getByPlaceholder("Buscar por nome ou CPF/CNPJ...").fill(name);
+   await expect(page.getByRole("row").filter({ hasText: name })).toBeVisible();
+}
+
+test.afterEach(async ({ e2eSession }) => {
+   const team = await findTeamByOrgAndSlug(
+      e2eSession.orgSlug,
+      e2eSession.teamSlug,
+   );
+   if (!team) return;
+   for (const id of createdPartyIds.splice(0)) {
+      await deletePartyById(team.id, id);
+   }
+});
+
 test("MON-958: disponibiliza modelos CSV e XLSX nos fluxos de importação", async ({
    page,
    e2eSession,
@@ -120,4 +222,93 @@ test("MON-958: disponibiliza modelos CSV e XLSX nos fluxos de importação", asy
       await expectCsvTemplate(page, item);
       await expectXlsxTemplate(page, item);
    }
+});
+
+test("MON-958: CSV importado em Clientes cria cliente", async ({
+   page,
+   e2eSession,
+}) => {
+   const name = `Cliente Import E2E ${stamp()}`;
+   await gotoImportFlow(page, e2eSession, customersTemplateCase);
+   await uploadCsv(
+      page,
+      "clientes.csv",
+      `Tipo,Nome,CPF/CNPJ,E-mail,Telefone\nEmpresa,${name},,cliente-import@email.com,(11) 99999-9999\n`,
+   );
+
+   await page.getByRole("button", { name: "Salvar importação" }).click();
+   await page
+      .getByRole("alertdialog")
+      .getByRole("button", { name: "Salvar" })
+      .click();
+   await expect(
+      page.getByText(/1 relacionamento\(s\) importado\(s\)/),
+   ).toBeVisible();
+   await rememberParty(e2eSession, name);
+   await expectRelationshipRow(page, name);
+});
+
+test("MON-958: XLSX importado em Fornecedores cria fornecedor", async ({
+   page,
+   e2eSession,
+}) => {
+   const name = `Fornecedor Import E2E ${stamp()}`;
+   await gotoImportFlow(page, e2eSession, suppliersTemplateCase);
+   await uploadXlsx(page, "fornecedores.xlsx", [
+      {
+         Tipo: "Empresa",
+         Nome: name,
+         "CPF/CNPJ": "",
+         "E-mail": "fornecedor-import@email.com",
+         Telefone: "(11) 98888-8888",
+      },
+   ]);
+
+   await page.getByRole("button", { name: "Salvar importação" }).click();
+   await page
+      .getByRole("alertdialog")
+      .getByRole("button", { name: "Salvar" })
+      .click();
+   await expect(
+      page.getByText(/1 relacionamento\(s\) importado\(s\)/),
+   ).toBeVisible();
+   await rememberParty(e2eSession, name);
+   await expectRelationshipRow(page, name);
+});
+
+test("MON-958: documento duplicado não cria segundo relacionamento", async ({
+   page,
+   e2eSession,
+}) => {
+   const name = `Cliente Duplicado E2E ${stamp()}`;
+   const documentNumber = generateCpf();
+   await gotoImportFlow(page, e2eSession, customersTemplateCase);
+   await uploadCsv(
+      page,
+      "clientes-duplicados.csv",
+      `Tipo,Nome,CPF/CNPJ,E-mail,Telefone\nPessoa física,${name},${documentNumber},duplicado@email.com,(11) 99999-9999\nPessoa física,${name} 2,${documentNumber},duplicado2@email.com,(11) 98888-8888\n`,
+   );
+
+   await page.getByRole("button", { name: "Salvar importação" }).click();
+   await page
+      .getByRole("alertdialog")
+      .getByRole("button", { name: "Salvar" })
+      .click();
+   await expect(
+      page.getByText(/1 relacionamento\(s\) importado\(s\)/),
+   ).toBeVisible();
+
+   const team = await findTeamByOrgAndSlug(
+      e2eSession.orgSlug,
+      e2eSession.teamSlug,
+   );
+   expect(team).toBeTruthy();
+   if (!team) throw new Error("Time de E2E não encontrado.");
+   const parties = await findPartiesByDocument(
+      team.id,
+      "customer",
+      documentNumber,
+   );
+   for (const party of parties) createdPartyIds.push(party.id);
+   expect(parties).toHaveLength(1);
 });

--- a/apps/web/src/blocks/data-table/data-import/data-import-section.tsx
+++ b/apps/web/src/blocks/data-table/data-import/data-import-section.tsx
@@ -104,22 +104,32 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
    const duplicateIndices = useMemo(() => {
       if (!hasImportRows) return new Set<number>();
       const firstCol = montteColumns[0];
-      if (!firstCol) return new Set<number>();
-      const accKey = getColumnAccessorKey(firstCol);
+      const accKey =
+         config.duplicateColumnKey ??
+         (firstCol ? getColumnAccessorKey(firstCol) : "");
+      if (!accKey) return new Set<number>();
+      const normalizeValue =
+         config.normalizeDuplicateValue ??
+         ((value: unknown) => String(value ?? "").toLowerCase());
       const existing = new Set(
          table
             .getCoreRowModel()
-            .rows.map((r) => String(r.getValue(accKey) ?? "").toLowerCase()),
+            .rows.map((r) => normalizeValue(r.getValue(accKey))),
       );
       const result = new Set<number>();
       importRows.forEach((r, i) => {
-         const val = String(
-            (r as Record<string, unknown>)[accKey] ?? "",
-         ).toLowerCase();
+         const val = normalizeValue(r[accKey]);
          if (val && existing.has(val)) result.add(i);
       });
       return result;
-   }, [importRows, hasImportRows, table, montteColumns]);
+   }, [
+      importRows,
+      hasImportRows,
+      table,
+      montteColumns,
+      config.duplicateColumnKey,
+      config.normalizeDuplicateValue,
+   ]);
 
    const headerOptions = useMemo(
       () => [
@@ -223,8 +233,11 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
             () => "Erro ao importar linha.",
          );
          result.match(
-            () => {
-               toast.success("Linha importada com sucesso.");
+            (value) => {
+               toast.success(
+                  config.getSuccessMessage?.({ result: value, count: 1 }) ??
+                     "Linha importada com sucesso.",
+               );
                api.removeRows(new Set([rowIdx]));
             },
             (msg) => toast.error(msg),
@@ -263,9 +276,12 @@ function Inner<TData>({ table, api, config, state }: InnerProps<TData>) {
       );
       setSubmitting(false);
       result.match(
-         () => {
+         (value) => {
             toast.success(
-               `${toImport.length} linha(s) importada(s) com sucesso.`,
+               config.getSuccessMessage?.({
+                  result: value,
+                  count: toImport.length,
+               }) ?? `${toImport.length} linha(s) importada(s) com sucesso.`,
             );
             api.discard();
          },

--- a/apps/web/src/blocks/data-table/data-import/use-data-import.tsx
+++ b/apps/web/src/blocks/data-table/data-import/use-data-import.tsx
@@ -42,7 +42,10 @@ export interface DataImportConfig {
       row: Record<string, string>,
       index: number,
    ) => Record<string, unknown>;
-   onImport: (rows: Record<string, unknown>[]) => Promise<void>;
+   onImport: (rows: Record<string, unknown>[]) => Promise<unknown>;
+   getSuccessMessage?: (ctx: { result: unknown; count: number }) => string;
+   duplicateColumnKey?: string;
+   normalizeDuplicateValue?: (value: unknown) => string;
    template?: ImportTemplate;
    extraBulkActions?: (ctx: {
       selectedIndices: Set<number>;
@@ -251,9 +254,13 @@ export function useDataImport<TData>({
                (e) => (e as Error)?.message || "Erro ao importar dados.",
             );
             result.match(
-               () => {
+               (value) => {
                   toast.success(
-                     `${toImport.length} linha(s) importada(s) com sucesso.`,
+                     config.getSuccessMessage?.({
+                        result: value,
+                        count: toImport.length,
+                     }) ??
+                        `${toImport.length} linha(s) importada(s) com sucesso.`,
                   );
                   setState((s) => {
                      if (!s) return s;

--- a/apps/web/src/features/relationships/relationships-table.tsx
+++ b/apps/web/src/features/relationships/relationships-table.tsx
@@ -355,9 +355,19 @@ function isRelationshipImportResult(
 
 function getImportSuccessMessage(value: unknown, count: number) {
    if (!isRelationshipImportResult(value)) {
-      return `${count} relacionamento(s) importado(s).`;
+      const label =
+         count === 1
+            ? "relacionamento importado"
+            : "relacionamentos importados";
+      return `${count} ${label}.`;
    }
-   return `${value.created} relacionamento(s) importado(s). ${value.skipped} duplicado(s) ignorado(s).`;
+   const importedLabel =
+      value.created === 1
+         ? "relacionamento importado"
+         : "relacionamentos importados";
+   const skippedLabel =
+      value.skipped === 1 ? "duplicado ignorado" : "duplicados ignorados";
+   return `${value.created} ${importedLabel}. ${value.skipped} ${skippedLabel}.`;
 }
 
 function normalizeImportDuplicateValue(value: unknown) {

--- a/apps/web/src/features/relationships/relationships-table.tsx
+++ b/apps/web/src/features/relationships/relationships-table.tsx
@@ -46,6 +46,12 @@ import {
 } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { z } from "zod";
+import { DataImportButton } from "@/blocks/data-table/data-import/data-import-button";
+import { DataImportSection } from "@/blocks/data-table/data-import/data-import-section";
+import {
+   useDataImport,
+   type DataImportConfig,
+} from "@/blocks/data-table/data-import/use-data-import";
 import { DataTableBody } from "@/blocks/data-table/data-table-body";
 import { DataTableColumnVisibility } from "@/blocks/data-table/data-table-column-visibility";
 import { DataTableHeader } from "@/blocks/data-table/data-table-header";
@@ -62,14 +68,18 @@ import { PageFilter } from "@/components/page-filters/page-filter";
 import { PageFilters } from "@/components/page-filters/page-filters";
 import { useActiveTeam } from "@/hooks/use-active-team";
 import { useAlertDialog } from "@/hooks/use-alert-dialog";
+import { useCsvFile } from "@/hooks/use-csv-file";
 import { useDashboardSlugs } from "@/hooks/use-dashboard-slugs";
 import { useSheet } from "@/hooks/use-sheet";
+import { useXlsxFile } from "@/hooks/use-xlsx-file";
 import {
    archiveRelationshipAction,
    deleteRelationshipAction,
+   importRelationshipsAction,
    relationshipsCollectionOptions,
    restoreRelationshipAction,
    updateRelationshipAction,
+   type RelationshipImportBulkOutput,
    type RelationshipKind,
    type RelationshipRole,
    type RelationshipsCollectionRow,
@@ -84,64 +94,60 @@ const relationshipSortIdSchema = z.enum([
    "email",
    "phone",
 ]);
-const editSchema = z
-   .object({
-      kind: z.enum(KIND_VALUES),
-      name: z
-         .string()
-         .trim()
-         .min(2, "Nome deve ter no mínimo 2 caracteres.")
-         .max(160, "Nome deve ter no máximo 160 caracteres."),
-      documentNumber: z.string().trim(),
-      email: z.union([
-         z.literal(""),
-         z.string().email("Informe um e-mail válido."),
-      ]),
-      phone: z.string().trim(),
-   })
-   .superRefine((value, ctx) => {
-      const documentDigits = value.documentNumber.replace(/\D/g, "");
-      if (
-         documentDigits &&
-         value.kind === "person" &&
-         !isValidCpf(value.documentNumber)
-      ) {
-         ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ["documentNumber"],
-            message:
-               documentDigits.length === 11
-                  ? "CPF inválido."
-                  : "CPF deve conter 11 dígitos.",
-         });
-      }
-      if (
-         documentDigits &&
-         value.kind === "company" &&
-         !isValidCnpj(value.documentNumber)
-      ) {
-         ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ["documentNumber"],
-            message:
-               documentDigits.length === 14
-                  ? "CNPJ inválido."
-                  : "CNPJ deve conter 14 dígitos.",
-         });
-      }
-      const phoneDigits = value.phone.replace(/\D/g, "");
-      if (
-         phoneDigits &&
-         phoneDigits.length !== 10 &&
-         phoneDigits.length !== 11
-      ) {
-         ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ["phone"],
-            message: "Telefone deve ter 10 ou 11 dígitos.",
-         });
-      }
-   });
+const relationshipImportRowSchema = z.object({
+   kind: z.enum(KIND_VALUES),
+   name: z
+      .string()
+      .trim()
+      .min(2, "Nome deve ter no mínimo 2 caracteres.")
+      .max(160, "Nome deve ter no máximo 160 caracteres."),
+   documentNumber: z.string().trim(),
+   email: z.union([
+      z.literal(""),
+      z.string().email("Informe um e-mail válido."),
+   ]),
+   phone: z.string().trim(),
+});
+
+const editSchema = relationshipImportRowSchema.superRefine((value, ctx) => {
+   const documentDigits = value.documentNumber.replace(/\D/g, "");
+   if (
+      documentDigits &&
+      value.kind === "person" &&
+      !isValidCpf(value.documentNumber)
+   ) {
+      ctx.addIssue({
+         code: z.ZodIssueCode.custom,
+         path: ["documentNumber"],
+         message:
+            documentDigits.length === 11
+               ? "CPF inválido."
+               : "CPF deve conter 11 dígitos.",
+      });
+   }
+   if (
+      documentDigits &&
+      value.kind === "company" &&
+      !isValidCnpj(value.documentNumber)
+   ) {
+      ctx.addIssue({
+         code: z.ZodIssueCode.custom,
+         path: ["documentNumber"],
+         message:
+            documentDigits.length === 14
+               ? "CNPJ inválido."
+               : "CNPJ deve conter 14 dígitos.",
+      });
+   }
+   const phoneDigits = value.phone.replace(/\D/g, "");
+   if (phoneDigits && phoneDigits.length !== 10 && phoneDigits.length !== 11) {
+      ctx.addIssue({
+         code: z.ZodIssueCode.custom,
+         path: ["phone"],
+         message: "Telefone deve ter 10 ou 11 dígitos.",
+      });
+   }
+});
 
 type RelationshipEditValues = z.input<typeof editSchema>;
 type RelationshipSortId = z.infer<typeof relationshipSortIdSchema>;
@@ -198,6 +204,10 @@ function normalizeNullable(value: string) {
 
 function normalizeDigits(value: string) {
    return value.replace(/\D/g, "") || null;
+}
+
+function normalizeImportDocument(value: string) {
+   return value.toUpperCase().replace(/[^A-Z0-9]/g, "") || null;
 }
 
 function formatDocumentNumber(
@@ -304,6 +314,67 @@ function getEditErrorMessage(error: z.ZodError<RelationshipEditValues>) {
    return error.issues[0]?.message ?? "Revise os campos destacados.";
 }
 
+function normalizeHeaderValue(value: string) {
+   return value
+      .trim()
+      .toLowerCase()
+      .normalize("NFD")
+      .replace(/[̀-ͯ]/g, "");
+}
+
+function resolveImportKind(value: unknown, documentNumber: string) {
+   const normalized = normalizeHeaderValue(String(value ?? ""));
+   if (normalized === "empresa" || normalized === "company") return "company";
+   if (
+      normalized === "pessoa fisica" ||
+      normalized === "pessoa física" ||
+      normalized === "person"
+   ) {
+      return "person";
+   }
+   const normalizedDocument = documentNumber
+      .toUpperCase()
+      .replace(/[^A-Z0-9]/g, "");
+   const documentDigits = documentNumber.replace(/\D/g, "");
+   if (documentDigits.length === 11) return "person";
+   if (normalizedDocument.length === 14) return "company";
+   return "company";
+}
+
+function isRelationshipImportResult(
+   value: unknown,
+): value is RelationshipImportBulkOutput {
+   return (
+      typeof value === "object" &&
+      value !== null &&
+      "created" in value &&
+      "skipped" in value &&
+      "errors" in value
+   );
+}
+
+function getImportSuccessMessage(value: unknown, count: number) {
+   if (!isRelationshipImportResult(value)) {
+      return `${count} relacionamento(s) importado(s).`;
+   }
+   return `${value.created} relacionamento(s) importado(s). ${value.skipped} duplicado(s) ignorado(s).`;
+}
+
+function normalizeImportDuplicateValue(value: unknown) {
+   return normalizeImportDocument(String(value ?? "")) ?? "";
+}
+
+function buildImportErrorMessage(
+   errors: RelationshipImportBulkOutput["errors"],
+) {
+   const details = errors
+      .slice(0, 3)
+      .map((error) => `linha ${error.index + 2}: ${error.message}`)
+      .join("; ");
+   const extra = errors.length > 3 ? `; mais ${errors.length - 3} erro(s)` : "";
+   return `Importação retornou ${errors.length} erro(s): ${details}${extra}.`;
+}
+
 function normalizeSorting(sorting: SortingState) {
    const normalized: Array<{ id: RelationshipSortId; desc: boolean }> = [];
    for (const rule of sorting) {
@@ -364,6 +435,8 @@ export function RelationshipsTable({
    const { slug, teamSlug } = useDashboardSlugs();
    const { openAlertDialog } = useAlertDialog();
    const { openSheet } = useSheet();
+   const { parse: parseCsv, generate: generateCsv } = useCsvFile();
+   const { parse: parseXlsx, generate: generateXlsx } = useXlsxFile();
    const layout = useDataTableLayout(storageKey);
    const [editingId, setEditingId] = useState<string | null>(null);
    const [editValues, setEditValues] = useState<RelationshipEditValues | null>(
@@ -388,6 +461,173 @@ export function RelationshipsTable({
             }),
          ),
       [activeTeamId, queryClient, role, searchState.search, searchState.view],
+   );
+
+   const importConfig: DataImportConfig = useMemo(
+      () => ({
+         parseFile: async (file: File) => {
+            const ext = file.name.split(".").pop()?.toLowerCase();
+            if (ext === "xlsx" || ext === "xls") return parseXlsx(file);
+            return parseCsv(file);
+         },
+         mapRow: (row) => {
+            const documentNumber = String(row.documentNumber ?? "");
+            return {
+               kind: resolveImportKind(row.kind, documentNumber),
+               name: String(row.name ?? "").trim(),
+               documentNumber,
+               email: String(row.email ?? "").trim(),
+               phone: String(row.phone ?? ""),
+            };
+         },
+         duplicateColumnKey: "documentNumber",
+         normalizeDuplicateValue: normalizeImportDuplicateValue,
+         getSuccessMessage: ({ result, count }) =>
+            getImportSuccessMessage(result, count),
+         template: {
+            label: "Baixar modelo",
+            description: "Modelo com Tipo, Nome, CPF/CNPJ, E-mail e Telefone.",
+            formats: [
+               {
+                  filename: "modelo-relacionamentos.csv",
+                  label: "CSV",
+                  createBlob: () =>
+                     generateCsv(
+                        [
+                           {
+                              Tipo: "Empresa",
+                              Nome: "Acme Ltda",
+                              "CPF/CNPJ": "12.345.678/0001-95",
+                              "E-mail": "financeiro@acme.com.br",
+                              Telefone: "(11) 99999-9999",
+                           },
+                           {
+                              Tipo: "Pessoa física",
+                              Nome: "Maria Silva",
+                              "CPF/CNPJ": "123.456.789-09",
+                              "E-mail": "maria@email.com",
+                              Telefone: "(11) 98888-8888",
+                           },
+                        ],
+                        ["Tipo", "Nome", "CPF/CNPJ", "E-mail", "Telefone"],
+                     ),
+               },
+               {
+                  filename: "modelo-relacionamentos.xlsx",
+                  label: "XLSX",
+                  createBlob: () =>
+                     generateXlsx(
+                        [
+                           {
+                              Tipo: "Empresa",
+                              Nome: "Acme Ltda",
+                              "CPF/CNPJ": "12.345.678/0001-95",
+                              "E-mail": "financeiro@acme.com.br",
+                              Telefone: "(11) 99999-9999",
+                           },
+                           {
+                              Tipo: "Pessoa física",
+                              Nome: "Maria Silva",
+                              "CPF/CNPJ": "123.456.789-09",
+                              "E-mail": "maria@email.com",
+                              Telefone: "(11) 98888-8888",
+                           },
+                        ],
+                        ["Tipo", "Nome", "CPF/CNPJ", "E-mail", "Telefone"],
+                     ),
+               },
+            ],
+         },
+         onImport: async (rows) => {
+            if (!activeTeamId) throw new Error("Time ativo não encontrado.");
+            const parsedRows = rows.map((row, index) => {
+               const values = {
+                  kind: row.kind,
+                  name: String(row.name ?? ""),
+                  documentNumber: String(row.documentNumber ?? ""),
+                  email: String(row.email ?? ""),
+                  phone: String(row.phone ?? ""),
+               };
+               const parsed = relationshipImportRowSchema.safeParse(values);
+               return { index, parsed };
+            });
+            const invalidRows = parsedRows.filter(
+               (entry) => !entry.parsed.success,
+            );
+            if (invalidRows.length > 0) {
+               const details = invalidRows
+                  .slice(0, 3)
+                  .map((entry) => {
+                     const message = entry.parsed.success
+                        ? "Linha inválida."
+                        : getEditErrorMessage(entry.parsed.error);
+                     return `linha ${entry.index + 2}: ${message}`;
+                  })
+                  .join("; ");
+               const extra =
+                  invalidRows.length > 3
+                     ? `; mais ${invalidRows.length - 3} erro(s)`
+                     : "";
+               throw new Error(
+                  `Corrija ${invalidRows.length} linha(s) antes de importar: ${details}${extra}.`,
+               );
+            }
+
+            const importRelationships = importRelationshipsAction(collection);
+            const importResult: { value: RelationshipImportBulkOutput | null } =
+               {
+                  value: null,
+               };
+            const rowsToImport = parsedRows.flatMap((entry) => {
+               if (!entry.parsed.success) return [];
+               return [
+                  {
+                     kind: entry.parsed.data.kind,
+                     name: entry.parsed.data.name.trim(),
+                     documentNumber: normalizeImportDocument(
+                        entry.parsed.data.documentNumber,
+                     ),
+                     email: normalizeNullable(entry.parsed.data.email),
+                     phone: normalizeDigits(entry.parsed.data.phone),
+                  },
+               ];
+            });
+            const transaction = importRelationships({
+               role,
+               rows: rowsToImport,
+               onResult: (value) => {
+                  importResult.value = value;
+               },
+            });
+            const result = await Result.tryPromise({
+               try: () => transaction.isPersisted.promise,
+               catch: (error) => error,
+            });
+            if (Result.isError(result)) {
+               throw new Error(
+                  getErrorMessage(
+                     result.error,
+                     "Erro ao importar relacionamentos.",
+                  ),
+               );
+            }
+            if (importResult.value?.errors.length) {
+               throw new Error(
+                  buildImportErrorMessage(importResult.value.errors),
+               );
+            }
+            return importResult.value;
+         },
+      }),
+      [
+         activeTeamId,
+         collection,
+         generateCsv,
+         generateXlsx,
+         parseCsv,
+         parseXlsx,
+         role,
+      ],
    );
 
    const { data: liveRelationships, isLoading } = useLiveQuery(
@@ -590,7 +830,17 @@ export function RelationshipsTable({
          {
             accessorKey: "kind",
             header: "Tipo",
-            meta: { label: "Tipo", filterVariant: "select", exportable: true },
+            meta: {
+               label: "Tipo",
+               filterVariant: "select",
+               exportable: true,
+               isEditable: true,
+               cellComponent: "select",
+               editOptions: [
+                  { value: "company", label: "Empresa" },
+                  { value: "person", label: "Pessoa física" },
+               ],
+            },
             cell: ({ row }) => {
                const editing = editingId === row.original.id && editValues;
                if (editing) {
@@ -624,7 +874,14 @@ export function RelationshipsTable({
          {
             accessorKey: "name",
             header: "Nome",
-            meta: { label: "Nome", filterVariant: "text", exportable: true },
+            meta: {
+               label: "Nome",
+               filterVariant: "text",
+               exportable: true,
+               isEditable: true,
+               cellComponent: "text",
+               required: true,
+            },
             cell: ({ row }) => {
                const editing = editingId === row.original.id && editValues;
                if (editing) {
@@ -648,6 +905,8 @@ export function RelationshipsTable({
                label: "CPF/CNPJ",
                filterVariant: "text",
                exportable: true,
+               isEditable: true,
+               cellComponent: "text",
             },
             cell: ({ row }) => {
                const editing = editingId === row.original.id && editValues;
@@ -683,7 +942,13 @@ export function RelationshipsTable({
          {
             accessorKey: "email",
             header: "E-mail",
-            meta: { label: "E-mail", filterVariant: "text", exportable: true },
+            meta: {
+               label: "E-mail",
+               filterVariant: "text",
+               exportable: true,
+               isEditable: true,
+               cellComponent: "text",
+            },
             cell: ({ row }) => {
                const editing = editingId === row.original.id && editValues;
                if (editing) {
@@ -708,6 +973,8 @@ export function RelationshipsTable({
                label: "Telefone",
                filterVariant: "text",
                exportable: true,
+               isEditable: true,
+               cellComponent: "text",
             },
             cell: ({ row }) => {
                const editing = editingId === row.original.id && editValues;
@@ -1032,6 +1299,8 @@ export function RelationshipsTable({
       getCoreRowModel: getCoreRowModel(),
    });
 
+   const importApi = useDataImport({ table, config: importConfig });
+
    const selectedRows = table.getSelectedRowModel().rows;
    const selectedIds = selectedRows.map((row) => row.original.id);
    const resetSelection = () => table.resetRowSelection();
@@ -1101,6 +1370,7 @@ export function RelationshipsTable({
                   />
                </PageFilters>
                <DataTableColumnVisibility table={table} />
+               <DataImportButton api={importApi} config={importConfig} />
                <Button
                   onClick={handleOpenCreate}
                   size="icon-sm"
@@ -1121,6 +1391,11 @@ export function RelationshipsTable({
             <ScrollArea className="flex-1 min-h-0 rounded-md border bg-card">
                <Table>
                   <DataTableHeader table={table} />
+                  <DataImportSection
+                     api={importApi}
+                     config={importConfig}
+                     table={table}
+                  />
                   <DataTableBody<RelationshipsCollectionRow> table={table} />
                </Table>
                {!isLoading && table.getRowCount() === 0 ? (

--- a/apps/web/src/integrations/tanstack-db/relationships.ts
+++ b/apps/web/src/integrations/tanstack-db/relationships.ts
@@ -12,6 +12,9 @@ export type RelationshipRole = RelationshipsCollectionRow["role"];
 export type RelationshipKind = RelationshipsCollectionRow["kind"];
 export type RelationshipCreateInput = Inputs["relationships"]["create"];
 export type RelationshipUpdateInput = Inputs["relationships"]["update"];
+export type RelationshipImportBulkInput = Inputs["relationships"]["importBulk"];
+export type RelationshipImportBulkOutput =
+   Outputs["relationships"]["importBulk"];
 
 type RelationshipsCollectionOptionsParams = {
    queryClient: QueryClient;
@@ -33,6 +36,10 @@ type RelationshipUpdateActionInput = {
 
 type RelationshipIdActionInput = {
    id: string;
+};
+
+type RelationshipImportActionInput = RelationshipImportBulkInput & {
+   onResult?: (result: RelationshipImportBulkOutput) => void;
 };
 
 type RelationshipsCollection = Collection<RelationshipsCollectionRow, string>;
@@ -134,6 +141,18 @@ export function createRelationshipAction(collection: RelationshipsCollection) {
          const created = await orpc.relationships.create.call(input);
          await safeRefetchRelationships(collection);
          return created;
+      },
+   });
+}
+
+export function importRelationshipsAction(collection: RelationshipsCollection) {
+   return createOptimisticAction<RelationshipImportActionInput>({
+      onMutate: () => {},
+      mutationFn: async ({ onResult, ...input }) => {
+         const result = await orpc.relationships.importBulk.call(input);
+         onResult?.(result);
+         await safeRefetchRelationships(collection);
+         return result;
       },
    });
 }

--- a/modules/relationships/src/router/index.ts
+++ b/modules/relationships/src/router/index.ts
@@ -16,6 +16,10 @@ import { defineErrorCatalog } from "evlog";
 import { z } from "zod";
 import {
    createPartySchema,
+   isValidCnpj,
+   isValidCpf,
+   normalizeDocument,
+   normalizePhone,
    partyRoleValues,
    parties,
    updatePartySchema,
@@ -100,6 +104,21 @@ const idInput = z.object({
 
 const createInput = createPartySchema;
 const updateInput = idInput.merge(updatePartySchema);
+const importBulkInput = z.object({
+   role: relationshipRoleSchema,
+   rows: z
+      .array(
+         z.object({
+            kind: z.enum(["person", "company"]).optional(),
+            name: z.string(),
+            documentNumber: z.string().nullable().optional(),
+            email: z.string().nullable().optional(),
+            phone: z.string().nullable().optional(),
+         }),
+      )
+      .min(1, "Informe pelo menos uma linha para importar.")
+      .max(1000, "Importe no máximo 1000 linhas por vez."),
+});
 
 const cnpjLookupInput = z.object({
    cnpj: z
@@ -117,6 +136,33 @@ function roleFriendly(role: PartyRole) {
 
 function formatDuplicateMessage(role: PartyRole) {
    return `Já existe um ${roleFriendly(role)} com esse documento para este time.`;
+}
+
+function normalizeImportEmail(value: string | null | undefined) {
+   const trimmed = value?.trim().toLowerCase() ?? "";
+   return trimmed || null;
+}
+
+function inferKindFromDocument(documentNumber: string | null) {
+   if (!documentNumber) return "company";
+   const digits = documentNumber.replace(/\D/g, "");
+   if (digits.length === 11) return "person";
+   if (documentNumber.length === 14) return "company";
+   return "company";
+}
+
+function getFirstZodMessage(error: z.ZodError) {
+   return error.issues[0]?.message ?? "Linha inválida.";
+}
+
+function validateImportedDocument(
+   kind: "person" | "company",
+   document: string | null,
+) {
+   if (!document) return null;
+   if (kind === "person" && !isValidCpf(document)) return "CPF inválido.";
+   if (kind === "company" && !isValidCnpj(document)) return "CNPJ inválido.";
+   return null;
 }
 
 async function getOwnedRelationship(db: DbClient, teamId: string, id: string) {
@@ -306,6 +352,107 @@ export const create = protectedProcedure
       );
       if (Result.isError(result)) throw result.error;
       return result.value;
+   });
+
+export const importBulk = protectedProcedure
+   .input(importBulkInput)
+   .handler(async ({ context, input }) => {
+      const validationErrors: Array<{ index: number; message: string }> = [];
+      const validRows = input.rows
+         .map((row, index) => {
+            const documentNumber = normalizeDocument(row.documentNumber);
+            const kind = row.kind ?? inferKindFromDocument(documentNumber);
+            const documentError = validateImportedDocument(
+               kind,
+               documentNumber,
+            );
+            if (documentError) {
+               validationErrors.push({ index, message: documentError });
+               return null;
+            }
+
+            const candidate = {
+               role: input.role,
+               kind,
+               name: row.name,
+               documentNumber,
+               email: normalizeImportEmail(row.email),
+               phone: normalizePhone(row.phone),
+            };
+            const parsed = createPartySchema.safeParse(candidate);
+            if (!parsed.success) {
+               validationErrors.push({
+                  index,
+                  message: getFirstZodMessage(parsed.error),
+               });
+               return null;
+            }
+            return { index, data: parsed.data };
+         })
+         .filter((row): row is NonNullable<typeof row> => row !== null);
+
+      if (validationErrors.length > 0) {
+         return { created: 0, skipped: 0, errors: validationErrors };
+      }
+
+      const imported = await Result.tryPromise({
+         try: () =>
+            context.db.transaction(async (tx) => {
+               let created = 0;
+               let skipped = 0;
+               const errors = [...validationErrors];
+               const seenDocuments = new Set<string>();
+
+               for (const row of validRows) {
+                  if (row.data.documentNumber) {
+                     const documentKey = row.data.documentNumber;
+                     if (seenDocuments.has(documentKey)) {
+                        skipped += 1;
+                        continue;
+                     }
+                     seenDocuments.add(documentKey);
+
+                     const existing = await tx.query.parties.findFirst({
+                        where: (fields, { and, eq }) =>
+                           and(
+                              eq(fields.teamId, context.teamId),
+                              eq(fields.role, input.role),
+                              eq(fields.documentNumber, documentKey),
+                           ),
+                        columns: { id: true },
+                     });
+                     if (existing) {
+                        skipped += 1;
+                        continue;
+                     }
+                  }
+
+                  const [inserted] = await tx
+                     .insert(parties)
+                     .values({ ...row.data, teamId: context.teamId })
+                     .returning({ id: parties.id });
+
+                  if (!inserted) {
+                     errors.push({
+                        index: row.index,
+                        message: "Falha ao importar esta linha.",
+                     });
+                     continue;
+                  }
+
+                  created += 1;
+               }
+
+               return { created, skipped, errors };
+            }),
+         catch: () =>
+            new RelationshipsRouterError({
+               error: relationshipsRouterErrors.INTERNAL(),
+               message: "Falha ao importar relacionamentos.",
+            }),
+      });
+      if (Result.isError(imported)) throw imported.error;
+      return imported.value;
    });
 
 export const update = protectedProcedure

--- a/modules/relationships/src/router/index.ts
+++ b/modules/relationships/src/router/index.ts
@@ -5,6 +5,7 @@ import {
    asc,
    eq,
    ilike,
+   inArray,
    isNotNull,
    isNull,
    ne,
@@ -14,12 +15,14 @@ import {
 import { Result, TaggedError } from "better-result";
 import { defineErrorCatalog } from "evlog";
 import { z } from "zod";
+import { team, teamMember } from "@core/database/schemas/auth";
 import {
    createPartySchema,
    isValidCnpj,
    isValidCpf,
    normalizeDocument,
    normalizePhone,
+   type NewParty,
    partyRoleValues,
    parties,
    updatePartySchema,
@@ -357,6 +360,48 @@ export const create = protectedProcedure
 export const importBulk = protectedProcedure
    .input(importBulkInput)
    .handler(async ({ context, input }) => {
+      const accessResult = await Result.tryPromise({
+         try: async () => {
+            const [ownedTeams, memberships] = await Promise.all([
+               context.db
+                  .select({ id: team.id })
+                  .from(team)
+                  .where(
+                     and(
+                        eq(team.id, context.teamId),
+                        eq(team.organizationId, context.organizationId),
+                     ),
+                  )
+                  .limit(1),
+               context.db
+                  .select({ id: teamMember.id })
+                  .from(teamMember)
+                  .where(
+                     and(
+                        eq(teamMember.teamId, context.teamId),
+                        eq(teamMember.userId, context.userId),
+                     ),
+                  )
+                  .limit(1),
+            ]);
+            const ownedTeam = ownedTeams[0];
+            const membership = memberships[0];
+            return { ownedTeam, membership };
+         },
+         catch: () =>
+            new RelationshipsRouterError({
+               error: relationshipsRouterErrors.INTERNAL(),
+               message: "Falha ao verificar permissão do time.",
+            }),
+      });
+      if (Result.isError(accessResult)) throw accessResult.error;
+      if (!accessResult.value.ownedTeam || !accessResult.value.membership) {
+         throw new RelationshipsRouterError({
+            error: relationshipsRouterErrors.FORBIDDEN(),
+            message: "Ação não permitida para este time.",
+         });
+      }
+
       const validationErrors: Array<{ index: number; message: string }> = [];
       const validRows = input.rows
          .map((row, index) => {
@@ -395,55 +440,75 @@ export const importBulk = protectedProcedure
          return { created: 0, skipped: 0, errors: validationErrors };
       }
 
+      const documentKeys = Array.from(
+         new Set(
+            validRows
+               .map((row) => row.data.documentNumber)
+               .filter((document): document is string => document !== null),
+         ),
+      );
+
+      const existingDocumentsResult = await Result.tryPromise({
+         try: () => {
+            if (documentKeys.length === 0) return Promise.resolve([]);
+            return context.db
+               .select({ documentNumber: parties.documentNumber })
+               .from(parties)
+               .where(
+                  and(
+                     eq(parties.teamId, context.teamId),
+                     eq(parties.role, input.role),
+                     inArray(parties.documentNumber, documentKeys),
+                  ),
+               );
+         },
+         catch: () =>
+            new RelationshipsRouterError({
+               error: relationshipsRouterErrors.INTERNAL(),
+               message: "Falha ao verificar documentos duplicados.",
+            }),
+      });
+      if (Result.isError(existingDocumentsResult)) {
+         throw existingDocumentsResult.error;
+      }
+
+      let skipped = 0;
+      const seenDocuments = new Set(
+         existingDocumentsResult.value
+            .map((row) => row.documentNumber)
+            .filter((document): document is string => document !== null),
+      );
+      const rowsToInsert: NewParty[] = [];
+      for (const row of validRows) {
+         const documentKey = row.data.documentNumber;
+         if (documentKey) {
+            if (seenDocuments.has(documentKey)) {
+               skipped += 1;
+               continue;
+            }
+            seenDocuments.add(documentKey);
+         }
+         rowsToInsert.push({ ...row.data, teamId: context.teamId });
+      }
+
+      if (rowsToInsert.length === 0) {
+         return { created: 0, skipped, errors: [] };
+      }
+
       const imported = await Result.tryPromise({
-         try: () =>
+         try: async () =>
             context.db.transaction(async (tx) => {
-               let created = 0;
-               let skipped = 0;
-               const errors = [...validationErrors];
-               const seenDocuments = new Set<string>();
+               const inserted = await tx
+                  .insert(parties)
+                  .values(rowsToInsert)
+                  .onConflictDoNothing()
+                  .returning({ id: parties.id });
 
-               for (const row of validRows) {
-                  if (row.data.documentNumber) {
-                     const documentKey = row.data.documentNumber;
-                     if (seenDocuments.has(documentKey)) {
-                        skipped += 1;
-                        continue;
-                     }
-                     seenDocuments.add(documentKey);
-
-                     const existing = await tx.query.parties.findFirst({
-                        where: (fields, { and, eq }) =>
-                           and(
-                              eq(fields.teamId, context.teamId),
-                              eq(fields.role, input.role),
-                              eq(fields.documentNumber, documentKey),
-                           ),
-                        columns: { id: true },
-                     });
-                     if (existing) {
-                        skipped += 1;
-                        continue;
-                     }
-                  }
-
-                  const [inserted] = await tx
-                     .insert(parties)
-                     .values({ ...row.data, teamId: context.teamId })
-                     .returning({ id: parties.id });
-
-                  if (!inserted) {
-                     errors.push({
-                        index: row.index,
-                        message: "Falha ao importar esta linha.",
-                     });
-                     continue;
-                  }
-
-                  created += 1;
-               }
-
-               return { created, skipped, errors };
+               return {
+                  created: inserted.length,
+                  skipped: skipped + rowsToInsert.length - inserted.length,
+                  errors: [],
+               };
             }),
          catch: () =>
             new RelationshipsRouterError({


### PR DESCRIPTION
## Resumo
- Adiciona `relationships.importBulk`
- Adiciona action TanStack DB para importação em lote
- Habilita importação CSV/XLSX em Clientes e Fornecedores
- Estende DataImport para duplicidade customizada e resumo de sucesso
- Estende cobertura E2E de modelos/importação

## Validação
- ✅ `bun --filter @modules/relationships typecheck`
- ✅ `bun nx run web:typecheck`
- ✅ `bun nx run web-e2e:typecheck`
- ✅ `git diff --check`
- ⚠️ `bunx playwright test -c apps/web-e2e/playwright.config.ts apps/web-e2e/tests/import-templates.spec.ts` bloqueado por resolução existente de módulo: `dayjs/plugin/customParseFormat` em `core/utils/dist/dates.js`