### PR TITLE
fix: preserve PR review inline comments

### DIFF
--- a/.agents/skills/code-review/references/pr-review.md
+++ b/.agents/skills/code-review/references/pr-review.md
@@ -58,14 +58,14 @@ gh run view "$RUN_ID" --log-failed > .agent-artifacts/pr-review/ci-failed.log
 
 Cada finding publicado precisa ter evidencia concreta:
 
-- diff hunk e linha exata elegivel para comentario;
+- diff hunk e linha elegivel para comentario, preferindo a linha exata do achado;
 - 60-100 linhas ao redor do arquivo atual;
 - imports/exports relacionados quando a causa for cross-file;
 - testes proximos ou ausencia relevante de teste;
 - regra aplicavel de `AGENTS.md` ou skill;
 - comentario anterior do bot quando houver risco de duplicado.
 
-Se a linha exata nao existe no patch atual, nao publicar comentario. Guarde como descartado/artefato para depuracao. Coloque no summary apenas se for risco real e marcado como baixa confianca.
+Se a linha exata nao existe no patch atual, tente ancorar o comentario na linha comentavel mais proxima do mesmo arquivo quando ela estiver perto do achado, e deixe claro no corpo qual linha o achado apontava originalmente. Se varios achados cairem na mesma ancora, combine em um comentario. Se o arquivo nao aparece no diff ou nao ha linha comentavel proxima, guarde como descartado/artefato para depuracao e coloque no summary apenas se for risco real.
 
 ## Gates anti-ruido
 
@@ -127,7 +127,7 @@ Entrada:
 - checks relevantes.
 
 Retorne JSON no schema Finding[]. Cada finding precisa ter impacto concreto,
-evidencia, path, line, side, severity e confidence. A linha precisa existir no diff.
+evidencia, path, line, side, severity e confidence. Prefira a linha exata do achado; se ela nao estiver comentavel, use a linha comentavel mais proxima no mesmo arquivo e mencione a linha original no corpo.
 ```
 
 ## Prompt de stale/dedupe
@@ -171,7 +171,7 @@ Impacto: [bug ou risco especifico].
 Correcao: [mudanca pequena].
 ```
 
-Nao publicar comentario inline se ele nao couber nesse formato ou se a linha nao for exatamente comentavel no diff.
+Nao publicar comentario inline se ele nao couber nesse formato ou se nao houver linha comentavel no mesmo arquivo do diff.
 
 ## Review de CI
 

--- a/.flue/agents/pr-review.ts
+++ b/.flue/agents/pr-review.ts
@@ -47,7 +47,7 @@ const reviewResultSchema = v.object({
    comments: v.optional(v.array(reviewCommentSchema), []),
 });
 
-type ReviewComment = v.InferOutput<typeof reviewCommentSchema>;
+export type ReviewComment = v.InferOutput<typeof reviewCommentSchema>;
 
 const prReviewAgentErrors = defineErrorCatalog("flue.pr-review.agent", {
    BAD_PAYLOAD: {
@@ -107,7 +107,7 @@ function formatInlineComment(comment: ReviewComment) {
 ${comment.body}`;
 }
 
-function parseDiffReviewLines(patch: string) {
+export function parseDiffReviewLines(patch: string) {
    const allowed = new Map<string, { left: Set<number>; right: Set<number> }>();
    let currentPath: string | undefined;
    let oldLine = 0;
@@ -171,7 +171,102 @@ function hasActionableContent(comment: ReviewComment) {
    );
 }
 
-function splitValidInlineComments(
+const MAX_FALLBACK_LINE_DISTANCE = 30;
+
+function findNearestReviewLine(lines: Set<number>, targetLine: number) {
+   let nearestLine: number | undefined;
+
+   for (const line of lines) {
+      if (nearestLine === undefined) {
+         nearestLine = line;
+         continue;
+      }
+
+      const currentDistance = Math.abs(line - targetLine);
+      const nearestDistance = Math.abs(nearestLine - targetLine);
+      if (
+         currentDistance < nearestDistance ||
+         (currentDistance === nearestDistance && line < nearestLine)
+      ) {
+         nearestLine = line;
+      }
+   }
+
+   if (nearestLine === undefined) return undefined;
+
+   const distance = Math.abs(nearestLine - targetLine);
+   if (distance > MAX_FALLBACK_LINE_DISTANCE) return undefined;
+
+   return nearestLine;
+}
+
+function withFallbackAnchor(comment: ReviewComment, fallbackLine: number) {
+   return {
+      ...comment,
+      line: fallbackLine,
+      body: `${comment.body}\n\nObservação: o achado apontava para a linha ${comment.line}, que não está comentável no diff atual; ancorei na linha alterada mais próxima do mesmo arquivo para não perder o comentário inline.`,
+   };
+}
+
+function severityRank(severity: ReviewComment["severity"]) {
+   if (severity === "critical") return 5;
+   if (severity === "major") return 4;
+   if (severity === "minor") return 3;
+   if (severity === "trivial") return 2;
+   return 1;
+}
+
+function highestSeverity(comments: Array<ReviewComment>) {
+   let selected: ReviewComment["severity"] = "info";
+
+   for (const comment of comments) {
+      if (severityRank(comment.severity) > severityRank(selected)) {
+         selected = comment.severity;
+      }
+   }
+
+   return selected;
+}
+
+function combineAnchoredComments(comments: Array<ReviewComment>) {
+   const grouped = new Map<string, Array<ReviewComment>>();
+
+   for (const comment of comments) {
+      const key = `${comment.path}\u0000${comment.side}\u0000${comment.line}`;
+      const group = grouped.get(key) ?? [];
+      group.push(comment);
+      grouped.set(key, group);
+   }
+
+   const combined: Array<ReviewComment> = [];
+   for (const group of grouped.values()) {
+      const first = group[0];
+      if (!first) continue;
+
+      if (group.length === 1) {
+         combined.push(first);
+         continue;
+      }
+
+      combined.push({
+         ...first,
+         severity: highestSeverity(group),
+         confidence: Math.max(...group.map((comment) => comment.confidence)),
+         actionable: group.some((comment) => comment.actionable),
+         title: `${group.length} achados nesta linha`,
+         body: group
+            .map(
+               (comment, index) =>
+                  `**${index + 1}. ${comment.title}**\n\n${comment.body}`,
+            )
+            .join("\n\n---\n\n"),
+      });
+   }
+
+   return combined;
+}
+
+export function splitValidInlineComments(
    comments: Array<ReviewComment>,
    patch: string,
 ) {
@@ -217,18 +312,25 @@ function splitValidInlineComments(
 
       const lineSet =
          comment.side === "LEFT" ? fileLines.left : fileLines.right;
-      if (!lineSet.has(comment.line)) {
-         skipped.push({
-            ...comment,
-            reason: "Linha não é comentável no diff atual.",
-         });
+      if (lineSet.has(comment.line)) {
+         valid.push(comment);
          continue;
       }
 
-      valid.push(comment);
+      const fallbackLine = findNearestReviewLine(lineSet, comment.line);
+      if (fallbackLine !== undefined) {
+         valid.push(withFallbackAnchor(comment, fallbackLine));
+         continue;
+      }
+
+      skipped.push({
+         ...comment,
+         reason:
+            "Arquivo aparece no diff, mas não possui linha comentável próxima o suficiente.",
+      });
    }
 
-   return { valid, skipped };
+   return { valid: combineAnchoredComments(valid), skipped };
 }
 
 async function publishReview({
@@ -263,6 +365,17 @@ async function publishReview({
    }));
 
    const [owner, repoName] = repo.split("/");
+   if (!owner || !repoName) {
+      return Result.err(
+         new PrReviewAgentError({
+            error: prReviewAgentErrors.BAD_PAYLOAD(),
+            message: "repo inválido. Use owner/repo.",
+            repo,
+            prNumber,
+         }),
+      );
+   }
+
    const octokit = new Octokit({ auth: token });
    return Result.tryPromise({
       try: async () => {
@@ -468,7 +581,7 @@ export default async function ({ init, payload, env }: FlueContext) {
       JSON.stringify(promptContextSize, null, 2),
    );
 
-   const task = `Revise a PR #${prNumber} usando a skill de code review do Montte. Use apenas o contexto pré-coletado em args. Não rode comandos nem colete dados pelo GitHub. Retorne comentários inline somente para linhas existentes no patch, com severidade, confiança >= 0.7 e correção concreta.`;
+   const task = `Revise a PR #${prNumber} usando a skill de code review do Montte. Use apenas o contexto pré-coletado em args. Não rode comandos nem colete dados pelo GitHub. Todo achado acionável citado no summary também deve aparecer em comments[]; summary não substitui comentário inline. Retorne comentários inline com severidade, confiança >= 0.7 e correção concreta. Se a linha exata não estiver disponível, use a linha numérica comentável mais próxima no mesmo arquivo.`;
 
    const modelHarnessResult = await Result.tryPromise({
       try: () =>

--- a/__tests__/pr-review-inline-comments.test.ts
+++ b/__tests__/pr-review-inline-comments.test.ts
@@ -1,0 +1,173 @@
+import { beforeAll, describe, expect, it } from "vitest";
+
+type ReviewComment = {
+   path: string;
+   line: number;
+   side: "RIGHT" | "LEFT";
+   severity: "critical" | "major" | "minor" | "trivial" | "info";
+   confidence: number;
+   actionable: boolean;
+   title: string;
+   body: string;
+};
+
+type DiffReviewLines = Map<string, { left: Set<number>; right: Set<number> }>;
+
+let parseDiffReviewLines: (patch: string) => DiffReviewLines;
+let splitValidInlineComments: (
+   comments: Array<ReviewComment>,
+   patch: string,
+) => {
+   valid: Array<ReviewComment>;
+   skipped: Array<ReviewComment & { reason: string }>;
+};
+
+beforeAll(async () => {
+   const modulePath = "../.flue/agents/pr-review.ts";
+   const reviewModule = await import(modulePath);
+   parseDiffReviewLines = reviewModule.parseDiffReviewLines;
+   splitValidInlineComments = reviewModule.splitValidInlineComments;
+});
+
+const patch = [
+   "diff --git a/modules/relationships/src/router/index.ts b/modules/relationships/src/router/index.ts",
+   "index 1111111..2222222 100644",
+   "--- a/modules/relationships/src/router/index.ts",
+   "+++ b/modules/relationships/src/router/index.ts",
+   "@@ -452,6 +452,11 @@ export const relationshipsRouter = router({",
+   "    create: protectedProcedure",
+   "       .input(createPartyInput)",
+   "       .handler(async ({ context, input }) => {",
+   "+         const importBulk = protectedProcedure",
+   "+            .input(importBulkInput)",
+   "+            .handler(async ({ context, input }) => {",
+   "+               for (const row of input.rows) {",
+   "+                  await context.db.insert(parties).values(row);",
+   "       }),",
+   " });",
+   "diff --git a/apps/web/src/features/relationships/relationships-table.tsx b/apps/web/src/features/relationships/relationships-table.tsx",
+   "index 3333333..4444444 100644",
+   "--- a/apps/web/src/features/relationships/relationships-table.tsx",
+   "+++ b/apps/web/src/features/relationships/relationships-table.tsx",
+   "@@ -506,3 +506,5 @@ function getImportSuccessMessage(value: ImportResult) {",
+   "+   return `${value.created} relacionamento(s) importado(s). ${value.skipped} duplicado(s) ignorado(s).`;",
+   "+}",
+].join("\n");
+
+function comment(input: Partial<ReviewComment>): ReviewComment {
+   return {
+      path: "modules/relationships/src/router/index.ts",
+      line: 455,
+      side: "RIGHT",
+      severity: "major",
+      confidence: 0.9,
+      actionable: true,
+      title: "Comentário publicável",
+      body: "Correção: ajuste o handler para preservar o contrato.",
+      ...input,
+   };
+}
+
+describe("PR review inline comments", () => {
+   it("mapeia linhas exatas comentáveis no diff", () => {
+      const lines = parseDiffReviewLines(patch);
+
+      expect(
+         lines.get("modules/relationships/src/router/index.ts")?.right.has(455),
+      ).toBe(true);
+      expect(
+         lines
+            .get("apps/web/src/features/relationships/relationships-table.tsx")
+            ?.right.has(507),
+      ).toBe(true);
+   });
+
+   it("mantém comentário quando a linha informada existe no patch", () => {
+      const result = splitValidInlineComments([comment({ line: 455 })], patch);
+
+      expect(result.valid).toHaveLength(1);
+      expect(result.valid[0]?.line).toBe(455);
+      expect(result.skipped).toHaveLength(0);
+   });
+
+   it("ancora achado aproximado na linha comentável mais próxima do mesmo arquivo", () => {
+      const result = splitValidInlineComments([comment({ line: 464 })], patch);
+
+      expect(result.valid).toHaveLength(1);
+      expect(result.valid[0]?.line).toBe(461);
+      expect(result.valid[0]?.body).toContain("linha 464");
+      expect(result.valid[0]?.body).toContain("linha alterada mais próxima");
+      expect(result.skipped).toHaveLength(0);
+   });
+
+   it("usa fallback por arquivo em vez de descartar linha fora do diff", () => {
+      const result = splitValidInlineComments(
+         [
+            comment({
+               path: "apps/web/src/features/relationships/relationships-table.tsx",
+               line: 530,
+               severity: "minor",
+            }),
+         ],
+         patch,
+      );
+
+      expect(result.valid).toHaveLength(1);
+      expect(result.valid[0]?.path).toBe(
+         "apps/web/src/features/relationships/relationships-table.tsx",
+      );
+      expect(result.valid[0]?.line).toBe(507);
+      expect(result.skipped).toHaveLength(0);
+   });
+
+   it("combina achados que caem na mesma âncora", () => {
+      const result = splitValidInlineComments(
+         [
+            comment({
+               line: 464,
+               severity: "minor",
+               title: "Timeout ausente",
+            }),
+            comment({
+               line: 465,
+               severity: "critical",
+               title: "Ownership ausente",
+            }),
+         ],
+         patch,
+      );
+
+      expect(result.valid).toHaveLength(1);
+      expect(result.valid[0]?.line).toBe(461);
+      expect(result.valid[0]?.severity).toBe("critical");
+      expect(result.valid[0]?.title).toBe("2 achados nesta linha");
+      expect(result.valid[0]?.body).toContain("Timeout ausente");
+      expect(result.valid[0]?.body).toContain("Ownership ausente");
+   });
+
+   it("descarta fallback distante para evitar comentário em trecho não relacionado", () => {
+      const result = splitValidInlineComments([comment({ line: 900 })], patch);
+
+      expect(result.valid).toHaveLength(0);
+      expect(result.skipped).toEqual([
+         expect.objectContaining({
+            reason:
+               "Arquivo aparece no diff, mas não possui linha comentável próxima o suficiente.",
+         }),
+      ]);
+   });
+
+   it("ainda descarta comentário quando o arquivo não aparece no diff", () => {
+      const result = splitValidInlineComments(
+         [comment({ path: "modules/relationships/src/missing.ts" })],
+         patch,
+      );
+
+      expect(result.valid).toHaveLength(0);
+      expect(result.skipped).toEqual([
+         expect.objectContaining({
+            reason: "Arquivo não aparece no diff atual.",
+         }),
+      ]);
+   });
+});


### PR DESCRIPTION
## Resumo
- evita que achados acionáveis fiquem só no summary quando a linha exata não é comentável
- ancora comentários na linha comentável mais próxima do mesmo arquivo
- combina múltiplos achados que caem na mesma âncora
- atualiza a skill de PR review para alinhar a regra de fallback

## Validação
- bunx vitest run __tests__/pr-review-inline-comments.test.ts
- git diff --check