### PR TITLE
fix: avoid release notes validation name collision

### DIFF
--- a/.flue/agents/release-notes.ts
+++ b/.flue/agents/release-notes.ts
@@ -170,8 +170,13 @@ export default async function ({ init, payload }: FlueContext) {
    });
    if (Result.isError(filesResult)) throw filesResult.error;
 
-   const { changes, skill, releaseNotes, automatedReleaseNotes, validation } =
-      filesResult.value;
+   const {
+      changes,
+      skill,
+      releaseNotes,
+      automatedReleaseNotes,
+      validation: validationReferenceContent,
+   } = filesResult.value;
 
    await Result.tryPromise({
       try: () => rm(outputFile, { force: true }),
@@ -200,7 +205,7 @@ ${automatedReleaseNotes}
 
 Referência release-validation.md:
 
-${validation}
+${validationReferenceContent}
 
 Mudanças normalizadas:
 


### PR DESCRIPTION
## Resumo
- renomeia o conteúdo da referência de validação para evitar colisão com o resultado da validação
- corrige falha de build do Flue no agente de release notes

## Validação
- ./node_modules/.bin/flue build --target node
- git diff --check