### PR TITLE
MON-1151: adicionar forma de pagamento em Mais opções

### DIFF
--- a/apps/web/src/integrations/tanstack-db/transactions.ts
+++ b/apps/web/src/integrations/tanstack-db/transactions.ts
@@ -53,6 +53,7 @@ type TransactionCreateActionInput = {
 
 type TransactionsWhereInput = {
    bankAccountId?: string;
+   paymentMethod?: string;
    relationshipId?: string;
    overdueOnly?: boolean;
    search?: string;
@@ -135,6 +136,9 @@ function parseTransactionsWhere(options: LoadSubsetOptions | undefined) {
                if (key === "bankAccountId" && typeof value === "string") {
                   return { bankAccountId: value };
                }
+               if (key === "paymentMethod" && typeof value === "string") {
+                  return { paymentMethod: value };
+               }
                if (key === "relationshipId" && typeof value === "string") {
                   return { relationshipId: value };
                }
@@ -178,6 +182,7 @@ function parseTransactionSortId(value: string): TransactionSortId | undefined {
       case "date":
       case "dueDate":
       case "name":
+      case "paymentMethod":
       case "relationshipName":
       case "status":
       case "type":
@@ -214,6 +219,7 @@ function transactionsInputFromLoadSubsetOptions(
       status:
          where.status && where.status.length > 0 ? where.status : base.status,
       bankAccountId: where.bankAccountId ?? base.bankAccountId,
+      paymentMethod: where.paymentMethod,
       relationshipId: where.relationshipId ?? base.relationshipId,
       sorting,
    };

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-form-sheet.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-form-sheet.tsx
@@ -103,7 +103,22 @@ const TYPE_OPTIONS: { value: TransactionType; label: string }[] = [
 
 type TransactionStatus = "paid" | "pending";
 type StatusOption = { value: TransactionStatus; label: string };
+type PaymentMethod = NonNullable<TransactionCreateInput["paymentMethod"]>;
 type RecurrenceFrequency = "daily" | "weekly" | "biweekly" | "monthly";
+
+const PAYMENT_METHOD_NONE_VALUE = "__none";
+
+const PAYMENT_METHOD_OPTIONS: { value: PaymentMethod; label: string }[] = [
+   { value: "pix", label: "Pix" },
+   { value: "credit_card", label: "Cartão de crédito" },
+   { value: "debit_card", label: "Cartão de débito" },
+   { value: "boleto", label: "Boleto" },
+   { value: "cash", label: "Dinheiro" },
+   { value: "transfer", label: "Transferência" },
+   { value: "cheque", label: "Cheque" },
+   { value: "automatic_debit", label: "Débito automático" },
+   { value: "other", label: "Outro" },
+];
 
 const STATUS_OPTIONS: StatusOption[] = [
    { value: "paid", label: "Efetivado" },
@@ -124,6 +139,12 @@ const ATTACHMENT_MAX_FILES = 5;
 
 function parseStatus(value: string): TransactionStatus | undefined {
    return STATUS_OPTIONS.find((s) => s.value === value)?.value;
+}
+
+function parsePaymentMethod(value: string): PaymentMethod | "" | undefined {
+   if (value === PAYMENT_METHOD_NONE_VALUE) return "";
+   return PAYMENT_METHOD_OPTIONS.find((option) => option.value === value)
+      ?.value;
 }
 
 function parseRecurrenceFrequency(
@@ -153,6 +174,19 @@ const formSchema = z
          .positive("Valor deve ser maior que zero."),
       date: z.string().min(1, "Data é obrigatória."),
       status: z.enum(["pending", "paid"]),
+      paymentMethod: z
+         .enum([
+            "pix",
+            "credit_card",
+            "debit_card",
+            "boleto",
+            "cash",
+            "transfer",
+            "other",
+            "cheque",
+            "automatic_debit",
+         ])
+         .or(z.literal("")),
       ignored: z.boolean(),
       isInstallment: z.boolean(),
       installmentCount: z
@@ -318,6 +352,7 @@ const DEFAULT_VALUES: FormValues = {
    amount: 0,
    date: dayjs().format("YYYY-MM-DD"),
    status: "paid",
+   paymentMethod: "",
    ignored: false,
    isInstallment: false,
    installmentCount: 2,
@@ -717,7 +752,7 @@ export function TransactionFormSheet({
                value.type === "transfer" ? null : value.categoryId || null,
             attachments,
             description: value.description.trim() || null,
-            paymentMethod: null,
+            paymentMethod: value.paymentMethod || null,
          });
       },
    });
@@ -1284,6 +1319,43 @@ export function TransactionFormSheet({
                                  {STATUS_OPTIONS.map((o) => (
                                     <SelectItem key={o.value} value={o.value}>
                                        {o.label}
+                                    </SelectItem>
+                                 ))}
+                              </SelectContent>
+                           </Select>
+                        </Field>
+                     )}
+                  </form.Field>
+
+                  <form.Field name="paymentMethod">
+                     {(field) => (
+                        <Field>
+                           <FieldLabel htmlFor={field.name}>
+                              Forma de pagamento
+                           </FieldLabel>
+                           <Select
+                              value={
+                                 field.state.value || PAYMENT_METHOD_NONE_VALUE
+                              }
+                              onValueChange={(value) => {
+                                 const parsed = parsePaymentMethod(value);
+                                 if (parsed === undefined) return;
+                                 field.handleChange(parsed);
+                              }}
+                           >
+                              <SelectTrigger id={field.name} name={field.name}>
+                                 <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                 <SelectItem value={PAYMENT_METHOD_NONE_VALUE}>
+                                    Não informado
+                                 </SelectItem>
+                                 {PAYMENT_METHOD_OPTIONS.map((option) => (
+                                    <SelectItem
+                                       key={option.value}
+                                       value={option.value}
+                                    >
+                                       {option.label}
                                     </SelectItem>
                                  ))}
                               </SelectContent>

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-sorting.ts
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transaction-sorting.ts
@@ -9,6 +9,7 @@ export const transactionSortIdSchema = z.enum([
    "date",
    "dueDate",
    "name",
+   "paymentMethod",
    "relationshipName",
    "status",
    "type",

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-columns.tsx
@@ -47,6 +47,27 @@ export type CategoryOption = { id: string; name: string };
 export type CreditCardOption = { id: string; name: string };
 export type RelationshipOption = { id: string; name: string };
 
+type PaymentMethod = NonNullable<TransactionRow["paymentMethod"]>;
+
+const PAYMENT_METHOD_NONE_VALUE = "__none";
+
+const PAYMENT_METHOD_OPTIONS: { value: PaymentMethod; label: string }[] = [
+   { value: "pix", label: "Pix" },
+   { value: "credit_card", label: "Cartão de crédito" },
+   { value: "debit_card", label: "Cartão de débito" },
+   { value: "boleto", label: "Boleto" },
+   { value: "cash", label: "Dinheiro" },
+   { value: "transfer", label: "Transferência" },
+   { value: "cheque", label: "Cheque" },
+   { value: "automatic_debit", label: "Débito automático" },
+   { value: "other", label: "Outro" },
+];
+
+const PAYMENT_METHOD_EDIT_OPTIONS = [
+   { value: PAYMENT_METHOD_NONE_VALUE, label: "Não informado" },
+   ...PAYMENT_METHOD_OPTIONS,
+];
+
 export function formatBRL(value: string | number): string {
    const raw = String(value).trim();
    return format(of(raw === "" ? "0" : raw, "BRL"), "pt-BR");
@@ -339,6 +360,38 @@ export function buildTransactionColumns(options?: {
                onSave={async (value) => dispatchPatch(row, { type: value })}
                options={typeOptions}
                value={row.original.type}
+            />
+         ),
+      },
+      {
+         accessorKey: "paymentMethod",
+         header: "Forma de pagamento",
+         meta: {
+            label: "Forma de pagamento",
+            cellComponent: "select",
+            isEditable: true,
+            editMode: "inline",
+            bulkEditIcon: CreditCard,
+            bulkEditAction: "Definir forma de pagamento",
+            editOptions: PAYMENT_METHOD_EDIT_OPTIONS,
+            filterVariant: "select",
+            groupable: true,
+            formatGroupLabel: (value) =>
+               PAYMENT_METHOD_EDIT_OPTIONS.find(
+                  (option) => option.value === value,
+               )?.label ?? "Não informado",
+         },
+         cell: ({ row }) => (
+            <InlineEditSelect
+               ariaLabel="Forma de pagamento"
+               onSave={async (value) =>
+                  dispatchPatch(row, {
+                     paymentMethod:
+                        value === PAYMENT_METHOD_NONE_VALUE ? null : value,
+                  })
+               }
+               options={PAYMENT_METHOD_EDIT_OPTIONS}
+               value={row.original.paymentMethod ?? PAYMENT_METHOD_NONE_VALUE}
             />
          ),
       },

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
@@ -33,6 +33,7 @@ import {
    createCollection,
    eq,
    ilike,
+   isNull,
    or,
    useLiveQuery,
 } from "@tanstack/react-db";
@@ -136,6 +137,7 @@ const routeApi = getRouteApi(
 );
 
 type ImportLookupItem = { id: string; name: string };
+type PaymentMethod = NonNullable<TransactionCreateInput["paymentMethod"]>;
 function isTransactionStatus(value: unknown): value is "pending" | "paid" {
    return value === "pending" || value === "paid";
 }
@@ -183,6 +185,10 @@ const IMPORT_HEADER_LABELS: Record<string, string> = {
    cliente: "Cliente",
    fornecedor: "Fornecedor",
    cartao: "Cartão",
+   formapagamento: "Forma de pagamento",
+   formadepagamento: "Forma de pagamento",
+   paymentmethod: "Forma de pagamento",
+   payment: "Forma de pagamento",
    card: "Cartão",
    creditcard: "Cartão",
    creditcardname: "Cartão",
@@ -296,6 +302,34 @@ function parseImportType(
 function cleanImportText(value: unknown): string {
    const text = String(value ?? "").trim();
    return text === "-" ? "" : text;
+}
+
+function parseImportPaymentMethod(value: unknown): PaymentMethod | null {
+   const normalized = normalizeImportLookup(value);
+   if (!normalized) return null;
+   if (normalized === "pix") return "pix";
+   if (normalized.includes("credito") || normalized.includes("crédito")) {
+      return "credit_card";
+   }
+   if (normalized.includes("debito") || normalized.includes("débito")) {
+      if (
+         normalized.includes("automatico") ||
+         normalized.includes("automático")
+      ) {
+         return "automatic_debit";
+      }
+      return "debit_card";
+   }
+   if (normalized.includes("boleto")) return "boleto";
+   if (normalized.includes("dinheiro") || normalized.includes("cash")) {
+      return "cash";
+   }
+   if (normalized.includes("transfer")) return "transfer";
+   if (normalized.includes("cheque")) return "cheque";
+   if (normalized.includes("outro") || normalized.includes("other")) {
+      return "other";
+   }
+   return null;
 }
 
 function parseImportStatus(value: unknown): {
@@ -649,6 +683,23 @@ export function TransactionsList() {
             );
          }
 
+         const paymentMethodFilterValue = columnFilters.find(
+            (filter) => filter.id === "paymentMethod",
+         )?.value;
+         if (paymentMethodFilterValue === "__none") {
+            query = query.where(({ transaction }) =>
+               isNull(transaction.paymentMethod),
+            );
+         }
+         if (
+            typeof paymentMethodFilterValue === "string" &&
+            paymentMethodFilterValue !== "__none"
+         ) {
+            query = query.where(({ transaction }) =>
+               eq(transaction.paymentMethod, paymentMethodFilterValue),
+            );
+         }
+
          const normalizedSorting = normalizeTransactionSorting(sorting);
          if (normalizedSorting.length > 0) {
             for (const rule of normalizedSorting) {
@@ -692,6 +743,12 @@ export function TransactionsList() {
                   case "name":
                      query = query.orderBy(
                         ({ transaction }) => transaction.name,
+                        rule.desc ? "desc" : "asc",
+                     );
+                     break;
+                  case "paymentMethod":
+                     query = query.orderBy(
+                        ({ transaction }) => transaction.paymentMethod,
                         rule.desc ? "desc" : "asc",
                      );
                      break;
@@ -1285,6 +1342,7 @@ export function TransactionsList() {
                   safeCreditCards,
                   row.creditCardName,
                ),
+               paymentMethod: parseImportPaymentMethod(row.paymentMethod),
                suggestedCategoryId: null,
                suggestedCategoryName: null,
             };
@@ -1306,6 +1364,7 @@ export function TransactionsList() {
                               Tipo: "Receita",
                               Valor: "1500.00",
                               Status: "Efetivado",
+                              "Forma de pagamento": "Pix",
                               Vencimento: "",
                               Conta: safeBankAccounts[0]?.name ?? "",
                               Cartão: "",
@@ -1318,6 +1377,7 @@ export function TransactionsList() {
                            "Tipo",
                            "Valor",
                            "Status",
+                           "Forma de pagamento",
                            "Vencimento",
                            "Conta",
                            "Cartão",
@@ -1337,6 +1397,7 @@ export function TransactionsList() {
                               Tipo: "Receita",
                               Valor: "1500.00",
                               Status: "Efetivado",
+                              "Forma de pagamento": "Pix",
                               Vencimento: "",
                               Conta: safeBankAccounts[0]?.name ?? "",
                               Cartão: "",
@@ -1349,6 +1410,7 @@ export function TransactionsList() {
                            "Tipo",
                            "Valor",
                            "Status",
+                           "Forma de pagamento",
                            "Vencimento",
                            "Conta",
                            "Cartão",
@@ -1445,7 +1507,7 @@ export function TransactionsList() {
                      attachments: [],
                      description: null,
                      creditCardId,
-                     paymentMethod: null,
+                     paymentMethod: parseImportPaymentMethod(r.paymentMethod),
                      status: parseImportStatus(r.status).status,
                      ignored:
                         r.ignored === true ||

--- a/modules/cashbook/src/router/transactions-list.ts
+++ b/modules/cashbook/src/router/transactions-list.ts
@@ -24,6 +24,7 @@ const sortIdSchema = z.enum([
    "date",
    "dueDate",
    "name",
+   "paymentMethod",
    "relationshipName",
    "status",
    "type",

--- a/modules/cashbook/src/transactions.ts
+++ b/modules/cashbook/src/transactions.ts
@@ -71,6 +71,7 @@ export type TransactionSortId =
    | "date"
    | "dueDate"
    | "name"
+   | "paymentMethod"
    | "relationshipName"
    | "status"
    | "type";
@@ -115,6 +116,9 @@ function buildTransactionOrderBy(
             break;
          case "name":
             orderBy.push(direction(transactions.name));
+            break;
+         case "paymentMethod":
+            orderBy.push(direction(transactions.paymentMethod));
             break;
          case "relationshipName":
             orderBy.push(direction(parties.name));


### PR DESCRIPTION
## Resumo
- adiciona Forma de pagamento em Mais opções no modal de novo lançamento
- salva a forma de pagamento escolhida ao criar/importar lançamentos
- exibe e permite editar Forma de pagamento na tabela de lançamentos
- inclui Forma de pagamento no modelo CSV/XLSX de importação

## Validação
- bun --filter web typecheck
- git diff --check