### PR TITLE
feat(contracts): scaffold contracts module

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -54,6 +54,7 @@
       "@modules/cards": "workspace:*",
       "@modules/cashbook": "workspace:*",
       "@modules/classification": "workspace:*",
+      "@modules/contracts": "workspace:*",
       "@modules/inbox": "workspace:*",
       "@modules/insights": "workspace:*",
       "@modules/relationships": "workspace:*",

--- a/apps/web/src/integrations/orpc/router/index.ts
+++ b/apps/web/src/integrations/orpc/router/index.ts
@@ -4,6 +4,7 @@ import * as agentSettingsRouter from "@modules/account/router/agent-settings";
 import * as apiKeysRouter from "@modules/account/router/api-keys";
 import * as bankAccountsRouter from "@modules/cashbook/router/bank-accounts";
 import * as creditCardsRouter from "@modules/cards/router/credit-cards";
+import * as contractsRouter from "@modules/contracts/router";
 import * as statementsRouter from "@modules/cards/router/statements";
 import * as categoriesRouter from "@modules/classification/router/categories";
 import * as categoriesBulkRouter from "@modules/classification/router/categories-bulk";
@@ -41,6 +42,7 @@ export default {
    categories: categoriesRouter,
    categoriesBulk: categoriesBulkRouter,
    cnpj: cnpjRouter,
+   contracts: contractsRouter,
    financialSettings: financialSettingsRouter,
    inbox: inboxRouter,
    reports: reportsRouter,

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -26,6 +26,7 @@
          "@modules/cards/*": ["../../modules/cards/src/*"],
          "@modules/cashbook/*": ["../../modules/cashbook/src/*"],
          "@modules/classification/*": ["../../modules/classification/src/*"],
+         "@modules/contracts/*": ["../../modules/contracts/src/*"],
          "@modules/inbox/*": ["../../modules/inbox/src/*"],
          "@modules/relationships/*": ["../../modules/relationships/src/*"],
          "@modules/workflows/*": ["../../modules/workflows/src/*"]

--- a/bun.lock
+++ b/bun.lock
@@ -116,6 +116,7 @@
         "@modules/cards": "workspace:*",
         "@modules/cashbook": "workspace:*",
         "@modules/classification": "workspace:*",
+        "@modules/contracts": "workspace:*",
         "@modules/inbox": "workspace:*",
         "@modules/insights": "workspace:*",
         "@modules/relationships": "workspace:*",
@@ -614,6 +615,23 @@
         "drizzle-kit": "catalog:database",
         "drizzle-seed": "catalog:database",
         "pg": "catalog:database",
+        "typescript": "catalog:development",
+        "vitest": "catalog:testing",
+      },
+    },
+    "modules/contracts": {
+      "name": "@modules/contracts",
+      "version": "0.1.0",
+      "dependencies": {
+        "@core/database": "workspace:*",
+        "@core/orpc": "workspace:*",
+        "better-result": "catalog:validation",
+        "drizzle-orm": "catalog:database",
+        "evlog": "catalog:logging",
+        "zod": "catalog:validation",
+      },
+      "devDependencies": {
+        "@tooling/typescript": "workspace:*",
         "typescript": "catalog:development",
         "vitest": "catalog:testing",
       },
@@ -1771,6 +1789,8 @@
     "@modules/cashbook": ["@modules/cashbook@workspace:modules/cashbook"],
 
     "@modules/classification": ["@modules/classification@workspace:modules/classification"],
+
+    "@modules/contracts": ["@modules/contracts@workspace:modules/contracts"],
 
     "@modules/inbox": ["@modules/inbox@workspace:modules/inbox"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -631,6 +631,8 @@
         "zod": "catalog:validation",
       },
       "devDependencies": {
+        "@electric-sql/pglite": "^0.3.15",
+        "@orpc/server": "catalog:orpc",
         "@tooling/typescript": "workspace:*",
         "typescript": "catalog:development",
         "vitest": "catalog:testing",

--- a/core/database/src/testing/setup-test-db.ts
+++ b/core/database/src/testing/setup-test-db.ts
@@ -19,6 +19,7 @@ export async function setupTestDb() {
       "crm",
       "platform",
       "relationships",
+      "contracts",
    ]);
    await apply();
 

--- a/modules/contracts/__tests__/router.test.ts
+++ b/modules/contracts/__tests__/router.test.ts
@@ -1,0 +1,356 @@
+import { call } from "@orpc/server";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { setupTestDb } from "@core/database/testing/setup-test-db";
+import { seedTeam, seedUser } from "@core/database/testing/factories";
+import { createTestContext } from "@core/orpc/testing/create-test-context";
+import {
+   contractDocuments,
+   contractExtractions,
+   contracts,
+} from "@core/database/schemas/contracts";
+
+vi.mock("@core/orpc/server", async () =>
+   (await import("@core/orpc/testing/mock-server")).createMockServerModule(),
+);
+
+import * as contractsRouter from "../src/router";
+
+let testDb: Awaited<ReturnType<typeof setupTestDb>>;
+
+beforeAll(async () => {
+   testDb = await setupTestDb();
+}, 30_000);
+
+afterAll(async () => {
+   await testDb.cleanup();
+});
+
+async function createContext() {
+   const { teamId, organizationId } = await seedTeam(testDb.db);
+   const userId = await seedUser(testDb.db);
+   const ctx = createTestContext(testDb.db, {
+      teamId,
+      organizationId,
+      userId,
+   });
+
+   return { ctx, organizationId, teamId, userId };
+}
+
+async function insertDocument(input: {
+   organizationId: string;
+   teamId: string;
+   name: string;
+   status?: "uploaded" | "processing" | "needs_review" | "approved" | "failed";
+}) {
+   const [document] = await testDb.db
+      .insert(contractDocuments)
+      .values({
+         organizationId: input.organizationId,
+         teamId: input.teamId,
+         fileKey: `contract-documents/${crypto.randomUUID()}.pdf`,
+         originalFileName: input.name,
+         mimeType: "application/pdf",
+         fileSize: 1024,
+         ingestionStatus: input.status ?? "uploaded",
+      })
+      .returning();
+
+   expect(document).toBeDefined();
+   return document;
+}
+
+describe("contracts router", () => {
+   it("lista documentos com ownership, filtros, busca e ordenação", async () => {
+      const owner = await createContext();
+      const other = await createContext();
+
+      await insertDocument({
+         organizationId: owner.organizationId,
+         teamId: owner.teamId,
+         name: "zeta contrato.pdf",
+         status: "uploaded",
+      });
+      await insertDocument({
+         organizationId: owner.organizationId,
+         teamId: owner.teamId,
+         name: "alpha contrato.pdf",
+         status: "needs_review",
+      });
+      await insertDocument({
+         organizationId: other.organizationId,
+         teamId: other.teamId,
+         name: "alpha contrato outro time.pdf",
+         status: "needs_review",
+      });
+
+      const result = await call(
+         contractsRouter.listDocuments,
+         {
+            page: 1,
+            pageSize: 10,
+            search: "contrato",
+            status: "needs_review",
+            sorting: [{ id: "originalFileName", desc: false }],
+         },
+         { context: owner.ctx },
+      );
+
+      expect(result.total).toBe(1);
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]?.originalFileName).toBe("alpha contrato.pdf");
+      expect(result.items[0]?.teamId).toBe(owner.teamId);
+   });
+
+   it("busca documento com extrações e contratos do mesmo time", async () => {
+      const owner = await createContext();
+      const document = await insertDocument({
+         organizationId: owner.organizationId,
+         teamId: owner.teamId,
+         name: "contrato aprovado.pdf",
+      });
+      const [extraction] = await testDb.db
+         .insert(contractExtractions)
+         .values({
+            documentId: document.id,
+            model: "openrouter/test",
+            promptVersion: "v1",
+            status: "completed",
+            confidence: "0.91",
+            data: { document: { type: "service" } },
+         })
+         .returning();
+      expect(extraction).toBeDefined();
+
+      const [contract] = await testDb.db
+         .insert(contracts)
+         .values({
+            organizationId: owner.organizationId,
+            teamId: owner.teamId,
+            documentId: document.id,
+            approvedExtractionId: extraction?.id,
+            title: "Contrato aprovado",
+            type: "service",
+            status: "active",
+            counterpartyName: "Cliente Teste",
+         })
+         .returning();
+      expect(contract).toBeDefined();
+
+      const result = await call(
+         contractsRouter.getDocument,
+         { id: document.id },
+         { context: owner.ctx },
+      );
+
+      expect(result.id).toBe(document.id);
+      expect(result.extractions).toHaveLength(1);
+      expect(result.contracts).toHaveLength(1);
+      expect(result.contracts[0]?.id).toBe(contract?.id);
+   });
+
+   it("bloqueia leitura de documento de outro time", async () => {
+      const owner = await createContext();
+      const other = await createContext();
+      const document = await insertDocument({
+         organizationId: other.organizationId,
+         teamId: other.teamId,
+         name: "contrato outro time.pdf",
+      });
+
+      await expect(
+         call(
+            contractsRouter.getDocument,
+            { id: document.id },
+            { context: owner.ctx },
+         ),
+      ).rejects.toThrow("Documento de contrato não encontrado.");
+   });
+
+   it("lista contratos com ownership, filtros, busca e paginação", async () => {
+      const owner = await createContext();
+      const other = await createContext();
+
+      await testDb.db.insert(contracts).values([
+         {
+            organizationId: owner.organizationId,
+            teamId: owner.teamId,
+            title: "Contrato B",
+            type: "service",
+            status: "active",
+            counterpartyName: "Empresa B",
+            signatureStatus: "signed",
+            amount: "200.00",
+         },
+         {
+            organizationId: owner.organizationId,
+            teamId: owner.teamId,
+            title: "Contrato A",
+            type: "fiscal_address",
+            status: "needs_review",
+            counterpartyName: "Empresa A",
+            signatureStatus: "unsigned",
+            amount: "100.00",
+         },
+         {
+            organizationId: other.organizationId,
+            teamId: other.teamId,
+            title: "Contrato A outro time",
+            type: "fiscal_address",
+            status: "needs_review",
+            counterpartyName: "Empresa A",
+            signatureStatus: "unsigned",
+         },
+      ]);
+
+      const result = await call(
+         contractsRouter.listContracts,
+         {
+            page: 1,
+            pageSize: 1,
+            search: "Empresa",
+            status: "needs_review",
+            type: "fiscal_address",
+            signatureStatus: "unsigned",
+            sorting: [{ id: "title", desc: false }],
+         },
+         { context: owner.ctx },
+      );
+
+      expect(result.total).toBe(1);
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]?.title).toBe("Contrato A");
+      expect(result.items[0]?.teamId).toBe(owner.teamId);
+   });
+
+   it("busca contrato aprovado com documento e extração", async () => {
+      const owner = await createContext();
+      const document = await insertDocument({
+         organizationId: owner.organizationId,
+         teamId: owner.teamId,
+         name: "contrato com vinculos.pdf",
+      });
+      const [extraction] = await testDb.db
+         .insert(contractExtractions)
+         .values({
+            documentId: document.id,
+            model: "openrouter/test",
+            promptVersion: "v1",
+            status: "completed",
+            data: { terms: { startsAt: "2026-01-01" } },
+         })
+         .returning();
+      expect(extraction).toBeDefined();
+      const [contract] = await testDb.db
+         .insert(contracts)
+         .values({
+            organizationId: owner.organizationId,
+            teamId: owner.teamId,
+            documentId: document.id,
+            approvedExtractionId: extraction?.id,
+            title: "Contrato com vínculos",
+            type: "service",
+            status: "active",
+            counterpartyName: "Cliente Teste",
+         })
+         .returning();
+      expect(contract).toBeDefined();
+
+      const result = await call(
+         contractsRouter.getContract,
+         { id: contract?.id ?? crypto.randomUUID() },
+         { context: owner.ctx },
+      );
+
+      expect(result.id).toBe(contract?.id);
+      expect(result.document?.id).toBe(document.id);
+      expect(result.approvedExtraction?.id).toBe(extraction?.id);
+   });
+
+   it("bloqueia leitura de contrato de outro time", async () => {
+      const owner = await createContext();
+      const other = await createContext();
+      const [contract] = await testDb.db
+         .insert(contracts)
+         .values({
+            organizationId: other.organizationId,
+            teamId: other.teamId,
+            title: "Contrato outro time",
+            type: "service",
+            status: "active",
+            counterpartyName: "Cliente Externo",
+         })
+         .returning();
+      expect(contract).toBeDefined();
+
+      await expect(
+         call(
+            contractsRouter.getContract,
+            { id: contract?.id ?? crypto.randomUUID() },
+            { context: owner.ctx },
+         ),
+      ).rejects.toThrow("Contrato não encontrado.");
+   });
+
+   it("busca extração somente quando o documento pertence ao time", async () => {
+      const owner = await createContext();
+      const other = await createContext();
+      const ownerDocument = await insertDocument({
+         organizationId: owner.organizationId,
+         teamId: owner.teamId,
+         name: "contrato owner.pdf",
+      });
+      const otherDocument = await insertDocument({
+         organizationId: other.organizationId,
+         teamId: other.teamId,
+         name: "contrato outro.pdf",
+      });
+      const [ownerExtraction] = await testDb.db
+         .insert(contractExtractions)
+         .values({
+            documentId: ownerDocument.id,
+            model: "openrouter/test",
+            promptVersion: "v1",
+            status: "completed",
+         })
+         .returning();
+      const [otherExtraction] = await testDb.db
+         .insert(contractExtractions)
+         .values({
+            documentId: otherDocument.id,
+            model: "openrouter/test",
+            promptVersion: "v1",
+            status: "completed",
+         })
+         .returning();
+      expect(ownerExtraction).toBeDefined();
+      expect(otherExtraction).toBeDefined();
+
+      const result = await call(
+         contractsRouter.getExtraction,
+         { id: ownerExtraction?.id ?? crypto.randomUUID() },
+         { context: owner.ctx },
+      );
+      expect(result.id).toBe(ownerExtraction?.id);
+
+      await expect(
+         call(
+            contractsRouter.getExtraction,
+            { id: otherExtraction?.id ?? crypto.randomUUID() },
+            { context: owner.ctx },
+         ),
+      ).rejects.toThrow("Extração de contrato não encontrada.");
+   });
+
+   it("rejeita UUID inválido antes de consultar", async () => {
+      const owner = await createContext();
+
+      await expect(
+         call(
+            contractsRouter.getContract,
+            { id: "contrato-invalido" },
+            { context: owner.ctx },
+         ),
+      ).rejects.toThrow();
+   });
+});

--- a/modules/contracts/package.json
+++ b/modules/contracts/package.json
@@ -6,8 +6,7 @@
    "type": "module",
    "exports": {
       "./router": "./src/router/index.ts",
-      "./router/*": "./src/router/*.ts",
-      "./*": "./src/*.ts"
+      "./router/*": "./src/router/*.ts"
    },
    "scripts": {
       "check": "oxlint ./src",
@@ -25,6 +24,8 @@
       "zod": "catalog:validation"
    },
    "devDependencies": {
+      "@electric-sql/pglite": "^0.3.15",
+      "@orpc/server": "catalog:orpc",
       "@tooling/typescript": "workspace:*",
       "typescript": "catalog:development",
       "vitest": "catalog:testing"

--- a/modules/contracts/package.json
+++ b/modules/contracts/package.json
@@ -1,0 +1,32 @@
+{
+   "name": "@modules/contracts",
+   "version": "0.1.0",
+   "private": true,
+   "license": "Apache-2.0",
+   "type": "module",
+   "exports": {
+      "./router": "./src/router/index.ts",
+      "./router/*": "./src/router/*.ts",
+      "./*": "./src/*.ts"
+   },
+   "scripts": {
+      "check": "oxlint ./src",
+      "format": "oxfmt --write ./src",
+      "format:check": "oxfmt --check ./src",
+      "test": "vitest run --passWithNoTests",
+      "typecheck": "tsgo"
+   },
+   "dependencies": {
+      "@core/database": "workspace:*",
+      "@core/orpc": "workspace:*",
+      "better-result": "catalog:validation",
+      "drizzle-orm": "catalog:database",
+      "evlog": "catalog:logging",
+      "zod": "catalog:validation"
+   },
+   "devDependencies": {
+      "@tooling/typescript": "workspace:*",
+      "typescript": "catalog:development",
+      "vitest": "catalog:testing"
+   }
+}

--- a/modules/contracts/src/router/index.ts
+++ b/modules/contracts/src/router/index.ts
@@ -1,0 +1,376 @@
+import {
+   and,
+   asc,
+   count,
+   desc,
+   eq,
+   getTableColumns,
+   ilike,
+   or,
+} from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
+import { Result, TaggedError } from "better-result";
+import { defineErrorCatalog } from "evlog";
+import { z } from "zod";
+import {
+   contractDocuments,
+   contractExtractions,
+   contracts,
+   contractStatusEnum,
+   contractTypeEnum,
+   ingestionStatusEnum,
+   signatureStatusEnum,
+} from "@core/database/schemas/contracts";
+import { protectedProcedure } from "@core/orpc/server";
+
+const contractsRouterErrors = defineErrorCatalog("contracts.router", {
+   INTERNAL: {
+      status: 500,
+      message: "Falha interna em contratos.",
+      tags: ["contracts"],
+   },
+   NOT_FOUND: {
+      status: 404,
+      message: "Contrato não encontrado.",
+      tags: ["contracts"],
+   },
+});
+
+declare module "evlog" {
+   interface RegisteredErrorCatalogs {
+      "contracts.router": typeof contractsRouterErrors;
+   }
+}
+
+type ContractsRouterCatalogError =
+   | ReturnType<typeof contractsRouterErrors.INTERNAL>
+   | ReturnType<typeof contractsRouterErrors.NOT_FOUND>;
+
+class ContractsRouterError extends TaggedError("ContractsRouterError")<{
+   error: ContractsRouterCatalogError;
+   message: string;
+}>() {}
+
+const idInput = z.object({ id: z.string().uuid() });
+
+const paginationInput = z.object({
+   page: z.number().int().positive().catch(1).default(1),
+   pageSize: z.number().int().positive().max(100).catch(20).default(20),
+});
+
+const documentListInput = paginationInput.extend({
+   search: z.string().trim().max(160).optional(),
+   status: z.enum(ingestionStatusEnum).optional(),
+   sorting: z
+      .array(
+         z.object({
+            id: z.enum([
+               "createdAt",
+               "updatedAt",
+               "originalFileName",
+               "status",
+            ]),
+            desc: z.boolean(),
+         }),
+      )
+      .max(3)
+      .optional(),
+});
+
+const contractListInput = paginationInput.extend({
+   search: z.string().trim().max(160).optional(),
+   status: z.enum(contractStatusEnum).optional(),
+   type: z.enum(contractTypeEnum).optional(),
+   signatureStatus: z.enum(signatureStatusEnum).optional(),
+   sorting: z
+      .array(
+         z.object({
+            id: z.enum([
+               "title",
+               "counterpartyName",
+               "type",
+               "status",
+               "signatureStatus",
+               "startsAt",
+               "endsAt",
+               "amount",
+               "updatedAt",
+            ]),
+            desc: z.boolean(),
+         }),
+      )
+      .max(3)
+      .optional(),
+});
+
+type DocumentSortRule = NonNullable<
+   z.infer<typeof documentListInput>["sorting"]
+>[number];
+type ContractSortRule = NonNullable<
+   z.infer<typeof contractListInput>["sorting"]
+>[number];
+
+const defaultDocumentSort: DocumentSortRule = { id: "updatedAt", desc: true };
+const defaultContractSort: ContractSortRule = { id: "updatedAt", desc: true };
+
+function buildDocumentOrderBy(sorting: DocumentSortRule[] | undefined): SQL[] {
+   const rules = sorting?.length ? sorting : [defaultDocumentSort];
+   const orderBy: SQL[] = [];
+
+   for (const sort of rules) {
+      const direction = sort.desc ? desc : asc;
+      switch (sort.id) {
+         case "createdAt":
+            orderBy.push(direction(contractDocuments.createdAt));
+            break;
+         case "updatedAt":
+            orderBy.push(direction(contractDocuments.updatedAt));
+            break;
+         case "originalFileName":
+            orderBy.push(direction(contractDocuments.originalFileName));
+            break;
+         case "status":
+            orderBy.push(direction(contractDocuments.ingestionStatus));
+            break;
+      }
+   }
+
+   return [...orderBy, asc(contractDocuments.id)];
+}
+
+function buildContractOrderBy(sorting: ContractSortRule[] | undefined): SQL[] {
+   const rules = sorting?.length ? sorting : [defaultContractSort];
+   const orderBy: SQL[] = [];
+
+   for (const sort of rules) {
+      const direction = sort.desc ? desc : asc;
+      switch (sort.id) {
+         case "title":
+            orderBy.push(direction(contracts.title));
+            break;
+         case "counterpartyName":
+            orderBy.push(direction(contracts.counterpartyName));
+            break;
+         case "type":
+            orderBy.push(direction(contracts.type));
+            break;
+         case "status":
+            orderBy.push(direction(contracts.status));
+            break;
+         case "signatureStatus":
+            orderBy.push(direction(contracts.signatureStatus));
+            break;
+         case "startsAt":
+            orderBy.push(direction(contracts.startsAt));
+            break;
+         case "endsAt":
+            orderBy.push(direction(contracts.endsAt));
+            break;
+         case "amount":
+            orderBy.push(direction(contracts.amount));
+            break;
+         case "updatedAt":
+            orderBy.push(direction(contracts.updatedAt));
+            break;
+      }
+   }
+
+   return [...orderBy, asc(contracts.id)];
+}
+
+export const listDocuments = protectedProcedure
+   .input(documentListInput)
+   .handler(async ({ context, input }) => {
+      const offset = (input.page - 1) * input.pageSize;
+      const search = input.search?.trim();
+      const where = and(
+         eq(contractDocuments.teamId, context.teamId),
+         input.status
+            ? eq(contractDocuments.ingestionStatus, input.status)
+            : undefined,
+         search
+            ? ilike(contractDocuments.originalFileName, `%${search}%`)
+            : undefined,
+      );
+
+      const result = await Result.tryPromise({
+         try: () =>
+            Promise.all([
+               context.db
+                  .select(getTableColumns(contractDocuments))
+                  .from(contractDocuments)
+                  .where(where)
+                  .orderBy(...buildDocumentOrderBy(input.sorting))
+                  .limit(input.pageSize)
+                  .offset(offset),
+               context.db
+                  .select({ total: count() })
+                  .from(contractDocuments)
+                  .where(where),
+            ]),
+         catch: () =>
+            new ContractsRouterError({
+               error: contractsRouterErrors.INTERNAL(),
+               message: "Falha ao listar documentos de contrato.",
+            }),
+      });
+      if (Result.isError(result)) throw result.error;
+
+      const [items, totalRows] = result.value;
+      const total = totalRows[0]?.total ?? 0;
+
+      return { items, total, page: input.page, pageSize: input.pageSize };
+   });
+
+export const getDocument = protectedProcedure
+   .input(idInput)
+   .handler(async ({ context, input }) => {
+      const result = await Result.tryPromise({
+         try: () =>
+            context.db.query.contractDocuments.findFirst({
+               where: (f, { and, eq }) =>
+                  and(eq(f.id, input.id), eq(f.teamId, context.teamId)),
+               with: {
+                  extractions: {
+                     orderBy: (f, { desc }) => [desc(f.createdAt)],
+                     limit: 10,
+                  },
+                  contracts: {
+                     orderBy: (f, { desc }) => [desc(f.updatedAt)],
+                     limit: 10,
+                  },
+               },
+            }),
+         catch: () =>
+            new ContractsRouterError({
+               error: contractsRouterErrors.INTERNAL(),
+               message: "Falha ao buscar documento de contrato.",
+            }),
+      });
+      if (Result.isError(result)) throw result.error;
+      if (!result.value) {
+         throw new ContractsRouterError({
+            error: contractsRouterErrors.NOT_FOUND(),
+            message: "Documento de contrato não encontrado.",
+         });
+      }
+
+      return result.value;
+   });
+
+export const listContracts = protectedProcedure
+   .input(contractListInput)
+   .handler(async ({ context, input }) => {
+      const offset = (input.page - 1) * input.pageSize;
+      const search = input.search?.trim();
+      const where = and(
+         eq(contracts.teamId, context.teamId),
+         input.status ? eq(contracts.status, input.status) : undefined,
+         input.type ? eq(contracts.type, input.type) : undefined,
+         input.signatureStatus
+            ? eq(contracts.signatureStatus, input.signatureStatus)
+            : undefined,
+         search
+            ? or(
+                 ilike(contracts.title, `%${search}%`),
+                 ilike(contracts.counterpartyName, `%${search}%`),
+              )
+            : undefined,
+      );
+
+      const result = await Result.tryPromise({
+         try: () =>
+            Promise.all([
+               context.db
+                  .select(getTableColumns(contracts))
+                  .from(contracts)
+                  .where(where)
+                  .orderBy(...buildContractOrderBy(input.sorting))
+                  .limit(input.pageSize)
+                  .offset(offset),
+               context.db
+                  .select({ total: count() })
+                  .from(contracts)
+                  .where(where),
+            ]),
+         catch: () =>
+            new ContractsRouterError({
+               error: contractsRouterErrors.INTERNAL(),
+               message: "Falha ao listar contratos.",
+            }),
+      });
+      if (Result.isError(result)) throw result.error;
+
+      const [items, totalRows] = result.value;
+      const total = totalRows[0]?.total ?? 0;
+
+      return { items, total, page: input.page, pageSize: input.pageSize };
+   });
+
+export const getContract = protectedProcedure
+   .input(idInput)
+   .handler(async ({ context, input }) => {
+      const result = await Result.tryPromise({
+         try: () =>
+            context.db.query.contracts.findFirst({
+               where: (f, { and, eq }) =>
+                  and(eq(f.id, input.id), eq(f.teamId, context.teamId)),
+               with: {
+                  document: true,
+                  approvedExtraction: true,
+               },
+            }),
+         catch: () =>
+            new ContractsRouterError({
+               error: contractsRouterErrors.INTERNAL(),
+               message: "Falha ao buscar contrato.",
+            }),
+      });
+      if (Result.isError(result)) throw result.error;
+      if (!result.value) {
+         throw new ContractsRouterError({
+            error: contractsRouterErrors.NOT_FOUND(),
+            message: "Contrato não encontrado.",
+         });
+      }
+
+      return result.value;
+   });
+
+export const getExtraction = protectedProcedure
+   .input(idInput)
+   .handler(async ({ context, input }) => {
+      const result = await Result.tryPromise({
+         try: () =>
+            context.db
+               .select(getTableColumns(contractExtractions))
+               .from(contractExtractions)
+               .innerJoin(
+                  contractDocuments,
+                  eq(contractDocuments.id, contractExtractions.documentId),
+               )
+               .where(
+                  and(
+                     eq(contractExtractions.id, input.id),
+                     eq(contractDocuments.teamId, context.teamId),
+                  ),
+               )
+               .limit(1),
+         catch: () =>
+            new ContractsRouterError({
+               error: contractsRouterErrors.INTERNAL(),
+               message: "Falha ao buscar extração de contrato.",
+            }),
+      });
+      if (Result.isError(result)) throw result.error;
+
+      const extraction = result.value[0];
+      if (!extraction) {
+         throw new ContractsRouterError({
+            error: contractsRouterErrors.NOT_FOUND(),
+            message: "Extração de contrato não encontrada.",
+         });
+      }
+
+      return extraction;
+   });

--- a/modules/contracts/tsconfig.json
+++ b/modules/contracts/tsconfig.json
@@ -6,7 +6,6 @@
       "declarationMap": false,
       "noEmit": true,
       "rootDir": "../..",
-      "jsx": "react-jsx",
       "paths": {
          "@core/database": ["../../core/database/src/index.ts"],
          "@core/database/*": ["../../core/database/src/*"],

--- a/modules/contracts/tsconfig.json
+++ b/modules/contracts/tsconfig.json
@@ -1,0 +1,23 @@
+{
+   "extends": "@tooling/typescript/core.json",
+   "compilerOptions": {
+      "composite": false,
+      "declaration": false,
+      "declarationMap": false,
+      "noEmit": true,
+      "rootDir": "../..",
+      "jsx": "react-jsx",
+      "paths": {
+         "@core/database": ["../../core/database/src/index.ts"],
+         "@core/database/*": ["../../core/database/src/*"],
+         "@core/orpc/*": ["../../core/orpc/src/*"],
+         "@modules/contracts/*": ["./src/*"]
+      }
+   },
+   "include": ["src"],
+   "references": [
+      {
+         "path": "../../core/database"
+      }
+   ]
+}

--- a/modules/contracts/vitest.config.ts
+++ b/modules/contracts/vitest.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+   resolve: {
+      tsconfigPaths: true,
+   },
+   test: {
+      include: ["./__tests__/**/*.test.ts"],
+      hookTimeout: 30_000,
+      fileParallelism: false,
+      env: {
+         DATABASE_URL: "postgresql://test:test@localhost:5432/test",
+         REDIS_URL: "redis://localhost:6379",
+         POSTHOG_HOST: "https://us.i.posthog.com",
+         POSTHOG_KEY: "phc_test",
+         POSTHOG_PERSONAL_API_KEY: "phx_test",
+         STRIPE_SECRET_KEY: "sk_test_xxx",
+         STRIPE_WEBHOOK_SECRET: "whsec_test",
+         RESEND_API_KEY: "re_test_xxx",
+         BETTER_AUTH_SECRET: "test-secret-at-least-32-characters-long",
+         JWT_SECRET: "test-jwt-secret-at-least-32-characters",
+         BETTER_AUTH_TRUSTED_ORIGINS: "http://localhost:3000",
+         HYPRPAY_API_KEY: "hyprpay_test",
+         AWS_ENDPOINT_URL: "http://localhost:9000",
+         AWS_ACCESS_KEY_ID: "test",
+         AWS_SECRET_ACCESS_KEY: "test",
+         NODE_ENV: "test",
+         LOG_LEVEL: "error",
+         OPENROUTER_API_KEY: "mock",
+         OPENROUTER_BASE_URL: "http://127.0.0.1:14010/v1",
+      },
+   },
+});


### PR DESCRIPTION
## Resumo
- cria o pacote `@modules/contracts`
- adiciona router oRPC mínimo para documentos, contratos e extrações
- registra o router no app web e atualiza lockfile

## Validação
- `bun --filter @modules/contracts typecheck`
- `bun --filter web typecheck`
- `bun --filter @modules/contracts check`
- `git diff --check`

Obs: `apps/web/src/routeTree.gen.ts` e outros arquivos não rastreados já estavam locais e não entraram no commit.