### PR TITLE
fix(contracts): enforce team scope in reads

### DIFF
--- a/modules/contracts/__tests__/router.test.ts
+++ b/modules/contracts/__tests__/router.test.ts
@@ -100,6 +100,7 @@ describe("contracts router", () => {
       expect(result.items).toHaveLength(1);
       expect(result.items[0]?.originalFileName).toBe("alpha contrato.pdf");
       expect(result.items[0]?.teamId).toBe(owner.teamId);
+      expect(Object.hasOwn(result.items[0] ?? {}, "fileKey")).toBe(false);
    });
 
    it("busca documento com extrações e contratos do mesmo time", async () => {
@@ -147,6 +148,33 @@ describe("contracts router", () => {
       expect(result.extractions).toHaveLength(1);
       expect(result.contracts).toHaveLength(1);
       expect(result.contracts[0]?.id).toBe(contract?.id);
+   });
+
+   it("não expõe contrato de outro time vinculado ao documento", async () => {
+      const owner = await createContext();
+      const other = await createContext();
+      const document = await insertDocument({
+         organizationId: owner.organizationId,
+         teamId: owner.teamId,
+         name: "contrato owner.pdf",
+      });
+      await testDb.db.insert(contracts).values({
+         organizationId: other.organizationId,
+         teamId: other.teamId,
+         documentId: document.id,
+         title: "Contrato malformado",
+         type: "service",
+         status: "active",
+         counterpartyName: "Cliente Externo",
+      });
+
+      const result = await call(
+         contractsRouter.getDocument,
+         { id: document.id },
+         { context: owner.ctx },
+      );
+
+      expect(result.contracts).toHaveLength(0);
    });
 
    it("bloqueia leitura de documento de outro time", async () => {
@@ -221,6 +249,7 @@ describe("contracts router", () => {
       expect(result.items).toHaveLength(1);
       expect(result.items[0]?.title).toBe("Contrato A");
       expect(result.items[0]?.teamId).toBe(owner.teamId);
+      expect(Object.hasOwn(result.items[0] ?? {}, "content")).toBe(false);
    });
 
    it("busca contrato aprovado com documento e extração", async () => {
@@ -265,6 +294,50 @@ describe("contracts router", () => {
       expect(result.id).toBe(contract?.id);
       expect(result.document?.id).toBe(document.id);
       expect(result.approvedExtraction?.id).toBe(extraction?.id);
+   });
+
+   it("não expõe documento e extração de outro time no detalhe do contrato", async () => {
+      const owner = await createContext();
+      const other = await createContext();
+      const otherDocument = await insertDocument({
+         organizationId: other.organizationId,
+         teamId: other.teamId,
+         name: "contrato outro time.pdf",
+      });
+      const [otherExtraction] = await testDb.db
+         .insert(contractExtractions)
+         .values({
+            documentId: otherDocument.id,
+            model: "openrouter/test",
+            promptVersion: "v1",
+            status: "completed",
+         })
+         .returning();
+      expect(otherExtraction).toBeDefined();
+      const [contract] = await testDb.db
+         .insert(contracts)
+         .values({
+            organizationId: owner.organizationId,
+            teamId: owner.teamId,
+            documentId: otherDocument.id,
+            approvedExtractionId: otherExtraction?.id,
+            title: "Contrato malformado",
+            type: "service",
+            status: "active",
+            counterpartyName: "Cliente Teste",
+         })
+         .returning();
+      expect(contract).toBeDefined();
+
+      const result = await call(
+         contractsRouter.getContract,
+         { id: contract?.id ?? crypto.randomUUID() },
+         { context: owner.ctx },
+      );
+
+      expect(result.id).toBe(contract?.id);
+      expect(result.document).toBeNull();
+      expect(result.approvedExtraction).toBeNull();
    });
 
    it("bloqueia leitura de contrato de outro time", async () => {

--- a/modules/contracts/src/router/index.ts
+++ b/modules/contracts/src/router/index.ts
@@ -113,6 +113,41 @@ type ContractSortRule = NonNullable<
 const defaultDocumentSort: DocumentSortRule = { id: "updatedAt", desc: true };
 const defaultContractSort: ContractSortRule = { id: "updatedAt", desc: true };
 
+const documentListColumns = {
+   id: contractDocuments.id,
+   organizationId: contractDocuments.organizationId,
+   teamId: contractDocuments.teamId,
+   originalFileName: contractDocuments.originalFileName,
+   mimeType: contractDocuments.mimeType,
+   fileSize: contractDocuments.fileSize,
+   pageCount: contractDocuments.pageCount,
+   ingestionStatus: contractDocuments.ingestionStatus,
+   uploadedByUserId: contractDocuments.uploadedByUserId,
+   createdAt: contractDocuments.createdAt,
+   updatedAt: contractDocuments.updatedAt,
+};
+
+const contractListColumns = {
+   id: contracts.id,
+   organizationId: contracts.organizationId,
+   teamId: contracts.teamId,
+   relationshipId: contracts.relationshipId,
+   documentId: contracts.documentId,
+   approvedExtractionId: contracts.approvedExtractionId,
+   title: contracts.title,
+   type: contracts.type,
+   status: contracts.status,
+   counterpartyName: contracts.counterpartyName,
+   signatureStatus: contracts.signatureStatus,
+   startsAt: contracts.startsAt,
+   endsAt: contracts.endsAt,
+   amount: contracts.amount,
+   approvedByUserId: contracts.approvedByUserId,
+   approvedAt: contracts.approvedAt,
+   createdAt: contracts.createdAt,
+   updatedAt: contracts.updatedAt,
+};
+
 function buildDocumentOrderBy(sorting: DocumentSortRule[] | undefined): SQL[] {
    const rules = sorting?.length ? sorting : [defaultDocumentSort];
    const orderBy: SQL[] = [];
@@ -197,7 +232,7 @@ export const listDocuments = protectedProcedure
          try: () =>
             Promise.all([
                context.db
-                  .select(getTableColumns(contractDocuments))
+                  .select(documentListColumns)
                   .from(contractDocuments)
                   .where(where)
                   .orderBy(...buildDocumentOrderBy(input.sorting))
@@ -236,6 +271,7 @@ export const getDocument = protectedProcedure
                      limit: 10,
                   },
                   contracts: {
+                     where: (f, { eq }) => eq(f.teamId, context.teamId),
                      orderBy: (f, { desc }) => [desc(f.updatedAt)],
                      limit: 10,
                   },
@@ -282,7 +318,7 @@ export const listContracts = protectedProcedure
          try: () =>
             Promise.all([
                context.db
-                  .select(getTableColumns(contracts))
+                  .select(contractListColumns)
                   .from(contracts)
                   .where(where)
                   .orderBy(...buildContractOrderBy(input.sorting))
@@ -310,15 +346,11 @@ export const listContracts = protectedProcedure
 export const getContract = protectedProcedure
    .input(idInput)
    .handler(async ({ context, input }) => {
-      const result = await Result.tryPromise({
+      const contractResult = await Result.tryPromise({
          try: () =>
             context.db.query.contracts.findFirst({
                where: (f, { and, eq }) =>
                   and(eq(f.id, input.id), eq(f.teamId, context.teamId)),
-               with: {
-                  document: true,
-                  approvedExtraction: true,
-               },
             }),
          catch: () =>
             new ContractsRouterError({
@@ -326,15 +358,64 @@ export const getContract = protectedProcedure
                message: "Falha ao buscar contrato.",
             }),
       });
-      if (Result.isError(result)) throw result.error;
-      if (!result.value) {
+      if (Result.isError(contractResult)) throw contractResult.error;
+      if (!contractResult.value) {
          throw new ContractsRouterError({
             error: contractsRouterErrors.NOT_FOUND(),
             message: "Contrato não encontrado.",
          });
       }
 
-      return result.value;
+      const contract = contractResult.value;
+      const documentId = contract.documentId;
+      const approvedExtractionId = contract.approvedExtractionId;
+      const relationResult = await Result.tryPromise({
+         try: () =>
+            Promise.all([
+               documentId
+                  ? context.db.query.contractDocuments.findFirst({
+                       where: (f, { and, eq }) =>
+                          and(
+                             eq(f.id, documentId),
+                             eq(f.teamId, context.teamId),
+                          ),
+                    })
+                  : Promise.resolve(null),
+               approvedExtractionId
+                  ? context.db
+                       .select(getTableColumns(contractExtractions))
+                       .from(contractExtractions)
+                       .innerJoin(
+                          contractDocuments,
+                          eq(
+                             contractDocuments.id,
+                             contractExtractions.documentId,
+                          ),
+                       )
+                       .where(
+                          and(
+                             eq(contractExtractions.id, approvedExtractionId),
+                             eq(contractDocuments.teamId, context.teamId),
+                          ),
+                       )
+                       .limit(1)
+                  : Promise.resolve([]),
+            ]),
+         catch: () =>
+            new ContractsRouterError({
+               error: contractsRouterErrors.INTERNAL(),
+               message: "Falha ao buscar vínculos do contrato.",
+            }),
+      });
+      if (Result.isError(relationResult)) throw relationResult.error;
+
+      const [document, extractionRows] = relationResult.value;
+
+      return {
+         ...contract,
+         document: document ?? null,
+         approvedExtraction: extractionRows[0] ?? null,
+      };
    });
 
 export const getExtraction = protectedProcedure


### PR DESCRIPTION
## Resumo
- restringe relações carregadas no router de contratos ao `teamId` ativo
- evita expor `contracts.content` e `contract_documents.fileKey` nas listagens
- adiciona regressões para vínculos malformados entre times

## Validação
- `bun --filter @modules/contracts test`
- `bun --filter @modules/contracts check`
- `git diff --check`

## Nota
- `bun --filter @modules/contracts typecheck` e `bun --filter web typecheck` falham nesta worktree limpa por dist/paths de pacotes internos não buildados/preexistentes; não há erro apontando para `modules/contracts/src/router/index.ts` após a correção.