### PR TITLE
Corrige filtros e ações de lançamentos

### DIFF
--- a/apps/web/src/integrations/tanstack-db/transactions.ts
+++ b/apps/web/src/integrations/tanstack-db/transactions.ts
@@ -32,6 +32,8 @@ type TransactionsCollectionOptionsParams = {
    overdueOnly?: boolean;
    status?: Array<"pending" | "paid">;
    bankAccountId?: string;
+   dateFrom?: string;
+   dateTo?: string;
    relationshipId?: string;
 };
 
@@ -43,6 +45,8 @@ type TransactionsPageInfoCollectionOptionsParams = {
    overdueOnly?: boolean;
    status?: Array<"pending" | "paid">;
    bankAccountId?: string;
+   dateFrom?: string;
+   dateTo?: string;
    relationshipId?: string;
 };
 
@@ -53,6 +57,8 @@ type TransactionCreateActionInput = {
 
 type TransactionsWhereInput = {
    bankAccountId?: string;
+   dateFrom?: string;
+   dateTo?: string;
    paymentMethod?: string;
    relationshipId?: string;
    overdueOnly?: boolean;
@@ -135,6 +141,9 @@ function parseTransactionsWhere(options: LoadSubsetOptions | undefined) {
                const key = field.join(".");
                if (key === "bankAccountId" && typeof value === "string") {
                   return { bankAccountId: value };
+               }
+               if (key === "date" && typeof value === "string") {
+                  return { dateFrom: value, dateTo: value };
                }
                if (key === "paymentMethod" && typeof value === "string") {
                   return { paymentMethod: value };
@@ -219,6 +228,8 @@ function transactionsInputFromLoadSubsetOptions(
       status:
          where.status && where.status.length > 0 ? where.status : base.status,
       bankAccountId: where.bankAccountId ?? base.bankAccountId,
+      dateFrom: where.dateFrom ?? base.dateFrom,
+      dateTo: where.dateTo ?? base.dateTo,
       paymentMethod: where.paymentMethod,
       relationshipId: where.relationshipId ?? base.relationshipId,
       sorting,
@@ -334,6 +345,8 @@ export function transactionsCollectionOptions({
    overdueOnly,
    status,
    bankAccountId,
+   dateFrom,
+   dateTo,
    relationshipId,
 }: TransactionsCollectionOptionsParams) {
    const base = {
@@ -342,6 +355,8 @@ export function transactionsCollectionOptions({
       overdueOnly,
       status,
       bankAccountId,
+      dateFrom,
+      dateTo,
       relationshipId,
    };
    return queryCollectionOptions({
@@ -353,6 +368,8 @@ export function transactionsCollectionOptions({
          overdueOnly ? "overdue" : "all-dates",
          status?.join(",") ?? "all-status",
          bankAccountId ?? "all-accounts",
+         dateFrom ?? "open-start",
+         dateTo ?? "open-end",
          relationshipId ?? "all-relationships",
       ].join(":"),
       queryKey: (options) =>
@@ -396,6 +413,8 @@ export function transactionsPageInfoCollectionOptions({
    overdueOnly,
    status,
    bankAccountId,
+   dateFrom,
+   dateTo,
    relationshipId,
 }: TransactionsPageInfoCollectionOptionsParams) {
    const id = [
@@ -405,6 +424,8 @@ export function transactionsPageInfoCollectionOptions({
       overdueOnly ? "overdue" : "all-dates",
       status?.join(",") ?? "all-status",
       bankAccountId ?? "all-accounts",
+      dateFrom ?? "open-start",
+      dateTo ?? "open-end",
       relationshipId ?? "all-relationships",
    ].join(":");
    return queryCollectionOptions({
@@ -418,6 +439,8 @@ export function transactionsPageInfoCollectionOptions({
          overdueOnly,
          status,
          bankAccountId,
+         dateFrom,
+         dateTo,
          relationshipId,
       ],
       queryFn: async () => {
@@ -429,6 +452,8 @@ export function transactionsPageInfoCollectionOptions({
             overdueOnly,
             status,
             bankAccountId,
+            dateFrom,
+            dateTo,
             relationshipId,
          });
          return [{ id, total: result.total }];

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-columns.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-columns.tsx
@@ -341,6 +341,26 @@ export function buildTransactionColumns(options?: {
          ),
       },
       {
+         accessorKey: "description",
+         header: "Observações",
+         meta: {
+            label: "Observações",
+            cellComponent: "text",
+            isEditable: true,
+            editMode: "inline",
+         },
+         cell: ({ row }) => (
+            <InlineEditText
+               ariaLabel="Observações"
+               onSave={async (value) =>
+                  dispatchPatch(row, { description: value.trim() || null })
+               }
+               placeholder="—"
+               value={row.original.description ?? ""}
+            />
+         ),
+      },
+      {
          accessorKey: "type",
          header: "Tipo",
          meta: {
@@ -714,7 +734,7 @@ export function buildTransactionColumns(options?: {
                   ariaLabel="Valor"
                   className={colorClass}
                   onSave={async (value) =>
-                     dispatchPatch(row, { amount: value })
+                     dispatchPatch(row, { amount: value.toFixed(2) })
                   }
                   value={numeric}
                   valueInCents={false}

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
@@ -1,3 +1,4 @@
+import { Badge } from "@packages/ui/components/badge";
 import { ScrollArea } from "@packages/ui/components/scroll-area";
 import { SearchInput } from "@packages/ui/components/search-input";
 import { Table } from "@packages/ui/components/table";
@@ -5,6 +6,7 @@ import { TooltipProvider } from "@packages/ui/components/tooltip";
 import { Button } from "@packages/ui/components/button";
 import { Calendar } from "@packages/ui/components/calendar";
 import { Checkbox } from "@packages/ui/components/checkbox";
+import { DateRangePicker } from "@packages/ui/components/date-range-picker";
 import {
    Command,
    CommandEmpty,
@@ -59,6 +61,7 @@ import {
    RotateCcw,
    Trash2,
    Undo2,
+   X,
 } from "lucide-react";
 import { Result } from "better-result";
 import { useCallback, useMemo, useRef, useState } from "react";
@@ -138,6 +141,14 @@ const routeApi = getRouteApi(
 
 type ImportLookupItem = { id: string; name: string };
 type PaymentMethod = NonNullable<TransactionCreateInput["paymentMethod"]>;
+
+const DATE_RANGE_PRESETS = [
+   { label: "Hoje", value: "today" },
+   { label: "Este mês", value: "this-month" },
+   { label: "Últimos 30 dias", value: "last-30-days" },
+   { label: "Próximo mês", value: "next-month" },
+];
+
 function isTransactionStatus(value: unknown): value is "pending" | "paid" {
    return value === "pending" || value === "paid";
 }
@@ -148,6 +159,34 @@ function getStringColumnFilterValue(
 ): string | undefined {
    const value = filters.find((filter) => filter.id === id)?.value;
    return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function getDateRangePresetRange(value: string) {
+   const today = dayjs();
+   switch (value) {
+      case "today":
+         return { from: today, to: today };
+      case "this-month":
+         return { from: today.startOf("month"), to: today.endOf("month") };
+      case "last-30-days":
+         return { from: today.subtract(29, "day"), to: today };
+      case "next-month": {
+         const nextMonth = today.add(1, "month");
+         return {
+            from: nextMonth.startOf("month"),
+            to: nextMonth.endOf("month"),
+         };
+      }
+      default:
+         return { from: today.startOf("month"), to: today.endOf("month") };
+   }
+}
+
+function formatDateRangeLabel(dateFrom: string, dateTo: string) {
+   const from = dateFrom ? dayjs(dateFrom).format("DD/MM/YYYY") : "início";
+   const to = dateTo ? dayjs(dateTo).format("DD/MM/YYYY") : "hoje";
+   if (dateFrom && dateTo && dateFrom === dateTo) return from;
+   return `${from} – ${to}`;
 }
 
 function normalizeImportLookup(value: unknown): string {
@@ -459,6 +498,8 @@ export function TransactionsList() {
       status,
       search,
       bankId,
+      dateFrom,
+      dateTo,
       relationshipId,
    } = routeApi.useSearch();
 
@@ -508,11 +549,15 @@ export function TransactionsList() {
                overdueOnly: false,
                status: effectiveStatus.length > 0 ? effectiveStatus : undefined,
                bankAccountId: effectiveBankId || undefined,
+               dateFrom: dateFrom || undefined,
+               dateTo: dateTo || undefined,
                relationshipId: effectiveRelationshipId || undefined,
             }),
          ),
       [
          collectionTeamId,
+         dateFrom,
+         dateTo,
          effectiveBankId,
          effectiveRelationshipId,
          effectiveStatus,
@@ -532,11 +577,15 @@ export function TransactionsList() {
                overdueOnly: false,
                status: effectiveStatus.length > 0 ? effectiveStatus : undefined,
                bankAccountId: effectiveBankId || undefined,
+               dateFrom: dateFrom || undefined,
+               dateTo: dateTo || undefined,
                relationshipId: effectiveRelationshipId || undefined,
             }),
          ),
       [
          collectionTeamId,
+         dateFrom,
+         dateTo,
          effectiveBankId,
          effectiveRelationshipId,
          effectiveStatus,
@@ -1855,6 +1904,30 @@ export function TransactionsList() {
    const importApi = useDataImport({ table, config: importConfig });
    importUpdateRef.current = importApi.updateRow;
 
+   const selectedDateRange = useMemo(() => {
+      if (!dateFrom) return null;
+      const from = dayjs(dateFrom);
+      const to = dateTo ? dayjs(dateTo) : from;
+      if (!from.isValid() || !to.isValid()) return null;
+      return { from: from.toDate(), to: to.toDate() };
+   }, [dateFrom, dateTo]);
+   const dateRangeLabel = dateFrom
+      ? formatDateRangeLabel(dateFrom, dateTo || dateFrom)
+      : "Período";
+   const clearDateRange = useCallback(
+      () =>
+         navigate({
+            search: (prev) => ({
+               ...prev,
+               dateFrom: "",
+               dateTo: "",
+               page: 1,
+            }),
+            replace: true,
+         }),
+      [navigate],
+   );
+
    const selectedRows = table.getSelectedRowModel().rows;
    const selectedIds = selectedRows.map((r) => r.original.id);
    const resetSelection = () => table.resetRowSelection();
@@ -1944,6 +2017,37 @@ export function TransactionsList() {
                   value={searchInput.value}
                />
                <div className="flex flex-wrap items-center gap-2">
+                  <DateRangePicker
+                     presets={DATE_RANGE_PRESETS}
+                     selectedRange={selectedDateRange}
+                     onPresetSelect={(preset) => {
+                        const range = getDateRangePresetRange(preset);
+                        navigate({
+                           search: (prev) => ({
+                              ...prev,
+                              dateFrom: range.from.format("YYYY-MM-DD"),
+                              dateTo: range.to.format("YYYY-MM-DD"),
+                              page: 1,
+                           }),
+                           replace: true,
+                        });
+                     }}
+                     onRangeSelect={(range) =>
+                        navigate({
+                           search: (prev) => ({
+                              ...prev,
+                              dateFrom: dayjs(range.from).format("YYYY-MM-DD"),
+                              dateTo: dayjs(range.to).format("YYYY-MM-DD"),
+                              page: 1,
+                           }),
+                           replace: true,
+                        })
+                     }
+                     label={dateRangeLabel}
+                     onClear={dateFrom ? clearDateRange : undefined}
+                     clearIcon={<X className="size-4" />}
+                     triggerClassName="h-8"
+                  />
                   <DataTableColumnVisibility table={table} />
                   <ExportButton table={table} fileBase="lancamentos" />
                   <DataImportButton api={importApi} config={importConfig} />
@@ -1959,7 +2063,29 @@ export function TransactionsList() {
                </div>
             </div>
             <TooltipProvider>
-               <DataTableFilterChips table={table} />
+               <div className="flex flex-wrap items-center gap-2">
+                  {dateFrom ? (
+                     <Badge variant="secondary" className="gap-2 pr-2">
+                        <span className="text-xs">
+                           Período:{" "}
+                           {formatDateRangeLabel(dateFrom, dateTo || dateFrom)}
+                        </span>
+                        <Button
+                           className="size-4"
+                           onClick={clearDateRange}
+                           size="icon"
+                           type="button"
+                           variant="ghost"
+                        >
+                           <X className="size-2" />
+                           <span className="sr-only">
+                              Remover filtro período
+                           </span>
+                        </Button>
+                     </Badge>
+                  ) : null}
+                  <DataTableFilterChips table={table} />
+               </div>
                <ScrollArea className="flex-1 min-h-0 rounded-md border bg-card">
                   <Table
                      className="min-w-max"

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/transactions.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/transactions.tsx
@@ -8,6 +8,12 @@ import { buildTransactionColumns } from "./-transactions/transactions-columns";
 
 const skeletonColumns = buildTransactionColumns();
 
+const isoDateSearchParam = z
+   .string()
+   .regex(/^\d{4}-\d{2}-\d{2}$/)
+   .catch("")
+   .default("");
+
 const transactionsSearchSchema = z.object({
    sorting: z
       .array(z.object({ id: z.string(), desc: z.boolean() }))
@@ -31,6 +37,8 @@ const transactionsSearchSchema = z.object({
       .default([]),
    bankId: z.string().catch("").default(""),
    relationshipId: z.string().catch("").default(""),
+   dateFrom: isoDateSearchParam,
+   dateTo: isoDateSearchParam,
    grouping: z.array(z.string()).catch([]).default([]),
 });
 

--- a/modules/cashbook/__tests__/router/transactions.test.ts
+++ b/modules/cashbook/__tests__/router/transactions.test.ts
@@ -365,6 +365,123 @@ describe("transactions router", () => {
       expect(result.data.map((row) => row.name)).toEqual(["Oculto"]);
    });
 
+   it("getAll filtra lançamentos por intervalo de data", async () => {
+      const { teamId, organizationId } = await seedTeam(testDb.db);
+      const ctx = createTestContext(testDb.db, { teamId, organizationId });
+      const [account] = await testDb.db
+         .insert(bankAccounts)
+         .values({
+            teamId,
+            name: "Conta Período",
+            type: "checking",
+            initialBalance: "0",
+            status: "active",
+         })
+         .returning();
+
+      await testDb.db.insert(transactions).values([
+         {
+            teamId,
+            type: "income",
+            name: "Antes",
+            amount: "10.00",
+            date: "2026-05-01",
+            status: "paid",
+            ignored: false,
+            bankAccountId: account.id,
+         },
+         {
+            teamId,
+            type: "income",
+            name: "Dentro",
+            amount: "20.00",
+            date: "2026-05-15",
+            status: "paid",
+            ignored: false,
+            bankAccountId: account.id,
+         },
+         {
+            teamId,
+            type: "income",
+            name: "Depois",
+            amount: "30.00",
+            date: "2026-06-01",
+            status: "paid",
+            ignored: false,
+            bankAccountId: account.id,
+         },
+      ]);
+
+      const result = await call(
+         transactionsListRouter.getAll,
+         { dateFrom: "2026-05-10", dateTo: "2026-05-20" },
+         { context: ctx },
+      );
+
+      expect(result.total).toBe(1);
+      expect(result.data.map((row) => row.name)).toEqual(["Dentro"]);
+   });
+
+   it("bulkRemove exclui lançamento origem de recorrência sem erro de chave estrangeira", async () => {
+      const { teamId, organizationId } = await seedTeam(testDb.db);
+      const ctx = createTestContext(testDb.db, { teamId, organizationId });
+      const [account] = await testDb.db
+         .insert(bankAccounts)
+         .values({
+            teamId,
+            name: "Conta Exclusão Recorrente",
+            type: "checking",
+            initialBalance: "0",
+            status: "active",
+         })
+         .returning();
+
+      await call(
+         transactionsRouter.create,
+         {
+            type: "income",
+            name: "Receita recorrente removível",
+            amount: "150.00",
+            date: "2026-05-15",
+            status: "pending",
+            ignored: false,
+            bankAccountId: account.id,
+            isRecurring: true,
+            recurrenceFrequency: "monthly",
+         },
+         { context: ctx },
+      );
+
+      const rows = await testDb.db
+         .select()
+         .from(transactions)
+         .where(eq(transactions.teamId, teamId))
+         .orderBy(asc(transactions.recurrenceOccurrenceNumber));
+      const source = rows[0];
+      expect(source).toBeDefined();
+      if (!source) return;
+
+      await expect(
+         call(
+            transactionsRouter.bulkRemove,
+            { ids: [source.id] },
+            { context: ctx },
+         ),
+      ).resolves.toEqual({ success: true });
+
+      const recurrences = await testDb.db
+         .select()
+         .from(transactionRecurrences)
+         .where(eq(transactionRecurrences.teamId, teamId));
+      const remainingRows = await testDb.db
+         .select()
+         .from(transactions)
+         .where(eq(transactions.teamId, teamId));
+
+      expect(recurrences).toHaveLength(0);
+      expect(remainingRows.some((row) => row.id === source.id)).toBe(false);
+   });
+
    it("getAll ignora operador textual em coluna monetária", async () => {
       const { teamId, organizationId } = await seedTeam(testDb.db);
       const ctx = createTestContext(testDb.db, { teamId, organizationId });

--- a/modules/cashbook/src/router/transactions.ts
+++ b/modules/cashbook/src/router/transactions.ts
@@ -1100,11 +1100,19 @@ export const bulkRemove = protectedProcedure
    .handler(async ({ context, input }) => {
       const result = await Result.tryPromise({
          try: () =>
-            context.db.transaction(async (tx) =>
-               tx
+            context.db.transaction(async (tx) => {
+               await tx
+                  .delete(transactionRecurrences)
+                  .where(
+                     inArray(
+                        transactionRecurrences.sourceTransactionId,
+                        input.ids,
+                     ),
+                  );
+               return tx
                   .delete(transactions)
-                  .where(inArray(transactions.id, input.ids)),
-            ),
+                  .where(inArray(transactions.id, input.ids));
+            }),
          catch: () =>
             new TransactionRouterError({
                error: transactionRouterErrors.INTERNAL(),

--- a/scripts/audit-transaction-payment-method-notes.ts
+++ b/scripts/audit-transaction-payment-method-notes.ts
@@ -1,0 +1,136 @@
+import { config } from "dotenv";
+import { resolve } from "node:path";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { sql } from "drizzle-orm";
+
+const root = process.cwd();
+config({ path: resolve(root, "apps/web/.env.local") });
+config({ path: resolve(root, "apps/web/.env.production"), override: true });
+config({
+   path: "/home/yorizel/Documents/montte-nx/apps/web/.env.production",
+   override: true,
+});
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+   console.error("DATABASE_URL não definido.");
+   process.exit(1);
+}
+
+const client = postgres(databaseUrl, { max: 1, prepare: false });
+const db = drizzle(client);
+
+const paymentMatchers = [
+   {
+      paymentMethod: "pix",
+      label: "Pix",
+      pattern: "(^|[^[:alnum:]])pix([^[:alnum:]]|$)",
+   },
+   {
+      paymentMethod: "credit_card",
+      label: "Cartão de crédito",
+      pattern: "cart[aã]o[[:space:]]+(de[[:space:]]+)?cr[eé]dito|credito",
+   },
+   {
+      paymentMethod: "debit_card",
+      label: "Cartão de débito",
+      pattern: "cart[aã]o[[:space:]]+(de[[:space:]]+)?d[eé]bito|debito",
+   },
+   { paymentMethod: "boleto", label: "Boleto", pattern: "boleto" },
+   {
+      paymentMethod: "cash",
+      label: "Dinheiro",
+      pattern: "dinheiro|esp[eé]cie",
+   },
+   {
+      paymentMethod: "transfer",
+      label: "Transferência",
+      pattern: "transfer[eê]ncia|ted|doc",
+   },
+   { paymentMethod: "cheque", label: "Cheque", pattern: "cheque" },
+   {
+      paymentMethod: "automatic_debit",
+      label: "Débito automático",
+      pattern:
+         "d[eé]bito[[:space:]]+autom[aá]tico|debito[[:space:]]+automatico",
+   },
+];
+
+const casesSql = paymentMatchers
+   .map(
+      (matcher) =>
+         `WHEN description ~* '${matcher.pattern.replace(/'/g, "''")}' THEN '${matcher.paymentMethod}'`,
+   )
+   .join("\n            ");
+
+const query = sql.raw(`
+   WITH candidates AS (
+      SELECT
+         id,
+         team_id AS "teamId",
+         name,
+         description,
+         payment_method AS "paymentMethod",
+         date,
+         amount,
+         CASE
+            ${casesSql}
+            ELSE NULL
+         END AS "suggestedPaymentMethod"
+      FROM finance.transactions
+      WHERE payment_method IS NULL
+        AND description IS NOT NULL
+        AND btrim(description) <> ''
+   ), matched AS (
+      SELECT *
+      FROM candidates
+      WHERE "suggestedPaymentMethod" IS NOT NULL
+   )
+   SELECT
+      "suggestedPaymentMethod",
+      count(*)::int AS count,
+      json_agg(
+         json_build_object(
+            'id', id,
+            'teamId', "teamId",
+            'name', name,
+            'date', date,
+            'amount', amount,
+            'description', description
+         )
+         ORDER BY date DESC
+      ) FILTER (WHERE true) AS samples
+   FROM (
+      SELECT *, row_number() OVER (PARTITION BY "suggestedPaymentMethod" ORDER BY date DESC, id) AS rn
+      FROM matched
+   ) ranked
+   WHERE rn <= 10
+   GROUP BY "suggestedPaymentMethod"
+   ORDER BY count DESC;
+`);
+
+const totalQuery = sql.raw(`
+   WITH candidates AS (
+      SELECT
+         CASE
+            ${casesSql}
+            ELSE NULL
+         END AS "suggestedPaymentMethod"
+      FROM finance.transactions
+      WHERE payment_method IS NULL
+        AND description IS NOT NULL
+        AND btrim(description) <> ''
+   )
+   SELECT "suggestedPaymentMethod", count(*)::int AS count
+   FROM candidates
+   WHERE "suggestedPaymentMethod" IS NOT NULL
+   GROUP BY "suggestedPaymentMethod"
+   ORDER BY count DESC;
+`);
+
+const rows = await db.execute(query);
+const totals = await db.execute(totalQuery);
+
+console.log(JSON.stringify({ totals, samples: rows }, null, 2));
+await client.end();

--- a/scripts/migrate-transaction-payment-method-from-description.ts
+++ b/scripts/migrate-transaction-payment-method-from-description.ts
@@ -1,0 +1,184 @@
+import { config } from "dotenv";
+import { resolve } from "node:path";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { sql } from "drizzle-orm";
+
+const args = new Set(process.argv.slice(2));
+const apply = args.has("--apply");
+const clearExactDescription = !args.has("--keep-description");
+const env =
+   process.argv.find((arg) => arg.startsWith("--env="))?.slice(6) ?? "local";
+
+const root = process.cwd();
+config({ path: resolve(root, "apps/web/.env.local") });
+if (env === "production") {
+   config({ path: resolve(root, "apps/web/.env.production"), override: true });
+}
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+   console.error("DATABASE_URL não definido.");
+   process.exit(1);
+}
+
+const client = postgres(databaseUrl, { max: 1, prepare: false });
+const db = drizzle(client);
+
+const paymentMatchers = [
+   {
+      paymentMethod: "automatic_debit",
+      pattern:
+         "d[eé]bito[[:space:]]+autom[aá]tico|debito[[:space:]]+automatico",
+      exactPattern:
+         "^[[:space:]]*(d[eé]bito[[:space:]]+autom[aá]tico|debito[[:space:]]+automatico)[[:space:]]*$",
+   },
+   {
+      paymentMethod: "pix",
+      pattern: "(^|[^[:alnum:]])pix([^[:alnum:]]|$)",
+      exactPattern: "^[[:space:]]*pix[[:space:]]*$",
+   },
+   {
+      paymentMethod: "credit_card",
+      pattern: "cart[aã]o[[:space:]]+(de[[:space:]]+)?cr[eé]dito|credito",
+      exactPattern:
+         "^[[:space:]]*(cart[aã]o[[:space:]]+(de[[:space:]]+)?cr[eé]dito|credito)[[:space:]]*$",
+   },
+   {
+      paymentMethod: "debit_card",
+      pattern: "cart[aã]o[[:space:]]+(de[[:space:]]+)?d[eé]bito|debito",
+      exactPattern:
+         "^[[:space:]]*(cart[aã]o[[:space:]]+(de[[:space:]]+)?d[eé]bito|debito)[[:space:]]*$",
+   },
+   {
+      paymentMethod: "boleto",
+      pattern: "boleto",
+      exactPattern: "^[[:space:]]*boleto[[:space:]]*$",
+   },
+   {
+      paymentMethod: "cash",
+      pattern: "dinheiro|esp[eé]cie",
+      exactPattern:
+         "^[[:space:]]*(dinheiro|em[[:space:]]+dinheiro|esp[eé]cie)[[:space:]]*$",
+   },
+   {
+      paymentMethod: "transfer",
+      pattern: "transfer[eê]ncia|ted|doc",
+      exactPattern: "^[[:space:]]*(transfer[eê]ncia|ted|doc)[[:space:]]*$",
+   },
+   {
+      paymentMethod: "cheque",
+      pattern: "cheque",
+      exactPattern: "^[[:space:]]*cheque[[:space:]]*$",
+   },
+];
+
+const casesSql = paymentMatchers
+   .map(
+      (matcher) =>
+         `WHEN description ~* '${matcher.pattern.replace(/'/g, "''")}' THEN '${matcher.paymentMethod}'`,
+   )
+   .join("\n            ");
+
+const exactCasesSql = paymentMatchers
+   .map(
+      (matcher) =>
+         `WHEN description ~* '${matcher.exactPattern.replace(/'/g, "''")}' THEN true`,
+   )
+   .join("\n            ");
+
+const matchedCte = `
+   WITH candidates AS (
+      SELECT
+         id,
+         team_id,
+         name,
+         description,
+         date,
+         amount,
+         CASE
+            ${casesSql}
+            ELSE NULL
+         END AS suggested_payment_method,
+         CASE
+            ${exactCasesSql}
+            ELSE false
+         END AS exact_description
+      FROM finance.transactions
+      WHERE payment_method IS NULL
+        AND description IS NOT NULL
+        AND btrim(description) <> ''
+   ), matched AS (
+      SELECT *
+      FROM candidates
+      WHERE suggested_payment_method IS NOT NULL
+   )
+`;
+
+if (!apply) {
+   const rows = await db.execute(
+      sql.raw(`${matchedCte}
+      SELECT
+         suggested_payment_method AS "suggestedPaymentMethod",
+         count(*)::int AS count,
+         count(*) FILTER (WHERE exact_description)::int AS "exactDescriptionCount",
+         json_agg(
+            json_build_object(
+               'id', id,
+               'teamId', team_id,
+               'name', name,
+               'date', date,
+               'amount', amount,
+               'description', description,
+               'clearDescription', exact_description
+            )
+            ORDER BY date DESC
+         ) AS samples
+      FROM (
+         SELECT *, row_number() OVER (PARTITION BY suggested_payment_method ORDER BY date DESC, id) AS rn
+         FROM matched
+      ) ranked
+      WHERE rn <= 20
+      GROUP BY suggested_payment_method
+      ORDER BY count DESC;
+   `),
+   );
+   console.log(JSON.stringify({ mode: "dry-run", rows }, null, 2));
+   await client.end();
+   process.exit(0);
+}
+
+const updated = await db.execute(
+   sql.raw(`${matchedCte}
+   UPDATE finance.transactions AS t
+   SET
+      payment_method = matched.suggested_payment_method::finance.payment_method,
+      description = CASE
+         WHEN ${clearExactDescription ? "matched.exact_description" : "false"} THEN NULL
+         ELSE t.description
+      END,
+      updated_at = now()
+   FROM matched
+   WHERE t.id = matched.id
+   RETURNING
+      t.id,
+      t.team_id AS "teamId",
+      t.name,
+      t.payment_method AS "paymentMethod",
+      t.description;
+`),
+);
+
+console.log(
+   JSON.stringify(
+      {
+         mode: "apply",
+         clearExactDescription,
+         updatedCount: updated.length,
+         updated,
+      },
+      null,
+      2,
+   ),
+);
+await client.end();


### PR DESCRIPTION
## Resumo
- adiciona filtro de período na tela de lançamentos usando DateRangePicker e chips
- exibe/edita Observações na tabela e corrige edição inline de valor
- corrige bulk delete de lançamentos recorrentes e adiciona testes
- adiciona scripts dry-run/apply para migrar forma de pagamento salva em observações

## Validação
- bun --filter @modules/cashbook test -- --run __tests__/router/transactions.test.ts
- bun --filter @modules/cashbook typecheck
- bun --filter web typecheck
- git diff --check

## Operação em prod
- Migração executada para 3 lançamentos com observação `Dinheiro/dinheiro`: `paymentMethod = cash`, `description = null`.
