### PR TITLE
fix: corrigir CSV dos modelos de importação no Excel pt-BR

### DIFF
--- a/apps/web/src/hooks/use-csv-file.ts
+++ b/apps/web/src/hooks/use-csv-file.ts
@@ -1,6 +1,8 @@
 import { parseBufferOrThrow, generateFromObjects } from "@f-o-t/csv";
 import { useCallback } from "react";
 
+const UTF8_BOM = String.fromCharCode(0xfeff);
+
 export type CsvData = {
    headers: string[];
    rows: string[][];
@@ -20,9 +22,13 @@ export function useCsvFile() {
 
    const generate = useCallback(
       (rows: Record<string, string>[], headers: string[]): Blob =>
-         new Blob([generateFromObjects(rows, { headers })], {
-            type: "text/csv;charset=utf-8;",
-         }),
+         // BOM força o Excel a ler como UTF-8 (senão os acentos quebram);
+         // ";" é o separador de lista do Excel pt-BR (senão tudo cai numa coluna).
+         // O parse de import auto-detecta delimiter e encoding, então o round-trip segue ok.
+         new Blob(
+            [UTF8_BOM, generateFromObjects(rows, { headers, delimiter: ";" })],
+            { type: "text/csv;charset=utf-8;" },
+         ),
       [],
    );
 


### PR DESCRIPTION
## Problema

Os modelos de importação baixáveis (categorias, centros de custo, cartões, contas bancárias, lançamentos, relacionamentos) abriam **quebrados no Excel em pt-BR**:

- **Acentos viravam mojibake** — `Cartão` → `CartÃ£o`, `Móveis e Utensílios` → `MÃ³veis e UtensÃ­lios`. O CSV não tinha BOM, então o Excel lia como ANSI/Latin-1.
- **Tudo numa coluna só** — o arquivo usava vírgula, mas o Excel pt-BR separa lista por `;`, então a linha inteira caía na célula A.

## Fix

Em `apps/web/src/hooks/use-csv-file.ts` (o `generate` é compartilhado por **todos os 6 modelos** e pelo export-button):

- Prefixa **BOM UTF-8** para o Excel detectar a codificação.
- Usa **`;`** como delimitador (separador de lista do Excel pt-BR).

O parse de import (`parseBufferOrThrow`) **auto-detecta** delimitador e codificação, então o arquivo preenchido continua importável — round-trip preservado. XLSX não era afetado (binário).

## Validação
- `tsc --noEmit` (apps/web): sem erros
- `oxlint`: 0 warnings / 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)