### PR TITLE
Exportar relatórios com React PDF

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -67,6 +67,7 @@
       "@orpc/tanstack-query": "catalog:orpc",
       "@orpc/zod": "catalog:orpc",
       "@packages/ui": "workspace:*",
+      "@react-pdf/renderer": "catalog:pdf",
       "@tailwindcss/vite": "catalog:vite",
       "@tanstack/ai": "catalog:tanstack-ai",
       "@tanstack/ai-openrouter": "catalog:tanstack-ai",

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-reports/report-panels.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-reports/report-panels.tsx
@@ -29,7 +29,6 @@ import {
    costCentersReportCollectionOptions,
    profitAndLossReportCollectionOptions,
    reportTransactionsCollectionOptions,
-   reportTransactionsSummaryCollectionOptions,
 } from "@/integrations/tanstack-db/reports";
 import { type Inputs, type Outputs } from "@/integrations/orpc/client";
 import type { SavedReport } from "./report-labels";
@@ -172,8 +171,7 @@ function ProfitAndLossData({
          bankAccountId: config.bankAccountId,
          categoryId: config.categoryId,
          tagId: config.tagId,
-         page: 1,
-         pageSize: 100,
+         all: true,
          sorting: [{ id: "date", desc: true }],
       }),
       [
@@ -185,25 +183,6 @@ function ProfitAndLossData({
          config.tagId,
       ],
    );
-   const summaryInput = useMemo(
-      () => ({
-         dateFrom: config.dateFrom,
-         dateTo: config.dateTo,
-         status: transactionStatusFilter(config.status),
-         bankAccountId: config.bankAccountId,
-         categoryId: config.categoryId,
-         tagId: config.tagId,
-      }),
-      [
-         config.dateFrom,
-         config.dateTo,
-         config.status,
-         config.bankAccountId,
-         config.categoryId,
-         config.tagId,
-      ],
-   );
-
    const reportCollection = useMemo(
       () =>
          createCollection(
@@ -226,17 +205,6 @@ function ProfitAndLossData({
          ),
       [queryClient, teamId, transactionsInput],
    );
-   const transactionsSummaryCollection = useMemo(
-      () =>
-         createCollection(
-            reportTransactionsSummaryCollectionOptions({
-               queryClient,
-               input: summaryInput,
-               teamId,
-            }),
-         ),
-      [queryClient, teamId, summaryInput],
-   );
    const { data: reports, isLoading: isReportLoading } = useLiveQuery(
       (q) =>
          q.from({ report: reportCollection }).select(({ report }) => report),
@@ -250,27 +218,13 @@ function ProfitAndLossData({
                .select(({ transaction }) => transaction),
          [transactionsCollection],
       );
-   const { data: summaries, isLoading: isSummaryLoading } = useLiveQuery(
-      (q) =>
-         q
-            .from({ summary: transactionsSummaryCollection })
-            .select(({ summary }) => summary),
-      [transactionsSummaryCollection],
-   );
-
    const report = reports[0];
    const transactionRows = transactions.filter(
       (row) => row.type !== "transfer",
    );
-   const summary = summaries[0];
-   const transactionTotal = summary?.total ?? transactions.length;
+   const transactionTotal = transactionRows.length;
 
-   if (
-      !report ||
-      isReportLoading ||
-      isTransactionsLoading ||
-      isSummaryLoading
-   ) {
+   if (!report || isReportLoading || isTransactionsLoading) {
       return <EmptyReport title="Carregando relatório DRE" />;
    }
 
@@ -917,7 +871,6 @@ function ReportQuality({
 }) {
    const uncategorized = transactions.filter((row) => !row.categoryId).length;
    const withoutCostCenter = transactions.filter((row) => !row.tagId).length;
-   const omitted = Math.max(0, transactionTotal - transactions.length);
    const resultLabel =
       numberValue(report.totals.result) >= 0 ? "positivo" : "negativo";
 
@@ -950,12 +903,6 @@ function ReportQuality({
                },
             ]}
          />
-         {omitted > 0 ? (
-            <p className="text-muted-foreground text-sm">
-               Mostrando os 100 lançamentos mais recentes. Existem {omitted}{" "}
-               lançamentos adicionais na base deste relatório.
-            </p>
-         ) : null}
       </ReportBlock>
    );
 }

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-reports/report-pdf.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-reports/report-pdf.tsx
@@ -1,0 +1,995 @@
+/* oxlint-disable react-doctor/no-multi-comp react-doctor/only-export-components -- Componentes pequenos e coesos do documento PDF; ficam juntos para preservar consistência visual entre relatórios. */
+import { format, of } from "@f-o-t/money";
+import {
+   Document,
+   Page,
+   StyleSheet,
+   Text,
+   View,
+   pdf,
+} from "@react-pdf/renderer";
+import dayjs from "dayjs";
+import type { ReactNode } from "react";
+import { orpc, type Inputs, type Outputs } from "@/integrations/orpc/client";
+import type { SavedReport } from "./report-labels";
+
+type ProfitAndLossReport = Outputs["reports"]["profitAndLoss"];
+type CashFlowReport = Outputs["reports"]["cashFlow"];
+type CostCenterReport = Outputs["reports"]["expensesByCostCenter"];
+type AgingReport = Outputs["reports"]["aging"];
+type CategoryExpenseReport = Outputs["reports"]["expensesByCategory"];
+type TransactionRow = Outputs["transactions"]["getAll"]["data"][number];
+type TransactionStatus = "pending" | "paid";
+
+type ReportPdfPayload =
+   | { type: "dre"; data: ProfitAndLossReport; transactions: TransactionRow[] }
+   | { type: "cash-flow"; data: CashFlowReport }
+   | { type: "cost-centers"; data: CostCenterReport }
+   | { type: "aging"; data: AgingReport }
+   | { type: "categories"; data: CategoryExpenseReport };
+
+const REPORT_TYPE_LABELS: Record<SavedReport["type"], string> = {
+   dre: "Resultado / DRE",
+   "cash-flow": "Fluxo de caixa",
+   "cost-centers": "Centro de Custo",
+   aging: "A receber / pagar",
+   categories: "Despesas por categoria",
+};
+
+const percentFormatter = new Intl.NumberFormat("pt-BR", {
+   style: "percent",
+   maximumFractionDigits: 1,
+});
+
+const generatedAtFormatter = new Intl.DateTimeFormat("pt-BR", {
+   dateStyle: "short",
+   timeStyle: "short",
+});
+
+const styles = StyleSheet.create({
+   page: {
+      paddingTop: 26,
+      paddingRight: 28,
+      paddingBottom: 34,
+      paddingLeft: 28,
+      fontSize: 8,
+      fontFamily: "Helvetica",
+      color: "#111827",
+      backgroundColor: "#ffffff",
+   },
+   header: {
+      marginBottom: 18,
+      padding: 14,
+      borderRadius: 10,
+      backgroundColor: "#111827",
+      color: "#ffffff",
+   },
+   brandRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      marginBottom: 12,
+   },
+   brand: {
+      fontSize: 10,
+      fontWeight: 700,
+      letterSpacing: 1.2,
+      color: "#a7f3d0",
+      textTransform: "uppercase",
+   },
+   generatedAt: {
+      fontSize: 7,
+      color: "#d1d5db",
+   },
+   title: {
+      fontSize: 18,
+      fontWeight: 700,
+      color: "#ffffff",
+      marginBottom: 5,
+   },
+   subtitle: {
+      fontSize: 9,
+      color: "#d1d5db",
+   },
+   metaRow: {
+      flexDirection: "row",
+      gap: 6,
+      marginTop: 10,
+   },
+   pill: {
+      paddingTop: 4,
+      paddingRight: 7,
+      paddingBottom: 4,
+      paddingLeft: 7,
+      borderRadius: 999,
+      backgroundColor: "#1f2937",
+      color: "#e5e7eb",
+      fontSize: 7,
+   },
+   section: {
+      gap: 8,
+      marginBottom: 16,
+   },
+   sectionTitle: {
+      fontSize: 11,
+      fontWeight: 700,
+      color: "#111827",
+      paddingBottom: 5,
+      borderBottomWidth: 1,
+      borderBottomColor: "#e5e7eb",
+   },
+   summary: {
+      flexDirection: "row",
+      flexWrap: "wrap",
+      gap: 8,
+      marginBottom: 14,
+   },
+   summaryItem: {
+      minWidth: 108,
+      padding: 10,
+      borderWidth: 1,
+      borderColor: "#e5e7eb",
+      borderRadius: 8,
+      gap: 4,
+      backgroundColor: "#f9fafb",
+   },
+   summaryIncome: {
+      borderColor: "#a7f3d0",
+      backgroundColor: "#ecfdf5",
+   },
+   summaryExpense: {
+      borderColor: "#fecaca",
+      backgroundColor: "#fef2f2",
+   },
+   summaryLabel: {
+      fontSize: 7,
+      color: "#6b7280",
+      textTransform: "uppercase",
+      letterSpacing: 0.5,
+   },
+   summaryValue: {
+      fontSize: 12,
+      fontWeight: 700,
+      color: "#111827",
+   },
+   table: {
+      borderWidth: 1,
+      borderColor: "#d1d5db",
+      borderBottomWidth: 0,
+      borderRadius: 6,
+   },
+   row: {
+      flexDirection: "row",
+      borderBottomWidth: 1,
+      borderBottomColor: "#e5e7eb",
+      minHeight: 22,
+   },
+   headerRow: {
+      backgroundColor: "#f3f4f6",
+   },
+   totalRow: {
+      backgroundColor: "#f9fafb",
+   },
+   groupRow: {
+      backgroundColor: "#fafafa",
+   },
+   cell: {
+      padding: 5,
+      borderRightWidth: 1,
+      borderRightColor: "#e5e7eb",
+      justifyContent: "center",
+   },
+   lastCell: {
+      borderRightWidth: 0,
+   },
+   headText: {
+      fontSize: 7,
+      fontWeight: 700,
+      color: "#374151",
+      textTransform: "uppercase",
+      letterSpacing: 0.4,
+   },
+   text: {
+      fontSize: 8,
+      lineHeight: 1.25,
+   },
+   strongText: {
+      fontWeight: 700,
+      color: "#111827",
+   },
+   rightText: {
+      textAlign: "right",
+   },
+   mutedText: {
+      color: "#6b7280",
+   },
+   incomeText: {
+      color: "#047857",
+   },
+   expenseText: {
+      color: "#b91c1c",
+   },
+   footer: {
+      position: "absolute",
+      left: 28,
+      right: 28,
+      bottom: 14,
+      paddingTop: 6,
+      borderTopWidth: 1,
+      borderTopColor: "#e5e7eb",
+      flexDirection: "row",
+      justifyContent: "space-between",
+      color: "#6b7280",
+      fontSize: 7,
+   },
+});
+
+function formatBRL(value: string | number): string {
+   return format(of(String(value), "BRL"), "pt-BR");
+}
+
+function formatPercent(value: number): string {
+   return percentFormatter.format(value);
+}
+
+function numberValue(value: string | number | null | undefined) {
+   const parsed = Number(value ?? 0);
+   return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function transactionStatusFilter(
+   status: SavedReport["config"]["status"],
+): TransactionStatus | TransactionStatus[] {
+   if (status === "all") return ["pending", "paid"];
+   return status;
+}
+
+function signedAmount(row: TransactionRow) {
+   const value = numberValue(row.amount);
+   if (row.type === "expense") return -value;
+   return value;
+}
+
+function fileSafeName(value: string) {
+   return value
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "");
+}
+
+function ReportHeader({ report }: { report: SavedReport }) {
+   const statusLabel =
+      report.config.status === "paid"
+         ? "Realizados"
+         : report.config.status === "pending"
+           ? "Planejados"
+           : "Realizados e planejados";
+
+   return (
+      <View style={styles.header} fixed>
+         <View style={styles.brandRow}>
+            <Text style={styles.brand}>Montte</Text>
+            <Text style={styles.generatedAt}>
+               Gerado em {generatedAtFormatter.format(new Date())}
+            </Text>
+         </View>
+         <Text style={styles.title}>{report.name}</Text>
+         <Text style={styles.subtitle}>{REPORT_TYPE_LABELS[report.type]}</Text>
+         <View style={styles.metaRow}>
+            <Text style={styles.pill}>
+               {dayjs(report.config.dateFrom).format("DD/MM/YYYY")} —{" "}
+               {dayjs(report.config.dateTo).format("DD/MM/YYYY")}
+            </Text>
+            <Text style={styles.pill}>{statusLabel}</Text>
+            {report.type === "dre" && report.config.dreOnly ? (
+               <Text style={styles.pill}>Somente categorias DRE</Text>
+            ) : null}
+         </View>
+      </View>
+   );
+}
+
+type SummaryItem = {
+   label: string;
+   value: string;
+   tone?: "income" | "expense";
+};
+
+function Summary({ items }: { items: SummaryItem[] }) {
+   return (
+      <View style={styles.summary}>
+         {items.map((item) => (
+            <View
+               key={item.label}
+               style={[
+                  styles.summaryItem,
+                  item.tone === "income" ? styles.summaryIncome : {},
+                  item.tone === "expense" ? styles.summaryExpense : {},
+               ]}
+            >
+               <Text style={styles.summaryLabel}>{item.label}</Text>
+               <Text
+                  style={[
+                     styles.summaryValue,
+                     item.tone === "income" ? styles.incomeText : {},
+                     item.tone === "expense" ? styles.expenseText : {},
+                  ]}
+               >
+                  {item.value}
+               </Text>
+            </View>
+         ))}
+      </View>
+   );
+}
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+   return (
+      <View style={styles.section}>
+         <Text style={styles.sectionTitle}>{title}</Text>
+         {children}
+      </View>
+   );
+}
+
+function Cell({
+   children,
+   width,
+   header,
+   last,
+   right,
+   muted,
+   strong,
+   tone,
+}: {
+   children: ReactNode;
+   width: string;
+   header?: boolean;
+   last?: boolean;
+   right?: boolean;
+   muted?: boolean;
+   strong?: boolean;
+   tone?: "income" | "expense";
+}) {
+   return (
+      <View style={[styles.cell, { width }, last ? styles.lastCell : {}]}>
+         <Text
+            style={[
+               header ? styles.headText : styles.text,
+               right ? styles.rightText : {},
+               muted ? styles.mutedText : {},
+               strong ? styles.strongText : {},
+               tone === "income" ? styles.incomeText : {},
+               tone === "expense" ? styles.expenseText : {},
+            ]}
+         >
+            {children}
+         </Text>
+      </View>
+   );
+}
+
+function ProfitAndLossPdf({
+   report,
+   transactions,
+}: {
+   report: ProfitAndLossReport;
+   transactions: TransactionRow[];
+}) {
+   const income = numberValue(report.totals.income);
+   const result = numberValue(report.totals.result);
+   const rows = report.groups.flatMap((group) => [
+      {
+         id: group.id,
+         name: group.name,
+         type: group.type,
+         total: group.total,
+         periods: group.periods,
+         muted: false,
+      },
+      ...group.rows.map((row) => ({
+         id: row.id,
+         name: `  ${row.name}`,
+         type: group.type,
+         total: row.total,
+         periods: row.periods,
+         muted: true,
+      })),
+   ]);
+
+   return (
+      <>
+         <Summary
+            items={[
+               {
+                  label: "Receita",
+                  value: formatBRL(report.totals.income),
+                  tone: "income",
+               },
+               {
+                  label: "Despesas",
+                  value: formatBRL(report.totals.expense),
+                  tone: "expense",
+               },
+               {
+                  label: "Resultado líquido",
+                  value: formatBRL(report.totals.result),
+                  tone: result < 0 ? "expense" : "income",
+               },
+               { label: "Lançamentos", value: String(transactions.length) },
+               {
+                  label: "Margem",
+                  value: formatPercent(income === 0 ? 0 : result / income),
+               },
+            ]}
+         />
+         <Section title="DRE">
+            <View style={styles.table}>
+               <View style={[styles.row, styles.headerRow]} fixed>
+                  <Cell header width="28%">
+                     Grupo
+                  </Cell>
+                  {report.periods.map((period) => (
+                     <Cell header key={period.period} right width="14%">
+                        {period.label}
+                     </Cell>
+                  ))}
+                  <Cell header last right width="16%">
+                     Total
+                  </Cell>
+               </View>
+               {rows.map((row) => (
+                  <View
+                     key={row.id}
+                     style={[styles.row, row.muted ? {} : styles.groupRow]}
+                     wrap={false}
+                  >
+                     <Cell muted={row.muted} strong={!row.muted} width="28%">
+                        {row.name}
+                     </Cell>
+                     {report.periods.map((period) => (
+                        <Cell
+                           key={period.period}
+                           muted={row.muted}
+                           right
+                           width="14%"
+                        >
+                           {formatBRL(
+                              row.periods.find(
+                                 (item) => item.period === period.period,
+                              )?.amount ?? 0,
+                           )}
+                        </Cell>
+                     ))}
+                     <Cell
+                        last
+                        muted={row.muted}
+                        right
+                        width="16%"
+                        tone={row.type === "income" ? "income" : "expense"}
+                     >
+                        {formatBRL(row.total)}
+                     </Cell>
+                  </View>
+               ))}
+               <View style={[styles.row, styles.totalRow]} wrap={false}>
+                  <Cell strong width="28%">
+                     Resultado líquido
+                  </Cell>
+                  {report.periods.map((period) => {
+                     const income = report.groups.reduce((total, group) => {
+                        if (group.type !== "income") return total;
+                        return (
+                           total +
+                           numberValue(
+                              group.periods.find(
+                                 (item) => item.period === period.period,
+                              )?.amount,
+                           )
+                        );
+                     }, 0);
+                     const expense = report.groups.reduce((total, group) => {
+                        if (group.type !== "expense") return total;
+                        return (
+                           total +
+                           numberValue(
+                              group.periods.find(
+                                 (item) => item.period === period.period,
+                              )?.amount,
+                           )
+                        );
+                     }, 0);
+                     return (
+                        <Cell key={period.period} right width="14%">
+                           {formatBRL(income - expense)}
+                        </Cell>
+                     );
+                  })}
+                  <Cell last right width="16%">
+                     {formatBRL(report.totals.result)}
+                  </Cell>
+               </View>
+            </View>
+         </Section>
+         <Section title="Lançamentos da base">
+            <View style={styles.table}>
+               <View style={[styles.row, styles.headerRow]} fixed>
+                  <Cell header width="14%">
+                     Data
+                  </Cell>
+                  <Cell header width="28%">
+                     Lançamento
+                  </Cell>
+                  <Cell header width="20%">
+                     Categoria
+                  </Cell>
+                  <Cell header width="18%">
+                     Centro de Custo
+                  </Cell>
+                  <Cell header width="10%">
+                     Status
+                  </Cell>
+                  <Cell header last right width="10%">
+                     Valor
+                  </Cell>
+               </View>
+               {transactions.map((row) => (
+                  <View key={row.id} style={styles.row} wrap={false}>
+                     <Cell width="14%">
+                        {dayjs(row.date).format("DD/MM/YYYY")}
+                     </Cell>
+                     <Cell width="28%">
+                        {row.name ?? row.description ?? "Sem descrição"}
+                     </Cell>
+                     <Cell width="20%">
+                        {row.categoryName ?? "Sem categoria"}
+                     </Cell>
+                     <Cell width="18%">
+                        {row.tagName ?? "Sem Centro de Custo"}
+                     </Cell>
+                     <Cell width="10%">
+                        {row.status === "paid" ? "Realizado" : "Planejado"}
+                     </Cell>
+                     <Cell
+                        last
+                        right
+                        tone={signedAmount(row) < 0 ? "expense" : "income"}
+                        width="10%"
+                     >
+                        {formatBRL(signedAmount(row))}
+                     </Cell>
+                  </View>
+               ))}
+            </View>
+         </Section>
+      </>
+   );
+}
+
+function CashFlowPdf({ report }: { report: CashFlowReport }) {
+   const totalIncome = report.rows.reduce(
+      (acc, row) => acc + numberValue(row.income),
+      0,
+   );
+   const totalExpense = report.rows.reduce(
+      (acc, row) => acc + numberValue(row.expense),
+      0,
+   );
+   const initialBalance = numberValue(report.rows[0]?.initialBalance);
+   const endingBalance = numberValue(
+      report.rows[report.rows.length - 1]?.endingBalance,
+   );
+
+   return (
+      <>
+         <Summary
+            items={[
+               { label: "Saldo inicial", value: formatBRL(initialBalance) },
+               {
+                  label: "Entradas",
+                  value: formatBRL(totalIncome),
+                  tone: "income",
+               },
+               {
+                  label: "Saídas",
+                  value: formatBRL(totalExpense),
+                  tone: "expense",
+               },
+               {
+                  label: "Saldo final",
+                  value: formatBRL(endingBalance),
+                  tone: endingBalance < 0 ? "expense" : "income",
+               },
+            ]}
+         />
+         <Section title="Fluxo de caixa">
+            <View style={styles.table}>
+               <View style={[styles.row, styles.headerRow]} fixed>
+                  <Cell header width="24%">
+                     Período
+                  </Cell>
+                  <Cell header right width="19%">
+                     Saldo inicial
+                  </Cell>
+                  <Cell header right width="19%">
+                     Entradas
+                  </Cell>
+                  <Cell header right width="19%">
+                     Saídas
+                  </Cell>
+                  <Cell header last right width="19%">
+                     Saldo final
+                  </Cell>
+               </View>
+               {report.rows.map((row) => (
+                  <View key={row.period} style={styles.row} wrap={false}>
+                     <Cell width="24%">{row.label}</Cell>
+                     <Cell right width="19%">
+                        {formatBRL(row.initialBalance)}
+                     </Cell>
+                     <Cell right tone="income" width="19%">
+                        {formatBRL(row.income)}
+                     </Cell>
+                     <Cell right tone="expense" width="19%">
+                        {formatBRL(row.expense)}
+                     </Cell>
+                     <Cell last right width="19%">
+                        {formatBRL(row.endingBalance)}
+                     </Cell>
+                  </View>
+               ))}
+            </View>
+         </Section>
+      </>
+   );
+}
+
+function CostCentersPdf({ report }: { report: CostCenterReport }) {
+   return (
+      <>
+         <Summary
+            items={[
+               {
+                  label: "Total de despesas",
+                  value: formatBRL(report.total),
+                  tone: "expense",
+               },
+               { label: "Centros de custo", value: String(report.rows.length) },
+            ]}
+         />
+         <Section title="Despesas por Centro de Custo">
+            <View style={styles.table}>
+               <View style={[styles.row, styles.headerRow]} fixed>
+                  <Cell header width="34%">
+                     Centro de Custo
+                  </Cell>
+                  <Cell header width="34%">
+                     Categoria
+                  </Cell>
+                  <Cell header right width="16%">
+                     Valor
+                  </Cell>
+                  <Cell header last right width="16%">
+                     % do total
+                  </Cell>
+               </View>
+               {report.rows.flatMap((row) =>
+                  row.categories.map((category) => (
+                     <View
+                        key={`${row.id}:${category.id}`}
+                        style={styles.row}
+                        wrap={false}
+                     >
+                        <Cell width="34%">{row.name}</Cell>
+                        <Cell width="34%">{category.name}</Cell>
+                        <Cell right width="16%">
+                           {formatBRL(category.amount)}
+                        </Cell>
+                        <Cell last right width="16%">
+                           {formatPercent(category.percent)}
+                        </Cell>
+                     </View>
+                  )),
+               )}
+            </View>
+         </Section>
+      </>
+   );
+}
+
+function AgingPdf({ report }: { report: AgingReport }) {
+   const total = report.buckets.reduce(
+      (acc, bucket) => acc + numberValue(bucket.amount),
+      0,
+   );
+   return (
+      <>
+         <Summary
+            items={[
+               { label: "Total", value: formatBRL(total) },
+               ...report.buckets.map((bucket) => ({
+                  label: bucket.label,
+                  value: formatBRL(bucket.amount),
+               })),
+            ]}
+         />
+         <Section title="Títulos">
+            <View style={styles.table}>
+               <View style={[styles.row, styles.headerRow]} fixed>
+                  <Cell header width="18%">
+                     Categoria
+                  </Cell>
+                  <Cell header width="14%">
+                     Tipo
+                  </Cell>
+                  <Cell header width="24%">
+                     Lançamento
+                  </Cell>
+                  <Cell header width="14%">
+                     Vencimento
+                  </Cell>
+                  <Cell header width="16%">
+                     Centro de Custo
+                  </Cell>
+                  <Cell header last right width="14%">
+                     Valor
+                  </Cell>
+               </View>
+               {report.rows.map((row) => (
+                  <View key={row.id} style={styles.row} wrap={false}>
+                     <Cell width="18%">
+                        {row.categoryName ?? "Sem categoria"}
+                     </Cell>
+                     <Cell width="14%">
+                        {row.type === "income"
+                           ? "A receber"
+                           : row.type === "expense"
+                             ? "A pagar"
+                             : "Transferência"}
+                     </Cell>
+                     <Cell width="24%">{row.name}</Cell>
+                     <Cell width="14%">
+                        {dayjs(row.dueDate).format("DD/MM/YYYY")}
+                     </Cell>
+                     <Cell width="16%">
+                        {row.tagName ?? "Sem Centro de Custo"}
+                     </Cell>
+                     <Cell last right width="14%">
+                        {formatBRL(row.amount)}
+                     </Cell>
+                  </View>
+               ))}
+            </View>
+         </Section>
+      </>
+   );
+}
+
+function CategoryExpensesPdf({ report }: { report: CategoryExpenseReport }) {
+   const totalCount = report.rows.reduce(
+      (acc, row) => acc + numberValue(row.count),
+      0,
+   );
+   return (
+      <>
+         <Summary
+            items={[
+               {
+                  label: "Total de despesas",
+                  value: formatBRL(report.total),
+                  tone: "expense",
+               },
+               { label: "Categorias", value: String(report.rows.length) },
+               { label: "Lançamentos", value: String(totalCount) },
+            ]}
+         />
+         <Section title="Despesas por categoria">
+            <View style={styles.table}>
+               <View style={[styles.row, styles.headerRow]} fixed>
+                  <Cell header width="40%">
+                     Categoria
+                  </Cell>
+                  <Cell header right width="20%">
+                     Valor
+                  </Cell>
+                  <Cell header right width="20%">
+                     % do total
+                  </Cell>
+                  <Cell header last right width="20%">
+                     Lançamentos
+                  </Cell>
+               </View>
+               {report.rows.map((row) => (
+                  <View key={row.id} style={styles.row} wrap={false}>
+                     <Cell width="40%">{row.name}</Cell>
+                     <Cell right width="20%">
+                        {formatBRL(row.amount)}
+                     </Cell>
+                     <Cell right width="20%">
+                        {formatPercent(row.percent)}
+                     </Cell>
+                     <Cell last right width="20%">
+                        {row.count}
+                     </Cell>
+                  </View>
+               ))}
+            </View>
+         </Section>
+      </>
+   );
+}
+
+function PdfFooter() {
+   return (
+      <View fixed style={styles.footer}>
+         <Text>Montte ERP · Relatório financeiro</Text>
+         <Text
+            render={({ pageNumber, totalPages }) =>
+               `Página ${pageNumber} de ${totalPages}`
+            }
+         />
+      </View>
+   );
+}
+
+function ReportPdfDocument({
+   report,
+   payload,
+}: {
+   report: SavedReport;
+   payload: ReportPdfPayload;
+}) {
+   return (
+      <Document
+         author="Montte"
+         creator="Montte"
+         subject={REPORT_TYPE_LABELS[report.type]}
+         title={report.name}
+      >
+         <Page
+            orientation={payload.type === "dre" ? "landscape" : "portrait"}
+            size="A4"
+            style={styles.page}
+            wrap
+         >
+            <ReportHeader report={report} />
+            {payload.type === "dre" ? (
+               <ProfitAndLossPdf
+                  report={payload.data}
+                  transactions={payload.transactions}
+               />
+            ) : null}
+            {payload.type === "cash-flow" ? (
+               <CashFlowPdf report={payload.data} />
+            ) : null}
+            {payload.type === "cost-centers" ? (
+               <CostCentersPdf report={payload.data} />
+            ) : null}
+            {payload.type === "aging" ? (
+               <AgingPdf report={payload.data} />
+            ) : null}
+            {payload.type === "categories" ? (
+               <CategoryExpensesPdf report={payload.data} />
+            ) : null}
+            <PdfFooter />
+         </Page>
+      </Document>
+   );
+}
+
+async function loadReportPayload(
+   report: SavedReport,
+): Promise<ReportPdfPayload> {
+   const config = report.config;
+
+   if (report.type === "dre") {
+      const input: Inputs["reports"]["profitAndLoss"] = {
+         dateFrom: config.dateFrom,
+         dateTo: config.dateTo,
+         status: config.status,
+         bankAccountId: config.bankAccountId,
+         categoryId: config.categoryId,
+         tagId: config.tagId,
+         dreOnly: config.dreOnly,
+      };
+      const transactionsInput: Inputs["transactions"]["getAll"] = {
+         dateFrom: config.dateFrom,
+         dateTo: config.dateTo,
+         status: transactionStatusFilter(config.status),
+         bankAccountId: config.bankAccountId,
+         categoryId: config.categoryId,
+         tagId: config.tagId,
+         all: true,
+         sorting: [{ id: "date", desc: true }],
+      };
+      const [data, transactionsResult] = await Promise.all([
+         orpc.reports.profitAndLoss.call(input),
+         orpc.transactions.getAll.call(transactionsInput),
+      ]);
+      return {
+         type: report.type,
+         data,
+         transactions: transactionsResult.data.filter(
+            (row) => row.type !== "transfer",
+         ),
+      };
+   }
+
+   if (report.type === "cash-flow") {
+      const input: Inputs["reports"]["cashFlow"] = {
+         dateFrom: config.dateFrom,
+         dateTo: config.dateTo,
+         status: config.status,
+         bankAccountId: config.bankAccountId,
+         categoryId: config.categoryId,
+         tagId: config.tagId,
+      };
+      return {
+         type: report.type,
+         data: await orpc.reports.cashFlow.call(input),
+      };
+   }
+
+   if (report.type === "cost-centers") {
+      const input: Inputs["reports"]["expensesByCostCenter"] = {
+         dateFrom: config.dateFrom,
+         dateTo: config.dateTo,
+         status: config.status,
+         bankAccountId: config.bankAccountId,
+         categoryId: config.categoryId,
+         tagId: config.tagId,
+      };
+      return {
+         type: report.type,
+         data: await orpc.reports.expensesByCostCenter.call(input),
+      };
+   }
+
+   if (report.type === "aging") {
+      const input: Inputs["reports"]["aging"] = {
+         dateFrom: config.dateFrom,
+         dateTo: config.dateTo,
+         status: config.agingStatus,
+         type: config.agingType,
+         categoryId: config.categoryId,
+         tagId: config.tagId,
+      };
+      return { type: report.type, data: await orpc.reports.aging.call(input) };
+   }
+
+   const input: Inputs["reports"]["expensesByCategory"] = {
+      dateFrom: config.dateFrom,
+      dateTo: config.dateTo,
+      status: config.status,
+      bankAccountId: config.bankAccountId,
+      categoryId: config.categoryId,
+      tagId: config.tagId,
+      depth: config.categoryDepth,
+      minAmount: config.minAmount,
+   };
+   return {
+      type: report.type,
+      data: await orpc.reports.expensesByCategory.call(input),
+   };
+}
+
+function triggerDownload(blob: Blob, filename: string) {
+   const url = URL.createObjectURL(blob);
+   const link = document.createElement("a");
+   link.href = url;
+   link.download = filename;
+   document.body.appendChild(link);
+   link.click();
+   link.remove();
+   URL.revokeObjectURL(url);
+}
+
+export async function downloadReportPdf(report: SavedReport) {
+   const payload = await loadReportPayload(report);
+   const blob = await pdf(
+      <ReportPdfDocument payload={payload} report={report} />,
+   ).toBlob();
+   triggerDownload(blob, `${fileSafeName(report.name) || "relatorio"}.pdf`);
+}

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/reports/$reportId.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/reports/$reportId.tsx
@@ -2,12 +2,13 @@ import { Button } from "@packages/ui/components/button";
 import { createCollection, useLiveQuery } from "@tanstack/react-db";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import dayjs from "dayjs";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import {
    ArrowLeft,
    CalendarDays,
    FileDown,
    Filter,
+   Loader2,
    ReceiptText,
 } from "lucide-react";
 import {
@@ -19,6 +20,7 @@ import { QueryBoundary } from "@/components/query-boundary";
 import { useActiveTeam } from "@/hooks/use-active-team";
 import { useDashboardSlugs } from "@/hooks/use-dashboard-slugs";
 import { reportByIdCollectionOptions } from "@/integrations/tanstack-db/reports";
+import { toast } from "@packages/ui/hooks/use-toast";
 import { REPORT_LABELS, type SavedReport } from "../-reports/report-labels";
 import { ReportData } from "../-reports/report-panels";
 import { DefaultHeader } from "../../-layout/default-header";
@@ -152,6 +154,7 @@ function ReportDetailWithTeam({ teamId }: { teamId: string }) {
 }
 
 function ReportDetailToolbar({ report }: { report: SavedReport }) {
+   const [isExporting, setIsExporting] = useState(false);
    const statusLabel =
       report.config.status === "paid"
          ? "Realizados"
@@ -191,12 +194,26 @@ function ReportDetailToolbar({ report }: { report: SavedReport }) {
          ) : null}
          <div className="flex flex-1 justify-end">
             <Button
-               onClick={() => window.print()}
+               disabled={isExporting}
+               onClick={() => {
+                  setIsExporting(true);
+                  import("../-reports/report-pdf")
+                     .then(({ downloadReportPdf }) => downloadReportPdf(report))
+                     .then(() => toast.success("PDF exportado."))
+                     .catch(() =>
+                        toast.error("Não foi possível exportar o PDF."),
+                     )
+                     .finally(() => setIsExporting(false));
+               }}
                size="icon-sm"
                tooltip="Exportar PDF"
                variant="outline"
             >
-               <FileDown />
+               {isExporting ? (
+                  <Loader2 className="animate-spin" />
+               ) : (
+                  <FileDown />
+               )}
                <span className="sr-only">Exportar PDF</span>
             </Button>
          </div>

--- a/bun.lock
+++ b/bun.lock
@@ -130,6 +130,7 @@
         "@orpc/tanstack-query": "catalog:orpc",
         "@orpc/zod": "catalog:orpc",
         "@packages/ui": "workspace:*",
+        "@react-pdf/renderer": "catalog:pdf",
         "@tailwindcss/vite": "catalog:vite",
         "@tanstack/ai": "catalog:tanstack-ai",
         "@tanstack/ai-openrouter": "catalog:tanstack-ai",
@@ -981,6 +982,9 @@
     },
     "payments": {
       "stripe": "^22.0.2",
+    },
+    "pdf": {
+      "@react-pdf/renderer": "^4.5.1",
     },
     "react": {
       "@types/react": "19.2.14",
@@ -2414,6 +2418,32 @@
 
     "@react-email/text": ["@react-email/text@0.1.6", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-TYqkioRS45wTR5il3dYk/SbUjjEdhSwh9BtRNB99qNH1pXAwA45H7rAuxehiu8iJQJH0IyIr+6n62gBz9ezmsw=="],
 
+    "@react-pdf/fns": ["@react-pdf/fns@3.1.3", "", {}, "sha512-0I7pApDr1/RLAKbizuLy/IHTEa93LSPy/bEwYniboC3Xqnp6Od8xFJKbKEzGw2wh/5zKFFwl00g4t9RwgIMc3w=="],
+
+    "@react-pdf/font": ["@react-pdf/font@4.0.8", "", { "dependencies": { "@react-pdf/pdfkit": "^5.1.1", "@react-pdf/types": "^2.11.1", "fontkit": "^2.0.2", "is-url": "^1.2.4" } }, "sha512-deNd+emtZAJho1IlzKL9bRoLAGv/6oXOIKO2oZfs4RuXUrK1onLHbJO7e2YoVLPFP/sQxisRTnzdJFtd35iKwA=="],
+
+    "@react-pdf/image": ["@react-pdf/image@3.1.0", "", { "dependencies": { "@react-pdf/svg": "^1.1.0", "jay-peg": "^1.1.1", "png-js": "^2.0.0" } }, "sha512-ks7Ry8v711r8NvKWSELehj0BXBNPRihSnWsM09nDD8Ur175zbWBCK217LLwQMKDNYDVpkZaipdoJPom1LGaE9g=="],
+
+    "@react-pdf/layout": ["@react-pdf/layout@4.6.1", "", { "dependencies": { "@react-pdf/fns": "3.1.3", "@react-pdf/image": "^3.1.0", "@react-pdf/primitives": "^4.3.0", "@react-pdf/stylesheet": "^6.2.1", "@react-pdf/textkit": "^6.3.0", "@react-pdf/types": "^2.11.1", "emoji-regex-xs": "^1.0.0", "queue": "^6.0.1", "yoga-layout": "^3.2.1" } }, "sha512-gN6PmWoEffvlIkifLfEhMsVucRywVMyH3rnxdyOVOhGy0nWJKKGpHyPc4plbDdpP6EfZ0r8prHXujDSkIG2nSA=="],
+
+    "@react-pdf/pdfkit": ["@react-pdf/pdfkit@5.1.1", "", { "dependencies": { "@babel/runtime": "^7.20.13", "@noble/ciphers": "^1.0.0", "@noble/hashes": "^1.6.0", "browserify-zlib": "^0.2.0", "fontkit": "^2.0.2", "jay-peg": "^1.1.1", "js-md5": "^0.8.3", "linebreak": "^1.1.0", "png-js": "^2.0.0", "vite-compatible-readable-stream": "^3.6.1" } }, "sha512-wNcdSsNlNYyGHGAgIdt453egBF7fiF9UxpRlklUfVvu8OWCrUppG9xiUrPLVoKiqWet5tMi0w6LmuFUJuYqjEg=="],
+
+    "@react-pdf/primitives": ["@react-pdf/primitives@4.3.0", "", {}, "sha512-nYXoZ36pvwNzbc54+DbL8RCn15jU7woJ9D/svnh5tpUXekJ+CbI4mZLo6boSv24CvJgychOu6h7gxX03B4ps0A=="],
+
+    "@react-pdf/reconciler": ["@react-pdf/reconciler@2.0.0", "", { "dependencies": { "object-assign": "^4.1.1", "scheduler": "0.25.0-rc-603e6108-20241029" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-7zaPRujpbHSmCpIrZ+b9HSTJHthcVZzX0Wx7RzvQGsGBUbHP4p6s5itXrAIOuQuPvDepoHGNOvf6xUuMVvdoyw=="],
+
+    "@react-pdf/render": ["@react-pdf/render@4.5.1", "", { "dependencies": { "@babel/runtime": "^7.20.13", "@react-pdf/fns": "3.1.3", "@react-pdf/primitives": "^4.3.0", "@react-pdf/textkit": "^6.3.0", "@react-pdf/types": "^2.11.1", "abs-svg-path": "^0.1.1", "color-string": "^2.1.4", "normalize-svg-path": "^1.1.0", "parse-svg-path": "^0.1.2", "svg-arc-to-cubic-bezier": "^3.2.0" } }, "sha512-IW/N4HWJWtioBXCf7n02IR24VJJ8gbdS3jGypf+vW/rSErEx3/URRzh9UK6Ma8Fpog9+T/W6GE2NHJ5AAKHhVA=="],
+
+    "@react-pdf/renderer": ["@react-pdf/renderer@4.5.1", "", { "dependencies": { "@babel/runtime": "^7.20.13", "@react-pdf/fns": "3.1.3", "@react-pdf/font": "^4.0.8", "@react-pdf/layout": "^4.6.1", "@react-pdf/pdfkit": "^5.1.1", "@react-pdf/primitives": "^4.3.0", "@react-pdf/reconciler": "^2.0.0", "@react-pdf/render": "^4.5.1", "@react-pdf/types": "^2.11.1", "events": "^3.3.0", "object-assign": "^4.1.1", "prop-types": "^15.6.2", "queue": "^6.0.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-5r1VQrE6FRLXX5wWUxwZzM24E2BJMo6g8AQWuS8WyPs9ugu5yMnb2g8/RpPYka/Z6J+RUEWc32wty2NoUJF42Q=="],
+
+    "@react-pdf/stylesheet": ["@react-pdf/stylesheet@6.2.1", "", { "dependencies": { "@react-pdf/fns": "3.1.3", "@react-pdf/types": "^2.11.1", "color-string": "^2.1.4", "hsl-to-hex": "^1.0.0", "media-engine": "^1.0.3", "postcss-value-parser": "^4.1.0" } }, "sha512-2+UEk+7e+z8baaWi2l5kPLWmwtJeOI+T5wW9GGeN3iDH7vd3kbTqOpN1yt9mmfNVZFxQsnDHpznFb5v5UF983A=="],
+
+    "@react-pdf/svg": ["@react-pdf/svg@1.1.0", "", { "dependencies": { "@react-pdf/primitives": "^4.3.0" } }, "sha512-cTIHXiz9x1HrbfqzfxfZP3FRdDwUXG77QWF6Fb5MP/lV3ONxR+g0Z3hwtBatCS9HeGBQCpxX/Lzb8wHE+co1PA=="],
+
+    "@react-pdf/textkit": ["@react-pdf/textkit@6.3.0", "", { "dependencies": { "@react-pdf/fns": "3.1.3", "bidi-js": "^1.0.2", "hyphen": "^1.6.4", "unicode-properties": "^1.4.1" } }, "sha512-v6+V8nAcVwm7s2s1jIG2MD3Iw//x/k+XrH1foWOELBE4b32pyDgKyPXN/6KJE0dnX7+fVy27uctLNCLNMvzKzQ=="],
+
+    "@react-pdf/types": ["@react-pdf/types@2.11.1", "", { "dependencies": { "@react-pdf/font": "^4.0.8", "@react-pdf/primitives": "^4.3.0", "@react-pdf/stylesheet": "^6.2.1" } }, "sha512-i9xQgfaDU9QoeNnbp6rltXCWg1huEh195rpOuN8cE4BZ2FuLdQrsIcb2dhFF9aOxXf+XBA6LOSpIW051MDD/bw=="],
+
     "@reduxjs/toolkit": ["@reduxjs/toolkit@2.12.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.1", "", { "os": "android", "cpu": "arm64" }, "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg=="],
@@ -3056,6 +3086,8 @@
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
+    "abs-svg-path": ["abs-svg-path@0.1.1", "", {}, "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA=="],
+
     "abstract-logging": ["abstract-logging@2.0.1", "", {}, "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
@@ -3186,6 +3218,8 @@
 
     "better-sqlite3": ["better-sqlite3@11.10.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ=="],
 
+    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
+
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
@@ -3204,7 +3238,11 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
+    "brotli": ["brotli@1.3.3", "", { "dependencies": { "base64-js": "^1.1.2" } }, "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg=="],
+
     "browser-image-compression": ["browser-image-compression@2.0.2", "", { "dependencies": { "uzip": "0.20201231.0" } }, "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw=="],
+
+    "browserify-zlib": ["browserify-zlib@0.2.0", "", { "dependencies": { "pako": "~1.0.5" } }, "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
@@ -3280,7 +3318,7 @@
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
-    "clone": ["clone@1.0.4", "", {}, "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="],
+    "clone": ["clone@2.1.2", "", {}, "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="],
 
     "cloudflare-video-element": ["cloudflare-video-element@1.3.5", "", {}, "sha512-zj9gjJa6xW8MNrfc4oKuwgGS0njRLpOlQjdifbuNxvy8k4Y3pKCyKCMG2XIsjd2iQGhgjS57b1P5VWdJlxcXBw=="],
 
@@ -3508,6 +3546,8 @@
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
+    "dfa": ["dfa@1.2.0", "", {}, "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q=="],
+
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "diff3": ["diff3@0.0.3", "", {}, "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g=="],
@@ -3567,6 +3607,8 @@
     "emmet": ["emmet@2.4.11", "", { "dependencies": { "@emmetio/abbreviation": "^2.3.3", "@emmetio/css-abbreviation": "^2.1.8" } }, "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "emoji-regex-xs": ["emoji-regex-xs@1.0.0", "", {}, "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg=="],
 
     "enabled": ["enabled@2.0.0", "", {}, "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="],
 
@@ -3758,6 +3800,8 @@
 
     "fontace": ["fontace@0.4.1", "", { "dependencies": { "fontkitten": "^1.0.2" } }, "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw=="],
 
+    "fontkit": ["fontkit@2.0.4", "", { "dependencies": { "@swc/helpers": "^0.5.12", "brotli": "^1.3.2", "clone": "^2.1.2", "dfa": "^1.2.0", "fast-deep-equal": "^3.1.3", "restructure": "^3.0.0", "tiny-inflate": "^1.0.3", "unicode-properties": "^1.4.0", "unicode-trie": "^2.0.0" } }, "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g=="],
+
     "fontkitten": ["fontkitten@1.0.3", "", { "dependencies": { "tiny-inflate": "^1.0.3" } }, "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw=="],
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
@@ -3892,6 +3936,10 @@
 
     "hookable": ["hookable@6.1.1", "", {}, "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ=="],
 
+    "hsl-to-hex": ["hsl-to-hex@1.0.0", "", { "dependencies": { "hsl-to-rgb-for-reals": "^1.1.0" } }, "sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA=="],
+
+    "hsl-to-rgb-for-reals": ["hsl-to-rgb-for-reals@1.1.1", "", {}, "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg=="],
+
     "html-entities": ["html-entities@2.6.0", "", {}, "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ=="],
 
     "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
@@ -3913,6 +3961,8 @@
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "httpxy": ["httpxy@0.5.1", "", {}, "sha512-JPhqYiixe1A1I+MXDewWDZqeudBGU8Q9jCHYN8ML+779RQzLjTi78HBvWz4jMxUD6h2/vUL12g4q/mFM0OUw1A=="],
+
+    "hyphen": ["hyphen@1.14.1", "", {}, "sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
@@ -3996,6 +4046,8 @@
 
     "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
 
+    "is-url": ["is-url@1.2.4", "", {}, "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="],
+
     "is-what": ["is-what@4.1.16", "", {}, "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A=="],
 
     "is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
@@ -4016,6 +4068,8 @@
 
     "jackspeak": ["jackspeak@4.2.3", "", { "dependencies": { "@isaacs/cliui": "^9.0.0" } }, "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg=="],
 
+    "jay-peg": ["jay-peg@1.1.1", "", { "dependencies": { "restructure": "^3.0.0" } }, "sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww=="],
+
     "jest-diff": ["jest-diff@30.4.1", "", { "dependencies": { "@jest/diff-sequences": "30.4.0", "@jest/get-type": "30.1.0", "chalk": "^4.1.2", "pretty-format": "30.4.1" } }, "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA=="],
 
     "jiti": ["jiti@2.4.2", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A=="],
@@ -4023,6 +4077,8 @@
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "js-levenshtein": ["js-levenshtein@1.1.6", "", {}, "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="],
+
+    "js-md5": ["js-md5@0.8.3", "", {}, "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ=="],
 
     "js-tiktoken": ["js-tiktoken@1.0.21", "", { "dependencies": { "base64-js": "^1.5.1" } }, "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g=="],
 
@@ -4140,6 +4196,8 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
+    "linebreak": ["linebreak@1.1.0", "", { "dependencies": { "base64-js": "0.0.8", "unicode-trie": "^2.0.0" } }, "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ=="],
+
     "lines-and-columns": ["lines-and-columns@2.0.3", "", {}, "sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w=="],
 
     "localforage": ["localforage@1.10.0", "", { "dependencies": { "lie": "3.1.1" } }, "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg=="],
@@ -4233,6 +4291,8 @@
     "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
 
     "media-chrome": ["media-chrome@4.19.0", "", { "dependencies": { "ce-la-react": "^0.3.2" } }, "sha512-HWhDTwts+BSbdPkkB1VsJXp5kvL0IxY7xFT5tBwliM2+89kTPVTnHnev+9it2f9PweANjT/C8/C/S0PW9oyZbA=="],
+
+    "media-engine": ["media-engine@1.0.3", "", {}, "sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg=="],
 
     "media-played-ranges-mixin": ["media-played-ranges-mixin@0.1.0", "", {}, "sha512-zTsvkleu5sAyTsPVxDI+KUbCwy/lXwHgOPi3ER9S3lhtAWhGTQH6qxvfrVMym1cvoLU36SPbVr6Qe8Zxyc0WpA=="],
 
@@ -4408,6 +4468,8 @@
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
+    "normalize-svg-path": ["normalize-svg-path@1.1.0", "", { "dependencies": { "svg-arc-to-cubic-bezier": "^3.0.0" } }, "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg=="],
+
     "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
 
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
@@ -4496,6 +4558,8 @@
 
     "parse-srcset": ["parse-srcset@1.0.2", "", {}, "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="],
 
+    "parse-svg-path": ["parse-svg-path@0.1.2", "", {}, "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ=="],
+
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@7.1.0", "", { "dependencies": { "domhandler": "^5.0.3", "parse5": "^7.0.0" } }, "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g=="],
@@ -4574,6 +4638,8 @@
 
     "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
 
+    "png-js": ["png-js@2.0.0", "", { "dependencies": { "fflate": "^0.8.2" } }, "sha512-GdzJuUMc6ZSpxFJWVxtOH1bzYHym+TOnveqUjb+VJIbZWbZzyiRGFiKhbiielfpYbgMlhHVhsJ0FTazfuRFkMA=="],
+
     "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
 
     "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
@@ -4583,6 +4649,8 @@
     "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 
     "postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
+
+    "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
     "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
 
@@ -4637,6 +4705,8 @@
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 
     "query-selector-shadow-dom": ["query-selector-shadow-dom@1.0.1", "", {}, "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw=="],
+
+    "queue": ["queue@6.0.2", "", { "dependencies": { "inherits": "~2.0.3" } }, "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA=="],
 
     "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 
@@ -4795,6 +4865,8 @@
     "resolve.exports": ["resolve.exports@2.0.3", "", {}, "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A=="],
 
     "restore-cursor": ["restore-cursor@3.1.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA=="],
+
+    "restructure": ["restructure@3.0.2", "", {}, "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw=="],
 
     "ret": ["ret@0.5.0", "", {}, "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw=="],
 
@@ -4996,6 +5068,8 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
+    "svg-arc-to-cubic-bezier": ["svg-arc-to-cubic-bezier@3.2.0", "", {}, "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g=="],
+
     "svgo": ["svgo@4.0.1", "", { "dependencies": { "commander": "^11.1.0", "css-select": "^5.1.0", "css-tree": "^3.0.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.1.1", "sax": "^1.5.0" }, "bin": "./bin/svgo.js" }, "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w=="],
 
     "table": ["table@6.9.0", "", { "dependencies": { "ajv": "^8.0.1", "lodash.truncate": "^4.4.2", "slice-ansi": "^4.0.0", "string-width": "^4.2.3", "strip-ansi": "^6.0.1" } }, "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A=="],
@@ -5122,7 +5196,11 @@
 
     "unicode-match-property-value-ecmascript": ["unicode-match-property-value-ecmascript@2.2.1", "", {}, "sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg=="],
 
+    "unicode-properties": ["unicode-properties@1.4.1", "", { "dependencies": { "base64-js": "^1.3.0", "unicode-trie": "^2.0.0" } }, "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg=="],
+
     "unicode-property-aliases-ecmascript": ["unicode-property-aliases-ecmascript@2.2.0", "", {}, "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ=="],
+
+    "unicode-trie": ["unicode-trie@2.0.0", "", { "dependencies": { "pako": "^0.2.5", "tiny-inflate": "^1.0.0" } }, "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ=="],
 
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 
@@ -5199,6 +5277,8 @@
     "vimeo-video-element": ["vimeo-video-element@1.7.2", "", { "dependencies": { "@vimeo/player": "2.29.0", "media-played-ranges-mixin": "^0.1.0" } }, "sha512-7QM7fvSZvTTSq4igxBuO6Gc+0u3Exgk4IaLNixVzilCPzHEf7SN8b6YLXSM5QCs0ineTJI4XjiUCSoIbabHvwg=="],
 
     "vite": ["vite@8.0.13", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.1", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw=="],
+
+    "vite-compatible-readable-stream": ["vite-compatible-readable-stream@3.6.1", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ=="],
 
     "vite-tsconfig-paths": ["vite-tsconfig-paths@6.1.1", "", { "dependencies": { "debug": "^4.1.1", "globrex": "^0.1.2", "tsconfck": "^3.0.3" }, "peerDependencies": { "vite": "*" } }, "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg=="],
 
@@ -5317,6 +5397,8 @@
     "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
 
     "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
+
+    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
     "youtube-video-element": ["youtube-video-element@1.9.0", "", { "dependencies": { "media-played-ranges-mixin": "^0.1.0" } }, "sha512-Hh0dbQM+FVlUaYUbpYkZNUvdKxTNcSNvTGzkQKYShltnX+LRHEp2eYvC2Zm43eU8Np+CBZuoNR2i+seCYzzAyg=="],
 
@@ -5552,6 +5634,12 @@
 
     "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
+    "@react-pdf/pdfkit/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+
+    "@react-pdf/pdfkit/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@react-pdf/reconciler/scheduler": ["scheduler@0.25.0-rc-603e6108-20241029", "", {}, "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA=="],
+
     "@reduxjs/toolkit/immer": ["immer@11.1.8", "", {}, "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA=="],
 
     "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
@@ -5686,6 +5774,8 @@
 
     "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
 
+    "defaults/clone": ["clone@1.0.4", "", {}, "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="],
+
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "dot-prop/type-fest": ["type-fest@5.6.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA=="],
@@ -5762,6 +5852,8 @@
 
     "light-my-request/set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
+    "linebreak/base64-js": ["base64-js@0.0.8", "", {}, "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="],
+
     "magicast/@babel/parser": ["@babel/parser@7.29.3", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA=="],
 
     "mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
@@ -5795,6 +5887,8 @@
     "pg-boss/serialize-error": ["serialize-error@13.0.1", "", { "dependencies": { "non-error": "^0.1.0", "type-fest": "^5.4.1" } }, "sha512-bBZaRwLH9PN5HbLCjPId4dP5bNGEtumcErgOX952IsvOhVPrm3/AeK1y0UHA/QaPG701eg0yEnOKsCOC6X/kaA=="],
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "png-js/fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
 
     "postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
@@ -5861,6 +5955,8 @@
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "typeid-js/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
+
+    "unicode-trie/pako": ["pako@0.2.9", "", {}, "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="],
 
     "unifont/ofetch": ["ofetch@1.5.1", "", { "dependencies": { "destr": "^2.0.5", "node-fetch-native": "^1.6.7", "ufo": "^1.6.1" } }, "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA=="],
 

--- a/modules/cashbook/src/router/transactions-list.ts
+++ b/modules/cashbook/src/router/transactions-list.ts
@@ -66,6 +66,7 @@ const filterSchema = z
          .enum(["all", "payable", "receivable", "settled", "ignored"])
          .optional(),
       ignored: z.boolean().optional(),
+      all: z.boolean().optional(),
       page: z.number().int().positive().default(1),
       pageSize: z.number().int().positive().max(100).default(20),
       conditionGroup: ConditionGroup.optional(),
@@ -109,9 +110,12 @@ export const getAll = protectedProcedure
                   },
                }).passed,
          );
-         const offset = (page - 1) * pageSize;
+         const data =
+            input?.all === true
+               ? filtered
+               : filtered.slice((page - 1) * pageSize, page * pageSize);
          return {
-            data: filtered.slice(offset, offset + pageSize),
+            data,
             total: filtered.length,
          };
       }
@@ -121,13 +125,15 @@ export const getAll = protectedProcedure
          .from(transactions)
          .where(where);
 
-      const data = await selectTransactionsWithJoins(
+      const dataQuery = selectTransactionsWithJoins(
          context.db,
          where,
          normalizeSorting(filter.sorting),
-      )
-         .limit(pageSize)
-         .offset((page - 1) * pageSize);
+      );
+      const data =
+         input?.all === true
+            ? await dataQuery
+            : await dataQuery.limit(pageSize).offset((page - 1) * pageSize);
 
       return { data, total: countRow?.total ?? 0 };
    });

--- a/package.json
+++ b/package.json
@@ -102,6 +102,9 @@
          "payments": {
             "stripe": "^22.0.2"
          },
+         "pdf": {
+            "@react-pdf/renderer": "^4.5.1"
+         },
          "react": {
             "@types/react": "19.2.14",
             "@types/react-dom": "19.2.3",


### PR DESCRIPTION
## Resumo
- troca a exportação de relatórios de window.print para geração via @react-pdf/renderer
- adiciona documento PDF próprio para os tipos de relatório existentes
- ajusta a snapshot de lançamentos da DRE para carregar todos os lançamentos do período, não só 100
- inclui os lançamentos da base no PDF da DRE usando a snapshot completa

## Validação
- bun run check -- modules/cashbook/src/router/transactions-list.ts apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-reports/report-panels.tsx apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-reports/report-pdf.tsx apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/reports/$reportId.tsx (0 erros; warnings existentes)
- bun run --filter web typecheck (ok no workspace principal)
- bun run --filter @modules/cashbook typecheck (ok no workspace principal)

Observação: no worktree limpo usado para abrir o PR, o typecheck completo falha por dist stale/missing references de pacotes core existentes; a validação acima foi rodada no workspace principal.