### PR TITLE
fix: corrigir paginação de lançamentos

### DIFF
--- a/apps/web-e2e/helpers/db.ts
+++ b/apps/web-e2e/helpers/db.ts
@@ -1,6 +1,6 @@
 import { config as loadEnv } from "dotenv";
 import path from "node:path";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { fromThrowable } from "neverthrow";
 import { Pool } from "pg";
@@ -368,6 +368,37 @@ export async function insertExpenseTransaction(
       .returning();
    if (!row) throw new Error("Failed to insert transaction");
    return row;
+}
+
+export async function insertExpenseTransactions(
+   teamId: string,
+   bankAccountId: string,
+   expenses: Array<{ name: string; date: string }>,
+) {
+   return db()
+      .insert(transactions)
+      .values(
+         expenses.map((expense): typeof transactions.$inferInsert => ({
+            teamId,
+            name: expense.name,
+            type: "expense",
+            amount: "10.00",
+            date: expense.date,
+            bankAccountId,
+            status: "pending",
+         })),
+      )
+      .returning();
+}
+
+export async function deleteTransactionsByIds(teamId: string, ids: string[]) {
+   if (ids.length === 0) return;
+
+   await db()
+      .delete(transactions)
+      .where(
+         and(eq(transactions.teamId, teamId), inArray(transactions.id, ids)),
+      );
 }
 
 export async function deleteTransactionById(teamId: string, id: string) {

--- a/apps/web-e2e/tests/datatable-url-state-sync.spec.ts
+++ b/apps/web-e2e/tests/datatable-url-state-sync.spec.ts
@@ -1,4 +1,11 @@
 import { expect, test } from "../fixtures";
+import {
+   deleteBankAccountById,
+   deleteTransactionsByIds,
+   findTeamByOrgAndSlug,
+   insertBankAccount,
+   insertExpenseTransactions,
+} from "../helpers/db";
 
 test("sort + pagination state syncs to URL and survives reload", async ({
    page,
@@ -30,4 +37,63 @@ test("sort + pagination state syncs to URL and survives reload", async ({
    await page.getByRole("option", { name: "50" }).click();
    await page.waitForURL(/pageSize=50/);
    expect(page.url()).toContain("pageSize=50");
+});
+
+test("página 2 mostra o 101º lançamento filtrado por conta", async ({
+   page,
+   e2eSession,
+}) => {
+   const team = await findTeamByOrgAndSlug(
+      e2eSession.orgSlug,
+      e2eSession.teamSlug,
+   );
+   if (!team) throw new Error("Time de E2E não encontrado.");
+
+   const account = await insertBankAccount(team.id, "Conta E2E paginação URL");
+   if (!account) throw new Error("Falha ao criar conta bancária de E2E.");
+
+   const oldTransactionName = "Lançamento antigo único E2E";
+   const transactionIds: string[] = [];
+
+   try {
+      const createdTransactions = await insertExpenseTransactions(
+         team.id,
+         account.id,
+         [
+            ...Array.from({ length: 100 }, (_, index) => ({
+               name: `Lançamento recente E2E ${String(index + 1).padStart(3, "0")}`,
+               date: "2025-01-02",
+            })),
+            { name: oldTransactionName, date: "2024-01-02" },
+         ],
+      );
+      transactionIds.push(
+         ...createdTransactions.map((transaction) => transaction.id),
+      );
+
+      await page.goto(
+         `/${e2eSession.orgSlug}/${e2eSession.teamSlug}/transactions?bankId=${account.id}&pageSize=100`,
+      );
+      await expect(
+         page.getByRole("heading", { name: "Lançamentos" }),
+      ).toBeVisible();
+      await expect(
+         page
+            .getByText(/^Lançamento recente E2E \d{3}$/, { exact: true })
+            .first(),
+      ).toBeVisible();
+
+      const nextPageButton = page.getByRole("button", {
+         name: "Próxima página",
+      });
+      await expect(nextPageButton).toBeEnabled();
+      await Promise.all([page.waitForURL(/page=2/), nextPageButton.click()]);
+
+      await expect(
+         page.getByText(oldTransactionName, { exact: true }),
+      ).toBeVisible();
+   } finally {
+      await deleteTransactionsByIds(team.id, transactionIds);
+      await deleteBankAccountById(team.id, account.id);
+   }
 });

--- a/apps/web/src/blocks/data-table/data-table-pagination.tsx
+++ b/apps/web/src/blocks/data-table/data-table-pagination.tsx
@@ -18,15 +18,17 @@ const DEFAULT_PAGE_SIZES = [10, 20, 50, 100];
 
 interface DataTablePaginationProps<TData> {
    table: Table<TData>;
+   totalRows?: number;
    pageSizes?: number[];
 }
 
 export function DataTablePagination<TData>({
    table,
    pageSizes = DEFAULT_PAGE_SIZES,
+   totalRows,
 }: DataTablePaginationProps<TData>) {
    const { pageIndex, pageSize } = table.getState().pagination;
-   const total = table.getRowCount();
+   const total = totalRows ?? table.getRowCount();
    const pageCount = table.getPageCount();
    const from = total === 0 ? 0 : pageIndex * pageSize + 1;
    const to = Math.min((pageIndex + 1) * pageSize, total);

--- a/apps/web/src/integrations/tanstack-db/transactions.ts
+++ b/apps/web/src/integrations/tanstack-db/transactions.ts
@@ -27,6 +27,8 @@ type TransactionSortId = NonNullable<
 type TransactionsCollectionOptionsParams = {
    queryClient: QueryClient;
    teamId: string;
+   page: number;
+   pageSize: number;
    search?: string;
    view?: "all" | "payable" | "receivable" | "settled" | "ignored";
    overdueOnly?: boolean;
@@ -220,17 +222,16 @@ function parseTransactionsSorting(options: LoadSubsetOptions | undefined) {
 
 function transactionsInputFromLoadSubsetOptions(
    options: LoadSubsetOptions | undefined,
-   base: Omit<
-      TransactionsCollectionOptionsParams,
-      "queryClient" | "teamId"
-   > = {},
+   base: Omit<TransactionsCollectionOptionsParams, "queryClient" | "teamId">,
 ): TransactionsCollectionInput {
    const where = parseTransactionsWhere(options);
    const sorting = parseTransactionsSorting(options);
-   const limit = options?.limit;
-   const input: TransactionsCollectionInput = {
-      page: 1,
-      pageSize: 1000,
+   const pageSize = Math.min(100, Math.max(1, options?.limit ?? base.pageSize));
+   const offset = (base.page - 1) * base.pageSize + (options?.offset ?? 0);
+
+   return {
+      page: Math.floor(offset / pageSize) + 1,
+      pageSize,
       search: where.search ?? base.search,
       view: where.view ?? base.view,
       overdueOnly: where.overdueOnly ?? base.overdueOnly,
@@ -245,15 +246,6 @@ function transactionsInputFromLoadSubsetOptions(
       relationshipId: where.relationshipId ?? base.relationshipId,
       sorting,
    };
-
-   if (limit !== undefined) {
-      const pageSize = Math.min(1000, Math.max(1, limit));
-      const offset = options?.offset ?? 0;
-      input.page = Math.floor(offset / pageSize) + 1;
-      input.pageSize = pageSize;
-   }
-
-   return input;
 }
 
 function hasLoadSubsetOptions(options: LoadSubsetOptions | undefined) {
@@ -351,6 +343,8 @@ export function buildOptimisticTransactionRow({
 export function transactionsCollectionOptions({
    queryClient,
    teamId,
+   page,
+   pageSize,
    search,
    view,
    overdueOnly,
@@ -363,6 +357,8 @@ export function transactionsCollectionOptions({
    relationshipId,
 }: TransactionsCollectionOptionsParams) {
    const base = {
+      page,
+      pageSize,
       search,
       view,
       overdueOnly,
@@ -378,6 +374,8 @@ export function transactionsCollectionOptions({
       id: [
          "transactions",
          teamId,
+         page,
+         pageSize,
          search ?? "",
          view ?? "all",
          overdueOnly ? "overdue" : "all-dates",

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/-transactions/transactions-list.tsx
@@ -559,6 +559,8 @@ export function TransactionsList() {
             transactionsCollectionOptions({
                queryClient,
                teamId: collectionTeamId,
+               page,
+               pageSize,
                search: trimmedSearch || undefined,
                view: "all",
                overdueOnly: false,
@@ -573,6 +575,8 @@ export function TransactionsList() {
          ),
       [
          collectionTeamId,
+         page,
+         pageSize,
          dueDateRangeFilter.from,
          dueDateRangeFilter.to,
          effectiveDateFrom,
@@ -834,10 +838,7 @@ export function TransactionsList() {
                .orderBy(({ transaction }) => transaction.createdAt, "desc");
          }
 
-         return query
-            .limit(pageSize)
-            .offset((page - 1) * pageSize)
-            .select(({ transaction }) => transaction);
+         return query.limit(pageSize).select(({ transaction }) => transaction);
       },
       [
          effectiveBankId,
@@ -2236,7 +2237,7 @@ export function TransactionsList() {
                   )}
                </ScrollArea>
             </TooltipProvider>
-            <DataTablePagination table={table} />
+            <DataTablePagination table={table} totalRows={total} />
          </div>
       </div>
    );

--- a/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/transactions.tsx
+++ b/apps/web/src/routes/_authenticated/$slug/$teamSlug/_dashboard/transactions.tsx
@@ -24,7 +24,7 @@ const transactionsSearchSchema = z.object({
       .catch([])
       .default([]),
    page: z.number().int().min(1).catch(1).default(1),
-   pageSize: z.number().int().catch(20).default(20),
+   pageSize: z.number().int().min(1).max(100).catch(20).default(20),
    search: z.string().catch("").default(""),
    view: z
       .enum(["all", "payable", "receivable", "settled", "ignored"])


### PR DESCRIPTION
## Problema

Com 100 lançamentos por página, a segunda página podia ficar vazia. A consulta do TanStack DB acumulava o offset local e solicitava um `pageSize` acima do limite de 100 aceito pela API.

## Correção

- escopa a collection de lançamentos por `page` e `pageSize`;
- consulta cada página remota sem reaplicar o offset global no subset local;
- limita `pageSize` da rota ao intervalo aceito pela API;
- usa o total remoto no rodapé da paginação;
- cobre o fluxo com 101 lançamentos filtrados por conta.

## Validação

- `bun nx run web:typecheck --skipSync`
- `bun nx run web-e2e:build --skipSync`
- Playwright focado: `página 2 mostra o 101º lançamento filtrado por conta` (1 teste passou)
- `bunx react-doctor@latest --scope changed` (82/100, sem achados listados)
- `git diff --check`